### PR TITLE
fix #229 - bind `drop.take` according to the sql terms order

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlQuery.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlQuery.scala
@@ -95,6 +95,4 @@ object CqlQuery {
       case (a: Property, o: PropertyOrdering)         => List(OrderByCriteria(a, o))
       case other                                      => fail(s"Invalid order by criteria $ast")
     }
-
-  AstShow
 }

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/BindVariables.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/BindVariables.scala
@@ -18,6 +18,11 @@ private[sources] case class BindVariables(state: (List[Ident], List[Ident]))
 
   override def apply(e: Query) =
     e match {
+      case Take(Drop(a, b), c) =>
+        val (ct, ctt) = apply(c)
+        val (bt, btt) = ctt.apply(b)
+        val (at, att) = btt.apply(a)
+        (Take(Drop(at, bt), ct), att)
       case Map(a, b, c) =>
         val (ct, ctt) = apply(c)
         val (at, att) = ctt.apply(a)

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/BindVariablesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/BindVariablesSpec.scala
@@ -1,0 +1,19 @@
+package io.getquill.sources.sql
+
+import io.getquill._
+import io.getquill.sources.mirror.Row
+
+class BindVariablesSpec extends Spec {
+
+  "binds values according to the sql terms order" - {
+    "drop.take" in {
+      val q =
+        quote { (offset: Int, size: Int) =>
+          query[TestEntity].drop(offset).take(size)
+        }
+      val mirror = mirrorSource.run(q)(1, 2)
+      mirror.sql mustEqual "SELECT x.s, x.i, x.l, x.o FROM TestEntity x LIMIT ? OFFSET ?"
+      mirror.binds mustEqual Row(2, 1)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #229

### Problem

The SQL terms order doesn't match the DSL term order for `drop.take`/`LIMIT OFFSET`.

### Solution

Take in consideration the terms order when binding the values.

### Notes

The issue doesn't seem to affect CQL, since it doesn't have `OFFSET` support.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers