### PR TITLE
refactor(naming): move package naming to the core project

### DIFF
--- a/quill-async/src/main/scala/io/getquill/source/async/AsyncSource.scala
+++ b/quill-async/src/main/scala/io/getquill/source/async/AsyncSource.scala
@@ -12,9 +12,9 @@ import com.github.mauricio.async.db.QueryResult
 import com.github.mauricio.async.db.RowData
 import com.github.mauricio.async.db.pool.ObjectFactory
 import com.typesafe.scalalogging.StrictLogging
+import io.getquill.naming.NamingStrategy
 import io.getquill.source.sql.SqlSource
 import io.getquill.source.sql.idiom.MySQLDialect
-import io.getquill.source.sql.naming.NamingStrategy
 import io.getquill.source.sql.idiom.SqlIdiom
 import language.experimental.macros
 import io.getquill.quotation.Quoted

--- a/quill-async/src/main/scala/io/getquill/source/async/mysql/MysqlAsyncSource.scala
+++ b/quill-async/src/main/scala/io/getquill/source/async/mysql/MysqlAsyncSource.scala
@@ -3,8 +3,8 @@ package io.getquill.source.async.mysql
 import com.github.mauricio.async.db.Configuration
 import com.github.mauricio.async.db.mysql.MySQLConnection
 import com.github.mauricio.async.db.mysql.pool.MySQLConnectionFactory
+import io.getquill.naming.NamingStrategy
 import io.getquill.source.async.AsyncSource
