### PR TITLE
allow arrow assoc while parsing value

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -329,10 +329,11 @@ trait Parsing extends SchemaConfigParsing {
     tree.tpe <:< t.tpe
 
   val valueParser: Parser[Value] = Parser[Value] {
-    case q"null"                         => NullValue
+    case q"null" => NullValue
     case Literal(c.universe.Constant(v)) => Constant(v)
-    case q"((..$v))" if (v.size > 1)     => Tuple(v.map(astParser(_)))
-    case q"$pack.Set.apply[..$t](..$v)"  => Set(v.map(astParser(_)))
+    case q"((..$v))" if (v.size > 1) => Tuple(v.map(astParser(_)))
+    case q"$pack.Set.apply[..$t](..$v)" => Set(v.map(astParser(_)))
+    case q"((scala.this.Predef.ArrowAssoc[$t1]($v1).$arrow[$t2]($v2)))" => Tuple(List(astParser(v1), astParser(v2)))
   }
 
   val actionParser: Parser[Ast] = Parser[Ast] {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -316,9 +316,21 @@ class QuotationSpec extends Spec {
         val q = quote(11L)
         quote(unquote(q)).ast mustEqual Constant(11L)
       }
-      "tuple" in {
-        val q = quote((1, "a"))
-        quote(unquote(q)).ast mustEqual Tuple(List(Constant(1), Constant("a")))
+      "tuple" - {
+        "literal" in {
+          val q = quote((1, "a"))
+          quote(unquote(q)).ast mustEqual Tuple(List(Constant(1), Constant("a")))
+        }
+        "arrow assoc" - {
+          "unicode arrow" in {
+            val q = quote(1 → "a")
+            quote(unquote(q)).ast mustEqual Tuple(List(Constant(1), Constant("a")))
+          }
+          "normal arrow" in {
+            val q = quote(1 -> "a" -> "b")
+            quote(unquote(q)).ast mustEqual Tuple(List(Tuple(List(Constant(1), Constant("a"))), Constant("b")))
+          }
+        }
       }
       "set" in {
         val q = quote(collection.Set(1, 2))


### PR DESCRIPTION
### Problem

```scala
quote {
  query[XXX].map(x => x.a -> x.b)
}
```
not compile

### Solution

Allow  parsing `ArrowAssoc` to `Tuple` 

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

