### PR TITLE
tolerant function parsing in option opeartion

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -224,11 +224,11 @@ trait Parsing {
   private def identClean(x: Ident) = x.copy(name = x.name.replace("$", ""))
 
   val optionOperationParser: Parser[OptionOperation] = Parser[OptionOperation] {
-    case q"$o.map[$t](($alias) => $body)" if (is[Option[Any]](o)) =>
+    case q"$o.map[$t]({($alias) => $body})" if (is[Option[Any]](o)) =>
       OptionOperation(OptionMap, astParser(o), identParser(alias), astParser(body))
-    case q"$o.forall(($alias) => $body)" if (is[Option[Any]](o)) =>
+    case q"$o.forall({($alias) => $body})" if (is[Option[Any]](o)) =>
       OptionOperation(OptionForall, astParser(o), identParser(alias), astParser(body))
-    case q"$o.exists(($alias) => $body)" if (is[Option[Any]](o)) =>
+    case q"$o.exists({($alias) => $body})" if (is[Option[Any]](o)) =>
       OptionOperation(OptionExists, astParser(o), identParser(alias), astParser(body))
   }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -475,6 +475,26 @@ class QuotationSpec extends Spec {
           }
           quote(unquote(q)).ast.body mustEqual BinaryOperation(Ident("a"), SetOperator.`contains`, Ident("b"))
         }
+        "within option operation" - {
+          "forall" in {
+            val q = quote { (a: collection.Set[Int], b: Option[Int]) =>
+              b.forall(a.contains)
+            }
+            quote(unquote(q)).ast.body mustBe an[OptionOperation]
+          }
+          "exists" in {
+            val q = quote { (a: collection.Set[Int], b: Option[Int]) =>
+              b.exists(a.contains)
+            }
+            quote(unquote(q)).ast.body mustBe an[OptionOperation]
+          }
+          "map" in {
+            val q = quote { (a: collection.Set[Int], b: Option[Int]) =>
+              b.map(a.contains)
+            }
+            quote(unquote(q)).ast.body mustBe an[OptionOperation]
+          }
+        }
       }
     }
     "unary operation" - {


### PR DESCRIPTION
### Problem
Following query failed to compile
```scala
val q = quote { (a: collection.Set[Int], b: Option[Int]) =>
   b.forall(a.contains)
}
```
```
la:480: Tree 'b.forall({
[error]   ((elem: Int) => a.contains(elem))
[error] })' can't be parsed to 'Ast'
[error]             val q = quote { (a: collection.Set[Int], b: Option[Int]) =>
[error]
```  
### Solution
Add braces while matching
```scala
    case q"$o.map[$t]({($alias) => $body})" if (is[Option[Any]](o)) =>
      OptionOperation(OptionMap, astParser(o), identParser(alias), astParser(body))
    case q"$o.forall({($alias) => $body})" if (is[Option[Any]](o)) =>
      OptionOperation(OptionForall, astParser(o), identParser(alias), astParser(body))
    case q"$o.exists({($alias) => $body})" if (is[Option[Any]](o)) =>
      OptionOperation(OptionExists, astParser(o), identParser(alias), astParser(body))
```


@getquill/maintainers
