### PR TITLE
typo in cassandra artifactid

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,7 +981,7 @@ db.pool.maxWaiters=2147483647
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-casandra" % "0.3.0"
+  "io.getquill" %% "quill-cassandra" % "0.3.0"
 )
 ```
 


### PR DESCRIPTION
the artifact is deployed on oss sonatype with two 's'. Modified the dependency sample accordingly 