### PR TITLE
add support for inline vals in quotation blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,14 @@ val areas = quote {
 }
 ```
 
-Quotations can also contain high-order functions:
+Quotations can also contain high-order functions and inline values:
 
 ```scala
 val area = quote {
-  (c: Circle) => pi * c.radius * c.radius
+  (c: Circle) => {
+    val r2 = c.radius * c.radius
+    pi * r2
+  }
 }
 ```
 

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
@@ -22,7 +22,10 @@ object CqlIdiom {
       case a: Function  => a.body.show
       case Infix(parts, params) =>
         StringContext(parts: _*).s(params.map(_.show): _*)
-      case a @ (_: Function | _: FunctionApply | _: Dynamic | _: If | _: OptionOperation | _: Query) =>
+      case a @ (
+        _: Function | _: FunctionApply | _: Dynamic | _: If | _: OptionOperation |
+        _: Query | _: Block | _: Val
+        ) =>
         fail(s"Invalid cql: '$a'")
     }
 

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -92,6 +92,12 @@ case class Set(values: List[Ast]) extends Value
 
 //************************************************************
 
+case class Block(statements: List[Ast]) extends Ast
+
+case class Val(name: Ident, body: Ast) extends Ast
+
+//************************************************************
+
 sealed trait Action extends Ast
 
 case class Update(query: Ast) extends Action

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -19,6 +19,8 @@ object AstShow {
     case ast: OptionOperation => ast.show
     case ast: Dynamic         => ast.show
     case ast: If              => ast.show
+    case ast: Block           => ast.show
+    case ast: Val             => ast.show
   }
 
   implicit val ifShow: Show[If] = Show[If] {
@@ -27,6 +29,14 @@ object AstShow {
 
   implicit val dynamicShow: Show[Dynamic] = Show[Dynamic] {
     case Dynamic(tree) => tree.toString
+  }
+
+  implicit val blockShow: Show[Block] = Show[Block] {
+    case Block(statements) => statements.map(_.show).mkString(" ")
+  }
+
+  implicit val valShow: Show[Val] = Show[Val] {
+    case Val(name, body) => s"$name = ${body.show}"
   }
 
   implicit val queryShow: Show[Query] = Show[Query] {

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -32,11 +32,11 @@ object AstShow {
   }
 
   implicit val blockShow: Show[Block] = Show[Block] {
-    case Block(statements) => statements.map(_.show).mkString(" ")
+    case Block(statements) => s"[${statements.map(_.show).mkString(" ")}]"
   }
 
   implicit val valShow: Show[Val] = Show[Val] {
-    case Val(name, body) => s"$name = ${body.show}"
+    case Val(name, body) => s"val $name = ${body.show}"
   }
 
   implicit val queryShow: Show[Query] = Show[Query] {

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -1,5 +1,7 @@
 package io.getquill.ast
 
+import io.getquill.util.Messages.fail
+
 trait StatefulTransformer[T] {
 
   val state: T
@@ -37,6 +39,9 @@ trait StatefulTransformer[T] {
         (If(at, bt, ct), ctt)
 
       case l: Dynamic => (l, this)
+
+      case e @ (_: Block | _: Val) =>
+        fail(s"invalid stateful tranformation '$e'")
     }
 
   def apply(e: Query): (Query, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -40,8 +40,13 @@ trait StatefulTransformer[T] {
 
       case l: Dynamic => (l, this)
 
-      case e @ (_: Block | _: Val) =>
-        fail(s"invalid stateful tranformation '$e'")
+      case Block(a) =>
+        val (at, att) = apply(a)(_.apply)
+        (Block(at), att)
+
+      case Val(a, b) =>
+        val (at, att) = apply(b)
+        (Val(a, at), att)
     }
 
   def apply(e: Query): (Query, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -20,8 +20,8 @@ trait StatelessTransformer {
 
       case e: Dynamic                  => e
 
-      case e @ (_: Block | _: Val) =>
-        fail(s"invalid stateless tranformation '$e'")
+      case Block(statements)           => Block(statements.map(apply))
+      case Val(name, body)             => Val(name, apply(body))
     }
 
   def apply(e: Query): Query =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -1,5 +1,7 @@
 package io.getquill.ast
 
+import io.getquill.util.Messages.fail
+
 trait StatelessTransformer {
 
   def apply(e: Ast): Ast =
@@ -17,6 +19,9 @@ trait StatelessTransformer {
       case If(a, b, c)                 => If(apply(a), apply(b), apply(c))
 
       case e: Dynamic                  => e
+
+      case e @ (_: Block | _: Val) =>
+        fail(s"invalid stateless tranformation '$e'")
     }
 
   def apply(e: Query): Query =

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -17,11 +17,14 @@ case class BetaReduction(map: collection.Map[Ident, Ast])
       case FunctionApply(Function(params, body), values) =>
         apply(BetaReduction(map ++ params.zip(values)).apply(body))
       case ident: Ident =>
-        map.getOrElse(ident, ident)
+        map.get(ident).map(BetaReduction(map - ident)(_)).getOrElse(ident)
       case Function(params, body) =>
         Function(params, BetaReduction(map -- params)(body))
       case OptionOperation(t, a, b, c) =>
         OptionOperation(t, apply(a), b, BetaReduction(map - b)(c))
+      case Block(statements) =>
+        val vals = statements.collect { case x: Val => x.name -> x.body }
+        BetaReduction(map ++ vals)(statements.last)
       case other =>
         super.apply(other)
     }

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -6,7 +6,7 @@ import io.getquill.ast._
 
 trait Liftables {
   val c: Context
-  import c.universe.{ Ident => _, Constant => _, Function => _, If => _, _ }
+  import c.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
 
   private val pack = q"io.getquill.ast"
 
@@ -15,6 +15,8 @@ trait Liftables {
     case ast: Action => actionLiftable(ast)
     case ast: Value => valueLiftable(ast)
     case ast: Ident => identLiftable(ast)
+    case Val(name, body) => q"$pack.Val($name, $body)"
+    case Block(statements) => q"$pack.Block($statements)"
     case Property(a, b) => q"$pack.Property($a, $b)"
     case Function(a, b) => q"$pack.Function($a, $b)"
     case FunctionApply(a, b) => q"$pack.FunctionApply($a, $b)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -66,14 +66,12 @@ trait Parsing extends SchemaConfigParsing {
 
   val patMatchParser: Parser[Ast] = Parser[Ast] {
     case q"$expr match { case ($fields) => $body }" =>
-      astParser(fields) match {
-        case Val(name, body) => BetaReduction(body, List(name -> body): _*)
-        case fieldsAst       => patMatchParser(expr, fieldsAst, body)
-      }
+      patMatchParser(expr, fields, body)
   }
 
-  private def patMatchParser(tupleTree: Tree, fields: Ast, bodyTree: Tree) = {
+  private def patMatchParser(tupleTree: Tree, fieldsTree: Tree, bodyTree: Tree) = {
     val tuple = astParser(tupleTree)
+    val fields = astParser(fieldsTree)
     val body = astParser(bodyTree)
     def property(path: List[Int]) =
       path.foldLeft(tuple) {

--- a/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
@@ -492,10 +492,10 @@ class AstShowSpec extends Spec {
         Val(Ident("a"), Entity("a")),
         Val(Ident("b"), Entity("b"))
       ))
-      (block: Ast).show mustEqual "a = query[a] b = query[b]"
+      (block: Ast).show mustEqual "[val a = query[a] val b = query[b]]"
     }
     "val" in {
-      (Val(Ident("a"), Entity("a")): Ast).show mustEqual "a = query[a]"
+      (Val(Ident("a"), Entity("a")): Ast).show mustEqual "val a = query[a]"
     }
   }
 

--- a/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
@@ -486,6 +486,19 @@ class AstShowSpec extends Spec {
     }
   }
 
+  "shows inline statement" - {
+    "block" in {
+      val block = Block(List(
+        Val(Ident("a"), Entity("a")),
+        Val(Ident("b"), Entity("b"))
+      ))
+      (block: Ast).show mustEqual "a = query[a] b = query[b]"
+    }
+    "val" in {
+      (Val(Ident("a"), Entity("a")): Ast).show mustEqual "a = query[a]"
+    }
+  }
+
   "shows option operations" - {
     "map" in {
       val q = quote {

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -292,5 +292,29 @@ class StatefulTransformerSpec extends Spec {
           att.state mustEqual List()
       }
     }
+
+    "block" in {
+      val ast: Ast = Block(List(
+        Val(Ident("a"), Entity("a")),
+        Val(Ident("b"), Entity("b"))
+      ))
+      Subject(Nil, Entity("a") -> Entity("b"), Entity("b") -> Entity("c"))(ast) match {
+        case (at, att) =>
+          at mustEqual Block(List(
+            Val(Ident("a"), Entity("b")),
+            Val(Ident("b"), Entity("c"))
+          ))
+          att.state mustEqual List(Entity("a"), Entity("b"))
+      }
+    }
+
+    "val" in {
+      val ast: Ast = Val(Ident("a"), Entity("a"))
+      Subject(Nil, Entity("a") -> Entity("b"))(ast) match {
+        case (at, att) =>
+          at mustEqual Val(Ident("a"), Entity("b"))
+          att.state mustEqual List(Entity("a"))
+      }
+    }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -190,5 +190,23 @@ class StatelessTransformerSpec extends Spec {
       val ast: Ast = Dynamic(Ident("a"))
       Subject(Ident("a") -> Ident("a'"))(ast) mustEqual ast
     }
+
+    "block" in {
+      val ast: Ast = Block(List(
+        Val(Ident("a"), Entity("a")),
+        Val(Ident("b"), Entity("b"))
+      ))
+      Subject(Entity("a") -> Entity("b"), Entity("b") -> Entity("c"))(ast) mustEqual
+        Block(List(
+          Val(Ident("a"), Entity("b")),
+          Val(Ident("b"), Entity("c"))
+        ))
+    }
+
+    "val" in {
+      val ast: Ast = Val(Ident("a"), Entity("a"))
+      Subject(Entity("a") -> Entity("b"))(ast) mustEqual
+        Val(Ident("a"), Entity("b"))
+    }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -23,6 +23,11 @@ class BetaReductionSpec extends Spec {
       BetaReduction(ast, Ident("a") -> Ident("a'")) mustEqual
         Ident("a'")
     }
+    "inlines val" in {
+      val (a, b, c) = (Ident("a"), Ident("b"), Ident("c"))
+      val map = collection.Map[Ident, Ast](c -> b, b -> a)
+      BetaReduction(map)(c) mustEqual a
+    }
     "avoids replacing idents of an outer scope" - {
       "function" in {
         val ast: Ast = Function(List(Ident("a")), Ident("a"))

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -23,10 +23,35 @@ class BetaReductionSpec extends Spec {
       BetaReduction(ast, Ident("a") -> Ident("a'")) mustEqual
         Ident("a'")
     }
-    "inlines val" in {
+    "with inline" - {
+      val entity = Entity("a")
       val (a, b, c) = (Ident("a"), Ident("b"), Ident("c"))
+      val (c1, c2, c3) = (Constant(1), Constant(2), Constant(3))
       val map = collection.Map[Ident, Ast](c -> b, b -> a)
-      BetaReduction(map)(c) mustEqual a
+
+      "top level block" in {
+        val block = Block(List(
+          Val(a, entity),
+          Val(b, a),
+          Map(c, b, c1)
+        ))
+        BetaReduction(map)(block) mustEqual Map(entity, b, c1)
+      }
+      "nested blocks" in {
+        val inner = Block(List(
+          Val(a, entity),
+          Val(b, c2),
+          Val(c, c3),
+          Tuple(List(a, b, c))
+        ))
+        val outer = Block(List(
+          Val(a, inner),
+          Val(b, a),
+          Val(c, b),
+          c
+        ))
+        BetaReduction(map)(outer) mustEqual Tuple(List(entity, c2, c3))
+      }
     }
     "avoids replacing idents of an outer scope" - {
       "function" in {

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
@@ -23,7 +23,7 @@ trait SqlIdiom {
       case a: Property          => a.show
       case a: Value             => a.show
       case a: If                => a.show
-      case a @ (_: Function | _: FunctionApply | _: Dynamic | _: OptionOperation) =>
+      case a @ (_: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block | _: Val) =>
         fail(s"Malformed query $a.")
     }
 


### PR DESCRIPTION
Fixes #77 

### Problem

Currently impossible to build up computations based on a series of steps within a `quote` block.

### Solution

Added two new AST types `Block` and `Val` which correspond to parse tree `q"{..$exprs}"` and `q"val $name: $typ = $body"` respectively. Given a `Block` the last statement (i.e. return value of the block) is inlined with the query expression(s) it represents. @see `BetaReduction.scala` `Block` and `Ident` case match

### Notes

Implementing `getOrElse` on `Option[T]` types would be a nice complement to this PR. I looked into it but can see no obvious way to encode this in the AST and somehow thread through default value to, for example, [JdbcDecoders](https://github.com/getquill/quill/blob/master/quill-jdbc/src/main/scala/io/getquill/sources/jdbc/JdbcDecoders.scala#L22)

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

