### PR TITLE
fix #209 - don't fail if the source annotation isn't available

### DIFF
--- a/quill-core/src/main/scala/io/getquill/sources/ResolveSourceMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/ResolveSourceMacro.scala
@@ -56,7 +56,6 @@ trait ResolveSourceMacro {
             None
         }
       case o =>
-        c.error("Can't load source at compile time. Query probing disabled.")
         None
     }
 

--- a/quill-core/src/test/scala/io/getquill/sources/ResolveSourceMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/ResolveSourceMacroSpec.scala
@@ -1,6 +1,7 @@
 package io.getquill.sources
 
 import io.getquill._
+import io.getquill.sources.mirror.MirrorSource
 
 class ResolveSourceMacroSpec extends Spec {
 
@@ -22,5 +23,10 @@ class ResolveSourceMacroSpec extends Spec {
     case class Fail()
     val s = source(new MirrorSourceConfig("s") with QueryProbing)
     "s.run(query[Fail].delete)" mustNot compile
+  }
+  
+  "doesn't fail if the quoted source annotation can't be found" in {
+    def test(db: MirrorSource) =
+      "db.run(qr1.delete)" must compile
   }
 }


### PR DESCRIPTION
cc/ @onilton @lvicentesanchez @godenji @jilen @gustavoamigo 