### PR TITLE
use scala 2.11.8 and new `GenBCode` backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import sbtrelease.ReleasePlugin
 lazy val quill = 
   (project in file("."))
     .settings(tutSettings ++ commonSettings ++ Seq(
-      scalaVersion := "2.11.7", 
+      scalaVersion := "2.11.8", 
       tutSourceDirectory := baseDirectory.value / "target" / "README.md"))
     .settings(sourceGenerators in Compile <+= Def.task {
       val source = baseDirectory.value / "README.md"
@@ -107,6 +107,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",   
     "-Ywarn-value-discard",
+    "-Ybackend:GenBCode",
     "-Xfuture",
     "-Ywarn-unused-import"
   ),


### PR DESCRIPTION
### Solution

Update to Scala 2.11.8 and enable the new compiler backend, which has better performance.

### Notes

I didn't enable `-Ydelambdafy:method -target:jvm-1.8` because Eclipse doesn't work with these flags yet.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