-import io.getquill.source.sql.naming.NamingStrategy
 import io.getquill.source.sql.idiom.MySQLDialect
 
 class MysqlAsyncSource[N <: NamingStrategy] extends AsyncSource[MySQLDialect.type, N, MySQLConnection] {

--- a/quill-async/src/main/scala/io/getquill/source/async/postgres/PostgresAsyncSource.scala
+++ b/quill-async/src/main/scala/io/getquill/source/async/postgres/PostgresAsyncSource.scala
@@ -3,8 +3,8 @@ package io.getquill.source.async.postgres
 import com.github.mauricio.async.db.Configuration
 import com.github.mauricio.async.db.postgresql.PostgreSQLConnection
 import com.github.mauricio.async.db.postgresql.pool.PostgreSQLConnectionFactory
+import io.getquill.naming.NamingStrategy
 import io.getquill.source.async.AsyncSource
-import io.getquill.source.sql.naming.NamingStrategy
 import io.getquill.source.sql.idiom.PostgresDialect
 
 class PostgresAsyncSource[N <: NamingStrategy] extends AsyncSource[PostgresDialect.type, N, PostgreSQLConnection] {

--- a/quill-async/src/test/scala/io/getquill/source/async/mysql/TestDB.scala
+++ b/quill-async/src/test/scala/io/getquill/source/async/mysql/TestDB.scala
@@ -1,5 +1,5 @@
 package io.getquill.source.async.mysql
 
-import io.getquill.source.sql.naming.Literal
+import io.getquill.naming.Literal
 
 object testMysqlDB extends MysqlAsyncSource[Literal]

--- a/quill-async/src/test/scala/io/getquill/source/async/postgres/TestDB.scala
+++ b/quill-async/src/test/scala/io/getquill/source/async/postgres/TestDB.scala
@@ -1,5 +1,5 @@
 package io.getquill.source.async.postgres
 
-import io.getquill.source.sql.naming.Literal
+import io.getquill.naming.Literal
 
 object testPostgresDB extends PostgresAsyncSource[Literal]

--- a/quill-core/src/main/scala/io/getquill/naming/NamingStrategy.scala
+++ b/quill-core/src/main/scala/io/getquill/naming/NamingStrategy.scala
@@ -1,4 +1,4 @@
-package io.getquill.source.sql.naming
+package io.getquill.naming
 
 trait NamingStrategy {
   def apply(s: String): String

--- a/quill-core/src/test/scala/io/getquill/naming/NamingStrategySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/naming/NamingStrategySpec.scala
@@ -1,4 +1,4 @@
-package io.getquill.source.sql.naming
+package io.getquill.naming
 
 import io.getquill.Spec
 

--- a/quill-finagle-mysql/src/main/scala/io/getquill/source/finagle/mysql/FinagleMysqlSource.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/source/finagle/mysql/FinagleMysqlSource.scala
@@ -8,6 +8,7 @@ import com.twitter.finagle.exp.mysql.Row
 import com.twitter.util.Future
 import com.twitter.util.Local
 import com.typesafe.scalalogging.StrictLogging
+import io.getquill.naming.NamingStrategy
 import io.getquill.source.sql.SqlSource
 import io.getquill.source.sql.idiom.MySQLDialect
 import scala.util.Success
@@ -16,7 +17,6 @@ import scala.util.Try
 import com.twitter.finagle.Service
 import com.twitter.finagle.exp.mysql.Request
 import com.twitter.finagle.exp.mysql.PrepareRequest
-import io.getquill.source.sql.naming.NamingStrategy
 
 class FinagleMysqlSource[N <: NamingStrategy]
     extends SqlSource[MySQLDialect.type, N, Row, List[Parameter]]

--- a/quill-finagle-mysql/src/test/scala/io/getquill/source/finagle/mysql/TestDB.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/source/finagle/mysql/TestDB.scala
@@ -1,5 +1,5 @@
 package io.getquill.source.finagle.mysql
 
-import io.getquill.source.sql.naming.Literal
+import io.getquill.naming.Literal
 
 object testDB extends FinagleMysqlSource[Literal]

--- a/quill-jdbc/src/main/scala/io/getquill/source/jdbc/JdbcSource.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/source/jdbc/JdbcSource.scala
@@ -5,12 +5,11 @@ import java.sql.PreparedStatement
 import java.sql.ResultSet
 import scala.util.DynamicVariable
 import com.typesafe.scalalogging.StrictLogging
+import io.getquill.naming.NamingStrategy
 import io.getquill.source.sql.SqlSource
 import scala.util.Try
 import io.getquill.source.sql.idiom.SqlIdiom
 import scala.util.control.NonFatal
-import io.getquill.source.sql.naming.NamingStrategy
-import io.getquill.source.sql.naming.SnakeCase
 
 class JdbcSource[D <: SqlIdiom, N <: NamingStrategy]
     extends SqlSource[D, N, ResultSet, PreparedStatement]

--- a/quill-jdbc/src/test/scala/io/getquill/source/jdbc/TestDB.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/source/jdbc/TestDB.scala
@@ -1,6 +1,6 @@
 package io.getquill.source.jdbc
 
+import io.getquill.naming.Literal
 import io.getquill.source.sql.idiom.MySQLDialect
-import io.getquill.source.sql.naming.Literal
 
 object testDB extends JdbcSource[MySQLDialect.type, Literal]

--- a/quill-sql/src/main/scala/io/getquill/source/sql/SqlSource.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/SqlSource.scala
@@ -4,9 +4,9 @@ import java.util.Date
 import language.experimental.macros
 import scala.reflect.ClassTag
 import scala.util.Try
+import io.getquill.naming.NamingStrategy
 import io.getquill.quotation.Quoted
 import io.getquill.source.sql.idiom.SqlIdiom
-import io.getquill.source.sql.naming.NamingStrategy
 
 abstract class SqlSource[D <: SqlIdiom, N <: NamingStrategy, R: ClassTag, S: ClassTag] extends io.getquill.source.Source[R, S] {
 

--- a/quill-sql/src/main/scala/io/getquill/source/sql/SqlSourceMacro.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/SqlSourceMacro.scala
@@ -4,12 +4,12 @@ import scala.reflect.macros.whitebox.Context
 import scala.util.Failure
 import scala.util.Success
 import io.getquill.ast._
+import io.getquill.naming.NamingStrategy
 import io.getquill.source.SourceMacro
 import io.getquill.source.sql.idiom.SqlIdiom
 import io.getquill.util.Messages.RichContext
 import io.getquill.util.Show.Shower
 import io.getquill.quotation.Quoted
-import io.getquill.source.sql.naming.NamingStrategy
 import scala.reflect.ClassTag
 import io.getquill.source.sql.idiom.SqlIdiom
 

--- a/quill-sql/src/main/scala/io/getquill/source/sql/idiom/MySQLDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/idiom/MySQLDialect.scala
@@ -1,8 +1,8 @@
 package io.getquill.source.sql.idiom
 
 import io.getquill.ast._
+import io.getquill.naming.NamingStrategy
 import io.getquill.util.Show._
-import io.getquill.source.sql.naming.NamingStrategy
 
 object MySQLDialect
     extends SqlIdiom

--- a/quill-sql/src/main/scala/io/getquill/source/sql/idiom/NullsOrderingClause.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/idiom/NullsOrderingClause.scala
@@ -1,8 +1,8 @@
 package io.getquill.source.sql.idiom
 
+import io.getquill.naming.NamingStrategy
 import io.getquill.source.sql.OrderByCriteria
 import io.getquill.util.Show.Shower
-import io.getquill.source.sql.naming.NamingStrategy
 
 trait NullsOrderingClause {
   this: SqlIdiom =>

--- a/quill-sql/src/main/scala/io/getquill/source/sql/idiom/OffsetWithoutLimitWorkaround.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/idiom/OffsetWithoutLimitWorkaround.scala
@@ -1,8 +1,8 @@
 package io.getquill.source.sql.idiom
 
 import io.getquill.ast.Ast
+import io.getquill.naming.NamingStrategy
 import io.getquill.util.Show._
-import io.getquill.source.sql.naming.NamingStrategy
 
 trait OffsetWithoutLimitWorkaround {
   self: SqlIdiom =>

--- a/quill-sql/src/main/scala/io/getquill/source/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/idiom/SqlIdiom.scala
@@ -1,13 +1,13 @@
 package io.getquill.source.sql.idiom
 
 import io.getquill.ast._
+import io.getquill.naming.NamingStrategy
 import io.getquill.source.sql._
 import io.getquill.util.Messages.fail
 import io.getquill.util.Show.Show
 import io.getquill.util.Show.Shower
 import io.getquill.util.Show.listShow
 import io.getquill.norm.BetaReduction
-import io.getquill.source.sql.naming.NamingStrategy
 
 trait SqlIdiom {
 

--- a/quill-sql/src/main/scala/io/getquill/source/sql/mirror/mirrorSource.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/mirror/mirrorSource.scala
@@ -1,12 +1,11 @@
 package io.getquill.source.sql.mirror
 
+import io.getquill.naming.{Literal, NamingStrategy}
 import io.getquill.source.mirror.Row
 import io.getquill.source.sql.SqlSource
 import io.getquill.source.sql.idiom.FallbackDialect
 import scala.util.Success
 import scala.util.Failure
-import io.getquill.source.sql.naming.NamingStrategy
-import io.getquill.source.sql.naming.Literal
 
 trait MirrorSourceTemplate[N <: NamingStrategy] extends SqlSource[MirrorDialect.type, N, Row, Row]
     with MirrorEncoders

--- a/quill-sql/src/test/scala/io/getquill/source/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/SqlQuerySpec.scala
@@ -2,12 +2,11 @@
 package io.getquill.source.sql
 
 import io.getquill._
+import io.getquill.naming.Literal
 import io.getquill.norm.QueryGenerator
 import io.getquill.norm.Normalize
 import io.getquill.source.sql.idiom.SqlIdiom
 import io.getquill.util.Show._
-import io.getquill.source.sql.naming.NamingStrategy
-import io.getquill.source.sql.naming.Literal
 
 class SqlQuerySpec extends Spec {
 

--- a/quill-sql/src/test/scala/io/getquill/source/sql/SqlSourceMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/SqlSourceMacroSpec.scala
@@ -1,10 +1,10 @@
 package io.getquill.source.sql
 
 import io.getquill._
+import io.getquill.naming.NamingStrategy
 import io.getquill.source.sql.idiom.SqlIdiom
 import scala.util.Try
 import java.util.Date
-import io.getquill.source.sql.naming.NamingStrategy
 
 class SqlSourceMacroSpec extends Spec {
 

--- a/quill-sql/src/test/scala/io/getquill/source/sql/idiom/MySQLDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/idiom/MySQLDialectSpec.scala
@@ -1,9 +1,9 @@
 package io.getquill.source.sql.idiom
 
+import io.getquill.naming.Literal
 import io.getquill.util.Show._
 import io.getquill._
 import io.getquill.ast._
-import io.getquill.source.sql.naming.Literal
 
 class MySQLDialectSpec extends Spec {
 

--- a/quill-sql/src/test/scala/io/getquill/source/sql/idiom/NullsFirstClauseSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/idiom/NullsFirstClauseSpec.scala
@@ -1,9 +1,9 @@
 package io.getquill.source.sql.idiom
 
 import io.getquill._
+import io.getquill.naming.Literal
 import io.getquill.source.sql.SqlQuery
 import io.getquill.util.Show._
-import io.getquill.source.sql.naming.Literal
 
 class NullsFirstClauseSpec extends Spec {
 

--- a/quill-sql/src/test/scala/io/getquill/source/sql/idiom/OffsetWithoutLimitWorkaroundSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/idiom/OffsetWithoutLimitWorkaroundSpec.scala
@@ -1,10 +1,10 @@
 package io.getquill.source.sql.idiom
 
+import io.getquill.naming.Literal
 import io.getquill.util.Show._
 import io.getquill._
 import io.getquill.source.sql.mirror.mirrorSource
 import io.getquill.source.sql.SqlQuery
-import io.getquill.source.sql.naming.Literal
 
 class OffsetWithoutLimitWorkaroundSpec extends Spec {
 

--- a/quill-sql/src/test/scala/io/getquill/source/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/idiom/SqlIdiomSpec.scala
@@ -2,15 +2,11 @@ package io.getquill.source.sql.idiom
 
 import io.getquill._
 import io.getquill.Spec
+import io.getquill.naming.{SnakeCase, UpperCase, Escape, Literal}
 import io.getquill.source.sql.mirror.mirrorSource.run
 import io.getquill.source.sql.mirror.mirrorSource
 import io.getquill.ast.Ast
-import io.getquill.source.sql.naming.NamingStrategy
-import io.getquill.source.sql.naming.Literal
 import io.getquill.source.sql.mirror.MirrorSourceTemplate
-import io.getquill.source.sql.naming.SnakeCase
-import io.getquill.source.sql.naming.UpperCase
-import io.getquill.source.sql.naming.Escape
 
 class SqlIdiomSpec extends Spec {
 


### PR DESCRIPTION
move the package io.getquil.source.sql.naming to io.getquill.naming