### PR TITLE
fix log category

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,8 +94,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
   ),
   EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource,
   unmanagedClasspath in Test ++= Seq(
-    baseDirectory.value / "src" / "test" / "resources",
-    baseDirectory.value / "src" / "test" / "resources" / "sql"
+    baseDirectory.value / "src" / "test" / "resources"
   ),
   scalacOptions ++= Seq(
     "-Xfatal-warnings",

--- a/quill-async/src/main/scala/io/getquill/sources/async/AsyncSource.scala
+++ b/quill-async/src/main/scala/io/getquill/sources/async/AsyncSource.scala
@@ -17,12 +17,16 @@ import language.experimental.macros
 import io.getquill.quotation.Quoted
 import io.getquill.sources.sql.SqlSourceMacro
 import io.getquill.sources.{ SourceConfig, BindedStatementBuilder }
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
 
 abstract class AsyncSource[D <: SqlIdiom, N <: NamingStrategy, C <: Connection](config: AsyncSourceConfig[D, N, C])
   extends SqlSource[D, N, RowData, BindedStatementBuilder[List[Any]]]
   with Decoders
-  with Encoders
-  with StrictLogging {
+  with Encoders {
+
+  protected val logger: Logger =
+    Logger(LoggerFactory.getLogger(classOf[AsyncSource[_, _, _]]))
 
   type QueryResult[T] = Future[List[T]]
   type ActionResult[T] = Future[Long]

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSourceSession.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSourceSession.scala
@@ -12,12 +12,16 @@ import io.getquill.sources.cassandra.encoding.Decoders
 import io.getquill.sources.cassandra.encoding.Encoders
 import io.getquill.CassandraSourceConfig
 import io.getquill.sources.BindedStatementBuilder
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
 
 abstract class CassandraSourceSession[N <: NamingStrategy](config: CassandraSourceConfig[N, _])
   extends CassandraSource[N, Row, BindedStatementBuilder[BoundStatement]]
-  with StrictLogging
   with Encoders
   with Decoders {
+
+  protected val logger: Logger =
+    Logger(LoggerFactory.getLogger(classOf[CassandraSourceSession[_]]))
 
   private val cluster = config.cluster
   protected val session = cluster.connect(config.keyspace)

--- a/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlSource.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlSource.scala
@@ -19,12 +19,16 @@ import com.twitter.finagle.exp.mysql.Request
 import com.twitter.finagle.exp.mysql.PrepareRequest
 import io.getquill.FinagleMysqlSourceConfig
 import io.getquill.sources.BindedStatementBuilder
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
 
 class FinagleMysqlSource[N <: NamingStrategy](config: FinagleMysqlSourceConfig[N])
   extends SqlSource[MySQLDialect, N, Row, BindedStatementBuilder[List[Parameter]]]
   with FinagleMysqlDecoders
-  with FinagleMysqlEncoders
-  with StrictLogging {
+  with FinagleMysqlEncoders {
+
+  protected val logger: Logger =
+    Logger(LoggerFactory.getLogger(classOf[FinagleMysqlSource[_]]))
 
   type QueryResult[T] = Future[List[T]]
   type ActionResult[T] = Future[Result]

--- a/quill-jdbc/src/main/scala/io/getquill/sources/jdbc/JdbcSource.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/sources/jdbc/JdbcSource.scala
@@ -11,12 +11,16 @@ import scala.util.control.NonFatal
 import scala.annotation.tailrec
 import io.getquill.JdbcSourceConfig
 import io.getquill.sources.BindedStatementBuilder
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
 
 class JdbcSource[D <: SqlIdiom, N <: NamingStrategy](config: JdbcSourceConfig[D, N])
   extends SqlSource[D, N, ResultSet, BindedStatementBuilder[PreparedStatement]]
   with JdbcEncoders
-  with JdbcDecoders
-  with StrictLogging {
+  with JdbcDecoders {
+
+  protected val logger: Logger =
+    Logger(LoggerFactory.getLogger(classOf[JdbcSource[_, _]]))
 
   type QueryResult[T] = List[T]
   type ActionResult[T] = Long


### PR DESCRIPTION
### Problem

Quill's logs are using the user's package. It should be possible to configure a log category for all quill messages.

### Solution

Use a fixed class to create the loggers.

### Notes

I've removed the custom `sql` classpath because it breaks the eclipse project. It was necessary to setup h2 for compile-time query probing, that's now disabled.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers