### PR TITLE
fix #220 - unquote quoted function bodies automatically

### DIFF
--- a/quill-core/src/main/scala/io/getquill/package.scala
+++ b/quill-core/src/main/scala/io/getquill/package.scala
@@ -14,6 +14,7 @@ package object getquill {
   def lift[T](v: T): T = v
 
   def quote[T](body: Quoted[T]): Quoted[T] = macro Macro.doubleQuote[T]
+  def quote[T, R](func: T => Quoted[R]): Quoted[T => R] = macro Macro.quotedFunctionBody[T, R]
   implicit def quote[T](body: T): Quoted[T] = macro Macro.quote[T]
   implicit def unquote[T](quoted: Quoted[T]): T = NonQuotedException()
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -30,12 +30,16 @@ trait Quotation extends Parsing with Liftables with Unliftables {
     """
   }
 
-  def doubleQuote[T: WeakTypeTag](body: Expr[Quoted[T]]) = {
+  def doubleQuote[T: WeakTypeTag](body: Expr[Quoted[T]]) =
     body.tree match {
       case q"null" => c.fail("Can't quote null")
       case tree    => q"io.getquill.unquote($tree)"
     }
-  }
+
+  def quotedFunctionBody[T, R](func: Expr[T => Quoted[R]]) =
+    func.tree match {
+      case q"(..$p) => $b" => q"io.getquill.quote((..$p) => io.getquill.unquote($b))"
+    }
 
   protected def unquote[T](tree: Tree)(implicit ct: ClassTag[T]) =
     astTree(tree).flatMap(astUnliftable.unapply).map {

--- a/quill-core/src/test/scala/io/getquill/PackageSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/PackageSpec.scala
@@ -50,6 +50,25 @@ class PackageSpec extends Spec {
     }
   }
 
+  "unquotes duble quotations" in {
+    val q: Quoted[EntityQuery[TestEntity]] = quote {
+      quote(query[TestEntity])
+    }
+    q.toString mustEqual "query[TestEntity]"
+  }
+
+  "unquotes quoted function bodies automatically" in {
+    implicit class QueryOps[Q <: Query[_]](q: Q) {
+      def allowFiltering = quote(infix"$q ALLOW FILTERING".as[Q])
+    }
+
+    val q: Quoted[Int => EntityQuery[TestEntity]] = quote {
+      (i: Int) =>
+        query[TestEntity].allowFiltering
+    }
+    q.toString mustEqual "(i) => infix\"" + "$" + "{query[TestEntity]} ALLOW FILTERING\""
+  }
+
   "fails if the infix is used outside of a quotation" in {
     val e = intercept[NonQuotedException] {
       infix"true"


### PR DESCRIPTION
@lvicentesanchez @godenji @gustavoamigo @jilen 

Note the quoted function return type.

Before:

```scala
    implicit class QueryOps[Q <: Query[_]](q: Q) {
      def allowFiltering = quote(infix"$q ALLOW FILTERING".as[Q])
    }

    val q: Quoted[Int => Quoted[EntityQuery[TestEntity]]] = quote {
      (i: Int) =>
        query[TestEntity].allowFiltering
    }
```

After:

```scala
    val q: Quoted[Int => EntityQuery[TestEntity]] = quote {
      (i: Int) =>
        query[TestEntity].allowFiltering
    }
```