### PR TITLE
Distinct operation

### DIFF
--- a/quill-core/src/main/scala/io/getquill/Query.scala
+++ b/quill-core/src/main/scala/io/getquill/Query.scala
@@ -35,6 +35,8 @@ sealed trait Query[+T] {
   def nonEmpty: Boolean
   def isEmpty: Boolean
   def contains[B >: T](value: B): Boolean
+
+  def distinct: Query[T]
 }
 
 sealed trait JoinQuery[A, B, R] extends Query[R] {

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -54,6 +54,8 @@ case class UnionAll(a: Ast, b: Ast) extends Query
 
 case class Join(typ: JoinType, a: Ast, b: Ast, aliasA: Ident, aliasB: Ident, on: Ast) extends Query
 
+case class Distinct(a: Ast) extends Query
+
 //************************************************************
 
 case class Infix(parts: List[String], params: List[Ast]) extends Ast

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -69,6 +69,9 @@ object AstShow {
 
     case Join(t, a, b, iA, iB, on) =>
       s"${a.show}.${t.show}(${b.show}).on((${iA.show}, ${iB.show}) => ${on.show})"
+
+    case Distinct(a) =>
+      s"${a.show}.distinct"
   }
 
   implicit val orderingShow: Show[Ordering] = Show[Ordering] {

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -86,6 +86,9 @@ trait StatefulTransformer[T] {
         val (bt, btt) = att.apply(b)
         val (ont, ontt) = btt.apply(on)
         (Join(t, at, bt, iA, iB, ont), ontt)
+      case Distinct(a) =>
+        val (at, att) = apply(a)
+        (Distinct(at), att)
     }
 
   def apply(e: Operation): (Operation, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -34,6 +34,7 @@ trait StatelessTransformer {
       case UnionAll(a, b)     => UnionAll(apply(a), apply(b))
       case Join(t, a, b, iA, iB, on) =>
         Join(t, apply(a), apply(b), iA, iB, apply(on))
+      case Distinct(a) => Distinct(apply(a))
     }
 
   def apply(e: Operation): Operation =

--- a/quill-core/src/main/scala/io/getquill/norm/ApplyIntermediateMap.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/ApplyIntermediateMap.scala
@@ -4,6 +4,8 @@ import io.getquill.ast._
 
 object ApplyIntermediateMap {
 
+  private def isomorphic(e: Ast, c: Ast, alias: Ident) = BetaReduction(e, alias -> c) == c
+
   def unapply(q: Query): Option[Query] =
     q match {
 
@@ -12,6 +14,11 @@ object ApplyIntermediateMap {
       case Filter(Map(a: GroupBy, b, c), d, e)    => None
       case SortBy(Map(a: GroupBy, b, c), d, e, f) => None
       case Map(a: GroupBy, b, c) if (b == c)      => None
+
+      //  map(i => (i.i, i.l)).distinct.map(x => (x._1, x._2)) =>
+      //    map(i => (i.i, i.l)).distinct
+      case Map(Distinct(Map(a, b, c)), d, e) if isomorphic(e, c, d) =>
+        Some(Distinct(Map(a, b, c)))
 
       // a.map(b => b) =>
       //    a

--- a/quill-core/src/main/scala/io/getquill/norm/AttachToEntity.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/AttachToEntity.scala
@@ -21,6 +21,7 @@ object AttachToEntity {
       case Drop(a: Query, b)                => Drop(apply(f, alias)(a), b)
       case GroupBy(a: Query, b, c)          => GroupBy(apply(f, Some(b))(a), b, c)
       case Aggregation(op, a: Query)        => Aggregation(op, apply(f, alias)(a))
+      case Distinct(a: Query)               => Distinct(apply(f, alias)(a))
 
       case _: Union | _: UnionAll | _: Join => f(q, alias.getOrElse(Ident("x")))
 

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -40,7 +40,7 @@ case class BetaReduction(map: collection.Map[Ident, Ast])
         GroupBy(apply(a), b, BetaReduction(map - b)(c))
       case Join(t, a, b, iA, iB, on) =>
         Join(t, apply(a), apply(b), iA, iB, BetaReduction(map - iA - iB)(on))
-      case _: Take | _: Entity | _: Drop | _: Union | _: UnionAll | _: Aggregation =>
+      case _: Take | _: Entity | _: Drop | _: Union | _: UnionAll | _: Aggregation | _: Distinct =>
         super.apply(query)
     }
 }

--- a/quill-core/src/main/scala/io/getquill/norm/NormalizeNestedStructures.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/NormalizeNestedStructures.scala
@@ -17,6 +17,7 @@ object NormalizeNestedStructures {
       case Drop(a, b)         => apply(a, b)(Drop)
       case Union(a, b)        => apply(a, b)(Union)
       case UnionAll(a, b)     => apply(a, b)(UnionAll)
+      case Distinct(a)        => apply(a)(Distinct)
       case Join(t, a, b, iA, iB, on) =>
         (Normalize(a), Normalize(b), Normalize(on)) match {
           case (`a`, `b`, `on`) => None

--- a/quill-core/src/main/scala/io/getquill/norm/capture/Dealias.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/Dealias.scala
@@ -41,6 +41,8 @@ case class Dealias(state: Option[Ident]) extends StatefulTransformer[Option[Iden
         val ((an, iAn, on), ont) = dealias(a, iA, o)((_, _, _))
         val ((bn, iBn, onn), onnt) = ont.dealias(b, iB, on)((_, _, _))
         (Join(t, an, bn, iAn, iBn, onn), Dealias(None))
+      case q: Distinct =>
+        (q, Dealias(None))
       case _: Entity =>
         (q, Dealias(None))
     }

--- a/quill-core/src/main/scala/io/getquill/norm/select/ExtractSelect.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/select/ExtractSelect.scala
@@ -18,6 +18,8 @@ private[select] object ExtractSelect {
         FlatMap(q, x, ensureFinalMap(p))
       case Aggregation(op, q: Query) =>
         Aggregation(op, q)
+      case Distinct(q: Query) =>
+        Distinct(q)
       case q =>
         val x = Ident("x")
         Map(q, x, x)
@@ -26,6 +28,8 @@ private[select] object ExtractSelect {
   private def extractSelect(query: Query): Ast =
     (query: @unchecked) match {
       case Aggregation(op, q: Query) =>
+        Ident("x")
+      case Distinct(q: Query) =>
         Ident("x")
       case Map(q, x, p) =>
         p

--- a/quill-core/src/main/scala/io/getquill/norm/select/ReplaceSelect.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/select/ReplaceSelect.scala
@@ -14,6 +14,7 @@ private[select] object ReplaceSelect {
   private def apply(query: Query, ast: Ast): Query =
     query match {
       case Aggregation(op, q: Query) => Aggregation(op, q)
+      case Distinct(q: Query)        => Distinct(q)
       case FlatMap(q, x, p: Query)   => FlatMap(q, x, apply(p, ast))
       case Map(q, x, p)              => Map(q, x, ast)
       case other                     => fail(s"Query doesn't have a final map (select). Ast: $query")

--- a/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
@@ -32,7 +32,7 @@ case class FreeVariables(state: State)
         val (_, freeB) = apply(a)
         val (_, freeOn) = FreeVariables(State(state.seen + iA + iB, collection.Set.empty))(on)
         (q, FreeVariables(State(state.seen, state.free ++ freeA.state.free ++ freeB.state.free ++ freeOn.state.free)))
-      case _: Entity | _: Take | _: Drop | _: Union | _: UnionAll | _: Aggregation =>
+      case _: Entity | _: Take | _: Drop | _: Union | _: UnionAll | _: Aggregation | _: Distinct =>
         super.apply(query)
     }
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -81,6 +81,7 @@ trait Liftables {
     case Union(a, b)            => q"$pack.Union($a, $b)"
     case UnionAll(a, b)         => q"$pack.UnionAll($a, $b)"
     case Join(a, b, c, d, e, f) => q"$pack.Join($a, $b, $c, $d, $e, $f)"
+    case Distinct(a)            => q"$pack.Distinct($a)"
   }
 
   implicit val propertyAliasLiftable: Liftable[PropertyAlias] = Liftable[PropertyAlias] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -167,6 +167,10 @@ trait Parsing {
 
     case q"${ joinCallParser(typ, a, b) }" =>
       c.fail("a join clause must be followed by 'on'.")
+
+    case q"$source.distinct" if (is[QuillQuery[Any]](source)) =>
+      Distinct(astParser(source))
+
   }
 
   implicit val orderingParser: Parser[Ordering] = Parser[Ordering] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -86,6 +86,8 @@ trait Unliftables {
     case q"$pack.UnionAll.apply(${ a: Ast }, ${ b: Ast })" => UnionAll(a, b)
     case q"$pack.Join.apply(${ t: JoinType }, ${ a: Ast }, ${ b: Ast }, ${ iA: Ident }, ${ iB: Ident }, ${ on: Ast })" =>
       Join(t, a, b, iA, iB, on)
+
+    case q"$pack.Distinct.apply(${ a: Ast })" => Distinct(a)
   }
 
   implicit val orderingUnliftable: Unliftable[Ordering] = Unliftable[Ordering] {

--- a/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
@@ -497,4 +497,12 @@ class AstShowSpec extends Spec {
     (q.ast.body: Ast).show mustEqual
       """if(i > 10) "a" else "b""""
   }
+
+  "shows distinct" in {
+    val q = quote {
+      query[TestEntity].distinct
+    }
+    (q.ast: Ast).show mustEqual
+      """query[TestEntity].distinct"""
+  }
 }

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -111,6 +111,14 @@ class StatefulTransformerSpec extends Spec {
             att.state mustEqual List(Ident("a"), Ident("b"), Ident("e"))
         }
       }
+      "distinct" in {
+        val ast: Ast = Distinct(Ident("a"))
+        Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {
+          case (at, att) =>
+            at mustEqual Distinct(Ident("a'"))
+            att.state mustEqual List(Ident("a"))
+        }
+      }
     }
 
     "operation" - {

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -72,6 +72,11 @@ class StatelessTransformerSpec extends Spec {
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("e") -> Ident("e'"))(ast) mustEqual
           Join(FullJoin, Ident("a'"), Ident("b'"), Ident("c"), Ident("d"), Ident("e'"))
       }
+
+      "distinct" in {
+        val ast: Ast = Distinct(Ident("a"))
+        Subject(Ident("a") -> Ident("a'"))(ast) mustEqual Distinct(Ident("a'"))
+      }
     }
 
     "operation" - {

--- a/quill-core/src/test/scala/io/getquill/norm/ApplyIntermediateMapSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ApplyIntermediateMapSpec.scala
@@ -83,5 +83,14 @@ class ApplyIntermediateMapSpec extends Spec {
       }
       ApplyIntermediateMap.unapply(q.ast) mustEqual Some(n.ast)
     }
+    "distinct" in {
+      val q = quote {
+        query[TestEntity].map(i => (i.i, i.l)).distinct.map(x => (x._1, x._2))
+      }
+      val n = quote {
+        query[TestEntity].map(i => (i.i, i.l)).distinct
+      }
+      ApplyIntermediateMap.unapply(q.ast) mustEqual Some(n.ast)
+    }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/norm/AttachToEntitySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/AttachToEntitySpec.scala
@@ -78,6 +78,15 @@ class AttachToEntitySpec extends Spec {
         }
         attachToEntity(q.ast) mustEqual n.ast
       }
+      "distinct" in {
+        val q = quote {
+          qr1.sortBy(b => b.s).drop(1).distinct
+        }
+        val n = quote {
+          qr1.sortBy(b => 1).sortBy(b => b.s).drop(1).distinct
+        }
+        attachToEntity(q.ast) mustEqual n.ast
+      }
     }
   }
 

--- a/quill-core/src/test/scala/io/getquill/norm/NormalizeNestedStructuresSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/NormalizeNestedStructuresSpec.scala
@@ -124,6 +124,15 @@ class NormalizeNestedStructuresSpec extends Spec {
         NormalizeNestedStructures.unapply(q.ast) mustEqual Some(n.ast)
       }
     }
+    "distinct" - {
+      val q = quote {
+        qr1.filter(t => t.s == ("a", "b")._1).distinct
+      }
+      val n = quote {
+        qr1.filter(t => t.s == "a").distinct
+      }
+      NormalizeNestedStructures.unapply(q.ast) mustEqual Some(n.ast)
+    }
   }
 
   "returns None if none of the nested structures changes" - {

--- a/quill-core/src/test/scala/io/getquill/norm/capture/DealiasSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/capture/DealiasSpec.scala
@@ -148,5 +148,11 @@ class DealiasSpec extends Spec {
     "entity" in {
       Dealias(qr1.ast) mustEqual qr1.ast
     }
+    "distinct" in {
+      val q = quote {
+        qr1.map(a => a.i).distinct
+      }
+      Dealias(q.ast) mustEqual q.ast
+    }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/norm/select/ExtractSelectSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/select/ExtractSelectSpec.scala
@@ -58,6 +58,16 @@ class ExtractSelectSpec extends Spec {
           select mustEqual Property(Ident("t"), "s")
       }
     }
+    "distinct" in {
+      val q = quote {
+        qr1.distinct
+      }
+      ExtractSelect(q.ast) match {
+        case (query, select) =>
+          query mustEqual q.ast
+          select mustEqual Ident("x")
+      }
+    }
   }
 
   "creates a final map (select) if necessary" - {

--- a/quill-core/src/test/scala/io/getquill/norm/select/ReplaceSelectSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/select/ReplaceSelectSpec.scala
@@ -41,6 +41,14 @@ class ReplaceSelectSpec extends Spec {
       }
       ReplaceSelect(q.ast, List(Ident("t"))) mustEqual q.ast
     }
+
+    "distinct query" in {
+      val q = quote {
+        qr1.map(t => t.l).distinct
+      }
+      ReplaceSelect(q.ast, List(Property(Ident("t"), "l"))) mustEqual
+        q.ast
+    }
   }
 
   "fails if the query doesn't have a final map (select)" - {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -162,6 +162,12 @@ class QuotationSpec extends Spec {
           quote(unquote(q)).ast mustEqual Aggregation(AggregationOperator.`max`, Map(Entity("TestEntity"), Ident("t"), Property(Ident("t"), "s")))
         }
       }
+      "distinct" in {
+        val q = quote {
+          qr1.distinct
+        }
+        quote(unquote(q)).ast mustEqual Distinct(Entity("TestEntity"))
+      }
 
       "take" in {
         val q = quote {
@@ -224,6 +230,8 @@ class QuotationSpec extends Spec {
           }
           quote(unquote(q)).ast mustEqual tree(FullJoin)
         }
+
+
         "fails if not followed by 'on'" in {
           """
           quote {

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/SqlQuery.scala
@@ -35,13 +35,14 @@ case class UnaryOperationSqlQuery(
 case class SelectValue(ast: Ast, alias: Option[String] = None)
 
 case class FlattenSqlQuery(
-  from:    List[Source],
-  where:   Option[Ast]           = None,
-  groupBy: List[Property]        = Nil,
-  orderBy: List[OrderByCriteria] = Nil,
-  limit:   Option[Ast]           = None,
-  offset:  Option[Ast]           = None,
-  select:  List[SelectValue]
+  from:     List[Source],
+  where:    Option[Ast]           = None,
+  groupBy:  List[Property]        = Nil,
+  orderBy:  List[OrderByCriteria] = Nil,
+  limit:    Option[Ast]           = None,
+  offset:   Option[Ast]           = None,
+  select:   List[SelectValue],
+  distinct: Boolean               = false
 )
   extends SqlQuery
 
@@ -102,7 +103,7 @@ object SqlQuery {
         val agg = b.select.collect {
           case s @ SelectValue(_: Aggregation, _) => s
         }
-        if (agg.isEmpty)
+        if (!b.distinct && agg.isEmpty)
           b.copy(select = selectValues(p))
         else
           FlattenSqlQuery(
@@ -166,6 +167,10 @@ object SqlQuery {
             offset = Some(n),
             select = select(alias)
           )
+
+      case Distinct(q: Query) =>
+        val b = base(q, alias)
+        b.copy(distinct = true)
 
       case other =>
         FlattenSqlQuery(from = sources :+ source(other, alias), select = select(alias))

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
@@ -47,11 +47,14 @@ trait SqlIdiom {
   }
 
   implicit def sqlQueryShow(implicit strategy: NamingStrategy): Show[SqlQuery] = Show[SqlQuery] {
-    case FlattenSqlQuery(from, where, groupBy, orderBy, limit, offset, select) =>
+    case FlattenSqlQuery(from, where, groupBy, orderBy, limit, offset, select, distinct) =>
+
+      val distinctShow = if (distinct) " DISTINCT" else ""
+
       val selectClause =
         select match {
-          case Nil => s"SELECT * FROM ${from.show}"
-          case _   => s"SELECT ${select.show} FROM ${from.show}"
+          case Nil => s"SELECT$distinctShow * FROM ${from.show}"
+          case _   => s"SELECT$distinctShow ${select.show} FROM ${from.show}"
         }
 
       val withWhere =

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/norm/ExpandNestedQueries.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/norm/ExpandNestedQueries.scala
@@ -17,7 +17,7 @@ object ExpandNestedQueries {
 
   private def expandNested(q: FlattenSqlQuery): SqlQuery =
     q match {
-      case FlattenSqlQuery(from, where, groupBy, orderBy, limit, offset, select) =>
+      case FlattenSqlQuery(from, where, groupBy, orderBy, limit, offset, select, distinct) =>
         val asts = Nil ++ where ++ groupBy ++ orderBy.map(_.ast) ++ limit ++ offset ++ select.map(_.ast)
         val from = q.from.map(expandSource(_, asts))
         q.copy(from = from)

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/SqlQuerySpec.scala
@@ -211,6 +211,13 @@ class SqlQuerySpec extends Spec {
       SqlQuery(q.ast).show mustEqual
         "SELECT MAX(t.i) FROM TestEntity t"
     }
+    "distinct query" in {
+      val q = quote {
+        qr1.map(t => t.i).distinct
+      }
+      SqlQuery(q.ast).show mustEqual
+        "SELECT DISTINCT t.i FROM TestEntity t"
+    }
     "limited query" - {
       "simple" in {
         val q = quote {

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomSpec.scala
@@ -3,6 +3,8 @@ package io.getquill.sources.sql.idiom
 import io.getquill._
 import io.getquill.Spec
 import io.getquill.naming.{ SnakeCase, UpperCase, Escape, Literal }
+import io.getquill.norm.select.ExtractSelect
+import io.getquill.quotation.FreeVariables
 import io.getquill.sources.sql.mirrorSource
 import io.getquill.ast.Ast
 
@@ -32,6 +34,39 @@ class SqlIdiomSpec extends Spec {
         }
         mirrorSource.run(q).sql mustEqual
           "SELECT a.s FROM TestEntity a, TestEntity2 b WHERE a.s = b.s"
+      }
+      "distinct" - {
+        "simple" in {
+          val q = quote {
+            qr1.distinct
+          }
+          mirrorSource.run(q).sql mustEqual
+            "SELECT DISTINCT x.* FROM TestEntity x"
+        }
+
+        "distinct single" in {
+          val q  = quote {
+            qr1.map(i => i.i).distinct
+          }
+          mirrorSource.run(q).sql mustEqual
+            "SELECT DISTINCT i.i FROM TestEntity i"
+        }
+
+        "distinct tuple" in {
+          val q = quote {
+            qr1.map(i => (i.i, i.l)).distinct
+          }
+          mirrorSource.run(q).sql mustEqual
+            "SELECT DISTINCT i.i, i.l FROM TestEntity i"
+        }
+
+        "distinct nesting" in {
+          val q = quote {
+            qr1.map(i => i.i).distinct.map(x => x + 1)
+          }
+          mirrorSource.run(q).sql mustEqual
+            "SELECT x + 1 FROM (SELECT DISTINCT i.i FROM TestEntity i) x"
+        }
       }
       "sorted" - {
         "simple" in {


### PR DESCRIPTION
Add support to `distinct` operation to SQL Queries. Fixes #87 

- [X] More tests
- [X] Add support to `query[Test].map(_.i).distinct.map(_ + 1)` 
- [x] `qr1.distinct` should not need nesting
- [x] remove anonymous identifier from tests

Cassandra CQL support will be added in a different PR https://github.com/getquill/quill/issues/190. 