### PR TITLE
fix #267 - don't quote the source creation tree if query probing is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,8 @@ This feature is disabled by default. To enable it, mix the `QueryProbing` trait 
 lazy val db = source(new MySourceConfig("configKey") with QueryProbing)
 ```
 
+The config configuration must be self-contained, not having references to variables outside its scope. This allows the macro load the source instance at compile-time.
+
 The configurations correspondent to the config key must be available at compile time. You can achieve it by adding this line to your project settings:
 
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,6 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",   
     "-Ywarn-value-discard",
-    "-Ybackend:GenBCode",
     "-Xfuture",
     "-Ywarn-unused-import"
   ),

--- a/quill-core/src/test/scala/io/getquill/sources/ResolveSourceMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/ResolveSourceMacroSpec.scala
@@ -10,7 +10,6 @@ class ResolveSourceMacroSpec extends Spec {
   "fails if the source can't be resolved at compile time" in {
     val s = source(new BuggyConfig with QueryProbing)
     "s.run(qr1)" mustNot compile
-    ()
   }
 
   "doesn't warn if query probing is disabled and the source can't be resolved at compile time" in {


### PR DESCRIPTION
Fixes #267 

### Problem

The source config must not have free variables in order to the query probing work. Currently, this is a requirement even if query probing is disabled, but it shouldn't be.

### Solution

Do not quote the source tree if the query probing is disabled.

### Notes

- I couldn't reproduce the error reported by the issue, so the change might not fix it, but I think it's a important change any way.
- `-Ybackend:GenBCode` is super flaky for incremental compilation in eclipse. I've disabled it.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
