### PR TITLE
* quill-cassandra: add support for DISTINCT.

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
@@ -32,11 +32,15 @@ object CqlIdiom {
 
   implicit def cqlQueryShow(implicit strategy: NamingStrategy): Show[CqlQuery] = Show[CqlQuery] {
 
-    case CqlQuery(entity, filter, orderBy, limit, select) =>
+    case CqlQuery(entity, filter, orderBy, limit, select, distinct) =>
+
+      val distinctShow = if (distinct) " DISTINCT" else ""
+
       val withSelect =
         select match {
-          case Nil => "SELECT *"
-          case s   => s"SELECT ${s.show}"
+          case Nil if distinct => fail(s"Cql only supports DISTINCT with a selection list.'")
+          case Nil             => "SELECT *"
+          case s               => s"SELECT$distinctShow ${s.show}"
         }
       val withEntity =
         s"$withSelect FROM ${entity.show}"

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/CassandraSourceMacroSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/CassandraSourceMacroSpec.scala
@@ -32,7 +32,7 @@ class CassandraSourceMacroSpec extends Spec {
     "s.run(q)" mustNot compile
   }
 
-  "binds inputs according to the sql terms order" - {
+  "binds inputs according to the cql terms order" - {
     "filter.update" in {
       val q = quote {
         (i: Int, l: Long) =>

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/CqlIdiomSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/CqlIdiomSpec.scala
@@ -36,6 +36,31 @@ class CqlIdiomSpec extends Spec {
     }
   }
 
+  "distinct" - {
+    "simple" in {
+      val q = quote {
+        qr1.distinct
+      }
+      "mirrorSource.run(q).cql" mustNot compile
+    }
+
+    "distinct single" in {
+      val q = quote {
+        qr1.map(i => i.i).distinct
+      }
+      mirrorSource.run(q).cql mustEqual
+        "SELECT DISTINCT i FROM TestEntity"
+    }
+
+    "distinct tuple" in {
+      val q = quote {
+        qr1.map(i => (i.i, i.l)).distinct
+      }
+      mirrorSource.run(q).cql mustEqual
+        "SELECT DISTINCT i, l FROM TestEntity"
+    }
+  }
+
   "order by criteria" - {
     "asc" in {
       val q = quote {

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/CqlQuerySpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/CqlQuerySpec.scala
@@ -119,6 +119,14 @@ class CqlQuerySpec extends Spec {
     }
   }
 
+  "distinct query" in {
+    val q = quote {
+      qr1.map(t => t.i).distinct
+    }
+    CqlQuery(q.ast).show mustEqual
+      "SELECT DISTINCT i FROM TestEntity"
+  }
+
   "all terms" in {
     val q = quote {
       qr1.filter(t => t.i == 1).sortBy(t => t.s).take(1).map(t => t.s)

--- a/quill-core/src/test/scala/io/getquill/sources/ResolveSourceMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/ResolveSourceMacroSpec.scala
@@ -24,7 +24,7 @@ class ResolveSourceMacroSpec extends Spec {
     val s = source(new MirrorSourceConfig("s") with QueryProbing)
     "s.run(query[Fail].delete)" mustNot compile
   }
-  
+
   "doesn't fail if the quoted source annotation can't be found" in {
     def test(db: MirrorSource) =
       "db.run(qr1.delete)" must compile


### PR DESCRIPTION
Closes #190.

Following the CQL3 specification, the macro expansion doesn't allow DISTINCT without a selection list.