### PR TITLE
Aggregation sum should return an Option

### DIFF
--- a/quill-core/src/main/scala/io/getquill/Query.scala
+++ b/quill-core/src/main/scala/io/getquill/Query.scala
@@ -20,7 +20,7 @@ sealed trait Query[+T] {
   def min[U >: T](implicit n: Numeric[U]): Option[T]
   def max[U >: T](implicit n: Numeric[U]): Option[T]
   def avg[U >: T](implicit n: Numeric[U]): Option[T]
-  def sum[U >: T](implicit n: Numeric[U]): T
+  def sum[U >: T](implicit n: Numeric[U]): Option[T]
   def size: Long
 
   def leftJoin[A >: T, B](q: Query[B]): OuterJoinQuery[A, B, (A, Option[B])]


### PR DESCRIPTION
I believe the sum operation in an aggregation should return an Option, for example in a left/right/outer join if the sum doesn't contain any elements the result should be NULL.