### PR TITLE
report column index instead of value class(prevent possible npe)

### DIFF
--- a/quill-async/src/main/scala/io/getquill/sources/async/Decoders.scala
+++ b/quill-async/src/main/scala/io/getquill/sources/async/Decoders.scala
@@ -24,7 +24,7 @@ trait Decoders {
           case value: T                        => value
           case value if (f.isDefinedAt(value)) => f(value)
           case value =>
-            fail(s"Value '$value' of ${value.getClass.getName} can't be decoded to '${classTag[T].runtimeClass}'")
+            fail(s"Value '$value' at index $index can't be decoded to '${classTag[T].runtimeClass}'")
         }
       }
     }


### PR DESCRIPTION
Prevent `NullPointerException`  while `value` is `null`, show column index instead class of value