### PR TITLE
remove "$" from scalac generated anonymous term

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
@@ -40,14 +40,11 @@ private case class AvoidAliasConflict(state: Set[Ident])
     (f(fresh, prr), t)
   }
 
-  private def freshIdent(x: Ident): Ident = {
-    // strip "$" from scalac generated anonymous term like `x$`
-    val clean = x.copy(name = x.name.replace("$", ""))
+  private def freshIdent(x: Ident): Ident =
     if (!state.contains(x))
-      clean
+      x
     else
-      freshIdent(clean, 1)
-  }
+      freshIdent(x, 1)
 
   private def freshIdent(x: Ident, n: Int): Ident = {
     val fresh = Ident(s"${x.name}$n")

--- a/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
@@ -40,11 +40,14 @@ private case class AvoidAliasConflict(state: Set[Ident])
     (f(fresh, prr), t)
   }
 
-  private def freshIdent(x: Ident): Ident =
+  private def freshIdent(x: Ident): Ident = {
+    // strip "$" from scalac generated anonymous term like `x$`
+    val clean = x.copy(name = x.name.replace("$", ""))
     if (!state.contains(x))
-      x
+      clean
     else
-      freshIdent(x, 1)
+      freshIdent(clean, 1)
+  }
 
   private def freshIdent(x: Ident, n: Int): Ident = {
     val fresh = Ident(s"${x.name}$n")

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -203,12 +203,13 @@ trait Parsing {
   }
 
   val identParser: Parser[Ident] = Parser[Ident] {
-    case t: ValDef                        => Ident(t.name.decodedName.toString)
-    case c.universe.Ident(TermName(name)) => Ident(name)
-    case q"$cls.this.$i"                  => Ident(i.decodedName.toString)
+    case t: ValDef                        => identClean(Ident(t.name.decodedName.toString))
+    case c.universe.Ident(TermName(name)) => identClean(Ident(name))
+    case q"$cls.this.$i"                  => identClean(Ident(i.decodedName.toString))
     case c.universe.Bind(TermName(name), c.universe.Ident(termNames.WILDCARD)) =>
-      Ident(name)
+      identClean(Ident(name))
   }
+  private def identClean(x: Ident) = x.copy(name = x.name.replace("$", ""))
 
   val optionOperationParser: Parser[OptionOperation] = Parser[OptionOperation] {
     case q"$o.map[$t](($alias) => $body)" if (is[Option[Any]](o)) =>

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -18,14 +18,14 @@ class FlattenOptionOperationSpec extends Spec {
         qr1.leftJoin(qr2).on((a, b) => a.s == b.s).filter(t => t._2.forall(_.i == t._1.i)).map(_._1.s)
       }
       FlattenOptionOperation(q.ast: Ast).toString mustEqual
-        "query[TestEntity].leftJoin(query[TestEntity2]).on((a, b) => a.s == b.s).filter(t => t._2.i == t._1.i).map(x$3 => x$3._1.s)"
+        "query[TestEntity].leftJoin(query[TestEntity2]).on((a, b) => a.s == b.s).filter(t => t._2.i == t._1.i).map(x3 => x3._1.s)"
     }
     "exists" in {
       val q = quote {
         qr1.leftJoin(qr2).on((a, b) => a.s == b.s).filter(t => t._2.exists(_.i == t._1.i)).map(_._1.s)
       }
       FlattenOptionOperation(q.ast: Ast).toString mustEqual
-        "query[TestEntity].leftJoin(query[TestEntity2]).on((a, b) => a.s == b.s).filter(t => t._2.i == t._1.i).map(x$5 => x$5._1.s)"
+        "query[TestEntity].leftJoin(query[TestEntity2]).on((a, b) => a.s == b.s).filter(t => t._2.i == t._1.i).map(x5 => x5._1.s)"
     }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -301,6 +301,12 @@ class QuotationSpec extends Spec {
       }
       quote(unquote(q)).ast.body mustEqual Property(Ident("t"), "s")
     }
+    "property anonymous" in {
+      val q = quote {
+        qr1.map(_.s)
+      }
+      quote(unquote(q)).ast.body mustEqual Property(Ident("x3"), "s")
+    }
     "function" - {
       "anonymous function" in {
         val q = quote {


### PR DESCRIPTION
In the event that the user elects *not* to supply table aliases (e.g. `User join UserRole on(_.id == _.userId)` scalac generates anonymous terms in the form of `x$`, which `freshIdent` then generates unique aliases for (in this case, `x$1` and `x$2`).

Some Quill users may prefer the more concise `on` syntax, but still want generated sql to be readable. Removing "$" from `Ident` term name provides similar readability to manually supplied table aliases.