### PR TITLE
prepare 0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.4.1 / 28-Feb-2016
+
+* [quill-sql: h2 dialect](https://github.com/getquill/quill/pull/189)
+* [support for auto encoding of wrapped types](https://github.com/getquill/quill/pull/199/files#diff-04c6e90faac2675aa89e2176d2eec7d8R854)
+* [non-batched actions](https://github.com/getquill/quill/pull/202/files#diff-04c6e90faac2675aa89e2176d2eec7d8L485)
+* `distinct` support [[0]](https://github.com/getquill/quill/pull/186/files#diff-02749abf4d0d51be99715cff7074bc9eR38) [[1]](https://github.com/getquill/quill/pull/212)
+* [postgres naming strategy](https://github.com/getquill/quill/pull/218)
+* [quill-core: unquote quoted function bodies automatically](https://github.com/getquill/quill/pull/222)
+* [don't fail if the source annotation isn't available](https://github.com/getquill/quill/pull/210)
+* [fix custom aggregations](https://github.com/getquill/quill/pull/207)
+* [quill-finagle-mysql: fix finagle mysql execute result loss](https://github.com/getquill/quill/pull/197)
+* [quill-cassandra: stream source - avoid blocking queries](https://github.com/getquill/quill/pull/185)
+
 # 0.4.0 / 19-Feb-2016
 
 * [new sources creation mechanism](https://github.com/getquill/quill/pull/136)

--- a/README.md
+++ b/README.md
@@ -943,7 +943,7 @@ sbt dependencies
 ```
 libraryDependencies ++= Seq(
   "mysql" % "mysql-connector-java" % "5.1.36",
-  "io.getquill" %% "quill-jdbc" % "0.4.1-SNAPSHOT"
+  "io.getquill" %% "quill-jdbc" % "0.4.1"
 )
 ```
 
@@ -974,7 +974,7 @@ sbt dependencies
 ```
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.4-1206-jdbc41",
-  "io.getquill" %% "quill-jdbc" % "0.4.1-SNAPSHOT"
+  "io.getquill" %% "quill-jdbc" % "0.4.1"
 )
 ```
 
@@ -1005,7 +1005,7 @@ db.connectionTimeout=30000
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-async" % "0.4.1-SNAPSHOT"
+  "io.getquill" %% "quill-async" % "0.4.1"
 )
 ```
 
@@ -1035,7 +1035,7 @@ db.poolValidationInterval=100
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-async" % "0.4.1-SNAPSHOT"
+  "io.getquill" %% "quill-async" % "0.4.1"
 )
 ```
 
@@ -1065,7 +1065,7 @@ db.poolValidationInterval=100
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-finagle-mysql" % "0.4.1-SNAPSHOT"
+  "io.getquill" %% "quill-finagle-mysql" % "0.4.1"
 )
 ```
 
@@ -1095,7 +1095,7 @@ db.pool.maxWaiters=2147483647
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-cassandra" % "0.4.1-SNAPSHOT"
+  "io.getquill" %% "quill-cassandra" % "0.4.1"
 )
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ then
 	openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in credentials.sbt.enc -out local.credentials.sbt -d
 	openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in deploy_key.pem.enc -out local.deploy_key.pem -d
 
-	if [[ $(git tag -l --contains HEAD) =~ 'release' ]]
+	if [[ $(cat version.sbt) != *"SNAPSHOT"* ]]
 	then
 		eval "$(ssh-agent -s)"
 		chmod 600 local.deploy_key.pem

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1-SNAPSHOT"
+version in ThisBuild := "0.4.1"


### PR DESCRIPTION
@gustavoamigo @jilen @lvicentesanchez @godenji 

We've got a few important fixes, so I think we should release a minor version. It'll deliver new features as well, but I think it's fine because I think we shouldn't follow strict semver before `1.0`.

I've changed the build script to check if the version is a non-snapshot instead of using a tag to know if a release should be triggered.