### PR TITLE
Add mysql quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,15 +804,15 @@ Quill has two built-in dialects:
 The second type parameter defines the naming strategy to be used when translating identifiers (table and column names) to SQL. 
 
 
-|           strategy             |          example           |
-|--------------------------------|----------------------------|
-| `io.getquill.naming.Literal`   | some_ident -> some_ident   |
-| `io.getquill.naming.Escape`    | some_ident -> "some_ident" |
-| `io.getquill.naming.UpperCase` | some_ident -> SOME_IDENT   |
-| `io.getquill.naming.LowerCase` | SOME_IDENT -> some_ident   |
-| `io.getquill.naming.SnakeCase` | someIdent -> some_ident    |
-| `io.getquill.naming.CamelCase` | some_ident -> someIdent    |
-
+|           strategy               |          example           |
+|----------------------------------|----------------------------|
+| `io.getquill.naming.Literal`     | some_ident -> some_ident   |
+| `io.getquill.naming.Escape`      | some_ident -> "some_ident" |
+| `io.getquill.naming.UpperCase`   | some_ident -> SOME_IDENT   |
+| `io.getquill.naming.LowerCase`   | SOME_IDENT -> some_ident   |
+| `io.getquill.naming.SnakeCase`   | someIdent -> some_ident    |
+| `io.getquill.naming.CamelCase`   | some_ident -> someIdent    |
+| `io.getquill.naming.MysqlEscape` | some_ident -> `some_ident` |
 
 Multiple transformations can be defined using mixin. For instance, the naming strategy 
 

--- a/README.md
+++ b/README.md
@@ -804,15 +804,15 @@ Quill has two built-in dialects:
 The second type parameter defines the naming strategy to be used when translating identifiers (table and column names) to SQL. 
 
 
-|           strategy               |          example           |
-|----------------------------------|----------------------------|
-| `io.getquill.naming.Literal`     | some_ident -> some_ident   |
-| `io.getquill.naming.Escape`      | some_ident -> "some_ident" |
-| `io.getquill.naming.UpperCase`   | some_ident -> SOME_IDENT   |
-| `io.getquill.naming.LowerCase`   | SOME_IDENT -> some_ident   |
-| `io.getquill.naming.SnakeCase`   | someIdent -> some_ident    |
-| `io.getquill.naming.CamelCase`   | some_ident -> someIdent    |
-| `io.getquill.naming.MysqlEscape` | some_ident -> `some_ident` |
+|           strategy               |          example             |
+|----------------------------------|------------------------------|
+| `io.getquill.naming.Literal`     | some_ident -> some_ident     |
+| `io.getquill.naming.Escape`      | some_ident -> "some_ident"   |
+| `io.getquill.naming.UpperCase`   | some_ident -> SOME_IDENT     |
+| `io.getquill.naming.LowerCase`   | SOME_IDENT -> some_ident     |
+| `io.getquill.naming.SnakeCase`   | someIdent -> some_ident      |
+| `io.getquill.naming.CamelCase`   | some_ident -> someIdent      |
+| `io.getquill.naming.MysqlEscape` | some_ident -> \`some_ident\` |
 
 Multiple transformations can be defined using mixin. For instance, the naming strategy 
 

--- a/quill-core/src/main/scala/io/getquill/naming/NamingStrategy.scala
+++ b/quill-core/src/main/scala/io/getquill/naming/NamingStrategy.scala
@@ -79,3 +79,12 @@ trait CamelCase extends NamingStrategy {
     }
 }
 object CamelCase extends CamelCase
+
+trait MysqlQuote extends NamingStrategy {
+  override def table(s: String) = quote(s)
+  override def column(s: String) = quote(s)
+  override def default(s: String) = s
+  private def quote(s: String) = s"`$s`"
+}
+
+object MysqlQuote extends MysqlQuote

--- a/quill-core/src/main/scala/io/getquill/naming/NamingStrategy.scala
+++ b/quill-core/src/main/scala/io/getquill/naming/NamingStrategy.scala
@@ -80,11 +80,11 @@ trait CamelCase extends NamingStrategy {
 }
 object CamelCase extends CamelCase
 
-trait MysqlQuote extends NamingStrategy {
+trait MysqlEscape extends NamingStrategy {
   override def table(s: String) = quote(s)
   override def column(s: String) = quote(s)
   override def default(s: String) = s
   private def quote(s: String) = s"`$s`"
 }
 
-object MysqlQuote extends MysqlQuote
+object MysqlEscape extends MysqlEscape

--- a/quill-core/src/test/scala/io/getquill/naming/NamingStrategySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/naming/NamingStrategySpec.scala
@@ -87,7 +87,7 @@ class NamingStrategySpec extends Spec {
   }
 
   "mysql quote" - {
-    val s = new NamingStrategy with MysqlQuote
+    val s = new NamingStrategy with MysqlEscape
 
     "quote table name with ``" in {
       s.table("order") mustEqual "`order`"

--- a/quill-core/src/test/scala/io/getquill/naming/NamingStrategySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/naming/NamingStrategySpec.scala
@@ -85,4 +85,20 @@ class NamingStrategySpec extends Spec {
       s.default("test_") mustEqual "test"
     }
   }
+
+  "mysql quote" - {
+    val s = new NamingStrategy with MysqlQuote
+
+    "quote table name with ``" in {
+      s.table("order") mustEqual "`order`"
+    }
+
+    "quote column name with ``" in {
+      s.column("count") mustEqual "`count`"
+    }
+
+    "persevere default naming strategy" in {
+      s.default("test") mustEqual("test")
+    }
+  }
 }


### PR DESCRIPTION
Ithink it  very common  to quote mysql `table`, `column` names.

The only problem is which sub-project this should be placed in.