### PR TITLE
* quill-core: use typeSymbol to create the config prefix, to rely on …

### DIFF
--- a/quill-core/src/main/scala/io/getquill/source/ResolveSourceMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/source/ResolveSourceMacro.scala
@@ -27,7 +27,7 @@ trait ResolveSourceMacro {
   }
 
   private def resolve[T <: Source[_, _]](tpe: Type)(implicit t: ClassTag[T]): Option[Source[_, _]] = {
-    val sourceName = tpe.termSymbol.name.decodedName.toString
+    val sourceName = tpe.typeSymbol.name.decodedName.toString
     resolve(sourceName, baseClasses[T](tpe)) match {
       case (None, errors) =>
         c.warning(NoPosition, s"Can't load the source '$sourceName' at compile time. The sql probing is disabled for the source. Trace: \n${errors.mkString("\n")}")
@@ -39,7 +39,7 @@ trait ResolveSourceMacro {
 
   private def baseClasses[T](tpe: Type)(implicit ct: ClassTag[T]): List[Class[Any]] =
     tpe.baseClasses.map(_.asClass.fullName)
-      .map(name => List(loadClass(name), loadClass(name + "$")).flatten).flatten
+      .flatMap(name => List(loadClass(name), loadClass(name + "$")).flatten)
       .filter(ct.runtimeClass.isAssignableFrom(_))
 
   private def resolve(name: String, classes: List[Class[Any]]): (Option[Source[_, _]], List[String]) =

--- a/quill-core/src/main/scala/io/getquill/source/Source.scala
+++ b/quill-core/src/main/scala/io/getquill/source/Source.scala
@@ -22,7 +22,7 @@ abstract class Source[R: ClassTag, S: ClassTag] extends Closeable {
         encoder(index, mapped.f(value), row)
     }
 
-  private val configPrefix =
+  private[source] val configPrefix =
     Source.configPrefix.value.getOrElse {
       getClass.getSimpleName.replaceAllLiterally("$", "")
     }

--- a/quill-core/src/test/scala/io/getquill/source/ResolveSourceMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/source/ResolveSourceMacroSpec.scala
@@ -14,4 +14,24 @@ class ResolveSourceMacroSpec extends Spec {
     case class Fail()
     "io.getquill.source.mirror.mirrorSource.run(query[Fail].delete)" must compile
   }
+
+  "identifies config prefix when source object used directly" in {
+    object ObjectSource extends MirrorSourceTemplate
+    "ObjectSource.run(qr1.delete)" must compile
+    ObjectSource.configPrefix must equal("ObjectSource2")
+  }
+
+  "identifies config prefix when source object is assigned to a variable" in {
+    object VariableSource extends MirrorSourceTemplate
+    val db = VariableSource
+    "db.run(qr1.delete)" must compile
+    db.configPrefix must equal("VariableSource2")
+  }
+
+  "identifies config prefix when source is a class" in {
+    class ClassSource() extends MirrorSourceTemplate
+    val db = new ClassSource()
+    "db.run(qr1.delete)" must compile
+    db.configPrefix must equal("ClassSource1")
+  }
 }

--- a/quill-core/src/test/scala/io/getquill/source/ResolveSourceMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/source/ResolveSourceMacroSpec.scala
@@ -18,20 +18,22 @@ class ResolveSourceMacroSpec extends Spec {
   "identifies config prefix when source object used directly" in {
     object ObjectSource extends MirrorSourceTemplate
     "ObjectSource.run(qr1.delete)" must compile
-    ObjectSource.configPrefix must equal("ObjectSource2")
+    checkConfigPrefix(ObjectSource, "ObjectSource2")
   }
 
   "identifies config prefix when source object is assigned to a variable" in {
     object VariableSource extends MirrorSourceTemplate
     val db = VariableSource
     "db.run(qr1.delete)" must compile
-    db.configPrefix must equal("VariableSource2")
+    checkConfigPrefix(db, "VariableSource2")
   }
 
   "identifies config prefix when source is a class" in {
     class ClassSource() extends MirrorSourceTemplate
     val db = new ClassSource()
     "db.run(qr1.delete)" must compile
-    db.configPrefix must equal("ClassSource1")
+    checkConfigPrefix(db, "ClassSource1")
   }
+
+  def checkConfigPrefix(source: Source[_, _], expected: String): Unit = source.configPrefix must equal(expected)
 }


### PR DESCRIPTION
…the type and not the variable name at macro expansion point.

The way the configPrefix is resolved now will fail the first time you compile this example,

https://github.com/lvicentesanchez/quill-test/blob/master/src/main/scala/repos/ScoreRepo.scala#L25

because the `MODULE$` doesn't exist and it will rely on the name of the variable at the expansion point. The second time you compile that file, it will work.

With this change, it will use the type of the variable and database probing will work even the first time you compile it.