### PR TITLE
mysql-async numeric types decoder fix

### DIFF
--- a/quill-async/src/main/scala/io/getquill/source/async/Decoders.scala
+++ b/quill-async/src/main/scala/io/getquill/source/async/Decoders.scala
@@ -7,8 +7,7 @@ import scala.math.BigDecimal.javaBigDecimal2bigDecimal
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
+import org.joda.time.LocalDate
 import org.joda.time.LocalDateTime
 
 import com.github.mauricio.async.db.RowData
@@ -25,7 +24,7 @@ trait Decoders {
           case value: T                        => value
           case value if (f.isDefinedAt(value)) => f(value)
           case value =>
-            fail(s"Value '$value' can't be decoded to '${classTag[T].runtimeClass}'")
+            fail(s"Value '$value' of ${value.getClass.getName} can't be decoded to '${classTag[T].runtimeClass}'")
         }
       }
     }
@@ -33,6 +32,8 @@ trait Decoders {
   trait NumericDecoder[T] extends Decoder[T] {
     def apply(index: Int, row: RowData) =
       row(index) match {
+        case v: Byte       => decode(v)
+        case v: Short      => decode(v)
         case v: Int        => decode(v)
         case v: Long       => decode(v)
         case v: Float      => decode(v)
@@ -63,14 +64,19 @@ trait Decoders {
     }
 
   implicit val booleanDecoder: Decoder[Boolean] = decoder[Boolean] {
-    case byte: Byte         => byte == (1: Byte)
+    case v: Byte         => v == (1: Byte)
+    case v: Short        => v == (1: Short)
+    case v: Int          => v == 1
+    case v: Long         => v == 1L
   }
 
   implicit val byteDecoder: Decoder[Byte] = decoder[Byte] {
     case v: Short => v.toByte
   }
 
-  implicit val shortDecoder: Decoder[Short] = decoder[Short]()
+  implicit val shortDecoder: Decoder[Short] = decoder[Short] {
+    case v: Byte => v.toShort
+  }
 
   implicit val intDecoder: Decoder[Int] =
     new NumericDecoder[Int] {
@@ -102,6 +108,8 @@ trait Decoders {
     decoder[Date] {
       case localDateTime: LocalDateTime =>
         localDateTime.toDate
+      case localDate: LocalDate =>
+        localDate.toDate
     }
 
   implicit val uuidDecoder: Decoder[UUID] = new Decoder[UUID] {

--- a/quill-async/src/test/scala/io/getquill/source/async/mysql/MysqlAsyncEncodingSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/source/async/mysql/MysqlAsyncEncodingSpec.scala
@@ -20,6 +20,63 @@ class MysqlAsyncEncodingSpec extends EncodingSpec {
     verify(Await.result(r, Duration.Inf).toList)
   }
 
+  "decode numeric types correctly" - {
+    "decode byte to" - {
+      prepareEncodingTestEntity()
+      "short" in {
+        case class EncodingTestEntity(v3: Short)
+        val v3List = Await.result(testMysqlDB.run(query[EncodingTestEntity]), Duration.Inf)
+        v3List.map(_.v3) must contain theSameElementsAs(List(1: Byte, 0: Byte))
+      }
+      "int" in {
+        case class EncodingTestEntity(v3: Int)
+        val v3List = Await.result(testMysqlDB.run(query[EncodingTestEntity]), Duration.Inf)
+        v3List.map(_.v3) must contain theSameElementsAs(List(1, 0))
+      }
+      "long" in {
+        case class EncodingTestEntity(v3: Long)
+        val v3List = Await.result(testMysqlDB.run(query[EncodingTestEntity]), Duration.Inf)
+        v3List.map(_.v3) must contain theSameElementsAs(List(1L, 0L))
+      }
+    }
+    "decode short to" - {
+      prepareEncodingTestEntity()
+      "int" in {
+        case class EncodingTestEntity(v5: Int)
+        val v5List = Await.result(testMysqlDB.run(query[EncodingTestEntity]), Duration.Inf)
+        v5List.map(_.v5) must contain theSameElementsAs(List(23, 0))
+      }
+      "long" in {
+        case class EncodingTestEntity(v5: Long)
+        val v5List = Await.result(testMysqlDB.run(query[EncodingTestEntity]), Duration.Inf)
+        v5List.map(_.v5) must contain theSameElementsAs(List(23L, 0L))
+      }
+    }
+    "decode int to long" in  {
+      case class EncodingTestEntity(v6: Long)
+      val v6List = Await.result(testMysqlDB.run(query[EncodingTestEntity]), Duration.Inf)
+      v6List.map(_.v6) must contain theSameElementsAs(List(33L, 0L))
+    }
+
+    "decode and encode any numeric as boolean" in {
+      case class EncodingTestEntity(v3: Boolean, v4: Boolean, v6: Boolean, v7: Boolean)
+      Await.result(testMysqlDB.run(query[EncodingTestEntity]), Duration.Inf)
+    }
+  }
+
+  "decode date types" in {
+    case class DateEncodingTestEntity(v1: Date, v2: Date, v3: Date)
+    val entity = new DateEncodingTestEntity(new Date, new Date, new Date)
+    val delete = quote(query[DateEncodingTestEntity].delete)
+    val insert = quote(query[DateEncodingTestEntity].insert)
+    val r = for {
+      _ <- testMysqlDB.run(delete)
+      _ <- testMysqlDB.run(insert)(List(entity))
+      result <- testMysqlDB.run(query[DateEncodingTestEntity])
+    } yield result
+    Await.result(r, Duration.Inf)
+  }
+
   "fails if the column has the wrong type" - {
     "numeric" in {
       Await.result(testMysqlDB.run(insert)(insertValues), Duration.Inf)
@@ -35,5 +92,13 @@ class MysqlAsyncEncodingSpec extends EncodingSpec {
         Await.result(testMysqlDB.run(query[EncodingTestEntity]), Duration.Inf)
       }
     }
+  }
+
+  private def prepareEncodingTestEntity() = {
+    val prepare = for {
+      _ <- testMysqlDB.run(delete)
+      _ <- testMysqlDB.run(insert)(insertValues)
+    } yield {}
+    Await.result(prepare, Duration.Inf)
   }
 }

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -48,6 +48,12 @@ CREATE TABLE EncodingTestEntity(
     o11 DATETIME
 );
 
+Create TABLE DateEncodingTestEntity(
+  v1 date,
+  v2 datetime,
+  v3 timestamp
+);
+
 CREATE TABLE TestEntity(
 	s VARCHAR(255),
     i INTEGER,


### PR DESCRIPTION
This pr did four things
- [x] Enable any numeric type mapping to `boolean`
- [x] Allow decode `byte`, `short` as numeric
- [x] Allow `LocalDate` decode to `java.util.date`
- [x] Complete the   encoding testing

@fwbrasil  To complete the testcases, a lot of `fields` will be add to `EncodingTestEntity`, shall I do it ?