### PR TITLE
Fixes bug #249 related to property aliases and actions

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/RenameAssignments.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/RenameAssignments.scala
@@ -1,0 +1,26 @@
+package io.getquill.norm
+
+import io.getquill.ast._
+
+object RenameAssignments extends StatelessTransformer {
+
+  override def apply(e: Action): Action =
+    e match {
+      case AssignedAction(insert @ Insert(table: Entity), assignments) =>
+        AssignedAction(insert, renameAssignments(assignments, table))
+
+      case AssignedAction(update @ Update(table: Entity), assignments) =>
+        AssignedAction(update, renameAssignments(assignments, table))
+
+      case AssignedAction(update @ Update(Filter(table: Entity, x, where)), assignments) =>
+        AssignedAction(update, renameAssignments(assignments, table))
+
+      case other =>
+        super.apply(other)
+    }
+
+  private def renameAssignments(assignments: List[Assignment], table: Entity) = {
+    val propertyAlias = table.properties.map(p => p.property -> p.alias).toMap
+    assignments.map(a => a.copy(property = propertyAlias.getOrElse(a.property, a.property)))
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/Prepare.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/Prepare.scala
@@ -1,7 +1,7 @@
 package io.getquill.sources.sql
 
 import io.getquill.ast._
-import io.getquill.norm.Normalize
+import io.getquill.norm.{ RenameProperties, RenameAssignments, Normalize, FlattenOptionOperation }
 import io.getquill.naming.NamingStrategy
 import io.getquill.sources.ExtractEntityAndInsertAction
 import io.getquill.sources.sql.idiom.SqlIdiom
@@ -9,7 +9,6 @@ import io.getquill.util.Show._
 import io.getquill.util.Messages._
 import io.getquill.norm.capture.AvoidAliasConflict
 import io.getquill.norm.capture.AvoidCapture
-import io.getquill.norm.FlattenOptionOperation
 import io.getquill.sources.sql.norm.ExpandJoin
 import io.getquill.sources.sql.norm.ExpandNestedQueries
 import io.getquill.sources.sql.norm.MergeSecondaryJoin
@@ -49,4 +48,7 @@ object Prepare {
       .andThen(Normalize.apply _)
       .andThen(MergeSecondaryJoin.apply _)
       .andThen(FlattenOptionOperation.apply _)
+      .andThen(RenameAssignments.apply _)
+      .andThen(RenameProperties.apply _)
+
 }

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/SqlQuery.scala
@@ -49,7 +49,7 @@ case class FlattenSqlQuery(
 object SqlQuery {
 
   def apply(query: Ast): SqlQuery =
-    RenameProperties(query) match {
+    query match {
       case Union(a, b)                  => SetOperationSqlQuery(apply(a), UnionOperation, apply(b))
       case UnionAll(a, b)               => SetOperationSqlQuery(apply(a), UnionAllOperation, apply(b))
       case UnaryOperation(op, q: Query) => UnaryOperationSqlQuery(op, apply(q))

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/norm/RenamePropertiesSpec.scala
@@ -14,6 +14,37 @@ class RenamePropertiesSpec extends Spec {
   }
 
   "renames properties according to the entity aliases" - {
+    "action" - {
+      "insert" in {
+        val q = quote {
+          e.insert
+        }
+        mirrorSource.run(q)(TestEntity("a", 1, 1L, None)).sql mustEqual
+          "INSERT INTO test_entity (field_s,field_i,l,o) VALUES (?, ?, ?, ?)"
+      }
+
+      "insert assigned" in {
+        val q = quote {
+          e.insert(_.i -> 1, _.l -> 1L, _.o -> 1, _.s -> "test")
+        }
+        mirrorSource.run(q).sql mustEqual
+          "INSERT INTO test_entity (field_i,l,o,field_s) VALUES (1, 1, 1, 'test')"
+      }
+      "update" in {
+        val q = quote {
+          e.filter(_.i == 999).update
+        }
+        mirrorSource.run(q)(TestEntity("a", 1, 1L, None)).sql mustEqual
+          "UPDATE test_entity SET field_s = ?, field_i = ?, l = ?, o = ? WHERE field_i = 999"
+      }
+      "delete" in {
+        val q: Quoted[Delete[TestEntity]] = quote {
+          e.filter(_.i == 999).delete
+        }
+        mirrorSource.run(q).sql mustEqual
+          "DELETE FROM test_entity WHERE field_i = 999"
+      }
+    }
     "generated" - {
       "alias" in {
         val q = quote {


### PR DESCRIPTION
Fixes #249 

### Problem

Property aliases are not applied to actions

### Solution

Created `RemaneAssignments.scala` to use property aliases and move the `RenameProperties.scala` to `sql/Prepare.scala`. 

### Notes

I didn't test it, but we need to check if the same behavior happens with `quill-cassandra`

@getquill/maintainers
