### PR TITLE
provide implicit to query case class companion objects directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,28 @@ db.run(a)
 // DELETE FROM Person WHERE name = ''
 ```
 
+# Implicit query #
+
+Quill provides implicit conversions from case class companion objects to `query[T]` through an extra import:
+
+```scala
+import io.getquill.ImplicitQuery._
+
+val q = quote {
+  for {
+    p <- Person if(p.id == 999)
+    c <- Contact if(c.personId == p.id)
+  } yield {
+    (p.name, c.phone)
+  }
+}
+
+db.run(q) 
+// SELECT p.name, c.phone FROM Person p, Contact c WHERE (p.id = 999) AND (c.personId = p.id)
+```
+
+Note the usage of `Person` and `Contact` instead of `query[Person]` and `query[Contact]`.
+
 # SQL-specific operations #
 
 Some operations are sql-specific and not provided with the generic quotation mechanism. The `io.getquill.source.sql.ops` package has some implicit classes for this kind of operations:

--- a/quill-core/src/main/scala/io/getquill/ImplicitQuery.scala
+++ b/quill-core/src/main/scala/io/getquill/ImplicitQuery.scala
@@ -1,0 +1,42 @@
+package io.getquill
+
+import language.experimental.macros
+import language.implicitConversions
+import scala.reflect.macros.whitebox.Context
+import io.getquill.util.Messages._
+
+object ImplicitQuery {
+  implicit def toQuery[P <: Product](f: Function1[_, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function2[_, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function3[_, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function4[_, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function5[_, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function6[_, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function7[_, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function8[_, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function9[_, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function10[_, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function11[_, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function12[_, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function13[_, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function14[_, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function15[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function16[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function17[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function18[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function19[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function20[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function21[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: Function22[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+}
+
+private[getquill] class ImplicitQueryMacro(val c: Context) {
+  import c.universe._
+
+  def toQuery[P <: Product](f: Expr[Any])(implicit p: WeakTypeTag[P]): Tree = {
+    if (!p.tpe.typeSymbol.asClass.isCaseClass || !f.actualType.typeSymbol.isModuleClass)
+      c.fail("Can't query a non-case class")
+
+    q"io.getquill.query[$p]"
+  }
+}

--- a/quill-core/src/test/scala/io/getquill/ImplicitQuerySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ImplicitQuerySpec.scala
@@ -1,0 +1,32 @@
+package io.getquill
+
+import io.getquill.source.mirror.mirrorSource
+
+class ImplicitQuerySpec extends Spec {
+
+  import ImplicitQuery._
+
+  "allows querying a case class companion" in {
+    val q = quote {
+      TestEntity.filter(t => t.s == "s")
+    }
+    mirrorSource.run(q).ast.toString mustEqual
+      """query[TestEntity].filter(t => t.s == "s").map(t => (t.s, t.i, t.l, t.o))"""
+  }
+
+  "fails if the if querying a non-case-class companion" in {
+    class Test(val a: String) extends Product {
+      def canEqual(that: Any) = ???
+      def productArity: Int = ???
+      def productElement(n: Int) = ???
+    }
+    object Test extends Function1[String, Test] {
+      def apply(a: String) = new Test(a)
+    }
+    """
+    val q = quote {
+      Test.filter(_.a == "s")
+    }
+    """ mustNot compile
+  }
+}


### PR DESCRIPTION
@mariusmuja @rfranco, I'd like to get your opinion on this if you have some time.

This change allows the user to query case class companions directly through an implicit conversion:

```scala
case class Person(id: Int, name: String)
val q = quote {
  Person.filter(_.name == "John")
}
```

Produces the same query as:

```scala
val q = quote {
  query[Person].filter(_.name == "John")
}
```

- I'm not sure this should be exposed as part of `io.getquill._`, I would like to avoid exposing so many implicit conversions.
- This could make harder to understand quill as it introduces two ways of doing the same thing.