### PR TITLE
#108 quill-play module and PlaySource

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ lazy val quill =
       IO.write(file, str)
       Seq()
     })
-    .dependsOn(`quill-core`, `quill-sql`, `quill-jdbc`, `quill-finagle-mysql`, `quill-async`, `quill-cassandra`)
-    .aggregate(`quill-core`, `quill-sql`, `quill-jdbc`, `quill-finagle-mysql`, `quill-async`, `quill-cassandra`)
+    .dependsOn(`quill-core`, `quill-sql`, `quill-jdbc`, `quill-finagle-mysql`, `quill-async`, `quill-cassandra`, `quill-play`)
+    .aggregate(`quill-core`, `quill-sql`, `quill-jdbc`, `quill-finagle-mysql`, `quill-async`, `quill-cassandra`, `quill-play`)
 
 lazy val `quill-core` = 
   (project in file("quill-core"))
@@ -41,6 +41,16 @@ lazy val `quill-jdbc` =
       parallelExecution in Test := false
     )
     .dependsOn(`quill-sql` % "compile->compile;test->test")
+
+lazy val `quill-play` =
+  (project in file("quill-play"))
+    .settings(commonSettings: _*)
+    .settings(
+      libraryDependencies ++= Seq(
+        "com.typesafe.play" %% "play-jdbc" % "2.4.6" % "provided"
+      )
+    )
+    .dependsOn(`quill-jdbc`)
 
 lazy val `quill-finagle-mysql` = 
   (project in file("quill-finagle-mysql"))

--- a/quill-jdbc/src/main/scala/io/getquill/source/jdbc/JdbcSource.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/source/jdbc/JdbcSource.scala
@@ -22,7 +22,9 @@ class JdbcSource[D <: SqlIdiom, N <: NamingStrategy]
   type ActionResult[T] = Int
   type BatchedActionResult[T] = List[Int]
 
-  protected val dataSource = DataSource(config)
+  protected def createDataSource = DataSource(config)
+
+  protected val dataSource = createDataSource
 
   override def close = dataSource.close
 

--- a/quill-play/src/main/scala/io/getquilll/source/play/PlaySource.scala
+++ b/quill-play/src/main/scala/io/getquilll/source/play/PlaySource.scala
@@ -1,0 +1,20 @@
+package io.getquilll.source.play
+
+import java.io.Closeable
+import javax.sql.DataSource
+
+import io.getquill.naming.NamingStrategy
+import io.getquill.source.jdbc.JdbcSource
+import io.getquill.source.sql.idiom.SqlIdiom
+
+/**
+  * Source to be used with the Play frameworks. It connects to Play's Hikari data source and reuses it.
+  */
+class PlaySource[ D <: SqlIdiom, N <: NamingStrategy ] extends JdbcSource[ D, N ] {
+
+  override def close: Unit = {} // do not close the source, Play will do it
+
+  override protected def createDataSource: DataSource with Closeable =
+  // reuse data source managed by Play
+    play.api.db.DB.getDataSource( )( play.api.Play.current ).asInstanceOf[ DataSource with Closeable ]
+}


### PR DESCRIPTION
Created quill-play module

Created PlaySource reusing Play's internal data source

Created for Play 2.4 but API does not differ from previous releases

Split `protected val dataSource` in `quill-jdbc` to allow its overriding. Overriding `val`s in Scala results in weird behavior and might produce (and produces) exceptions.