### PR TITLE
Faster local build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ In order to contribute to the project, just do as follows:
 Please, install [docker-machine-nfs](https://github.com/adlogix/docker-machine-nfs). It will change the default sharing
 of your Docker-Machine from Virtual Box Shared Folders to NFS, which is a lot faster. 
 
-#### Build without Docker for sbt
+#### Build locally, without docker
 
 Run the following command, it will restart your database service with random ports exposed to your host machine. 
 
@@ -63,7 +63,7 @@ export MYSQL_PORT_3306_TCP_ADDR=192.168.99.100
 export MYSQL_PORT_3306_TCP_PORT=<MySQL exposed port> 
 export POSTGRES_PORT_5432_TCP_ADDR=192.168.99.100 
 export POSTGRES_PORT_5432_TCP_PORT=<Postgres exposed port>
-``
+```
 
-Finally, you can use `sbt` normally.
+Finally, you can use `sbt` locally.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,18 +10,18 @@ Instructions on how to install Docker can be found in this [page](https://docs.d
 After installing Docker, you have to run the command bellow in order to setup the
 databases' schemas. If you don't change any schemas, you will only need to this once.
 
-`docker-compose run setup`
+`docker-compose run --rm setup`
 
 After that, just run the command bellow to build and test the project.
 
-`docker-compose run sbt sbt test`
+`docker-compose run --rm sbt sbt test`
 
 ## Changing database schema
 
 If you have changed any file that creates a database schema, you will
  have to setup the databases again. To do this, just run the command bellow.
 
-`docker-compose stop && docker-compose rm && docker-compose run setup`
+`docker-compose stop && docker-compose rm && docker-compose run --rm setup`
 
 ## Pull Request
 
@@ -33,4 +33,37 @@ In order to contribute to the project, just do as follows:
 4. Run the tests through `docker-compose run sbt sbt test`
 5. If everything is ok, commit and push to your fork
 6. Create a Pull Request, we'll be glad to review it
+
+
+## Running locally
+
+### For Mac users
+
+#### Improve build performance with Docker
+
+Please, install [docker-machine-nfs](https://github.com/adlogix/docker-machine-nfs). It will change the default sharing
+of your Docker-Machine from Virtual Box Shared Folders to NFS, which is a lot faster. 
+
+#### Build without Docker for sbt
+
+Run the following command, it will restart your database service with random ports exposed to your host machine. 
+
+`docker-compose stop && docker-compose rm && docker-compose run --rm --service-ports setup`
+
+After that, you have to find the ports that were associated with the services with the following command.
+
+`docker ps`
+
+With that, just export the following variables with the corresponding ports from the previous command.
+
+```
+export CASSANDRA_PORT_9042_TCP_ADDR=192.168.99.100
+export CASSANDRA_PORT_9042_TCP_PORT=<Cassandra exposed port> 
+export MYSQL_PORT_3306_TCP_ADDR=192.168.99.100
+export MYSQL_PORT_3306_TCP_PORT=<MySQL exposed port> 
+export POSTGRES_PORT_5432_TCP_ADDR=192.168.99.100 
+export POSTGRES_PORT_5432_TCP_PORT=<Postgres exposed port>
+``
+
+Finally, you can use `sbt` normally.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,5 +65,31 @@ export POSTGRES_PORT_5432_TCP_ADDR=192.168.99.100
 export POSTGRES_PORT_5432_TCP_PORT=<Postgres exposed port>
 ```
 
+*Note on the 192.168.99.100 address, usually [docker-machine](https://docs.docker.com/machine/) creates a Virtual Machine
+with this address. You can check it by running `docker-machine ps`.*
+
 Finally, you can use `sbt` locally.
 
+### For Linux users
+#### Build locally, without docker
+
+Run the following command, it will restart your database service with random ports exposed to your host machine. 
+
+`docker-compose stop && docker-compose rm && docker-compose run --rm --service-ports setup`
+
+After that, you have to find the ports that were associated with the database services with the following command.
+
+`docker ps`
+
+With that, just export the following variables with the corresponding ports from the previous command.
+
+```
+export CASSANDRA_PORT_9042_TCP_ADDR=127.0.0.1
+export CASSANDRA_PORT_9042_TCP_PORT=<Cassandra exposed port> 
+export MYSQL_PORT_3306_TCP_ADDR=127.0.0.1
+export MYSQL_PORT_3306_TCP_PORT=<MySQL exposed port> 
+export POSTGRES_PORT_5432_TCP_ADDR=127.0.0.1 
+export POSTGRES_PORT_5432_TCP_PORT=<Postgres exposed port>
+```
+
+Finally, you can use `sbt` locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,62 +34,51 @@ In order to contribute to the project, just do as follows:
 5. If everything is ok, commit and push to your fork
 6. Create a Pull Request, we'll be glad to review it
 
+### Improve build performance with Docker *(for Mac users only)*
 
-## Running locally
+Please, install and run [docker-machine-nfs](https://github.com/adlogix/docker-machine-nfs). It will change the default file sharing
+of your [docker-machine](https://docs.docker.com/machine/) from Virtual Box Shared Folders to NFS, which is a lot faster. 
 
-### For Mac users
+## Building locally without Docker
 
-#### Improve build performance with Docker
-
-Please, install [docker-machine-nfs](https://github.com/adlogix/docker-machine-nfs). It will change the default sharing
-of your Docker-Machine from Virtual Box Shared Folders to NFS, which is a lot faster. 
-
-#### Build locally, without docker
-
-Run the following command, it will restart your database service with random ports exposed to your host machine. 
+Run the following command, it will restart your database service with database ports exposed to your host machine. 
 
 `docker-compose stop && docker-compose rm && docker-compose run --rm --service-ports setup`
 
-After that, you have to find the ports that were associated with the services with the following command.
+After that, we need to set some environment variables in order to run `sbt` locally.  
 
-`docker ps`
+```
+export CASSANDRA_PORT_9042_TCP_ADDR=<docker host address>
+export CASSANDRA_PORT_9042_TCP_PORT=19042 
+export MYSQL_PORT_3306_TCP_ADDR=<docker host address>
+export MYSQL_PORT_3306_TCP_PORT=13306 
+export POSTGRES_PORT_5432_TCP_ADDR=<docker host address> 
+export POSTGRES_PORT_5432_TCP_PORT=15432
+```
 
-With that, just export the following variables with the corresponding ports from the previous command.
+For Mac users, the docker host address is the address of the [docker-machine](https://docs.docker.com/machine/), it's usually
+ 192.168.99.100. You can check it by running `docker-machine ps`. For Linux users, the host address is your localhost.
+
+Therefor, for Mac users the environment variables should be:
 
 ```
 export CASSANDRA_PORT_9042_TCP_ADDR=192.168.99.100
-export CASSANDRA_PORT_9042_TCP_PORT=<Cassandra exposed port> 
+export CASSANDRA_PORT_9042_TCP_PORT=19042 
 export MYSQL_PORT_3306_TCP_ADDR=192.168.99.100
-export MYSQL_PORT_3306_TCP_PORT=<MySQL exposed port> 
+export MYSQL_PORT_3306_TCP_PORT=13306 
 export POSTGRES_PORT_5432_TCP_ADDR=192.168.99.100 
-export POSTGRES_PORT_5432_TCP_PORT=<Postgres exposed port>
+export POSTGRES_PORT_5432_TCP_PORT=15432
 ```
 
-*Note on the 192.168.99.100 address, usually [docker-machine](https://docs.docker.com/machine/) creates a Virtual Machine
-with this address. You can check it by running `docker-machine ps`.*
-
-Finally, you can use `sbt` locally.
-
-### For Linux users
-#### Build locally, without docker
-
-Run the following command, it will restart your database service with random ports exposed to your host machine. 
-
-`docker-compose stop && docker-compose rm && docker-compose run --rm --service-ports setup`
-
-After that, you have to find the ports that were associated with the database services with the following command.
-
-`docker ps`
-
-With that, just export the following variables with the corresponding ports from the previous command.
+For Linux users, the environment variables should be:
 
 ```
 export CASSANDRA_PORT_9042_TCP_ADDR=127.0.0.1
-export CASSANDRA_PORT_9042_TCP_PORT=<Cassandra exposed port> 
+export CASSANDRA_PORT_9042_TCP_PORT=19042 
 export MYSQL_PORT_3306_TCP_ADDR=127.0.0.1
-export MYSQL_PORT_3306_TCP_PORT=<MySQL exposed port> 
+export MYSQL_PORT_3306_TCP_PORT=13306 
 export POSTGRES_PORT_5432_TCP_ADDR=127.0.0.1 
-export POSTGRES_PORT_5432_TCP_PORT=<Postgres exposed port>
+export POSTGRES_PORT_5432_TCP_PORT=15432
 ```
 
 Finally, you can use `sbt` locally.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 postgres:
   image: postgres
   ports:
-    - "5432"
+    - "15432:5432"
   environment:
     - POSTGRES_USER=postgres
 
@@ -9,7 +9,7 @@ postgres:
 mysql:
   image: mysql
   ports:
-    - "3306"
+    - "13306:3306"
   environment:
     - MYSQL_ROOT_PASSWORD=root
     - MYSQL_DATABASE=quill_test
@@ -18,11 +18,11 @@ mysql:
 cassandra:
   image: cassandra:2.1
   ports:
-    - "9042"
-    - "9160"
-    - "7199"
-    - "7001"
-    - "7000"
+    - "19042:9042"
+    - "19160:9160"
+    - "17199:7199"
+    - "17001:7001"
+    - "17000:7000"
 
 setup:
   build: .

--- a/quill-async/src/test/resources/application.conf
+++ b/quill-async/src/test/resources/application.conf
@@ -1,5 +1,5 @@
-testMysqlDB.host=mysql
-testMysqlDB.port=3306
+testMysqlDB.host=${?MYSQL_PORT_3306_TCP_ADDR}
+testMysqlDB.port=${?MYSQL_PORT_3306_TCP_PORT}
 testMysqlDB.user=root
 testMysqlDB.database=quill_test
 testMysqlDB.poolMaxQueueSize=4
@@ -7,7 +7,7 @@ testMysqlDB.poolMaxObjects=4
 testMysqlDB.poolMaxIdle=999999999
 testMysqlDB.poolValidationInterval=100
 
-testPostgresDB.host=postgres
-testPostgresDB.port=5432
+testPostgresDB.host=${?POSTGRES_PORT_5432_TCP_ADDR}
+testPostgresDB.port=${?POSTGRES_PORT_5432_TCP_PORT}
 testPostgresDB.user=postgres
 testPostgresDB.database=quill_test

--- a/quill-cassandra/src/test/resources/application.conf
+++ b/quill-cassandra/src/test/resources/application.conf
@@ -1,6 +1,6 @@
 testSyncDB.keyspace=quill_test
 testSyncDB.preparedStatementCacheSize=1000
-testSyncDB.session.contactPoint=${?CASSANDRA_PORT_9042_TCP_ADDR}y
+testSyncDB.session.contactPoint=${?CASSANDRA_PORT_9042_TCP_ADDR}
 testSyncDB.session.port=${?CASSANDRA_PORT_9042_TCP_PORT}
 testSyncDB.session.queryOptions.consistencyLevel=LOCAL_QUORUM
 testSyncDB.session.withoutMetrics=true

--- a/quill-cassandra/src/test/resources/application.conf
+++ b/quill-cassandra/src/test/resources/application.conf
@@ -1,6 +1,7 @@
 testSyncDB.keyspace=quill_test
 testSyncDB.preparedStatementCacheSize=1000
-testSyncDB.session.contactPoint=cassandra
+testSyncDB.session.contactPoint=${?CASSANDRA_PORT_9042_TCP_ADDR}y
+testSyncDB.session.port=${?CASSANDRA_PORT_9042_TCP_PORT}
 testSyncDB.session.queryOptions.consistencyLevel=LOCAL_QUORUM
 testSyncDB.session.withoutMetrics=true
 testSyncDB.session.withoutJMXReporting=false
@@ -11,10 +12,12 @@ testSyncDB.session.addressTranslater=com.datastax.driver.core.policies.IdentityT
 
 testAsyncDB.keyspace=quill_test
 testAsyncDB.preparedStatementCacheSize=1000
-testAsyncDB.session.contactPoint=cassandra
+testAsyncDB.session.contactPoint=${?CASSANDRA_PORT_9042_TCP_ADDR}
+testAsyncDB.session.port=${?CASSANDRA_PORT_9042_TCP_PORT}
 testAsyncDB.session.queryOptions.consistencyLevel=LOCAL_QUORUM
 
 testStreamDB.keyspace=quill_test
 testStreamDB.preparedStatementCacheSize=1000
-testStreamDB.session.contactPoint=cassandra
+testStreamDB.session.contactPoint=${?CASSANDRA_PORT_9042_TCP_ADDR}
+testStreamDB.session.port=${?CASSANDRA_PORT_9042_TCP_PORT}
 testStreamDB.session.queryOptions.consistencyLevel=LOCAL_QUORUM

--- a/quill-finagle-mysql/src/test/resources/application.conf
+++ b/quill-finagle-mysql/src/test/resources/application.conf
@@ -1,0 +1,4 @@
+testDB.dest=${?MYSQL_PORT_3306_TCP_ADDR}":"${?MYSQL_PORT_3306_TCP_PORT}
+testDB.user=finagle
+testDB.password=finagle
+testDB.database=quill_test

--- a/quill-finagle-mysql/src/test/resources/application.properties
+++ b/quill-finagle-mysql/src/test/resources/application.properties
@@ -1,4 +1,0 @@
-testDB.dest=mysql:3306
-testDB.user=finagle
-testDB.password=finagle
-testDB.database=quill_test

--- a/quill-jdbc/src/test/resources/application.conf
+++ b/quill-jdbc/src/test/resources/application.conf
@@ -1,6 +1,6 @@
 testMysqlDB.queryProbing=true
 testMysqlDB.dataSourceClassName=com.mysql.jdbc.jdbc2.optional.MysqlDataSource
-testMysqlDB.dataSource.url=jdbc:mysql://mysql/quill_test
+testMysqlDB.dataSource.url="jdbc:mysql://"${?MYSQL_PORT_3306_TCP_ADDR}":"${?MYSQL_PORT_3306_TCP_PORT}"/quill_test"
 testMysqlDB.dataSource.user=root
 testMysqlDB.dataSource.cachePrepStmts=true
 testMysqlDB.dataSource.prepStmtCacheSize=250
@@ -10,5 +10,5 @@ testMysqlDB.maximumPoolSize=1
 testPostgresDB.dataSourceClassName=org.postgresql.ds.PGSimpleDataSource
 testPostgresDB.dataSource.user=postgres
 testPostgresDB.dataSource.databaseName=quill_test
-testPostgresDB.dataSource.portNumber=5432
-testPostgresDB.dataSource.serverName=postgres
+testPostgresDB.dataSource.portNumber=${?POSTGRES_PORT_5432_TCP_PORT}
+testPostgresDB.dataSource.serverName=${?POSTGRES_PORT_5432_TCP_ADDR}


### PR DESCRIPTION
Some changes and some instruction on how to build locally without using docker in order to improve performance and to enable better integration with IDE and with queryProbing. 

I fixed the ports exposed in this version to make setup easier. There is one downside with this approach, we can have ports collision, but I don't think it should be any issue. 

Please, check [CONTRIBUTING.md (v2)](https://github.com/gustavoamigo/quill/blob/faster-local-build-v2/CONTRIBUTING.md) to see how it should work.

The previous version, setup was a little harder [CONTRIBUTING.md (v1)](https://github.com/gustavoamigo/quill/blob/faster-local-build/CONTRIBUTING.md), but ports were assigned dynamically.

Anyways, I think this version is better and should make development easier.  