### PR TITLE
Support Option.{isEmpty, nonEmpty, isDefined}

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
@@ -182,6 +182,9 @@ trait SqlIdiom {
 
   implicit def propertyShow(implicit valueShow: Show[Value], identShow: Show[Ident], strategy: NamingStrategy): Show[Property] =
     Show[Property] {
+      case Property(ident, "isEmpty")      => s"$ident IS NULL"
+      case Property(ident, "nonEmpty")     => s"$ident IS NOT NULL"
+      case Property(ident, "isDefined")    => s"$ident IS NOT NULL"
       case Property(Property(ident, a), b) => s"$ident.$a$b"
       case Property(ast, name)             => s"${scopedShow(ast)}.${strategy.column(name)}"
     }

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomSpec.scala
@@ -685,12 +685,35 @@ class SqlIdiomSpec extends Spec {
           "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE (1, 2) = t.i"
       }
     }
-    "property" in {
-      val q = quote {
-        qr1.map(t => t.s)
+    "property" - {
+      "column" in {
+        val q = quote {
+          qr1.map(t => t.s)
+        }
+        mirrorSource.run(q).sql mustEqual
+          "SELECT t.s FROM TestEntity t"
       }
-      mirrorSource.run(q).sql mustEqual
-        "SELECT t.s FROM TestEntity t"
+      "isEmpty" in {
+        val q = quote {
+          qr1.filter(t => t.o.isEmpty)
+        }
+        mirrorSource.run(q).sql mustEqual
+          "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NULL"
+      }
+      "nonEmpty" in {
+        val q = quote {
+          qr1.filter(t => t.o.nonEmpty)
+        }
+        mirrorSource.run(q).sql mustEqual
+          "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NOT NULL"
+      }
+      "isDefined" in {
+        val q = quote {
+          qr1.filter(t => t.o.isDefined)
+        }
+        mirrorSource.run(q).sql mustEqual
+          "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NOT NULL"
+      }
     }
     "infix" - {
       "part of the query" in {


### PR DESCRIPTION
Fixes #124 #143 
### Problem

`Option.isEmpty`, `Option.nonEmpty`, `Option.isDefined` is now not supported

### Solution

Show those properties as `IS NULL`, `IS NOT NULL`
### Notes


@getquill/maintainers
