### PR TITLE
fix #266 - unquote multi-param quoted function bodies automatically

### DIFF
--- a/quill-core/src/main/scala/io/getquill/package.scala
+++ b/quill-core/src/main/scala/io/getquill/package.scala
@@ -14,7 +14,17 @@ package object getquill {
   def lift[T](v: T): T = v
 
   def quote[T](body: Quoted[T]): Quoted[T] = macro Macro.doubleQuote[T]
-  def quote[T, R](func: T => Quoted[R]): Quoted[T => R] = macro Macro.quotedFunctionBody[T, R]
+  def quote[T1, R](func: T1 => Quoted[R]): Quoted[T1 => R] = macro Macro.quotedFunctionBody
+  def quote[T1, T2, R](func: (T1, T2) => Quoted[R]): Quoted[(T1, T2) => R] = macro Macro.quotedFunctionBody
+  def quote[T1, T2, T3, R](func: (T1, T2, T3) => Quoted[R]): Quoted[(T1, T2, T3) => R] = macro Macro.quotedFunctionBody
+  def quote[T1, T2, T3, T4, R](func: (T1, T2, T3, T4) => Quoted[R]): Quoted[(T1, T2, T3, T4) => R] = macro Macro.quotedFunctionBody
+  def quote[T1, T2, T3, T4, T5, R](func: (T1, T2, T3, T4, T5) => Quoted[R]): Quoted[(T1, T2, T3, T4, T5) => R] = macro Macro.quotedFunctionBody
+  def quote[T1, T2, T3, T4, T5, T6, R](func: (T1, T2, T3, T4, T5, T6) => Quoted[R]): Quoted[(T1, T2, T3, T4, T5, T6) => R] = macro Macro.quotedFunctionBody
+  def quote[T1, T2, T3, T4, T5, T6, T7, R](func: (T1, T2, T3, T4, T5, T6, T7) => Quoted[R]): Quoted[(T1, T2, T3, T4, T5, T6, T7) => R] = macro Macro.quotedFunctionBody
+  def quote[T1, T2, T3, T4, T5, T6, T7, T8, R](func: (T1, T2, T3, T4, T5, T6, T7, T8) => Quoted[R]): Quoted[(T1, T2, T3, T4, T5, T6, T7, T8) => R] = macro Macro.quotedFunctionBody
+  def quote[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](func: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => Quoted[R]): Quoted[(T1, T2, T3, T4, T5, T6, T7, T8, T9) => R] = macro Macro.quotedFunctionBody
+  def quote[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](func: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => Quoted[R]): Quoted[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R] = macro Macro.quotedFunctionBody
+
   implicit def quote[T](body: T): Quoted[T] = macro Macro.quote[T]
   implicit def unquote[T](quoted: Quoted[T]): T = NonQuotedException()
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -36,7 +36,7 @@ trait Quotation extends Parsing with Liftables with Unliftables {
       case tree    => q"io.getquill.unquote($tree)"
     }
 
-  def quotedFunctionBody[T, R](func: Expr[T => Quoted[R]]) =
+  def quotedFunctionBody(func: Expr[Any]) =
     func.tree match {
       case q"(..$p) => $b" => q"io.getquill.quote((..$p) => io.getquill.unquote($b))"
     }

--- a/quill-core/src/test/scala/io/getquill/PackageSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/PackageSpec.scala
@@ -57,16 +57,24 @@ class PackageSpec extends Spec {
     q.toString mustEqual "query[TestEntity]"
   }
 
-  "unquotes quoted function bodies automatically" in {
+  "unquotes quoted function bodies automatically" - {
     implicit class QueryOps[Q <: Query[_]](q: Q) {
       def allowFiltering = quote(infix"$q ALLOW FILTERING".as[Q])
     }
-
-    val q: Quoted[Int => EntityQuery[TestEntity]] = quote {
-      (i: Int) =>
-        query[TestEntity].allowFiltering
+    "one param" in {
+      val q: Quoted[Int => EntityQuery[TestEntity]] = quote {
+        (i: Int) =>
+          query[TestEntity].allowFiltering
+      }
+      q.toString mustEqual "(i) => infix\"" + "$" + "{query[TestEntity]} ALLOW FILTERING\""
     }
-    q.toString mustEqual "(i) => infix\"" + "$" + "{query[TestEntity]} ALLOW FILTERING\""
+    "multiple params" in {
+      val q: Quoted[(Int, Int, Int) => EntityQuery[TestEntity]] = quote {
+        (i: Int, j: Int, k: Int) =>
+          query[TestEntity].allowFiltering
+      }
+      q.toString mustEqual "(i, j, k) => infix\"" + "$" + "{query[TestEntity]} ALLOW FILTERING\""
+    }
   }
 
   "fails if the infix is used outside of a quotation" in {


### PR DESCRIPTION
Fixes #266

### Problem

The unquotation of function bodies currently works only for functions with arity one.

### Solution

Implement the unquotation for multi-param functions.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers