### PR TITLE
Upgrade Cassandra driver to version 3.0.0 and fix test issues.

### DIFF
--- a/Dockerfile-setup
+++ b/Dockerfile-setup
@@ -5,7 +5,7 @@ RUN apt-get update; \
   apt-get install -y python curl postgresql-client mysql-client > /dev/null
 
 RUN  cd /opt ; \
-     curl http://archive.apache.org/dist/cassandra/2.1.12/apache-cassandra-2.1.12-bin.tar.gz | tar zx
+     curl http://archive.apache.org/dist/cassandra/3.3/apache-cassandra-3.3-bin.tar.gz | tar zx
 
-ENV PATH /opt/apache-cassandra-2.1.12/bin:$PATH
+ENV PATH /opt/apache-cassandra-3.3/bin:$PATH
 

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val `quill-cassandra` =
     .settings(commonSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "com.datastax.cassandra" % "cassandra-driver-core" % "2.1.9",
+        "com.datastax.cassandra" % "cassandra-driver-core" % "3.0.0",
         "org.monifu" %% "monifu" % "1.0"
       ),
       parallelExecution in Test := false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ mysql:
     - MYSQL_ALLOW_EMPTY_PASSWORD=yes
 
 cassandra:
-  image: cassandra:2.1
+  image: cassandra:3.2
   ports:
     - "19042:9042"
     - "19160:9160"

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/encoding/Decoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/encoding/Decoders.scala
@@ -52,5 +52,5 @@ trait Decoders {
         row.getUUID(index)
       }
     }
-  implicit val dateDecoder = decoder(_.getDate)
+  implicit val dateDecoder = decoder(_.getTimestamp)
 }

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/encoding/Encoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/encoding/Encoders.scala
@@ -55,5 +55,5 @@ trait Encoders {
       bs.setBytes(idx, ByteBuffer.wrap(v))
     }
   implicit val uuidEncoder: Encoder[UUID] = encoder(_.setUUID)
-  implicit val dateEncoder = encoder(_.setDate)
+  implicit val dateEncoder = encoder(_.setTimestamp)
 }

--- a/quill-cassandra/src/test/resources/application.conf
+++ b/quill-cassandra/src/test/resources/application.conf
@@ -8,7 +8,7 @@ testSyncDB.session.withoutJMXReporting=false
 testSyncDB.session.credentials.0=root
 testSyncDB.session.credentials.1=pass
 testSyncDB.session.maxSchemaAgreementWaitSeconds=1
-testSyncDB.session.addressTranslater=com.datastax.driver.core.policies.IdentityTranslater
+testSyncDB.session.addressTranslator=com.datastax.driver.core.policies.IdentityTranslator
 
 testAsyncDB.keyspace=quill_test
 testAsyncDB.preparedStatementCacheSize=1000

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/package.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/package.scala
@@ -11,11 +11,11 @@ package object cassandra {
 
   val mirrorSource = source(new CassandraMirrorSourceConfig("test"))
 
-  val testSyncDB = source(new CassandraSyncSourceConfig[Literal]("testSyncDB"))
+  val testSyncDB = source(new CassandraSyncSourceConfig[Literal]("testSyncDB") with NoQueryProbing)
 
-  val testAsyncDB = source(new CassandraAsyncSourceConfig[Literal]("testAsyncDB"))
+  val testAsyncDB = source(new CassandraAsyncSourceConfig[Literal]("testAsyncDB") with NoQueryProbing)
 
-  val testStreamDB = source(new CassandraStreamSourceConfig[Literal]("testStreamDB"))
+  val testStreamDB = source(new CassandraStreamSourceConfig[Literal]("testStreamDB") with NoQueryProbing)
 
   def await[T](f: Future[T]): T = Await.result(f, Duration.Inf)
 }


### PR DESCRIPTION
Closes #167.

Compile-time query probing has been disabled as some [changes](https://github.com/datastax/java-driver/blob/3.0.0/driver-core/src/main/java/com/datastax/driver/core/TypeTokens.java) introduced in the new driver were making it to fail. This changes has been tested against Cassandra 3.2 and Cassandra 2.1.