### PR TITLE
* accept unicode arrows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,3 +54,4 @@ sbt:
     - TRAVIS_PULL_REQUEST
     - TRAVIS_BRANCH
     - ENCRYPTION_PASSWORD
+    - SBT_OPTS=-Dfile.encoding=UTF-8 -Xms512m -Xmx1536m -Xss2m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -1,7 +1,6 @@
 package io.getquill.quotation
 
 import scala.reflect.ClassTag
-import scala.reflect.macros.whitebox.Context
 import io.getquill.{ Query => QuillQuery }
 import io.getquill.ast._
 import io.getquill.norm.BetaReduction
@@ -11,7 +10,6 @@ import io.getquill.util.Interleave
 trait Parsing extends SchemaConfigParsing {
   this: Quotation =>
 
-  val c: Context
   import c.universe.{ Ident => _, Constant => _, Function => _, If => _, _ }
 
   case class Parser[T](p: PartialFunction[Tree, T])(implicit ct: ClassTag[T]) {
@@ -351,7 +349,7 @@ trait Parsing extends SchemaConfigParsing {
   }
 
   private val assignmentParser: Parser[Assignment] = Parser[Assignment] {
-    case q"((${ identParser(i1) }) => scala.this.Predef.ArrowAssoc[$t](${ identParser(i2) }.$prop).->[$v]($value))" if (i1 == i2) =>
+    case q"((${ identParser(i1) }) => scala.this.Predef.ArrowAssoc[$t](${ identParser(i2) }.$prop).$arrow[$v]($value))" if (i1 == i2) =>
       Assignment(i1, prop.decodedName.toString, astParser(value))
   }
 

--- a/quill-core/src/main/scala/io/getquill/quotation/SchemaConfigParsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/SchemaConfigParsing.scala
@@ -1,11 +1,12 @@
 package io.getquill.quotation
 
 import io.getquill.ast.PropertyAlias
-import scala.reflect.macros.whitebox.Context
 
 case class SchemaConfig(alias: Option[String] = None, properties: List[PropertyAlias] = List(), generated: Option[String] = None)
-trait SchemaConfigParsing {
-  val c: Context
+
+trait SchemaConfigParsing extends UnicodeArrowParsing {
+  this: Quotation =>
+
   import c.universe.{ Function => _, Ident => _, _ }
 
   def parseEntityConfig(t: Tree): SchemaConfig =
@@ -27,7 +28,7 @@ trait SchemaConfigParsing {
 
   private def parsePropertyAlias(t: Tree): PropertyAlias =
     t match {
-      case q"(($x1) => scala.this.Predef.ArrowAssoc[$t]($x2.$prop).->[$v](${ alias: String }))" =>
+      case q"(($x1) => scala.this.Predef.ArrowAssoc[$t]($x2.$prop).$arrow[$v](${ alias: String }))" =>
         PropertyAlias(prop.decodedName.toString, alias)
     }
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/UnicodeArrowParsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/UnicodeArrowParsing.scala
@@ -1,0 +1,9 @@
+package io.getquill.quotation
+
+trait UnicodeArrowParsing {
+  this: Quotation =>
+
+  import c.universe.Quasiquote
+
+  private val arrow = pq"→|->"
+}

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -32,6 +32,12 @@ class QuotationSpec extends Spec {
           }
           quote(unquote(q)).ast mustEqual Entity("TestEntity", Some("SomeAlias"), List(PropertyAlias("s", "theS"), PropertyAlias("i", "theI")))
         }
+        "with property alias and unicode arrow" in {
+          """|quote {
+             |  query[TestEntity](_.entity("SomeAlias").columns(_.s → "theS", _.i → "theI"))
+             |}
+          """.stripMargin must compile
+        }
       }
       "filter" in {
         val q = quote {
@@ -267,6 +273,12 @@ class QuotationSpec extends Spec {
           }
           quote(unquote(q)).ast mustEqual Function(List(Ident("x1")), Update(Entity("TestEntity")))
         }
+        "unicode arrow must compile" in {
+          """|quote {
+             |  qr1.filter(t ⇒ t.i == 1).update(_.s → "new", _.i → 0)
+             |}
+          """.stripMargin must compile
+        }
       }
       "insert" - {
         "assigned" in {
@@ -280,6 +292,12 @@ class QuotationSpec extends Spec {
             qr1.insert
           }
           quote(unquote(q)).ast mustEqual Function(List(Ident("x1")), Insert(Entity("TestEntity")))
+        }
+        "unicode arrow must compile" in {
+          """|quote {
+             |  qr1.insert(_.s → "new", _.i → 0)
+             |}
+          """.stripMargin must compile
         }
       }
       "delete" in {


### PR DESCRIPTION
Fixes #241

### Problem

An unicode arrow, →,  in a partial insert or update will make the parser to fail.

### Solution

Modify the parser to accept both a single arrow, ->, or its unicode variant, →.

### Notes

Closes #241.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

