### PR TITLE
readme - add note to avoid type widening

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Quotations are both compile-time and runtime values. Quill uses a type refinemen
 It is important to avoid giving explicit types to quotations when possible. For instance, this quotation can't be read at compile-time as the type refinement is lost:
 
 ```scala
+// Avoid type widening (Quoted[Query[Circle]]), or else the quotation will be dynamic.
 val q: Quoted[Query[Circle]] = quote {
   query[Circle].filter(c => c.radius > 10)
 }


### PR DESCRIPTION
### Problem

A user has used the type widening counterexample as an actual example.

### Solution

Add a note to the example code to make it clearer.

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

