### PR TITLE
configure pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -2,7 +2,7 @@ approve_by_comment: true
 approve_regex: '^:\+1:'
 reject_regex: '^:\-1:'
 reset_on_push: true
-author_approval: ignored
+author_approval: default
 reviewers:
     -
         name: maintainers

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,18 @@
+approve_by_comment: true
+approve_regex: '^:\+1:'
+reject_regex: '^:\-1:'
+reset_on_push: true
+author_approval: ignored
+reviewers:
+    -
+        name: maintainers
+        required: 2
+        members:
+            - fwbrasil
+            - godenji
+            - gustavoamigo
+            - jilen
+            - lvicentesanchez
+        conditions:
+            branches:
+                - master


### PR DESCRIPTION
This change introduces http://pullapprove.com/ to the pull request checks. It'll require at least two :+1: from any maintainer to authorize a merge.

Thoughts?

@gustavoamigo @lvicentesanchez @jilen @godenji 