### PR TITLE
[WIP] Proposal - Generated value

### DIFF
--- a/quill-core/src/main/scala/io/getquill/Query.scala
+++ b/quill-core/src/main/scala/io/getquill/Query.scala
@@ -52,6 +52,7 @@ sealed trait EntityQuery[T]
   override def filter(f: T => Boolean): EntityQuery[T]
   override def map[R](f: T => R): EntityQuery[R]
 
+  def generated(f: T => Any): EntityQuery[T]
   def insert: T => UnassignedAction[T] with Insert[T]
   def insert(f: (T => (Any, Any)), f2: (T => (Any, Any))*): Insert[T]
   def update: T => UnassignedAction[T] with Update[T]

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -1,6 +1,6 @@
 package io.getquill.ast
-
 import io.getquill.ast.AstShow.astShow
+
 import io.getquill.util.Show.Shower
 
 //************************************************************
@@ -17,9 +17,11 @@ sealed trait Ast {
 
 sealed trait Query extends Ast
 
-case class Entity(name: String, alias: Option[String] = None, properties: List[PropertyAlias] = List()) extends Query
+case class Entity(name: String, alias: Option[String] = None, properties: List[PropertyAlias] = List(), generated: Option[String] = None) extends Query
 
 case class PropertyAlias(property: String, alias: String)
+
+case class Generated(query: Ast, alias: Ident, body: Ast) extends Query
 
 case class Filter(query: Ast, alias: Ident, body: Ast) extends Query
 
@@ -28,16 +30,16 @@ case class Map(query: Ast, alias: Ident, body: Ast) extends Query
 case class FlatMap(query: Ast, alias: Ident, body: Ast) extends Query
 
 case class SortBy(query: Ast, alias: Ident, criterias: Ast, ordering: Ordering) extends Query
-
 sealed trait Ordering
-case class TupleOrdering(elems: List[Ordering]) extends Ordering
 
+case class TupleOrdering(elems: List[Ordering]) extends Ordering
 sealed trait PropertyOrdering extends Ordering
 case object Asc extends PropertyOrdering
 case object Desc extends PropertyOrdering
 case object AscNullsFirst extends PropertyOrdering
 case object DescNullsFirst extends PropertyOrdering
 case object AscNullsLast extends PropertyOrdering
+
 case object DescNullsLast extends PropertyOrdering
 
 case class GroupBy(query: Ast, alias: Ident, body: Ast) extends Query
@@ -54,9 +56,9 @@ case class UnionAll(a: Ast, b: Ast) extends Query
 
 case class Join(typ: JoinType, a: Ast, b: Ast, aliasA: Ident, aliasB: Ident, on: Ast) extends Query
 
-case class Distinct(a: Ast) extends Query
-
 //************************************************************
+
+case class Distinct(a: Ast) extends Query
 
 case class Infix(parts: List[String], params: List[Ast]) extends Ast
 
@@ -68,17 +70,17 @@ case class Property(ast: Ast, name: String) extends Ast
 
 case class OptionOperation(t: OptionOperationType, ast: Ast, alias: Ident, body: Ast) extends Ast
 
+//************************************************************
+
 case class If(condition: Ast, `then`: Ast, `else`: Ast) extends Ast
 
-//************************************************************
-
 sealed trait Operation extends Ast
-
 case class UnaryOperation(operator: UnaryOperator, ast: Ast) extends Operation
 case class BinaryOperation(a: Ast, operator: BinaryOperator, b: Ast) extends Operation
-case class FunctionApply(function: Ast, values: List[Ast]) extends Operation
 
 //************************************************************
+
+case class FunctionApply(function: Ast, values: List[Ast]) extends Operation
 
 sealed trait Value extends Ast
 
@@ -88,9 +90,9 @@ object NullValue extends Value
 
 case class Tuple(values: List[Ast]) extends Value
 
-case class Set(values: List[Ast]) extends Value
-
 //************************************************************
+
+case class Set(values: List[Ast]) extends Value
 
 sealed trait Action extends Ast
 

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -37,6 +37,8 @@ object AstShow {
         case params => s"query[${q.name}](${params.mkString(", ")})"
       }
 
+    case Generated(source, alias, body)      => s"${source.show}.generated(${alias.show} => ${body.show})"
+
     case Filter(source, alias, body) =>
       s"${source.show}.filter(${alias.show} => ${body.show})"
 
@@ -138,6 +140,7 @@ object AstShow {
     case Update(query)                       => s"${query.show}.update"
     case Insert(query)                       => s"${query.show}.insert"
     case Delete(query)                       => s"${query.show}.delete"
+
   }
 
   implicit val assignmentShow: Show[Assignment] = Show[Assignment] {

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -42,6 +42,10 @@ trait StatefulTransformer[T] {
   def apply(e: Query): (Query, StatefulTransformer[T]) =
     e match {
       case e: Entity => (e, this)
+      case Generated(a, b, c) =>
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
+        (Generated(at, b, ct), ctt)
       case Filter(a, b, c) =>
         val (at, att) = apply(a)
         val (ct, ctt) = att.apply(c)
@@ -133,6 +137,7 @@ trait StatefulTransformer[T] {
       case Delete(a) =>
         val (at, att) = apply(a)
         (Delete(at), att)
+
     }
 
   def apply(e: Assignment): (Assignment, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -22,6 +22,7 @@ trait StatelessTransformer {
   def apply(e: Query): Query =
     e match {
       case e: Entity          => e
+      case Generated(a, b, c) => Generated(apply(a), b, apply(c))
       case Filter(a, b, c)    => Filter(apply(a), b, apply(c))
       case Map(a, b, c)       => Map(apply(a), b, apply(c))
       case FlatMap(a, b, c)   => FlatMap(apply(a), b, apply(c))
@@ -58,6 +59,7 @@ trait StatelessTransformer {
       case Update(query)                       => Update(apply(query))
       case Insert(query)                       => Insert(apply(query))
       case Delete(query)                       => Delete(apply(query))
+
     }
 
   private def apply(e: Assignment): Assignment =

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -40,7 +40,7 @@ case class BetaReduction(map: collection.Map[Ident, Ast])
         GroupBy(apply(a), b, BetaReduction(map - b)(c))
       case Join(t, a, b, iA, iB, on) =>
         Join(t, apply(a), apply(b), iA, iB, BetaReduction(map - iA - iB)(on))
-      case _: Take | _: Entity | _: Drop | _: Union | _: UnionAll | _: Aggregation | _: Distinct =>
+      case _: Take | _: Entity | _: Drop | _: Union | _: UnionAll | _: Aggregation | _: Distinct | _: Generated =>
         super.apply(query)
     }
 }

--- a/quill-core/src/main/scala/io/getquill/norm/NormalizeNestedStructures.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/NormalizeNestedStructures.scala
@@ -7,6 +7,7 @@ object NormalizeNestedStructures {
   def unapply(q: Query): Option[Query] =
     q match {
       case e: Entity          => None
+      case Generated(a, b, c) => apply(a, c)(Generated(_, b, _))
       case Map(a, b, c)       => apply(a, c)(Map(_, b, _))
       case FlatMap(a, b, c)   => apply(a, c)(FlatMap(_, b, _))
       case Filter(a, b, c)    => apply(a, c)(Filter(_, b, _))

--- a/quill-core/src/main/scala/io/getquill/norm/capture/Dealias.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/Dealias.scala
@@ -43,7 +43,7 @@ case class Dealias(state: Option[Ident]) extends StatefulTransformer[Option[Iden
         (Join(t, an, bn, iAn, iBn, onn), Dealias(None))
       case q: Distinct =>
         (q, Dealias(None))
-      case _: Entity =>
+      case _: Entity | _: Generated =>
         (q, Dealias(None))
     }
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -69,7 +69,8 @@ trait Liftables {
   }
 
   implicit val queryLiftable: Liftable[Query] = Liftable[Query] {
-    case Entity(a, b, c)        => q"$pack.Entity($a, $b, $c)"
+    case Entity(a, b, c, d)     => q"$pack.Entity($a, $b, $c, $d)"
+    case Generated(a, b, c)     => q"$pack.Generated($a, $b, $c)"
     case Filter(a, b, c)        => q"$pack.Filter($a, $b, $c)"
     case Map(a, b, c)           => q"$pack.Map($a, $b, $c)"
     case FlatMap(a, b, c)       => q"$pack.FlatMap($a, $b, $c)"
@@ -110,6 +111,7 @@ trait Liftables {
     case Update(a)            => q"$pack.Update($a)"
     case Insert(a)            => q"$pack.Insert($a)"
     case Delete(a)            => q"$pack.Delete($a)"
+
   }
 
   implicit val assignmentLiftable: Liftable[Assignment] = Liftable[Assignment] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -119,6 +119,9 @@ trait Parsing {
     case q"$pack.query[${ t: Type }]" =>
       Entity(t.typeSymbol.name.decodedName.toString, None, List())
 
+    case q"$query.generated(($alias) => $body)" =>
+      Generated(astParser(query), identParser(alias), astParser(body))
+
     case q"$source.filter(($alias) => $body)" if (is[QuillQuery[Any]](source)) =>
       Filter(astParser(source), identParser(alias), astParser(body))
 
@@ -347,6 +350,7 @@ trait Parsing {
       Function(List(Ident("x1")), Insert(astParser(query)))
     case q"$query.delete" =>
       Delete(astParser(query))
+
   }
 
   private val assignmentParser: Parser[Assignment] = Parser[Assignment] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -74,7 +74,8 @@ trait Unliftables {
   }
 
   implicit val queryUnliftable: Unliftable[Query] = Unliftable[Query] {
-    case q"$pack.Entity.apply(${ a: String }, ${ b: Option[String] }, ${ c: List[PropertyAlias] })" => Entity(a, b, c)
+    case q"$pack.Entity.apply(${ a: String }, ${ b: Option[String] }, ${ c: List[PropertyAlias] }, ${ d: Option[String] })" => Entity(a, b, c, d)
+    case q"$pack.Generated.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Generated(a, b, c)
     case q"$pack.Filter.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Filter(a, b, c)
     case q"$pack.Map.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Map(a, b, c)
     case q"$pack.FlatMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => FlatMap(a, b, c)
@@ -121,6 +122,7 @@ trait Unliftables {
     case q"$pack.Update.apply(${ a: Ast })"                                   => Update(a)
     case q"$pack.Insert.apply(${ a: Ast })"                                   => Insert(a)
     case q"$pack.Delete.apply(${ a: Ast })"                                   => Delete(a)
+
   }
 
   implicit val assignmentUnliftable: Unliftable[Assignment] = Unliftable[Assignment] {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -231,7 +231,6 @@ class QuotationSpec extends Spec {
           quote(unquote(q)).ast mustEqual tree(FullJoin)
         }
 
-
         "fails if not followed by 'on'" in {
           """
           quote {

--- a/quill-core/src/test/scala/io/getquill/sources/ActionMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/ActionMacroSpec.scala
@@ -46,4 +46,11 @@ class ActionMacroSpec extends Spec {
       Row("s2", 12, 22L, Some(42))
     )
   }
+
+  "generated values" in {
+    val q = quote {
+      qr1.generated(x => x.i)
+    }
+    q.ast.toString mustEqual "query[TestEntity].generated(x => x.i)"
+  }
 }

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/BindVariables.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/BindVariables.scala
@@ -32,6 +32,14 @@ private[sources] case class BindVariables(state: (List[Ident], List[Ident]))
         val (at, att) = apply(assignments)(_.apply)
         val (wt, wtt) = att.apply(where)
         (AssignedAction(Update(Filter(table, x, wt)), at), wtt)
+
+      case AssignedAction(Insert(table: Entity), assignments) =>
+        val assignmentsWithoutGenerated =
+          table
+            .generated
+            .fold(assignments)(generated => assignments.filterNot(_.property == generated))
+        val (at, att) = apply(assignmentsWithoutGenerated)(_.apply)
+        (AssignedAction(Insert(table), at), att)
       case other =>
         super.apply(other)
     }

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/Prepare.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/Prepare.scala
@@ -9,9 +9,7 @@ import io.getquill.util.Messages._
 import io.getquill.norm.capture.AvoidAliasConflict
 import io.getquill.norm.capture.AvoidCapture
 import io.getquill.norm.FlattenOptionOperation
-import io.getquill.sources.sql.norm.ExpandJoin
-import io.getquill.sources.sql.norm.ExpandNestedQueries
-import io.getquill.sources.sql.norm.MergeSecondaryJoin
+import io.getquill.sources.sql.norm.{MergeGeneratedWithEntity, ExpandJoin, ExpandNestedQueries, MergeSecondaryJoin}
 
 object Prepare {
 
@@ -34,6 +32,7 @@ object Prepare {
     (identity[Ast] _)
       .andThen(Normalize.apply _)
       .andThen(ExpandJoin.apply _)
+      .andThen(MergeGeneratedWithEntity.apply _)
       .andThen(Normalize.apply _)
       .andThen(MergeSecondaryJoin.apply _)
       .andThen(FlattenOptionOperation.apply _)

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/norm/MergeGeneratedWithEntity.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/norm/MergeGeneratedWithEntity.scala
@@ -1,0 +1,36 @@
+package io.getquill.sources.sql.norm
+
+import io.getquill.ast._
+
+case class MergeGeneratedWithEntity(state: Option[String]) extends StatefulTransformer[Option[String]] {
+
+  override def apply(e: Query): (Query, StatefulTransformer[Option[String]]) =
+    e match {
+      case Generated(a: Entity, _, c) =>
+        val (at, att) = apply(a)
+        (at, MergeGeneratedWithEntity(singleProperty(c)))
+      case other => super.apply(other)
+    }
+
+  private def singleProperty(ast: Ast) = ast match {
+    case Property(Ident(a), b) => Some(b)
+    case _                     => None
+  }
+
+}
+
+case class SetGeneratedEntity(generated: Option[String]) extends StatelessTransformer {
+  override def apply(e: Query): Query =
+    e match {
+      case e: Entity => e.copy(generated = generated)
+      case other => super.apply(other)
+    }
+}
+
+object MergeGeneratedWithEntity {
+  def apply(q: Ast) =
+    new MergeGeneratedWithEntity(None)(q) match {
+      case (q, s) =>
+        SetGeneratedEntity(s.state)(q)
+    }
+}

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomSpec.scala
@@ -45,7 +45,7 @@ class SqlIdiomSpec extends Spec {
         }
 
         "distinct single" in {
-          val q  = quote {
+          val q = quote {
             qr1.map(i => i.i).distinct
           }
           mirrorSource.run(q).sql mustEqual
@@ -590,6 +590,14 @@ class SqlIdiomSpec extends Spec {
           }
           mirrorSource.run(q).sql mustEqual
             "INSERT INTO TestEntity (i,s) VALUES ((SELECT MAX(t.i) FROM TestEntity2 t), 's')"
+        }
+
+        "generated" in {
+          val q: Quoted[(TestEntity) => UnassignedAction[TestEntity] with Insert[TestEntity]] = quote {
+            qr1.generated(_.i).insert
+          }
+          val run = mirrorSource.run(q)(List(TestEntity("s",1, 2L, Some(1)))).sql mustEqual
+            "INSERT INTO TestEntity (s,l,o) VALUES (?, ?, ?)"
         }
       }
       "update" - {

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/norm/MergeGeneratedWithEntitySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/norm/MergeGeneratedWithEntitySpec.scala
@@ -1,0 +1,17 @@
+package io.getquill.sources.sql.norm
+
+import io.getquill._
+import io.getquill.Spec
+import io.getquill.ast.Entity
+
+class MergeGeneratedWithEntitySpec extends Spec {
+  "merge generated" in {
+    val q = quote {
+      qr1.generated(x => x.i)
+    }
+
+    val ast = MergeGeneratedWithEntity(q.ast)
+    ast mustEqual
+      Entity("TestEntity", generated = Some("i"))
+  }
+}


### PR DESCRIPTION
Proposal implementation to solve the problem of generated values in the database. 

Example:
```scala
val q = quote {
  qr1.generated(_.i).insert
}
val run = mirrorSource.run(q)(List(TestEntity("s",1, 2L, Some(1)))).sql mustEqual
  "INSERT INTO TestEntity (s,l,o) VALUES (?, ?, ?)"
```

The `generated` keyword would tell the insert action that one value should be ignored during insertion and should be returned as the result of the action. Also, I think it should return `List[Long]` or `List[Int]` according to the type of the generated value (I don't know yet how this would be done).

This is just a proposal, if we agree that this could be the way to go, we can discuss in details the code implementation.  
  