### PR TITLE
add set encoder to SqlSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,13 @@ val q = quote {
 db.run(q)
 // SELECT p.id, p.name, p.age FROM Person p WHERE p.id IN (1, 2)
 
+val q1 = quote { (ids: Set[Int]) =>
+  query[Person].filter(p => ids.contains(p.id))
+}
+
+db.run(q)
+// SELECT p.id, p.name, p.age FROM Person p WHERE p.id IN (?)
+
 val peopleWithContacts = quote {
   query[Person].filter(p => query[Contact].filter(c => c.personId == p.id).nonEmpty)
 }

--- a/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorEncoders.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorEncoders.scala
@@ -17,6 +17,11 @@ trait MirrorEncoders {
         row.add(value)
     }
 
+  implicit def setEncoder[T](implicit d: Encoder[T]): Encoder[Set[T]] =
+    new Encoder[Set[T]] {
+      def apply(index: Int, value: Set[T], row: Row) = row.add(value)
+    }
+
   implicit val stringEncoder = encoder[String]
   implicit val bigDecimalEncoder = encoder[BigDecimal]
   implicit val booleanEncoder = encoder[Boolean]

--- a/quill-core/src/test/scala/io/getquill/sources/SourceSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/SourceSpec.scala
@@ -31,6 +31,14 @@ class SourceSpec extends Spec {
     }
   }
 
+  "encoding set" in {
+    case class Entity(i: Int)
+    val q = quote { (is: Set[Int]) =>
+      query[Entity].filter(e => is.contains(e.i))
+    }
+    mirrorSource.run(q)(Set(1)).binds mustEqual Row(Set(1))
+  }
+
   "encodes `WrappedValue` extended value class" - {
     case class Entity(x: WrappedEncodable, s: String)
 

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/SqlSource.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/SqlSource.scala
@@ -21,6 +21,7 @@ abstract class SqlSource[D <: SqlIdiom, N <: NamingStrategy, R: ClassTag, S: Cla
 
   implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]]
   implicit def optionEncoder[T](implicit d: Encoder[T]): Encoder[Option[T]]
+  implicit def setEncoder[T](implicit d: Encoder[T]): Encoder[Set[T]]
 
   implicit val stringDecoder: Decoder[String]
   implicit val bigDecimalDecoder: Decoder[BigDecimal]

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/SqlSourceMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/SqlSourceMacroSpec.scala
@@ -58,6 +58,7 @@ class SqlSourceMacroSpec extends Spec {
 
       implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] = null
       implicit def optionEncoder[T](implicit d: Encoder[T]): Encoder[Option[T]] = null
+      implicit def setEncoder[T](implicit d: Encoder[T]): Encoder[Set[T]] = null
 
       implicit val stringDecoder: Decoder[String] = null
       implicit val bigDecimalDecoder: Decoder[BigDecimal] = null

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomSpec.scala
@@ -554,12 +554,21 @@ class SqlIdiomSpec extends Spec {
             mirrorSource.run(q).sql mustEqual
               "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.i IN (SELECT p.i FROM TestEntity2 p)"
           }
-          "set" in {
-            val q = quote {
-              qr1.filter(t => Set(1, 2).contains(t.i))
+          "set" - {
+            "direct value" in {
+              val q = quote {
+                qr1.filter(t => Set(1, 2).contains(t.i))
+              }
+              mirrorSource.run(q).sql mustEqual
+                "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.i IN (1, 2)"
             }
-            mirrorSource.run(q).sql mustEqual
-              "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.i IN (1, 2)"
+            "as param" in {
+              val q = quote { (is: Set[Int]) =>
+                qr1.filter(t => is.contains(t.i))
+              }
+              mirrorSource.run(q)(Set(1, 2)).sql mustEqual
+                "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.i IN (?)"
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes #issue_number

### Problem
Fix #244 

### Solution

Add `setEncoding` definition to `SqlSource` and implement it in `MirrorEncoder` 

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

