### PR TITLE
add /quill-docs/ to links in  gh-pages/index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1145,12 +1145,12 @@ db.session.addressTranslater=com.datastax.driver.core.policies.IdentityTranslate
 <h1>
 <a id="slick-comparison" class="anchor" href="#slick-comparison" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Slick comparison</h1>
 
-<p>Please refer to <a href="https://github.com/getquill/quill/blob/master/SLICK.md">SLICK.md</a> for a detailed comparison between Quill and Slick.</p>
+<p>Please refer to <a href="https://github.com/getquill/quill/blob/master/quill-docs/SLICK.md">SLICK.md</a> for a detailed comparison between Quill and Slick.</p>
 
 <h1>
 <a id="cassandra-libraries-comparison" class="anchor" href="#cassandra-libraries-comparison" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Cassandra libraries comparison</h1>
 
-<p>Please refer to <a href="https://github.com/getquill/quill/blob/master/CASSANDRA.md">CASSANDRA.md</a> for a detailed comparison between Quill and other main alternatives for interaction with Cassandra in Scala.</p>
+<p>Please refer to <a href="https://github.com/getquill/quill/blob/master/quill-docs/CASSANDRA.md">CASSANDRA.md</a> for a detailed comparison between Quill and other main alternatives for interaction with Cassandra in Scala.</p>
 
 <h1>
 <a id="acknowledgments" class="anchor" href="#acknowledgments" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Acknowledgments</h1>


### PR DESCRIPTION

### Problem

On http://getquill.io/ links to comparisons give 404.

- https://github.com/getquill/quill/blob/master/CASSANDRA.md
- https://github.com/getquill/quill/blob/master/SLICK.md


### Solution
Fix the urls  to 

- https://github.com/getquill/quill/blob/master/quill-docs/SLICK.md
- https://github.com/getquill/quill/blob/master/quill-docs/CASSANDRA.md
 
@getquill/maintainers
