### PR TITLE
Mirror sql joins

### DIFF
--- a/quill-core/src/main/scala/io/getquill/ImplicitQuery.scala
+++ b/quill-core/src/main/scala/io/getquill/ImplicitQuery.scala
@@ -4,30 +4,31 @@ import language.experimental.macros
 import language.implicitConversions
 import scala.reflect.macros.whitebox.Context
 import io.getquill.util.Messages._
+import scala.runtime._
 
 object ImplicitQuery {
-  implicit def toQuery[P <: Product](f: Function1[_, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function2[_, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function3[_, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function4[_, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function5[_, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function6[_, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function7[_, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function8[_, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function9[_, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function10[_, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function11[_, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function12[_, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function13[_, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function14[_, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function15[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function16[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function17[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function18[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function19[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function20[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function21[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
-  implicit def toQuery[P <: Product](f: Function22[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction1[_, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction2[_, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction3[_, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction4[_, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction5[_, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction6[_, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction7[_, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction8[_, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction9[_, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction10[_, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction11[_, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction12[_, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction13[_, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction14[_, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction15[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction16[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction17[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction18[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction19[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction20[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction21[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
+  implicit def toQuery[P <: Product](f: AbstractFunction22[_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, P]): Query[P] = macro ImplicitQueryMacro.toQuery[P]
 }
 
 private[getquill] class ImplicitQueryMacro(val c: Context) {

--- a/quill-core/src/main/scala/io/getquill/Query.scala
+++ b/quill-core/src/main/scala/io/getquill/Query.scala
@@ -27,7 +27,11 @@ sealed trait Query[+T] {
   def leftJoin[A >: T, B](q: Query[B]): JoinQuery[A, B, (A, Option[B])]
   def rightJoin[A >: T, B](q: Query[B]): JoinQuery[A, B, (Option[A], B)]
   def fullJoin[A >: T, B](q: Query[B]): JoinQuery[A, B, (Option[A], Option[B])]
-
+  
+  def join[A >: T](on: A => Boolean): Query[A]
+  def leftJoin[A >: T](on: A => Boolean): Query[Option[A]]
+  def rightJoin[A >: T](on: A => Boolean): Query[Option[A]]
+  
   def nonEmpty: Boolean
   def isEmpty: Boolean
 }

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -8,7 +8,12 @@ case class BetaReduction(map: collection.Map[Ident, Ast])
   override def apply(ast: Ast) =
     ast match {
       case Property(Tuple(values), name) =>
-        apply(values(name.drop(1).toInt - 1))
+        val aliases = values.distinct
+        aliases match{
+          case alias :: Nil if values.size > 1 =>
+            super.apply(Property(alias, name))
+          case _ => apply(values(name.drop(1).toInt - 1))
+        }
       case FunctionApply(Function(params, body), values) =>
         apply(BetaReduction(map ++ params.zip(values)).apply(body))
       case ident: Ident =>

--- a/quill-core/src/test/scala/io/getquill/ImplicitQuerySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ImplicitQuerySpec.scala
@@ -14,7 +14,7 @@ class ImplicitQuerySpec extends Spec {
       """query[TestEntity].filter(t => t.s == "s").map(t => (t.s, t.i, t.l, t.o))"""
   }
 
-  "fails if the if querying a non-case-class companion" in {
+  "fails if querying a non-case-class companion" in {
     class Test(val a: String) extends Product {
       def canEqual(that: Any) = ???
       def productArity: Int = ???
@@ -28,5 +28,19 @@ class ImplicitQuerySpec extends Spec {
       Test.filter(_.a == "s")
     }
     """ mustNot compile
+  }
+  
+  "only attempts to convert case class derived AbstractFunctionN to Query" - {
+
+    "preserves inferred type of secondary join FunctionN argument" in {
+      """
+      val q = quote {
+        for{
+          (a,b)<- TestEntity.join(TestEntity2).on(_.i == _.i)
+             c <- TestEntity3.leftJoin(_.i == a.i)
+        } yield(a,b,c)
+      }
+      """ must compile
+    }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -58,6 +58,12 @@ class BetaReductionSpec extends Spec {
       }
     }
   }
+  
+  "deduplicates aliases in secondary table join" in {
+    val aliases = List(Ident("x"), Ident("x"))
+    val ast: Ast = Property(Tuple(aliases), "field")
+    BetaReduction(ast, Ident("x") -> Tuple(aliases)) mustEqual ast
+  }
 
   "reapplies the beta reduction if the structure changes" in {
     val ast: Ast = Property(Ident("a"), "_1")

--- a/quill-sql/src/main/scala/io/getquill/source/sql/Prepare.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/Prepare.scala
@@ -11,6 +11,7 @@ import io.getquill.norm.capture.AvoidCapture
 import io.getquill.norm.FlattenOptionOperation
 import io.getquill.source.sql.norm.ExpandJoin
 import io.getquill.source.sql.norm.ExpandNestedQueries
+import io.getquill.source.sql.norm.MergeSecondaryJoin
 
 object Prepare {
 
@@ -28,11 +29,12 @@ object Prepare {
       }
     (sqlString, idents)
   }
-
+  
   private[this] val normalize =
     (identity[Ast] _)
       .andThen(Normalize.apply _)
       .andThen(ExpandJoin.apply _)
       .andThen(Normalize.apply _)
+      .andThen(MergeSecondaryJoin.apply _)
       .andThen(FlattenOptionOperation.apply _)
 }

--- a/quill-sql/src/main/scala/io/getquill/source/sql/norm/MergeSecondaryJoin.scala
+++ b/quill-sql/src/main/scala/io/getquill/source/sql/norm/MergeSecondaryJoin.scala
@@ -1,0 +1,30 @@
+package io.getquill.source.sql.norm
+
+import io.getquill.ast._
+
+object MergeSecondaryJoin extends StatelessTransformer {
+	
+  override def apply(q: Query) = q match {
+    case FlatMap(current: Join, _, body) =>
+      body match {
+        case FlatMap(next: Join, alias, body) if isSecondary(next) =>
+          body match {
+            case Map(last: Join, alias, body) if isSecondary(last) => 
+              Map( merge(merge(current, next), last), alias, body )
+            case _ =>
+              apply( FlatMap(merge(current, next), alias, body) )
+          }
+        case Map(last: Join, alias, body) if isSecondary(last) => 
+          Map( merge(current, last), alias, body )
+        case _ => q
+      }
+    case _ => q
+  }
+
+  private def merge(current: Join, next: Join): Join = {
+    val ident = next.aliasA
+    Join(next.typ, current, next.a, ident, ident, next.on)
+  }
+
+  private def isSecondary(j: Join): Boolean = j.a == j.b
+}

--- a/quill-sql/src/test/scala/io/getquill/source/sql/PrepareSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/PrepareSpec.scala
@@ -20,17 +20,42 @@ class PrepareSpec extends Spec {
       "SELECT t._1, t1._2 FROM TestEntity a LEFT JOIN (SELECT t.i _1 FROM TestEntity2 t) t ON a.i > t._1, TestEntity a1 LEFT JOIN (SELECT t1.l _2 FROM TestEntity2 t1) t1 ON a1.l < t1._2"
   }
   
-  "mirror sql joins" in {
-    val q = quote{
-      for{
-        (a,b)<- qr1 join qr2 on(_.i == _.i)
-           c <- qr1 join(_.i == a.i)
-           d <- qr2 join(_.i == b.i)
-           e <- qr3 join(_.i == c.i)
-      } yield (a,b,c,d,e)
-    }
-    mirrorSource.run(q).sql mustEqual
-      "SELECT x3.s, x3.i, x3.l, x3.o, x4.s, x4.i, x4.l, x4.o, x5.s, x5.i, x5.l, x5.o, x6.s, x6.i, x6.l, x6.o, x7.s, x7.i, x7.l, x7.o FROM TestEntity x3 INNER JOIN TestEntity2 x4 ON x3.i = x4.i INNER JOIN TestEntity x5 ON x5.i = x3.i INNER JOIN TestEntity2 x6 ON x6.i = x4.i INNER JOIN TestEntity3 x7 ON x7.i = x5.i"
+  "mirror sql joins" - {
+
+    "with one secondary table" in {
+	    val q = quote{
+	      for{
+	        (a,b)<- qr1 join qr2 on(_.i == _.i)
+	           c <- qr1 join(_.i == a.i)
+	      } yield (a,b,c)
+	    }
+	    mirrorSource.run(q).sql mustEqual
+	      "SELECT x3.s, x3.i, x3.l, x3.o, x4.s, x4.i, x4.l, x4.o, x5.s, x5.i, x5.l, x5.o FROM TestEntity x3 INNER JOIN TestEntity2 x4 ON x3.i = x4.i INNER JOIN TestEntity x5 ON x5.i = x3.i"
+	  }
+  
+	  "with many secondary tables" in {
+	    val q = quote{
+	      for{
+	        (a,b)<- qr1 join qr2 on(_.i == _.i)
+	           c <- qr1 join(_.i == a.i)
+	           d <- qr2 join(_.i == b.i)
+	           e <- qr3 join(_.i == c.i)
+	      } yield (a,b,c,d,e)
+	    }
+	    mirrorSource.run(q).sql mustEqual
+	      "SELECT x7.s, x7.i, x7.l, x7.o, x8.s, x8.i, x8.l, x8.o, x9.s, x9.i, x9.l, x9.o, x10.s, x10.i, x10.l, x10.o, x11.s, x11.i, x11.l, x11.o FROM TestEntity x7 INNER JOIN TestEntity2 x8 ON x7.i = x8.i INNER JOIN TestEntity x9 ON x9.i = x7.i INNER JOIN TestEntity2 x10 ON x10.i = x8.i INNER JOIN TestEntity3 x11 ON x11.i = x9.i"
+	  }
+
+    "with outer join" in {
+	    val q = quote{
+	      for{
+	        (a,b)<- qr1 join qr2 on(_.i == _.i)
+	           c <- qr1 rightJoin(_.i == a.i)
+	      } yield (a,b,c.map(_.i))
+	    }
+	    mirrorSource.run(q).sql mustEqual
+	      "SELECT x13.s, x13.i, x13.l, x13.o, x14.s, x14.i, x14.l, x14.o, x15.i FROM TestEntity x13 INNER JOIN TestEntity2 x14 ON x13.i = x14.i RIGHT JOIN TestEntity x15 ON x15.i = x13.i"
+	  }
   }
   	
 }

--- a/quill-sql/src/test/scala/io/getquill/source/sql/PrepareSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/source/sql/PrepareSpec.scala
@@ -19,4 +19,18 @@ class PrepareSpec extends Spec {
     mirrorSource.run(q).sql mustEqual
       "SELECT t._1, t1._2 FROM TestEntity a LEFT JOIN (SELECT t.i _1 FROM TestEntity2 t) t ON a.i > t._1, TestEntity a1 LEFT JOIN (SELECT t1.l _2 FROM TestEntity2 t1) t1 ON a1.l < t1._2"
   }
+  
+  "mirror sql joins" in {
+    val q = quote{
+      for{
+        (a,b)<- qr1 join qr2 on(_.i == _.i)
+           c <- qr1 join(_.i == a.i)
+           d <- qr2 join(_.i == b.i)
+           e <- qr3 join(_.i == c.i)
+      } yield (a,b,c,d,e)
+    }
+    mirrorSource.run(q).sql mustEqual
+      "SELECT x3.s, x3.i, x3.l, x3.o, x4.s, x4.i, x4.l, x4.o, x5.s, x5.i, x5.l, x5.o, x6.s, x6.i, x6.l, x6.o, x7.s, x7.i, x7.l, x7.o FROM TestEntity x3 INNER JOIN TestEntity2 x4 ON x3.i = x4.i INNER JOIN TestEntity x5 ON x5.i = x3.i INNER JOIN TestEntity2 x6 ON x6.i = x4.i INNER JOIN TestEntity3 x7 ON x7.i = x5.i"
+  }
+  	
 }


### PR DESCRIPTION
Closed previous PR as it had some extraneous commits from local WIP branch. This one should be easier to follow.

As discussed in [Joins and nested tuples](https://github.com/getquill/quill/issues/117) here is the implementation I've been working on. In a nutshell this PR enhances existing Quill join queries based on nested tuples with an alternate join syntax that mirrors that of sql.
