### PR TITLE
Comparison between Quill and other alternatives for CQL

### DIFF
--- a/CASSANDRA.md
+++ b/CASSANDRA.md
@@ -1,0 +1,71 @@
+
+This document compares Quill to the [Phantom](http://websudos.github.io/phantom/) library. This is an incomplete comparison, additions and corrections are welcome.
+
+## Abstraction level ##
+
+Although both Quill and Phantom represent column family rows as flat immutable structures (case classes without nested data) and provide a type-safe composable query DSL, they work at a different abstraction level. 
+
+Phantom provides an embedded DSL that help you write CQL queries in a type-safe manner. Quill is referred as a Language Integrated Query library to match the available publications on the subject. The paper ["Language-integrated query using comprehension syntax: state of the art, open problems, and work in progress"](http://research.microsoft.com/en-us/events/dcp2014/cheney.pdf) has an overview with some of the available implementations of language integrated queries.
+
+## QDSL versus EDSL ##
+
+Quill's DSL is a macro-based quotation mechanism, allowing usage of Scala types and operators directly. Please refer to the paper ["Everything old is new again: Quoted Domain Specific Languages"](http://homepages.inf.ed.ac.uk/wadler/papers/qdsl/qdsl.pdf) for more details. On the other hand, Phantom provides a DSL to create queries, that requires the usage of DSL provided operations. Example:
+
+**quill**
+```scala
+import io.getquill._
+import io.getquill.naming._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+val source = source(new CassandraAsyncSourceConfig[SnakeCase]("db") with NoQueryProbing)
+
+case class Person(name: String, age: Int)
+
+val getByName = quote {
+  (n: String) =>
+    query[Person].filter(_.name == name)
+}
+
+source.run(getByName)("Jane Doe")
+```
+
+**phantom**
+```scala
+import com.websudos.phantom.connectors._
+import com.websudos.phantom.dsl._
+
+import scala.concurrent.Future
+
+val ks = ContactPoint.local.keySpace("db")
+
+case class Person(name: String, age: Int)
+
+sealed class PersonCF(override val tableName: String) extends CassandraTable[PersonCF, Person] with Connector {
+  object name extends StringColumn(this) with PartitionKey[String]
+  object age extends IntColumn(this)
+
+  override def fromRow(r: Row): Person = Person(name(r), age(r))
+}
+
+object PersonCF extends PersonCF("person") extends ks.Connector {
+  def getByName(name: String): Future[Option[Person]] =
+    select.where(_.name eqs name).one()
+}
+
+PersonCF.getByname("Jane Doe")
+```
+
+Phantom requires explicit definition of the database model. The query definition also requires special equality operators.
+
+## Compile-time versus Runtime ##
+
+Quill's quoted DSL opens a new path to query generation. For the quotations that are known statically, the query normalization and translation to SQL happen at compile-time. The user receives feedback during compilation, knows the SQL string that will be used and, as an experimental feature disabled by default, if it will succeed when executed against the database.
+
+Phantom creates the queries at runtime, but the nature of the DSL allows for some simple compile time validations, e.g. checking the absence of primary keys in the database model when querying.
+
+## Non-blocking IO ##
+
+Both Phantom and Quill are built on top of the Datastax java driver and provide tools to query Cassandra in an asynchronous and/or reactive, non-blocking manner.
+
+Quill uses the [Monix.io](https://github.com/monixio/monix) library, compatible with the [reactive-streams](http://www.reactive-streams.org/) protocol, to provide an `Observable` of the result set. Phantom implements `Publisher/Subscriber`s on top of the [reactive-streams](http://www.reactive-streams.org/) specification.

--- a/CASSANDRA.md
+++ b/CASSANDRA.md
@@ -509,3 +509,24 @@ object Quill extends App {
 
 We only need to define implicit encodings from/to `String`.
 
+## Non-blocking IO ##
+
+This section would allow us to compare the different options the libraries offer to do non-blocking IO.
+
+**Java Driver (v3.0.0)**
+
+The Datastax driver allows you to execute queries [asynchronously](https://github.com/datastax/java-driver/tree/2.1/manual/async), returning `ListenableFuture`s.
+   
+**Phantom (v1.22.0)**
+
+Phantom is asynchronous by default and all operations returns `Future`s. It also provides an implementation of the [reactive-streams](https://github.com/reactive-streams/reactive-streams-jvm) specification on top of Akka. 
+
+**Quill (v0.3.2-SNAPSHOT)**
+
+Quill provides blocking, asynchronous and streaming sources for Cassandra. The asynchronous source returns `Future`s on all operations. The streaming source uses [Monix](https://github.com/monixio/monix) to return an `Observable`. Monix is a reactive library compatible with the [reactive-streams](https://github.com/reactive-streams/reactive-streams-jvm) protocol.
+
+## Other considerations ##
+
+So far we have only compared this libraries from technical point of view, but there are other things you might want to take into account like 3rd party dependencies. As both Phantom and Quill depend on the Datastax Java Driver, we are going to pay attention to which additional dependencies each of them add.
+
+Phantom is composed by several modules, each of them with their 3rd party dependencies. Overall it adds more 3rd party dependencies than Quill and it has dependencies on libraries like shapeless, play-iteratees, play-streams-experimental or akka-actor. Quill, on the other hand, only adds dependencies on monix and scalamacros resetallattrs.

--- a/CASSANDRA.md
+++ b/CASSANDRA.md
@@ -51,7 +51,7 @@ Phantom provides an embedded DSL that help you write CQL queries in a type-safe 
 
 ## Simple queries ##
 
-This section would allow us to compare how the different libraries let us query a column family to obtain one element.
+This section compares how the different libraries let the user query a column family to obtain some elements.
 
 **Java Driver (v3.0.0)**
 ```scala
@@ -151,7 +151,7 @@ object Phantom extends App {
 }
 ```
 
-Phantom requires explicit definition of the database model. The query definition also requires special equality operators.
+Phantom requires mapping classes to lift the database model to DSL types. The query definition also requires special equality operators.
 
 **Quill (v0.3.2-SNAPSHOT)**
 ```scala
@@ -184,11 +184,11 @@ During the compilation of this example, as the quotation is known statically, Qu
 
 ## Composable queries ##
 
-This section would allow us to compare how the different libraries let us compose querie, if possible.
+This section compares how the different libraries let the user compose queries.
 
 **Java Driver (v3.0.0)** 
 
-The Query Builder allows you to partially construct queries and add filters later:
+The Query Builder allows the user to partially construct queries and add filters later:
 
 ```scala
     val selectAllWeatherStations: Select =
@@ -197,7 +197,7 @@ The Query Builder allows you to partially construct queries and add filters late
       from("db", "weather_station")
 ```
 
-But that's a very limited composition capability.
+The DSL has limited composition compatibility.
 
 **Phantom (v1.22.0)**
 ```scala
@@ -257,7 +257,7 @@ object Phantom extends App {
 }
 ```
 
-Phantom allows you certain level of composability, but it gets a bit verbose due to the nature of the DSL. 
+Phantom allows the user certain level of composability, but it gets a bit verbose due to the nature of the DSL. 
 
 **Quill (v0.3.2-SNAPSHOT)**
 ```scala
@@ -300,7 +300,7 @@ Quill offers more advanced composability, but CQL being a much simpler query lan
 
 ## Extensibility ##
 
-This section would allow us to explore the extensibility capabilities of each library .
+This section explores the extensibility capabilities of each library .
 
 **Java Driver (v3.0.0)**
 
@@ -403,7 +403,7 @@ object JavaDriver extends App {
 }
 ```
 
-We need to create a new `TypeCodec` and register it in the `CodecRegistry`.
+It is necessary to create a new `TypeCodec` and register it in the `CodecRegistry`.
 
 **Phantom (v1.22.0)**
 ```scala
@@ -481,7 +481,7 @@ object Phantom extends App {
 }
 ```
 
-We need to define a new `Column` type and use it while defining the data model.
+It is necessary to define a new `Column` type to be used when defining the data model.
 
 **Quill (v0.3.2-SNAPSHOT)**
 ```scala
@@ -518,15 +518,15 @@ object Quill extends App {
 }
 ```
 
-We only need to define implicit encodings from/to `String`.
+Quill only requires definition of implicit encodings from/to `String`.
 
 ## Non-blocking IO ##
 
-This section would allow us to compare the different options the libraries offer to do non-blocking IO.
+This section compares the different options the libraries offer to do non-blocking IO.
 
 **Java Driver (v3.0.0)**
 
-The Datastax driver allows you to execute queries [asynchronously](https://github.com/datastax/java-driver/tree/2.1/manual/async), returning `ListenableFuture`s.
+The Datastax driver allows the user to execute queries [asynchronously](https://github.com/datastax/java-driver/tree/2.1/manual/async), returning `ListenableFuture`s.
    
 **Phantom (v1.22.0)**
 
@@ -538,6 +538,6 @@ Quill provides blocking, asynchronous and streaming sources for Cassandra. The a
 
 ## Other considerations ##
 
-So far we have only compared this libraries from technical point of view, but there are other things you might want to take into account like 3rd party dependencies. As both Phantom and Quill depend on the Datastax Java Driver, we are going to pay attention to which additional dependencies each of them add.
+There other aspects the user might want to take into account like 3rd party dependencies. As both Phantom and Quill depend on the Datastax Java Driver, we are going to pay attention to which additional dependencies each of them add.
 
 Phantom is composed by several modules, each of them with their 3rd party dependencies. Overall it adds more 3rd party dependencies than Quill and it has dependencies on libraries like shapeless, play-iteratees, play-streams-experimental or akka-actor. Quill, on the other hand, only adds dependencies on monix and scalamacros resetallattrs.

--- a/CASSANDRA.md
+++ b/CASSANDRA.md
@@ -1,6 +1,35 @@
 
 This document compares Quill to the [Datastax Java](https://github.com/datastax/java-driver) driver and the [Phantom](http://websudos.github.io/phantom/) library. This is an incomplete comparison, additions and corrections are welcome.
 
+All examples have been properly tested, and they should work out of the box.
+
+## Prerequisites ##
+
+The keyspace and column family needed for all examples are defined in this CQL script:
+
+```
+CREATE KEYSPACE IF NOT EXISTS db
+WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
+
+CREATE TABLE IF NOT EXISTS db.weather_station (
+  country TEXT,
+  city TEXT,
+  station_id TEXT,
+  entry INT,
+  value INT,
+  PRIMARY KEY (country, city, station_id)
+);
+```
+
+In order to make all Quill examples to work you will need to create this config file, named `application.conf` in your resources folder:
+
+```
+db.keyspace=db
+db.preparedStatementCacheSize=100
+db.session.contactPoint=127.0.0.1
+db.session.queryOptions.consistencyLevel=ONE
+```
+
 ## Abstraction level ##
 
 The Datastax Java driver provides simple abstractions that let you either write you queries as plain strings or to use a declarative Query Builder. It also provides a higher level [Object Mapper](https://github.com/datastax/java-driver/tree/2.1/manual/object_mapper). For this comparison we will only use the Query Builder.
@@ -9,28 +38,17 @@ Although both Quill and Phantom represent column family rows as flat immutable s
 
 Phantom provides an embedded DSL that help you write CQL queries in a type-safe manner. Quill is referred as a Language Integrated Query library to match the available publications on the subject. The paper ["Language-integrated query using comprehension syntax: state of the art, open problems, and work in progress"](http://research.microsoft.com/en-us/events/dcp2014/cheney.pdf) has an overview with some of the available implementations of language integrated queries.
 
-## A simple query ##
+## Simple query ##
 
-This example would allow us to compare how the different libraries let us query a column family to obtain one element. The keyspace and column family needed for this and other examples are defined in this CQL script:
+This example would allow us to compare how the different libraries let us query a column family to obtain one element.
 
-```
-CREATE KEYSPACE IF NOT EXISTS db
-WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
-
-CREATE TABLE IF NOT EXISTS db.people (
-  name TEXT,
-  age INT,
-  PRIMARY KEY (name)
-);
-```
-
-All examples have been properly tested, and they should work out of the box.
-
-**Java Driver**
+**Java Driver (v3.0.0)**
 ```scala
 import com.datastax.driver.core._
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.google.common.cache.{ CacheBuilder, CacheLoader, LoadingCache }
+
+import scala.collection.JavaConverters._
 
 object JavaDriver extends App {
 
@@ -49,26 +67,29 @@ object JavaDriver extends App {
         }
       )
 
-  case class People(name: String, age: Int)
+  case class WeatherStation(country: String, city: String, stationId: String, entry: Int, value: Int)
 
-  object People {
+  object WeatherStation {
 
-    def getByName(cache: LoadingCache[String, PreparedStatement], session: Session)(name: String): Option[People] = {
+    def getAllByCountry(cache: LoadingCache[String, PreparedStatement], session: Session)(country: String): List[WeatherStation] = {
       val query: Statement =
         QueryBuilder.select().
           all().
-          from("db", "people").
-          where(QueryBuilder.eq("name", QueryBuilder.bindMarker()))
+          from("db", "weather_station").
+          where(QueryBuilder.eq("country", QueryBuilder.bindMarker()))
 
-      Option(session.execute(cache.get(query.toString).bind(name)).one()).map(
-        row => Person(row.getString("name"), row.getInt("age"))
-      )
+      session.execute(cache.get(query.toString).bind(country)).
+        all().asScala.
+        map(
+          row => WeatherStation(row.getString("country"), row.getString("city"), row.getString("station_id"), row.getInt("entry"), row.getInt("value"))
+        ).
+          to[List]
     }
   }
 
-  val getPersonByName: String => Option[People] = Person.getByName(cache, session)_
+  val getAllByCountry: String => List[WeatherStation] = WeatherStation.getAllByCountry(cache, session)_
 
-  getPersonByName("Jane Doe")
+  getAllByCountry("UK")
 
   session.close()
   cluster.close()
@@ -77,16 +98,54 @@ object JavaDriver extends App {
 
 The Java driver requires explicit handling of a `PreparedStatement`s cache to avoid preparing the same statement more that once, that could affect performance.
 
-In order to make the Quill example to work you will need to create this config file, named `application.conf` in your resources folder:
+**Phantom (v1.22.0)**
+```scala
+import com.websudos.phantom.connectors.RootConnector
+import com.websudos.phantom.db._
+import com.websudos.phantom.dsl._
 
-```
-db.keyspace=db
-db.preparedStatementCacheSize=100
-db.session.contactPoint=127.0.0.1
-db.session.queryOptions.consistencyLevel=ONE
+import scala.concurrent.Future
+
+object Phantom extends App {
+
+  case class WeatherStation(country: String, city: String, stationId: String, entry: Int, value: Int)
+
+  abstract class WeatherStationCF(override val tableName: String) extends CassandraTable[WeatherStationCF, WeatherStation] with RootConnector {
+
+    object country extends StringColumn(this) with PartitionKey[String]
+    object city extends StringColumn(this) with PrimaryKey[String]
+    object stationId extends StringColumn(this) with PrimaryKey[String] {
+      override lazy val name: String = "station_id"
+    }
+    object entry extends IntColumn(this) with PrimaryKey[Int]
+    object value extends IntColumn(this)
+
+    override def fromRow(r: Row): WeatherStation =
+      WeatherStation(country(r), city(r), stationId(r), entry(r), value(r))
+  }
+
+  abstract class WeatherStationQueries extends WeatherStationCF("weather_station") {
+
+    def getAllByCountry(country: String): Future[List[WeatherStation]] =
+      select.where(_.country eqs country).fetch()
+  }
+
+  class DB(ks: KeySpaceDef) extends DatabaseImpl(ks) {
+
+    object stations extends WeatherStationQueries with connector.Connector
+  }
+
+  val db = new DB(ContactPoint.local.keySpace("db"))
+
+  val result = db.stations.getAllByCountry("UK")
+
+  result.onComplete { case _ => db.shutdown() }
+}
 ```
 
-**Quill**
+Phantom requires explicit definition of the database model. The query definition also requires special equality operators.
+
+**Quill (v0.3.2-SNAPSHOT)**
 ```scala
 import io.getquill._
 import io.getquill.naming._
@@ -97,61 +156,136 @@ object Quill extends App {
 
   val db = source(new CassandraAsyncSourceConfig[SnakeCase]("DB") with NoQueryProbing)
 
-  case class People(name: String, age: Int)
+  case class WeatherStation(country: String, city: String, stationId: String, entry: Int, value: Int)
 
-  object People {
-  
-    val getByName = quote {
-      (name: String) =>
-        query[People].filter(_.name == name)
+  object WeatherStation {
+
+    val getAllByCountry = quote {
+      (country: String) =>
+        query[WeatherStation].filter(_.country == country)
     }
   }
 
-  val result = db.run(People.getByName)("Jane Doe").map(_.headOption)
+  val result = db.run(WeatherStation.getAllByCountry)("UK").map(_.headOption)
 
   result.onComplete(_ => db.close())
 }
 ```
 
-During the compilation of this example, as the quotation is known statically, Quill will emit the CQL string as an info message, e.g. `SELECT name, age FROM person WHERE name = ?`.
+During the compilation of this example, as the quotation is known statically, Quill will emit the CQL string as an info message, e.g. `SELECT country, city, station_id, entry, value FROM weather_station WHERE country = ?`.
 
-**Phantom**
+## Composable queries ##
+
+This example would allow us to compare how the different libraries let us compose querie, if possible.
+
+**Java Driver (v3.0.0)** 
+
+The Query Builder allows you to partially construct queries and add filters later:
+
 ```scala
-import com.websudos.phantom.connectors.{ Connector, RootConnector }
+    val selectAllFromPeople: Select =
+      QueryBuilder.select().
+      all().
+      from("db", "people")
+```
+
+But that's a very limited composition capability.
+
+**Phantom (v1.22.0)**
+```scala
+import com.websudos.phantom.connectors.RootConnector
 import com.websudos.phantom.db._
 import com.websudos.phantom.dsl._
 
-import scala.concurrent._
+import scala.concurrent.Future
 
 object Phantom extends App {
 
-  case class People(name: String, age: Int)
+  case class WeatherStation(country: String, city: String, stationId: String, entry: Int, value: Int)
 
-  abstract class PeopleCF(override val tableName: String) extends CassandraTable[PeopleCF, People] with RootConnector {
-  
-    object name extends StringColumn(this) with PartitionKey[String]
-    object age extends IntColumn(this)
+  abstract class WeatherStationCF(override val tableName: String) extends CassandraTable[WeatherStationCF, WeatherStation] with RootConnector {
 
-    override def fromRow(r: Row): People = People(name(r), age(r))
+    object country extends StringColumn(this) with PartitionKey[String]
+    object city extends StringColumn(this) with PrimaryKey[String]
+    object stationId extends StringColumn(this) with PrimaryKey[String]
+    object entry extends IntColumn(this) with PrimaryKey[Int]
+    object value extends IntColumn(this)
+
+    override def fromRow(r: Row): WeatherStation =
+      WeatherStation(country(r), city(r), stationId(r), entry(r), value(r))
   }
 
-  abstract class PeopleQueries extends PeopleCF("people") {
-  
-    def getByName(name: String): Future[Option[People]] =
-      select.where(_.name eqs name).one()
+  abstract class WeatherStationQueries extends WeatherStationCF("weather_station") {
+
+    def getAllByCountry(country: String): Future[List[WeatherStation]] =
+      findAllByCountry(country).fetch()
+
+    def getAllByCountryAndCity(country: String, city: String): Future[List[WeatherStation]] =
+      findAllByCountryAndCity(country, city).fetch()
+
+    def getAllByCountryCityAndId(country: String, city: String, stationId: String): Future[List[WeatherStation]] =
+      findAllByCountryCityAndId(country, city, stationId).fetch()
+
+    private def findAllByCountry(country: String) =
+      select.where(_.country eqs country)
+
+    private def findAllByCountryAndCity(country: String, city: String) =
+      findAllByCountry(country).and(_.city eqs city)
+
+    private def findAllByCountryCityAndId(country: String, city: String, stationId: String) =
+      findAllByCountryAndCity(country, city).and(_.stationId eqs stationId)
   }
 
   class DB(ks: KeySpaceDef) extends DatabaseImpl(ks) {
-  
-    object people extends PeopleQueries with connector.Connector
+
+    object stations extends WeatherStationQueries with connector.Connector
   }
 
   val db = new DB(ContactPoint.local.keySpace("db"))
 
-  val result = db.people.getByName("Jane Doe")
+  val result = db.stations.getAllByCountryCityAndId("UK", "London", "SW27")
 
   result.onComplete { case _ => db.shutdown() }
 }
 ```
 
-Phantom requires explicit definition of the database model. The query definition also requires special equality operators.
+Phantom allows you certain level of composability, but it gets a bit verbose due to the nature of the DSL. 
+
+**Quill (v0.3.2-SNAPSHOT)**
+```scala
+import io.getquill._
+import io.getquill.naming._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object Quill extends App {
+
+  val db = source(new CassandraAsyncSourceConfig[SnakeCase]("DB") with NoQueryProbing)
+
+  case class WeatherStation(country: String, city: String, stationId: String, entry: Int, value: Int)
+
+  object WeatherStation {
+
+    val getAllByCountry = quote {
+      (country: String) =>
+        query[WeatherStation].filter(_.country == country)
+    }
+
+    val getAllByCountryAndCity = quote {
+      (country: String, city: String) =>
+        getAllByCountry(country).filter(_.city == city)
+    }
+
+    val getAllByCountryCityAndId = quote {
+      (country: String, city: String, stationId: String) =>
+        getAllByCountryAndCity(country, city).filter(_.stationId == stationId)
+    }
+  }
+
+  val result = db.run(WeatherStation.getAllByCountryCityAndId)("UK", "London", "SW27")
+
+  result.onComplete(_ => db.close())
+}
+```
+
+Quill offers more advanced composability, but CQL being a much simpler query language than SQL can't benefit much from it. During the compilation of this example, as the quotation is known statically, Quill will emit the CQL string as an info message, e.g. `SELECT country, city, station_id, entry, value FROM weather_station WHERE country = ? AND city = ? AND station_id = ?`.

--- a/CASSANDRA.md
+++ b/CASSANDRA.md
@@ -3,6 +3,17 @@ This document compares Quill to the [Datastax Java](https://github.com/datastax/
 
 All examples have been properly tested, and they should work out of the box.
 
+## Index ##
+
+* [Prerequisites](#prerequisites)
+* [Abstraction level](#abstraction-level)
+* [Simple queries](#simple-queries)
+* [Composable queries](#composable-queries)
+* [Extensibility](#extensibility)
+* [Custom data types](#custom-data-types)
+* [Non-blocking IO](#non-blocking-io)
+* [Other considerations](#other-considerations)
+
 ## Prerequisites ##
 
 The keyspace and column family needed for all examples are defined in this CQL script:
@@ -38,7 +49,7 @@ Although both Quill and Phantom represent column family rows as flat immutable s
 
 Phantom provides an embedded DSL that help you write CQL queries in a type-safe manner. Quill is referred as a Language Integrated Query library to match the available publications on the subject. The paper ["Language-integrated query using comprehension syntax: state of the art, open problems, and work in progress"](http://research.microsoft.com/en-us/events/dcp2014/cheney.pdf) has an overview with some of the available implementations of language integrated queries.
 
-## Simple query ##
+## Simple queries ##
 
 This section would allow us to compare how the different libraries let us query a column family to obtain one element.
 

--- a/README.md
+++ b/README.md
@@ -1097,6 +1097,10 @@ db.session.addressTranslater=com.datastax.driver.core.policies.IdentityTranslate
 
 Please refer to [SLICK.md](https://github.com/getquill/quill/blob/master/SLICK.md) for a detailed comparison between Quill and Slick.
 
+# Cassandra libraries comparison #
+
+Please refer to [CASSANDRA.md](https://github.com/getquill/quill/blob/master/CASSANDRA.md) for a detailed comparison between Quill and other main alternatives for interaction with Cassandra in Scala.
+
 # Acknowledgments #
 
 The project was created having Philip Wadler's talk ["A practical theory of language-integrated query"](http://www.infoq.com/presentations/theory-language-integrated-query) as its initial inspiration. The development was heavily influenced by the following papers:


### PR DESCRIPTION
Address #162.

This adds a draft of the comparison Quill and other alternatives for CQL. So far I have only found another one, [Phantom](http://websudos.github.io/phantom/). I was going to include [Astyanax](https://github.com/Netflix/astyanax), but given this [announcement](http://techblog.netflix.com/2016/02/astyanax-retiring-old-friend.html) it really doesn't makes sense.

Should I include the Datastax Java driver in the comparison?