### PR TITLE
Add support for explicit inner joins

### DIFF
--- a/quill-core/src/main/scala/io/getquill/Query.scala
+++ b/quill-core/src/main/scala/io/getquill/Query.scala
@@ -23,15 +23,16 @@ sealed trait Query[+T] {
   def sum[U >: T](implicit n: Numeric[U]): Option[T]
   def size: Long
 
-  def leftJoin[A >: T, B](q: Query[B]): OuterJoinQuery[A, B, (A, Option[B])]
-  def rightJoin[A >: T, B](q: Query[B]): OuterJoinQuery[A, B, (Option[A], B)]
-  def fullJoin[A >: T, B](q: Query[B]): OuterJoinQuery[A, B, (Option[A], Option[B])]
+  def join[A >: T, B](q: Query[B]): JoinQuery[A, B, (A, B)]
+  def leftJoin[A >: T, B](q: Query[B]): JoinQuery[A, B, (A, Option[B])]
+  def rightJoin[A >: T, B](q: Query[B]): JoinQuery[A, B, (Option[A], B)]
+  def fullJoin[A >: T, B](q: Query[B]): JoinQuery[A, B, (Option[A], Option[B])]
 
   def nonEmpty: Boolean
   def isEmpty: Boolean
 }
 
-sealed trait OuterJoinQuery[A, B, R] extends Query[R] {
+sealed trait JoinQuery[A, B, R] extends Query[R] {
   def on(f: (A, B) => Boolean): Query[R]
 }
 

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -52,7 +52,7 @@ case class Union(a: Ast, b: Ast) extends Query
 
 case class UnionAll(a: Ast, b: Ast) extends Query
 
-case class OuterJoin(typ: OuterJoinType, a: Ast, b: Ast, aliasA: Ident, aliasB: Ident, on: Ast) extends Query
+case class OuterJoin(typ: JoinType, a: Ast, b: Ast, aliasA: Ident, aliasB: Ident, on: Ast) extends Query
 
 //************************************************************
 

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -52,7 +52,7 @@ case class Union(a: Ast, b: Ast) extends Query
 
 case class UnionAll(a: Ast, b: Ast) extends Query
 
-case class OuterJoin(typ: JoinType, a: Ast, b: Ast, aliasA: Ident, aliasB: Ident, on: Ast) extends Query
+case class Join(typ: JoinType, a: Ast, b: Ast, aliasA: Ident, aliasB: Ident, on: Ast) extends Query
 
 //************************************************************
 

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -91,7 +91,8 @@ object AstShow {
       s"${q.ast}.$method((${q.alias.show}) => ${q.body.show})"
   }
 
-  implicit val outerJoinTypeShow: Show[OuterJoinType] = Show[OuterJoinType] {
+  implicit val joinTypeShow: Show[JoinType] = Show[JoinType] {
+  	case InnerJoin => "join"
     case LeftJoin  => "leftJoin"
     case RightJoin => "rightJoin"
     case FullJoin  => "fullJoin"

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -92,7 +92,7 @@ object AstShow {
   }
 
   implicit val joinTypeShow: Show[JoinType] = Show[JoinType] {
-  	case InnerJoin => "join"
+    case InnerJoin => "join"
     case LeftJoin  => "leftJoin"
     case RightJoin => "rightJoin"
     case FullJoin  => "fullJoin"

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -67,7 +67,7 @@ object AstShow {
     case UnionAll(a, b) =>
       s"${a.show}.unionAll(${b.show})"
 
-    case OuterJoin(t, a, b, iA, iB, on) =>
+    case Join(t, a, b, iA, iB, on) =>
       s"${a.show}.${t.show}(${b.show}).on((${iA.show}, ${iB.show}) => ${on.show})"
   }
 

--- a/quill-core/src/main/scala/io/getquill/ast/JoinType.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/JoinType.scala
@@ -1,0 +1,8 @@
+package io.getquill.ast
+
+sealed trait JoinType
+
+case object InnerJoin extends JoinType
+case object LeftJoin extends JoinType
+case object RightJoin extends JoinType
+case object FullJoin extends JoinType

--- a/quill-core/src/main/scala/io/getquill/ast/OuterJoinType.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/OuterJoinType.scala
@@ -1,7 +1,0 @@
-package io.getquill.ast
-
-sealed trait OuterJoinType
-
-case object LeftJoin extends OuterJoinType
-case object RightJoin extends OuterJoinType
-case object FullJoin extends OuterJoinType

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -81,11 +81,11 @@ trait StatefulTransformer[T] {
         val (at, att) = apply(a)
         val (bt, btt) = att.apply(b)
         (UnionAll(at, bt), btt)
-      case OuterJoin(t, a, b, iA, iB, on) =>
+      case Join(t, a, b, iA, iB, on) =>
         val (at, att) = apply(a)
         val (bt, btt) = att.apply(b)
         val (ont, ontt) = btt.apply(on)
-        (OuterJoin(t, at, bt, iA, iB, ont), ontt)
+        (Join(t, at, bt, iA, iB, ont), ontt)
     }
 
   def apply(e: Operation): (Operation, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -32,8 +32,8 @@ trait StatelessTransformer {
       case Drop(a, b)         => Drop(apply(a), apply(b))
       case Union(a, b)        => Union(apply(a), apply(b))
       case UnionAll(a, b)     => UnionAll(apply(a), apply(b))
-      case OuterJoin(t, a, b, iA, iB, on) =>
-        OuterJoin(t, apply(a), apply(b), iA, iB, apply(on))
+      case Join(t, a, b, iA, iB, on) =>
+        Join(t, apply(a), apply(b), iA, iB, apply(on))
     }
 
   def apply(e: Operation): Operation =

--- a/quill-core/src/main/scala/io/getquill/norm/AttachToEntity.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/AttachToEntity.scala
@@ -22,7 +22,7 @@ object AttachToEntity {
       case GroupBy(a: Query, b, c)               => GroupBy(apply(f, Some(b))(a), b, c)
       case Aggregation(op, a: Query)             => Aggregation(op, apply(f, alias)(a))
 
-      case _: Union | _: UnionAll | _: OuterJoin => f(q, alias.getOrElse(Ident("x")))
+      case _: Union | _: UnionAll | _: Join => f(q, alias.getOrElse(Ident("x")))
 
       case e: Entity                             => f(e, alias.getOrElse(Ident("x")))
 

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -33,8 +33,8 @@ case class BetaReduction(map: collection.Map[Ident, Ast])
         SortBy(apply(a), b, BetaReduction(map - b)(c), d)
       case GroupBy(a, b, c) =>
         GroupBy(apply(a), b, BetaReduction(map - b)(c))
-      case OuterJoin(t, a, b, iA, iB, on) =>
-        OuterJoin(t, apply(a), apply(b), iA, iB, BetaReduction(map - iA - iB)(on))
+      case Join(t, a, b, iA, iB, on) =>
+        Join(t, apply(a), apply(b), iA, iB, BetaReduction(map - iA - iB)(on))
       case _: Take | _: Entity | _: Drop | _: Union | _: UnionAll | _: Aggregation =>
         super.apply(query)
     }

--- a/quill-core/src/main/scala/io/getquill/norm/NormalizeNestedStructures.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/NormalizeNestedStructures.scala
@@ -17,10 +17,10 @@ object NormalizeNestedStructures {
       case Drop(a, b)        => apply(a, b)(Drop)
       case Union(a, b)       => apply(a, b)(Union)
       case UnionAll(a, b)    => apply(a, b)(UnionAll)
-      case OuterJoin(t, a, b, iA, iB, on) =>
+      case Join(t, a, b, iA, iB, on) =>
         (Normalize(a), Normalize(b), Normalize(on)) match {
           case (`a`, `b`, `on`) => None
-          case (a, b, on)       => Some(OuterJoin(t, a, b, iA, iB, on))
+          case (a, b, on)       => Some(Join(t, a, b, iA, iB, on))
         }
     }
 

--- a/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -15,20 +15,20 @@ case class RenameProperties(state: collection.Map[Ident, collection.Map[String, 
 
       case SortBy(q: Entity, x, p, o) => apply(q, x, p)(SortBy(_, _, _, o))
 
-      case q @ OuterJoin(t, a: Entity, b: Entity, iA, iB, o) =>
+      case q @ Join(t, a: Entity, b: Entity, iA, iB, o) =>
         val ((_, _, or), ort) = apply(a, iA, o)((_, _, _))
         val ((_, _, orr), orrt) = apply(b, iB, or)((_, _, _))
-        (OuterJoin(t, a, b, iA, iB, orr), RenameProperties(state ++ ort.state ++ orrt.state))
+        (Join(t, a, b, iA, iB, orr), RenameProperties(state ++ ort.state ++ orrt.state))
 
-      case q @ OuterJoin(t, a: Entity, b, iA, iB, o) =>
+      case q @ Join(t, a: Entity, b, iA, iB, o) =>
         val ((_, _, or), ort) = apply(a, iA, o)((_, _, _))
         val (br, brt) = apply(b)
-        (OuterJoin(t, a, br, iA, iB, or), RenameProperties(state ++ ort.state ++ brt.state))
+        (Join(t, a, br, iA, iB, or), RenameProperties(state ++ ort.state ++ brt.state))
 
-      case q @ OuterJoin(t, a: Query, b: Entity, iA, iB, o) =>
+      case q @ Join(t, a: Query, b: Entity, iA, iB, o) =>
         val (ar, art) = apply(a)
         val ((_, _, or), ort) = apply(b, iB, o)((_, _, _))
-        (OuterJoin(t, ar, b, iA, iB, or), RenameProperties(state ++ art.state ++ ort.state))
+        (Join(t, ar, b, iA, iB, or), RenameProperties(state ++ art.state ++ ort.state))
 
       case other => super.apply(q)
     }

--- a/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
@@ -21,14 +21,14 @@ private case class AvoidAliasConflict(state: Set[Ident])
       case SortBy(q: Entity, x, p, o) =>
         apply(x, p)(SortBy(q, _, _, o))
 
-      case OuterJoin(t, a, b, iA, iB, o) =>
+      case Join(t, a, b, iA, iB, o) =>
         val (ar, art) = apply(a)
         val (br, brt) = art.apply(b)
         val freshA = freshIdent(iA)
         val freshB = freshIdent(iB)
         val or = BetaReduction(o, iA -> freshA, iB -> freshB)
         val (orr, orrt) = AvoidAliasConflict(brt.state + freshA + freshB)(or)
-        (OuterJoin(t, ar, br, freshA, freshB, orr), orrt)
+        (Join(t, ar, br, freshA, freshB, orr), orrt)
 
       case other => super.apply(other)
     }

--- a/quill-core/src/main/scala/io/getquill/norm/capture/Dealias.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/Dealias.scala
@@ -37,10 +37,10 @@ case class Dealias(state: Option[Ident]) extends StatefulTransformer[Option[Iden
         val (an, _) = apply(a)
         val (bn, _) = apply(b)
         (UnionAll(an, bn), Dealias(None))
-      case OuterJoin(t, a, b, iA, iB, o) =>
+      case Join(t, a, b, iA, iB, o) =>
         val ((an, iAn, on), ont) = dealias(a, iA, o)((_, _, _))
         val ((bn, iBn, onn), onnt) = ont.dealias(b, iB, on)((_, _, _))
-        (OuterJoin(t, an, bn, iAn, iBn, onn), Dealias(None))
+        (Join(t, an, bn, iAn, iBn, onn), Dealias(None))
       case _: Entity =>
         (q, Dealias(None))
     }

--- a/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
@@ -27,7 +27,7 @@ case class FreeVariables(state: State)
       case q @ FlatMap(a, b, c)   => (q, free(a, b, c))
       case q @ SortBy(a, b, c, d) => (q, free(a, b, c))
       case q @ GroupBy(a, b, c)   => (q, free(a, b, c))
-      case q @ OuterJoin(t, a, b, iA, iB, on) =>
+      case q @ Join(t, a, b, iA, iB, on) =>
         val (_, freeA) = apply(a)
         val (_, freeB) = apply(a)
         val (_, freeOn) = FreeVariables(State(state.seen + iA + iB, Set.empty))(on)

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -96,7 +96,8 @@ trait Liftables {
     case DescNullsLast        => q"$pack.DescNullsLast"
   }
 
-  implicit val outerJoinTypeLiftable: Liftable[OuterJoinType] = Liftable[OuterJoinType] {
+  implicit val joinTypeLiftable: Liftable[JoinType] = Liftable[JoinType] {
+  	case InnerJoin  => q"$pack.InnerJoin"
     case LeftJoin  => q"$pack.LeftJoin"
     case RightJoin => q"$pack.RightJoin"
     case FullJoin  => q"$pack.FullJoin"

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -79,7 +79,7 @@ trait Liftables {
     case Drop(a, b)                  => q"$pack.Drop($a, $b)"
     case Union(a, b)                 => q"$pack.Union($a, $b)"
     case UnionAll(a, b)              => q"$pack.UnionAll($a, $b)"
-    case OuterJoin(a, b, c, d, e, f) => q"$pack.OuterJoin($a, $b, $c, $d, $e, $f)"
+    case Join(a, b, c, d, e, f) => q"$pack.Join($a, $b, $c, $d, $e, $f)"
   }
 
   implicit val propertyAliasLiftable: Liftable[PropertyAlias] = Liftable[PropertyAlias] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -159,7 +159,7 @@ trait Parsing {
       UnionAll(astParser(source), astParser(n))
 
     case q"${ joinCallParser(typ, a, b) }.on(($aliasA, $aliasB) => $body)" =>
-      OuterJoin(typ, a, b, identParser(aliasA), identParser(aliasB), astParser(body))
+      Join(typ, a, b, identParser(aliasA), identParser(aliasB), astParser(body))
 
     case q"${ joinCallParser(typ, a, b) }" =>
       c.fail("An outer join clause must be followed by 'on'.")

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -158,10 +158,10 @@ trait Parsing {
     case q"$source.++[$t]($n)" if (is[QuillQuery[Any]](source)) =>
       UnionAll(astParser(source), astParser(n))
 
-    case q"${ outerJoinCallParser(typ, a, b) }.on(($aliasA, $aliasB) => $body)" =>
+    case q"${ joinCallParser(typ, a, b) }.on(($aliasA, $aliasB) => $body)" =>
       OuterJoin(typ, a, b, identParser(aliasA), identParser(aliasB), astParser(body))
 
-    case q"${ outerJoinCallParser(typ, a, b) }" =>
+    case q"${ joinCallParser(typ, a, b) }" =>
       c.fail("An outer join clause must be followed by 'on'.")
   }
 
@@ -181,7 +181,8 @@ trait Parsing {
       PropertyAlias(prop.decodedName.toString, alias)
   }
 
-  val outerJoinCallParser: Parser[(OuterJoinType, Ast, Ast)] = Parser[(OuterJoinType, Ast, Ast)] {
+  val joinCallParser: Parser[(JoinType, Ast, Ast)] = Parser[(JoinType, Ast, Ast)] {
+  	case q"$a.join[$t, $u]($b)" if (is[QuillQuery[Any]](a))  => (InnerJoin, astParser(a), astParser(b))
     case q"$a.leftJoin[$t, $u]($b)" if (is[QuillQuery[Any]](a))  => (LeftJoin, astParser(a), astParser(b))
     case q"$a.rightJoin[$t, $u]($b)" if (is[QuillQuery[Any]](a)) => (RightJoin, astParser(a), astParser(b))
     case q"$a.fullJoin[$t, $u]($b)" if (is[QuillQuery[Any]](a))  => (FullJoin, astParser(a), astParser(b))

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -182,7 +182,7 @@ trait Parsing {
   }
 
   val joinCallParser: Parser[(JoinType, Ast, Ast)] = Parser[(JoinType, Ast, Ast)] {
-  	case q"$a.join[$t, $u]($b)" if (is[QuillQuery[Any]](a))  => (InnerJoin, astParser(a), astParser(b))
+    case q"$a.join[$t, $u]($b)" if (is[QuillQuery[Any]](a))  => (InnerJoin, astParser(a), astParser(b))
     case q"$a.leftJoin[$t, $u]($b)" if (is[QuillQuery[Any]](a))  => (LeftJoin, astParser(a), astParser(b))
     case q"$a.rightJoin[$t, $u]($b)" if (is[QuillQuery[Any]](a)) => (RightJoin, astParser(a), astParser(b))
     case q"$a.fullJoin[$t, $u]($b)" if (is[QuillQuery[Any]](a))  => (FullJoin, astParser(a), astParser(b))

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -107,7 +107,7 @@ trait Unliftables {
   }
 
   implicit val joinTypeUnliftable: Unliftable[JoinType] = Unliftable[JoinType] {
-  	case q"$pack.InnerJoin"  => InnerJoin
+    case q"$pack.InnerJoin" => InnerJoin
     case q"$pack.LeftJoin"  => LeftJoin
     case q"$pack.RightJoin" => RightJoin
     case q"$pack.FullJoin"  => FullJoin

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -83,8 +83,8 @@ trait Unliftables {
     case q"$pack.Drop.apply(${ a: Ast }, ${ b: Ast })" => Drop(a, b)
     case q"$pack.Union.apply(${ a: Ast }, ${ b: Ast })" => Union(a, b)
     case q"$pack.UnionAll.apply(${ a: Ast }, ${ b: Ast })" => UnionAll(a, b)
-    case q"$pack.OuterJoin.apply(${ t: JoinType }, ${ a: Ast }, ${ b: Ast }, ${ iA: Ident }, ${ iB: Ident }, ${ on: Ast })" =>
-      OuterJoin(t, a, b, iA, iB, on)
+    case q"$pack.Join.apply(${ t: JoinType }, ${ a: Ast }, ${ b: Ast }, ${ iA: Ident }, ${ iB: Ident }, ${ on: Ast })" =>
+      Join(t, a, b, iA, iB, on)
   }
 
   implicit val orderingUnliftable: Unliftable[Ordering] = Unliftable[Ordering] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -83,7 +83,7 @@ trait Unliftables {
     case q"$pack.Drop.apply(${ a: Ast }, ${ b: Ast })" => Drop(a, b)
     case q"$pack.Union.apply(${ a: Ast }, ${ b: Ast })" => Union(a, b)
     case q"$pack.UnionAll.apply(${ a: Ast }, ${ b: Ast })" => UnionAll(a, b)
-    case q"$pack.OuterJoin.apply(${ t: OuterJoinType }, ${ a: Ast }, ${ b: Ast }, ${ iA: Ident }, ${ iB: Ident }, ${ on: Ast })" =>
+    case q"$pack.OuterJoin.apply(${ t: JoinType }, ${ a: Ast }, ${ b: Ast }, ${ iA: Ident }, ${ iB: Ident }, ${ on: Ast })" =>
       OuterJoin(t, a, b, iA, iB, on)
   }
 
@@ -106,7 +106,8 @@ trait Unliftables {
     case q"scala.Some.apply[$t]($v)" => Some(u.unapply(v).get)
   }
 
-  implicit val outerJoinTypeUnliftable: Unliftable[OuterJoinType] = Unliftable[OuterJoinType] {
+  implicit val joinTypeUnliftable: Unliftable[JoinType] = Unliftable[JoinType] {
+  	case q"$pack.InnerJoin"  => InnerJoin
     case q"$pack.LeftJoin"  => LeftJoin
     case q"$pack.RightJoin" => RightJoin
     case q"$pack.FullJoin"  => FullJoin

--- a/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
@@ -46,7 +46,14 @@ class AstShowSpec extends Spec {
     }
   }
 
-  "shows outer join queries" - {
+  "shows join queries" - {
+    "inner join" in {
+      val q = quote {
+        qr1.join(qr2).on((a, b) => a.s == b.s)
+      }
+      (q.ast: Ast).show mustEqual
+        """query[TestEntity].join(query[TestEntity2]).on((a, b) => a.s == b.s)"""
+    }
     "left join" in {
       val q = quote {
         qr1.leftJoin(qr2).on((a, b) => a.s == b.s)

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -104,10 +104,10 @@ class StatefulTransformerSpec extends Spec {
         }
       }
       "outer join" in {
-        val ast: Ast = OuterJoin(FullJoin, Ident("a"), Ident("b"), Ident("c"), Ident("d"), Ident("e"))
+        val ast: Ast = Join(FullJoin, Ident("a"), Ident("b"), Ident("c"), Ident("d"), Ident("e"))
         Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("e") -> Ident("e'"))(ast) match {
           case (at, att) =>
-            at mustEqual OuterJoin(FullJoin, Ident("a'"), Ident("b'"), Ident("c"), Ident("d"), Ident("e'"))
+            at mustEqual Join(FullJoin, Ident("a'"), Ident("b'"), Ident("c"), Ident("d"), Ident("e'"))
             att.state mustEqual List(Ident("a"), Ident("b"), Ident("e"))
         }
       }

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -68,9 +68,9 @@ class StatelessTransformerSpec extends Spec {
           UnionAll(Ident("a'"), Ident("b'"))
       }
       "outer join" in {
-        val ast: Ast = OuterJoin(FullJoin, Ident("a"), Ident("b"), Ident("c"), Ident("d"), Ident("e"))
+        val ast: Ast = Join(FullJoin, Ident("a"), Ident("b"), Ident("c"), Ident("d"), Ident("e"))
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("e") -> Ident("e'"))(ast) mustEqual
-          OuterJoin(FullJoin, Ident("a'"), Ident("b'"), Ident("c"), Ident("d"), Ident("e'"))
+          Join(FullJoin, Ident("a'"), Ident("b'"), Ident("c"), Ident("d"), Ident("e'"))
       }
     }
 

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -49,7 +49,7 @@ class BetaReductionSpec extends Spec {
         BetaReduction(ast, Ident("b") -> Ident("b'")) mustEqual ast
       }
       "outer join" in {
-        val ast: Ast = OuterJoin(LeftJoin, Ident("a"), Ident("b"), Ident("c"), Ident("d"), Tuple(List(Ident("c"), Ident("d"))))
+        val ast: Ast = Join(LeftJoin, Ident("a"), Ident("b"), Ident("c"), Ident("d"), Tuple(List(Ident("c"), Ident("d"))))
         BetaReduction(ast, Ident("c") -> Ident("c'"), Ident("d") -> Ident("d'")) mustEqual ast
       }
       "option operation" in {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -198,7 +198,7 @@ class QuotationSpec extends Spec {
       "outer join" - {
 
         def tree(t: JoinType) =
-          OuterJoin(t, Entity("TestEntity"), Entity("TestEntity2"), Ident("a"), Ident("b"), BinaryOperation(Property(Ident("a"), "s"), EqualityOperator.`==`, Property(Ident("b"), "s")))
+          Join(t, Entity("TestEntity"), Entity("TestEntity2"), Ident("a"), Ident("b"), BinaryOperation(Property(Ident("a"), "s"), EqualityOperator.`==`, Property(Ident("b"), "s")))
 
         "left join" in {
           val q = quote {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -197,7 +197,7 @@ class QuotationSpec extends Spec {
       }
       "outer join" - {
 
-        def tree(t: OuterJoinType) =
+        def tree(t: JoinType) =
           OuterJoin(t, Entity("TestEntity"), Entity("TestEntity2"), Ident("a"), Ident("b"), BinaryOperation(Property(Ident("a"), "s"), EqualityOperator.`==`, Property(Ident("b"), "s")))
 
         "left join" in {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -195,11 +195,17 @@ class QuotationSpec extends Spec {
           quote(unquote(q)).ast mustEqual UnionAll(Entity("TestEntity"), Entity("TestEntity2"))
         }
       }
-      "outer join" - {
+      "join" - {
 
         def tree(t: JoinType) =
           Join(t, Entity("TestEntity"), Entity("TestEntity2"), Ident("a"), Ident("b"), BinaryOperation(Property(Ident("a"), "s"), EqualityOperator.`==`, Property(Ident("b"), "s")))
 
+        "inner join" in {
+          val q = quote {
+            qr1.join(qr2).on((a, b) => a.s == b.s)
+          }
+          quote(unquote(q)).ast mustEqual tree(InnerJoin)
+        }
         "left join" in {
           val q = quote {
             qr1.leftJoin(qr2).on((a, b) => a.s == b.s)

--- a/quill-sql/src/main/scala/io/getquill/source/sql/Prepare.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/Prepare.scala
@@ -10,7 +10,7 @@ import io.getquill.util.Messages._
 import io.getquill.norm.capture.AvoidAliasConflict
 import io.getquill.norm.capture.AvoidCapture
 import io.getquill.norm.FlattenOptionOperation
-import io.getquill.source.sql.norm.ExpandOuterJoin
+import io.getquill.source.sql.norm.ExpandJoin
 import io.getquill.source.sql.norm.ExpandNestedQueries
 
 object Prepare {
@@ -33,7 +33,7 @@ object Prepare {
   private[this] val normalize =
     (identity[Ast] _)
       .andThen(Normalize.apply _)
-      .andThen(ExpandOuterJoin.apply _)
+      .andThen(ExpandJoin.apply _)
       .andThen(Normalize.apply _)
       .andThen(FlattenOptionOperation.apply _)
 }

--- a/quill-sql/src/main/scala/io/getquill/source/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/SqlQuery.scala
@@ -13,7 +13,7 @@ sealed trait Source
 case class TableSource(entity: Entity, alias: String) extends Source
 case class QuerySource(query: SqlQuery, alias: String) extends Source
 case class InfixSource(infix: Infix, alias: String) extends Source
-case class OuterJoinSource(t: OuterJoinType, a: Source, b: Source, on: Ast) extends Source
+case class OuterJoinSource(t: JoinType, a: Source, b: Source, on: Ast) extends Source
 
 sealed trait SqlQuery
 

--- a/quill-sql/src/main/scala/io/getquill/source/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/SqlQuery.scala
@@ -13,7 +13,7 @@ sealed trait Source
 case class TableSource(entity: Entity, alias: String) extends Source
 case class QuerySource(query: SqlQuery, alias: String) extends Source
 case class InfixSource(infix: Infix, alias: String) extends Source
-case class OuterJoinSource(t: JoinType, a: Source, b: Source, on: Ast) extends Source
+case class JoinSource(t: JoinType, a: Source, b: Source, on: Ast) extends Source
 
 sealed trait SqlQuery
 
@@ -167,7 +167,7 @@ object SqlQuery {
     ast match {
       case entity: Entity                 => TableSource(entity, alias)
       case infix: Infix                   => InfixSource(infix, alias)
-      case OuterJoin(t, a, b, ia, ib, on) => OuterJoinSource(t, source(a, ia.name), source(b, ib.name), on)
+      case Join(t, a, b, ia, ib, on) => JoinSource(t, source(a, ia.name), source(b, ib.name), on)
       case other                          => QuerySource(apply(other), alias)
     }
 

--- a/quill-sql/src/main/scala/io/getquill/source/sql/VerifySqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/VerifySqlQuery.scala
@@ -54,6 +54,6 @@ object VerifySqlQuery {
       case s: TableSource     => List(s.alias)
       case s: QuerySource     => List(s.alias)
       case s: InfixSource     => List(s.alias)
-      case s: OuterJoinSource => aliases(s.a) ++ aliases(s.b)
+      case s: JoinSource => aliases(s.a) ++ aliases(s.b)
     }
 }

--- a/quill-sql/src/main/scala/io/getquill/source/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/idiom/SqlIdiom.scala
@@ -123,7 +123,7 @@ trait SqlIdiom {
   }
 
   implicit val joinTypeShow: Show[JoinType] = Show[JoinType] {
-  	case InnerJoin => "INNER JOIN"
+    case InnerJoin => "INNER JOIN"
     case LeftJoin  => "LEFT JOIN"
     case RightJoin => "RIGHT JOIN"
     case FullJoin  => "FULL JOIN"

--- a/quill-sql/src/main/scala/io/getquill/source/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/idiom/SqlIdiom.scala
@@ -122,7 +122,8 @@ trait SqlIdiom {
     case OuterJoinSource(t, a, b, on) => s"${a.show} ${t.show} ${b.show} ON ${on.show}"
   }
 
-  implicit val outerJoinTypeShow: Show[OuterJoinType] = Show[OuterJoinType] {
+  implicit val joinTypeShow: Show[JoinType] = Show[JoinType] {
+  	case InnerJoin => "INNER JOIN"
     case LeftJoin  => "LEFT JOIN"
     case RightJoin => "RIGHT JOIN"
     case FullJoin  => "FULL JOIN"

--- a/quill-sql/src/main/scala/io/getquill/source/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/idiom/SqlIdiom.scala
@@ -119,7 +119,7 @@ trait SqlIdiom {
     case TableSource(name, alias)     => s"${name.show} ${strategy.default(alias)}"
     case QuerySource(query, alias)    => s"(${query.show}) ${strategy.default(alias)}"
     case InfixSource(infix, alias)    => s"(${(infix: Ast).show}) ${strategy.default(alias)}"
-    case OuterJoinSource(t, a, b, on) => s"${a.show} ${t.show} ${b.show} ON ${on.show}"
+    case JoinSource(t, a, b, on) => s"${a.show} ${t.show} ${b.show} ON ${on.show}"
   }
 
   implicit val joinTypeShow: Show[JoinType] = Show[JoinType] {

--- a/quill-sql/src/main/scala/io/getquill/source/sql/norm/ExpandJoin.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/norm/ExpandJoin.scala
@@ -3,36 +3,36 @@ package io.getquill.source.sql.norm
 import io.getquill.ast._
 import io.getquill.norm.BetaReduction
 
-object ExpandOuterJoin extends StatelessTransformer {
+object ExpandJoin extends StatelessTransformer {
 
   override def apply(q: Query) =
     q match {
-      case q @ OuterJoin(_, _, _, Ident(a), Ident(b), _) =>
+      case q @ Join(_, _, _, Ident(a), Ident(b), _) =>
         val (qr, tuple) = expandedTuple(q)
         Map(qr, Ident(s"$a$b"), tuple)
       case other => super.apply(other)
     }
 
-  private def expandedTuple(q: OuterJoin): (OuterJoin, Tuple) =
+  private def expandedTuple(q: Join): (Join, Tuple) =
     q match {
 
-      case OuterJoin(t, a: OuterJoin, b: OuterJoin, tA, tB, o) =>
+      case Join(t, a: Join, b: Join, tA, tB, o) =>
         val (ar, at) = expandedTuple(a)
         val (br, bt) = expandedTuple(b)
         val or = BetaReduction(o, tA -> at, tB -> bt)
-        (OuterJoin(t, ar, br, tA, tB, or), Tuple(List(at, bt)))
+        (Join(t, ar, br, tA, tB, or), Tuple(List(at, bt)))
 
-      case OuterJoin(t, a: OuterJoin, b, tA, tB, o) =>
+      case Join(t, a: Join, b, tA, tB, o) =>
         val (ar, at) = expandedTuple(a)
         val or = BetaReduction(o, tA -> at)
-        (OuterJoin(t, ar, b, tA, tB, or), Tuple(List(at, tB)))
+        (Join(t, ar, b, tA, tB, or), Tuple(List(at, tB)))
 
-      case OuterJoin(t, a, b: OuterJoin, tA, tB, o) =>
+      case Join(t, a, b: Join, tA, tB, o) =>
         val (br, bt) = expandedTuple(b)
         val or = BetaReduction(o, tB -> bt)
-        (OuterJoin(t, a, br, tA, tB, or), Tuple(List(tA, bt)))
+        (Join(t, a, br, tA, tB, or), Tuple(List(tA, bt)))
 
-      case q @ OuterJoin(t, a, b, tA, tB, on) =>
+      case q @ Join(t, a, b, tA, tB, on) =>
         (q, Tuple(List(tA, tB)))
     }
 }

--- a/quill-sql/src/main/scala/io/getquill/source/sql/norm/ExpandNestedQueries.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/norm/ExpandNestedQueries.scala
@@ -5,7 +5,7 @@ import io.getquill.source.sql.FlattenSqlQuery
 import io.getquill.source.sql.InfixSource
 import io.getquill.source.sql.QuerySource
 import io.getquill.source.sql.SetOperationSqlQuery
-import io.getquill.source.sql.OuterJoinSource
+import io.getquill.source.sql.JoinSource
 import io.getquill.source.sql.SelectValue
 import io.getquill.source.sql.TableSource
 import io.getquill.source.sql.SqlQuery
@@ -33,8 +33,8 @@ object ExpandNestedQueries {
     s match {
       case QuerySource(q, alias) =>
         QuerySource(apply(q, references(alias, asts)), alias)
-      case OuterJoinSource(t, a, b, on) =>
-        OuterJoinSource(t, expandSource(a, asts :+ on), expandSource(b, asts :+ on), on)
+      case JoinSource(t, a, b, on) =>
+        JoinSource(t, expandSource(a, asts :+ on), expandSource(b, asts :+ on), on)
       case _: TableSource | _: InfixSource => s
     }
 

--- a/quill-sql/src/main/scala/io/getquill/source/sql/norm/FlattenGroupByAggregation.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/norm/FlattenGroupByAggregation.scala
@@ -33,7 +33,7 @@ case class FlattenGroupByAggregation(agg: Ident) extends StatelessTransformer {
       case Drop(a, b)                     => isGroupByAggregation(a)
       case Union(a, b)                    => isGroupByAggregation(a) || isGroupByAggregation(b)
       case UnionAll(a, b)                 => isGroupByAggregation(a) || isGroupByAggregation(b)
-      case OuterJoin(t, a, b, ta, tb, on) => isGroupByAggregation(a) || isGroupByAggregation(b)
+      case Join(t, a, b, ta, tb, on) => isGroupByAggregation(a) || isGroupByAggregation(b)
       case `agg`                          => true
       case other                          => false
     }

--- a/quill-sql/src/test/scala/io/getquill/source/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/idiom/SqlIdiomSpec.scala
@@ -267,7 +267,14 @@ class SqlIdiomSpec extends Spec {
             "SELECT x.s, x.i, x.l, x.o FROM (SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.i > 10 UNION ALL SELECT t1.s, t1.i, t1.l, t1.o FROM TestEntity t1 WHERE t1.s = 's') x"
         }
       }
-      "outer join" - {
+      "join" - {
+        "inner" in {
+          val q = quote {
+            qr1.join(qr2).on((a, b) => a.s == b.s).map(_._1)
+          }
+          mirrorSource.run(q).sql mustEqual
+            "SELECT a.s, a.i, a.l, a.o FROM TestEntity a INNER JOIN TestEntity2 b ON a.s = b.s"
+        }
         "left" in {
           val q = quote {
             qr1.leftJoin(qr2).on((a, b) => a.s == b.s).map(_._1)

--- a/quill-sql/src/test/scala/io/getquill/source/sql/norm/ExpandJoinSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/norm/ExpandJoinSpec.scala
@@ -15,6 +15,13 @@ class ExpandJoinSpec extends Spec {
         "query[TestEntity].leftJoin(query[TestEntity2]).on((a, b) => a.s == b.s).map(ab => (a, b))"
     }
     "nested" - {
+      "inner" in {
+        val q = quote {
+          qr1.join(qr2).on((a, b) => a.s == b.s).join(qr3).on((c, d) => c._1.s == d.s)
+        }
+        ExpandJoin(q.ast).toString mustEqual
+          "query[TestEntity].join(query[TestEntity2]).on((a, b) => a.s == b.s).join(query[TestEntity3]).on((c, d) => a.s == d.s).map(cd => ((a, b), d))"
+      }
       "left" in {
         val q = quote {
           qr1.leftJoin(qr2).on((a, b) => a.s == b.s).leftJoin(qr3).on((c, d) => c._1.s == d.s)

--- a/quill-sql/src/test/scala/io/getquill/source/sql/norm/ExpandJoinSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/norm/ExpandJoinSpec.scala
@@ -4,14 +4,14 @@ import io.getquill._
 import io.getquill.quote
 import io.getquill.unquote
 
-class ExpandOuterJoinSpec extends Spec {
+class ExpandJoinSpec extends Spec {
 
   "expands the outer join by mapping the result" - {
     "simple" in {
       val q = quote {
         qr1.leftJoin(qr2).on((a, b) => a.s == b.s)
       }
-      ExpandOuterJoin(q.ast).toString mustEqual
+      ExpandJoin(q.ast).toString mustEqual
         "query[TestEntity].leftJoin(query[TestEntity2]).on((a, b) => a.s == b.s).map(ab => (a, b))"
     }
     "nested" - {
@@ -19,21 +19,21 @@ class ExpandOuterJoinSpec extends Spec {
         val q = quote {
           qr1.leftJoin(qr2).on((a, b) => a.s == b.s).leftJoin(qr3).on((c, d) => c._1.s == d.s)
         }
-        ExpandOuterJoin(q.ast).toString mustEqual
+        ExpandJoin(q.ast).toString mustEqual
           "query[TestEntity].leftJoin(query[TestEntity2]).on((a, b) => a.s == b.s).leftJoin(query[TestEntity3]).on((c, d) => a.s == d.s).map(cd => ((a, b), d))"
       }
       "right" in {
         val q = quote {
           qr1.leftJoin(qr2.leftJoin(qr3).on((a, b) => a.s == b.s)).on((c, d) => c.s == d._1.s)
         }
-        ExpandOuterJoin(q.ast).toString mustEqual
+        ExpandJoin(q.ast).toString mustEqual
           "query[TestEntity].leftJoin(query[TestEntity2].leftJoin(query[TestEntity3]).on((a, b) => a.s == b.s)).on((c, d) => c.s == a.s).map(cd => (c, (a, b)))"
       }
       "both" in {
         val q = quote {
           qr1.leftJoin(qr2).on((a, b) => a.s == b.s).leftJoin(qr3.leftJoin(qr2).on((c, d) => c.s == d.s)).on((e, f) => e._1.s == f._1.s)
         }
-        ExpandOuterJoin(q.ast).toString mustEqual
+        ExpandJoin(q.ast).toString mustEqual
           "query[TestEntity].leftJoin(query[TestEntity2]).on((a, b) => a.s == b.s).leftJoin(query[TestEntity3].leftJoin(query[TestEntity2]).on((c, d) => c.s == d.s)).on((e, f) => a.s == c.s).map(ef => ((a, b), (c, d)))"
       }
     }

--- a/quill-sql/src/test/scala/io/getquill/source/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/norm/RenamePropertiesSpec.scala
@@ -78,13 +78,20 @@ class RenamePropertiesSpec extends Spec {
           "SELECT t.field_s FROM test_entity t ORDER BY t.l ASC NULLS FIRST"
       }
     }
-    "outer join" - {
+    "join" - {
       "both sides" in {
         val q = quote {
           e.leftJoin(e).on((a, b) => a.s == b.s).map(t => (t._1.s, t._2.map(_.s)))
         }
         mirrorSource.run(q).sql mustEqual
           "SELECT a.field_s, b.field_s FROM test_entity a LEFT JOIN test_entity b ON a.field_s = b.field_s"
+      }
+      "inner" in {
+        val q = quote {
+          e.join(f).on((a, b) => a.s == b.s).map(t => t._1.s)
+        }
+        mirrorSource.run(q).sql mustEqual
+          "SELECT a.field_s FROM test_entity a INNER JOIN (SELECT t.s FROM TestEntity t WHERE t.i = 1) t ON a.field_s = t.s"
       }
       "left" in {
         val q = quote {


### PR DESCRIPTION
Currently Quill only supports explicit outer joins. This pull request adds inner join support, thereby allowing the mixing of explicit inner and outer joins just as one would do in plain sql.

Beyond filling in missing functionality the rationale for this PR is that Applicative/implicit join filtering is limited to the where clause. In some cases it is beneficial at the sql level to bind joined tables with a concrete value in the `on` clause. For some relational databases this allows a form of pre-filtering *before* where clause conditions are applied.