### PR TITLE
allow free variable bindings within `db.run`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,6 @@ Additional notes.
 - [ ] Update `README.md` if applicable
 - [ ] Add `[WIP]` to the pull request title if it's work in progress
 - [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
-- [ ] Run `sbt scalariformFormat` to make sure that the source files are formatted
+- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted
 
 @getquill/maintainers

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ script:
 - docker-compose run sbt bash -c "./build/build.sh"
 after_success:
 - pip install --user codecov && codecov
-- docker-compose run sbt sbt clean
-after_script:
-- docker-compose run sbt bash -c "find \$HOME/.ivy2 -name \"ivydata-*.properties\" | xargs rm"
 cache:
   directories:
   - $HOME/.ivy2/cache

--- a/build/build.sh
+++ b/build/build.sh
@@ -31,5 +31,7 @@ then
 		sbt coverageOff publish
 	fi
 else
-	sbt clean coverage test tut coverageAggregate release-vcs-checks
+	sbt clean coverage test tut coverageAggregate 
+	git ls-files --modified --exclude-standard
+	sbt release-vcs-checks
 fi

--- a/build/build.sh
+++ b/build/build.sh
@@ -2,14 +2,14 @@
 chown root ~/.ssh/config
 chmod 644 ~/.ssh/config
 
-if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" ]]
+if [[ $TRAVIS_PULL_REQUEST == "false" ]]
 then
 	openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/secring.gpg.enc -out local.secring.gpg -d
 	openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/pubring.gpg.enc -out local.pubring.gpg -d
 	openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/credentials.sbt.enc -out local.credentials.sbt -d
 	openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/deploy_key.pem.enc -out local.deploy_key.pem -d
 
-	if [[ $(cat version.sbt) != *"SNAPSHOT"* ]]
+	if [[ $TRAVIS_BRANCH == "master" && $(cat version.sbt) != *"SNAPSHOT"* ]]
 	then
 		eval "$(ssh-agent -s)"
 		chmod 600 local.deploy_key.pem
@@ -22,8 +22,13 @@ then
 		git reset --hard origin/master
 		sbt tut 'release with-defaults'
 		git push --delete origin release
-	else
+	elif [[ $TRAVIS_BRANCH == "master" ]]
+	then
 		sbt clean coverage test tut coverageAggregate release-vcs-checks && sbt coverageOff publish
+	else
+		sbt clean coverage test tut coverageAggregate release-vcs-checks
+		echo "version in ThisBuild := \"$TRAVIS_BRANCH-SNAPSHOT\"" > version.sbt
+		sbt coverageOff publish
 	fi
 else
 	sbt clean coverage test tut coverageAggregate release-vcs-checks

--- a/build/build.sh
+++ b/build/build.sh
@@ -31,7 +31,5 @@ then
 		sbt coverageOff publish
 	fi
 else
-	sbt clean coverage test tut coverageAggregate 
-	git ls-files --modified --exclude-standard
-	sbt release-vcs-checks
+	sbt clean coverage test tut coverageAggregate release-vcs-checks
 fi

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraAsyncSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraAsyncSource.scala
@@ -30,10 +30,10 @@ class CassandraAsyncSource[N <: NamingStrategy](config: CassandraSourceConfig[N,
     session.executeAsync(prepare(cql, bind))
       .map(_.all.toList.map(extractor))
 
-  def execute(cql: String, generated: Option[String])(implicit ec: ExecutionContext): Future[ResultSet] =
-    session.executeAsync(prepare(cql))
+  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String])(implicit ec: ExecutionContext): Future[ResultSet] =
+    session.executeAsync(prepare(cql, bind))
 
-  def execute[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String])(implicit ec: ExecutionContext): ActionApply[T] = {
+  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String])(implicit ec: ExecutionContext): ActionApply[T] = {
     def run(values: List[T]): Future[List[ResultSet]] =
       values match {
         case Nil => Future.successful(List())

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraStreamSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraStreamSource.scala
@@ -38,10 +38,10 @@ class CassandraStreamSource[N <: NamingStrategy](config: CassandraSourceConfig[N
       .map(extractor)
   }
 
-  def execute(cql: String, generated: Option[String]): Observable[ResultSet] =
-    Observable.fromFuture(session.executeAsync(prepare(cql)))
+  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): Observable[ResultSet] =
+    Observable.fromFuture(session.executeAsync(prepare(cql, bind)))
 
-  def execute[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): Observable[T] => Observable[ResultSet] =
+  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): Observable[T] => Observable[ResultSet] =
     (values: Observable[T]) =>
       values.flatMap { value =>
         Observable.fromFuture(session.executeAsync(prepare(cql, bindParams(value))))

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSyncSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSyncSource.scala
@@ -28,10 +28,10 @@ class CassandraSyncSource[N <: NamingStrategy](config: CassandraSourceConfig[N, 
     session.execute(prepare(cql, bind))
       .all.toList.map(extractor)
 
-  def execute(cql: String, generated: Option[String]): ResultSet =
-    session.execute(prepare(cql))
+  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): ResultSet =
+    session.execute(prepare(cql, bind))
 
-  def execute[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): ActionApply[T] = {
+  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): ActionApply[T] = {
     val func = { (values: List[T]) =>
       @tailrec
       def run(values: List[T], acc: List[ResultSet]): List[ResultSet] =

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -15,7 +15,7 @@ case class BetaReduction(map: collection.Map[Ident, Ast])
           case _ => apply(values(name.drop(1).toInt - 1))
         }
       case FunctionApply(Function(params, body), values) =>
-        apply(BetaReduction(map ++ params.zip(values)).apply(body))
+        apply(BetaReduction(params.zip(values).toMap).apply(body))
       case ident: Ident =>
         map.get(ident).map(BetaReduction(map - ident)(_)).getOrElse(ident)
       case Function(params, body) =>

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -15,7 +15,7 @@ case class BetaReduction(map: collection.Map[Ident, Ast])
           case _ => apply(values(name.drop(1).toInt - 1))
         }
       case FunctionApply(Function(params, body), values) =>
-        apply(BetaReduction(params.zip(values).toMap).apply(body))
+        apply(BetaReduction(map ++ params.zip(values).toMap).apply(body))
       case ident: Ident =>
         map.get(ident).map(BetaReduction(map - ident)(_)).getOrElse(ident)
       case Function(params, body) =>

--- a/quill-core/src/main/scala/io/getquill/sources/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/ActionMacro.scala
@@ -33,7 +33,6 @@ trait ActionMacro extends EncodingMacro {
         val assignedAction = AssignedAction(action, idents.map(k => Assignment(Ident("x"), k.name, k)))
         val encodedParams = EncodeParams[S](c)(inPlaceParams, bindings.toMap)
 
-        // TODO inPlaceParams
         expandedTreeBatch(assignedAction, idents.toList ++ inPlaceParams.map(_._1), List(tpe), encodedParams)
 
       case functionParams =>

--- a/quill-core/src/main/scala/io/getquill/sources/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/ActionMacro.scala
@@ -12,37 +12,57 @@ trait ActionMacro extends EncodingMacro {
   val c: Context
   import c.universe.{ Ident => _, _ }
 
-  def runAction[S, T](action: Ast, params: List[(Ident, Type)])(implicit s: WeakTypeTag[S], t: WeakTypeTag[T]): Tree =
-    params match {
+  def runAction[S, T](
+    action:         Ast,
+    inPlaceParams:  collection.Map[Ident, (c.Type, c.Tree)],
+    functionParams: List[(Ident, c.Type)]
+  )(
+    implicit
+    s: WeakTypeTag[S],
+    t: WeakTypeTag[T]
+  ): Tree =
+    functionParams match {
       case Nil =>
-        expandedTree(action, params)
+        val encodedParams = EncodeParams[S](c)(inPlaceParams, collection.Map())
+        expandedTreeSingle(action, inPlaceParams.map(_._1).toList, encodedParams)
+
       case List((param, tpe)) if (t.tpe.erasure <:< c.weakTypeOf[UnassignedAction[Any]].erasure) =>
         val encodingValue = encoding(param, Encoding.inferEncoder[S](c))(c.WeakTypeTag(tpe))
         val bindings = bindingMap(encodingValue)
         val idents = bindings.map(_._1).toList
         val assignedAction = AssignedAction(action, idents.map(k => Assignment(Ident("x"), k.name, k)))
-        val encodedParams = EncodeParams.raw[S](c)(bindings.toMap)
-        expandedTree(assignedAction, idents.toList, List(tpe), encodedParams)
+        val encodedParams = EncodeParams[S](c)(inPlaceParams, bindings.toMap)
 
-      case params =>
-        val encodedParams = EncodeParams[S](c)(bindingMap(params))
-        expandedTree(action, params.map(_._1), params.map(_._2), encodedParams)
+        // TODO inPlaceParams
+        expandedTreeBatch(assignedAction, idents.toList ++ inPlaceParams.map(_._1), List(tpe), encodedParams)
+
+      case functionParams =>
+        val encodedParams = EncodeParams[S](c)(bindingMap(functionParams) ++ inPlaceParams, collection.Map())
+        expandedTreeBatch(action, functionParams.map(_._1) ++ inPlaceParams.map(_._1), functionParams.map(_._2), encodedParams)
     }
 
-  private def expandedTree(action: Ast, params: List[(Ident, Type)]) = {
-    q"""
-      val (sql, _, generated) =  ${prepare(action, params.map(_._1))}
-      ${c.prefix}.execute(sql, generated)
-    """
-  }
-
-  private def expandedTree(action: Ast, idents: List[Ident], paramsTypes: List[Type], encodedParams: Tree) = {
+  private def expandedTreeSingle(action: Ast, idents: List[Ident], encodedParams: Tree) = {
     q"""
     {
       val (sql, bindings: List[io.getquill.ast.Ident], generated) =
         ${prepare(action, idents)}
 
-      ${c.prefix}.execute[(..$paramsTypes)](
+      ${c.prefix}.execute(
+        sql,
+        $encodedParams(bindings.map(_.name)),
+        generated
+        )
+    }
+    """
+  }
+
+  private def expandedTreeBatch(action: Ast, idents: List[Ident], paramsTypes: List[Type], encodedParams: Tree) = {
+    q"""
+    {
+      val (sql, bindings: List[io.getquill.ast.Ident], generated) =
+        ${prepare(action, idents)}
+
+      ${c.prefix}.executeBatch[(..$paramsTypes)](
         sql,
         value => $encodedParams(bindings.map(_.name)),
         generated

--- a/quill-core/src/main/scala/io/getquill/sources/EncodeParams.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/EncodeParams.scala
@@ -7,33 +7,50 @@ import io.getquill.util.Messages._
 
 object EncodeParams {
 
-  def apply[S](c: Context)(params: collection.Map[Ident, (c.Type, c.Tree)])(implicit s: c.WeakTypeTag[S]): c.Tree =
-    raw[S](c) {
+  def apply[S](c: Context)(
+    params: collection.Map[Ident, (c.Type, c.Tree)],
+    raw:    collection.Map[Ident, (c.Tree, c.Tree)]
+  )(
+    implicit
+    s: c.WeakTypeTag[S]
+  ): c.Tree =
+    expand[S](c) {
       params.map {
         case (ident, (tpe, tree)) =>
           val encoder =
             Encoding.inferEncoder(c)(tpe)(s)
               .getOrElse(c.fail(s"Source doesn't know how do encode '$ident: $tpe'"))
           (ident, (encoder, tree))
-      }.toMap
+      }.toMap ++ raw
     }
 
-  def raw[S](c: Context)(params: collection.Map[Ident, (c.Tree, c.Tree)])(implicit s: c.WeakTypeTag[S]): c.Tree = {
+  private def expand[S](c: Context)(
+    params: collection.Map[Ident, (c.Tree, c.Tree)]
+  )(
+    implicit
+    s: c.WeakTypeTag[S]
+  ): c.Tree = {
     import c.universe._
     val encoders =
       for ((ident, (encoder, tree)) <- params) yield {
         q"${ident.name} -> ((row: $s, index: Int) => $encoder(index, $tree, row))"
       }
-    q"""
-    {
-      val bindingMap = collection.Map(..$encoders)
-      (bindings: List[String]) =>
-        (row: $s) =>
-          bindings.foldLeft((row, 0)) {
-            case ((row, index), binding) =>
-              (bindingMap(binding)(row, index), index + 1)
-          }._1
-    }
-    """
+    if (encoders.isEmpty)
+      q"""
+        (bindings: List[String]) =>
+          (row: $s) => row  
+      """
+    else
+      q"""
+      {
+        val bindingMap = collection.Map(..$encoders)
+        (bindings: List[String]) =>
+          (row: $s) =>
+            bindings.foldLeft((row, 0)) {
+              case ((row, index), binding) =>
+                (bindingMap(binding)(row, index), index + 1)
+            }._1
+      }
+      """
   }
 }

--- a/quill-core/src/main/scala/io/getquill/sources/SourceMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/SourceMacro.scala
@@ -24,7 +24,11 @@ trait SourceMacro extends Quotation with ActionMacro with QueryMacro with Resolv
       FreeVariables(ast).toList.map {
         case i @ Ident(name) =>
           i -> {
-            val tree = c.typecheck(q"${TermName(name)}")
+            val tree =
+              c.typecheck(q"${TermName(name)}", silent = true) match {
+                case EmptyTree => c.fail(s"Runtime value binded outside of `source.run`: $name")
+                case tree      => tree
+              }
             (tree.tpe, tree)
           }
       }.toMap

--- a/quill-core/src/main/scala/io/getquill/sources/SourceMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/SourceMacro.scala
@@ -17,25 +17,37 @@ trait SourceMacro extends Quotation with ActionMacro with QueryMacro with Resolv
 
   def run[R, S](quoted: Expr[Quoted[Any]])(implicit r: WeakTypeTag[R], s: WeakTypeTag[S]): Tree = {
     implicit val t = c.WeakTypeTag(quoted.actualType.baseType(c.weakTypeOf[Quoted[Any]].typeSymbol).typeArgs.head)
-    verifyFreeVariables(ast(quoted)) match {
 
-      case ast if (t.tpe.typeSymbol.fullName.startsWith("scala.Function")) =>
+    val ast = this.ast(quoted)
+
+    val inPlaceParams =
+      FreeVariables(ast).toList.map {
+        case i @ Ident(name) =>
+          i -> {
+            val tree = c.typecheck(q"${TermName(name)}")
+            (tree.tpe, tree)
+          }
+      }.toMap
+
+    t.tpe.typeSymbol.fullName.startsWith("scala.Function") match {
+
+      case true =>
         val bodyType = c.WeakTypeTag(t.tpe.typeArgs.takeRight(1).head)
         val params = (1 until t.tpe.typeArgs.size).map(i => Ident(s"p$i")).toList
-        run(FunctionApply(ast, params), params.zip(paramsTypes(t)))(r, s, bodyType)
+        run(FunctionApply(ast, params), inPlaceParams, params.zip(paramsTypes(t)))(r, s, bodyType)
 
-      case ast =>
-        run(ast, Nil)(r, s, t)
+      case false =>
+        run(ast, inPlaceParams, Nil)(r, s, t)
     }
   }
 
-  private def run[R, S, T](ast: Ast, params: List[(Ident, Type)])(implicit r: WeakTypeTag[R], s: WeakTypeTag[S], t: WeakTypeTag[T]): Tree =
+  private def run[R, S, T](ast: Ast, inPlaceParams: collection.Map[Ident, (Type, Tree)], params: List[(Ident, Type)])(implicit r: WeakTypeTag[R], s: WeakTypeTag[S], t: WeakTypeTag[T]): Tree =
     ast match {
       case ast if ((t.tpe.erasure <:< c.weakTypeTag[Action[Any]].tpe.erasure)) =>
-        runAction[S, T](ast, params)
+        runAction[S, T](ast, inPlaceParams, params)
 
       case ast =>
-        runQuery(ast, params)(r, s, queryType(t.tpe))
+        runQuery(ast, inPlaceParams, params)(r, s, queryType(t.tpe))
     }
 
   private def queryType(tpe: Type) =

--- a/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorSource.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorSource.scala
@@ -42,14 +42,14 @@ class MirrorSource(config: SourceConfig[MirrorSource])
     else
       Success(())
 
-  case class ActionMirror(ast: Ast)
+  case class ActionMirror(ast: Ast, bind: Row)
 
-  def execute(ast: Ast, generated: Option[String]) =
-    ActionMirror(ast)
+  def execute(ast: Ast, bindParams: Row => Row, generated: Option[String]) =
+    ActionMirror(ast, bindParams(Row()))
 
   case class BatchActionMirror(ast: Ast, bindList: List[Row])
 
-  def execute[T](ast: Ast, bindParams: T => Row => Row, generated: Option[String]) =
+  def executeBatch[T](ast: Ast, bindParams: T => Row => Row, generated: Option[String]) =
     (values: List[T]) =>
       BatchActionMirror(ast, values.map(bindParams).map(_(Row())))
 

--- a/quill-core/src/test/scala/io/getquill/sources/ActionMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/ActionMacroSpec.scala
@@ -3,6 +3,7 @@ package io.getquill.sources
 import io.getquill._
 import io.getquill.sources.mirror.Row
 import io.getquill.TestSource.mirrorSource
+import io.getquill.ast.Function
 
 class ActionMacroSpec extends Spec {
 
@@ -30,20 +31,51 @@ class ActionMacroSpec extends Spec {
       r.ast mustEqual q.ast.body
       r.bindList mustEqual List(Row(1, "a"), Row(2, "b"))
     }
+    "with in-place binding" in {
+      val q = quote { (i: Int) => (s: Int) => qr1.update(_.i -> i, _.s -> s)
+      }
+      val v = 1
+      val r = mirrorSource.run(q(v))(List(1, 2))
+      q.ast.body match {
+        case f: Function => r.ast mustEqual r.ast
+        case other       => fail
+      }
+      r.bindList mustEqual List(Row(1, v), Row(2, v))
+    }
   }
 
-  "expands unassigned actions" in {
-    val q = quote(qr1.insert)
-    val r = mirrorSource.run(q)(
-      List(
-        TestEntity("s", 1, 2L, Some(4)),
-        TestEntity("s2", 12, 22L, Some(42))
+  "expands unassigned actions" - {
+    "simple" in {
+      val q = quote(qr1.insert)
+      val r = mirrorSource.run(q)(
+        List(
+          TestEntity("s", 1, 2L, Some(4)),
+          TestEntity("s2", 12, 22L, Some(42))
+        )
       )
-    )
-    r.ast.toString mustEqual "query[TestEntity].insert(x => x.s -> s, x => x.i -> i, x => x.l -> l, x => x.o -> o)"
-    r.bindList mustEqual List(
-      Row("s", 1, 2L, Some(4)),
-      Row("s2", 12, 22L, Some(42))
-    )
+      r.ast.toString mustEqual "query[TestEntity].insert(x => x.s -> s, x => x.i -> i, x => x.l -> l, x => x.o -> o)"
+      r.bindList mustEqual List(
+        Row("s", 1, 2L, Some(4)),
+        Row("s2", 12, 22L, Some(42))
+      )
+    }
+    "with in-place param" in {
+      val q = quote {
+        (i: Int) => qr1.filter(_.i == i).update
+      }
+      val v = 1
+      val r = mirrorSource.run(q(v))(
+        List(
+          TestEntity("s", 1, 2L, Some(4)),
+          TestEntity("s2", 12, 22L, Some(42))
+        )
+      )
+
+      r.ast.toString mustEqual "query[TestEntity].filter(x6 => x6.i == v).update(x => x.s -> s, x => x.i -> i, x => x.l -> l, x => x.o -> o)"
+      r.bindList mustEqual List(
+        Row("s", 1, 2L, Some(4), v),
+        Row("s2", 12, 22L, Some(42), v)
+      )
+    }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/sources/ActionMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/ActionMacroSpec.scala
@@ -57,11 +57,14 @@ class ActionMacroSpec extends Spec {
       val r = mirrorSource.run(q)(
         List(
           TestEntity("s", 1, 2L, Some(4)),
-          TestEntity("s2", 12, 22L, Some(42))))
+          TestEntity("s2", 12, 22L, Some(42))
+        )
+      )
       r.ast.toString mustEqual "query[TestEntity].insert(x => x.s -> s, x => x.i -> i, x => x.l -> l, x => x.o -> o)"
       r.bindList mustEqual List(
         Row("s", 1, 2L, Some(4)),
-        Row("s2", 12, 22L, Some(42)))
+        Row("s2", 12, 22L, Some(42))
+      )
     }
     "with in-place param" in {
       val q = quote {
@@ -71,12 +74,15 @@ class ActionMacroSpec extends Spec {
       val r = mirrorSource.run(q(v))(
         List(
           TestEntity("s", 1, 2L, Some(4)),
-          TestEntity("s2", 12, 22L, Some(42))))
+          TestEntity("s2", 12, 22L, Some(42))
+        )
+      )
 
       r.ast.toString mustEqual "query[TestEntity].filter(t => t.i == v).update(x => x.s -> s, x => x.i -> i, x => x.l -> l, x => x.o -> o)"
       r.bindList mustEqual List(
         Row("s", 1, 2L, Some(4), v),
-        Row("s2", 12, 22L, Some(42), v))
+        Row("s2", 12, 22L, Some(42), v)
+      )
     }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/sources/QueryMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/QueryMacroSpec.scala
@@ -53,5 +53,10 @@ class QueryMacroSpec extends Spec {
       }
       r.binds mustEqual Row(v1, v2)
     }
+    "inline" in {
+      def q(i: Int) =
+        mirrorSource.run(qr1.filter(_.i == i))
+      q(1).binds mustEqual Row(1)
+    }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/sources/QueryMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/QueryMacroSpec.scala
@@ -3,10 +3,11 @@ package io.getquill.sources
 import io.getquill._
 import io.getquill.sources.mirror.Row
 import io.getquill.TestSource.mirrorSource
+import io.getquill.ast.Function
 
 class QueryMacroSpec extends Spec {
 
-  "runs non-binded action" in {
+  "runs non-binded query" in {
     val q = quote {
       qr1.map(_.i)
     }
@@ -29,6 +30,28 @@ class QueryMacroSpec extends Spec {
       val r = mirrorSource.run(q)(1, "a")
       r.ast mustEqual q.ast.body
       r.binds mustEqual Row(1, "a")
+    }
+    "in-place param" in {
+      val q = quote {
+        (p1: Int) => qr1.filter(t => t.i == p1).map(t => t.i)
+      }
+      val p1 = 1
+      val r = mirrorSource.run(q(p1))
+      r.ast mustEqual q.ast.body
+      r.binds mustEqual Row(p1)
+    }
+    "in-place param and function param" in {
+      val q = quote { (i1: Int) => (i2: Int) => qr1.filter(t => t.i == i1).map(t => t.i + i2)
+      }
+      val v1 = 1
+      val v2 = 2
+      val r = mirrorSource.run(q(v1))(v2)
+
+      q.ast.body match {
+        case f: Function => r.ast mustEqual r.ast
+        case other       => fail
+      }
+      r.binds mustEqual Row(v1, v2)
     }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/sources/SourceMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/SourceMacroSpec.scala
@@ -124,7 +124,7 @@ class SourceMacroSpec extends Spec {
     var db = source(new MirrorSourceConfig(""))
     "db.run(qr1)" must compile
   }
-  
+
   "fails if bind value is outside `source.run`" in {
     val q = {
       val i = 1

--- a/quill-core/src/test/scala/io/getquill/sources/SourceMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/SourceMacroSpec.scala
@@ -124,4 +124,14 @@ class SourceMacroSpec extends Spec {
     var db = source(new MirrorSourceConfig(""))
     "db.run(qr1)" must compile
   }
+  
+  "fails if bind value is outside `source.run`" in {
+    val q = {
+      val i = 1
+      quote {
+        qr1.filter(_.i == i)
+      }
+    }
+    "mirrorSource.run(q)" mustNot compile
+  }
 }


### PR DESCRIPTION
I'm planning to work on this change, please let me know you thoughts.

### Problem

The quotation mechanism for parametrized quotations requires too much boilerplate code for simple queries. Example from @takezoe's [gitbucket](https://github.com/gitbucket/gitbucket/commit/bc4af8e7c188881f285a1c8267912fdd0f0d9545#diff-8627cf516a3a5c11771924bf62d4b4cbR232):

```scala
   def updateGroupMembers(groupName: String, members: List[(String, Boolean)]): Unit = {
     db.run(
       quote { (groupName: String) => query[GroupMember].filter(_.groupName == groupName).delete }
     )(List(groupName))
``` 

There are two main problems here:

1. Inline quotations (see readme change) don't support parametrization, so `quote` must be explicit.
2. It's not possible to directly bind the runtime values.

### Solution

Allow references to runtime values within a `db.run` call:

```scala
   def updateGroupMembers(groupName: String, members: List[(String, Boolean)]): Unit = {
     db.run(query[GroupMember].filter(_.groupName == groupName).delete)
```

This will be the default way to bind runtime values, so the second parameters group will be removed.

### Notes

Quotations outside the `db.run` call won't support free variables. It'd be possible to implement it, but it's more complex and I think it'd make it harder to reason about query composition if we mix quotation composition with runtime values. 

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers