### PR TITLE
Allow empty password in Finagle Mysql client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val `quill-finagle-mysql` =
     .settings(commonSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "com.twitter" %% "finagle-mysql" % "6.27.0"
+        "com.twitter" %% "finagle-mysql" % "6.31.0"
       ),
       parallelExecution in Test := false
     )

--- a/quill-finagle-mysql/src/main/scala/io/getquill/source/finagle/mysql/FinagleMysqlClient.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/source/finagle/mysql/FinagleMysqlClient.scala
@@ -1,13 +1,15 @@
 package io.getquill.source.finagle.mysql
 
 import com.twitter.finagle.exp.Mysql
+import com.twitter.util.Try
 import com.typesafe.config.Config
+
 
 object FinagleMysqlClient {
 
   def apply(config: Config) = {
     val user = config.getString("user")
-    val password = config.getString("password")
+    val password = Try(config.getString("password")).getOrElse(null)
     val database = config.getString("database")
     val dest = config.getString("dest")
 


### PR DESCRIPTION
finagle-mysql allows empty passwords, which is not possible in quill's finagle
client. With this change, if the password is missing in the configuration, we
initialize the client with a null password.

Change in finagle 6.31.0:
https://github.com/twitter/finagle/commit/fde15f447cf1cab92e893b8fbf8f9378c6d9f00a