### PR TITLE
fix #252 - avoid silent error when importing the source's implicits for the encoding fallback resolution

### DIFF
--- a/quill-core/src/main/scala/io/getquill/util/InferImplicitValueWithFallback.scala
+++ b/quill-core/src/main/scala/io/getquill/util/InferImplicitValueWithFallback.scala
@@ -11,7 +11,8 @@ object InferImplicitValueWithFallback {
       c.typecheck(
         q"""{
           def infer = {
-            import $fallbackTree._
+            val t = $fallbackTree
+            import t._
             _root_.scala.Predef.implicitly[$tpe]
           }
           infer

--- a/quill-core/src/test/scala/io/getquill/sources/SourceMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/SourceMacroSpec.scala
@@ -119,4 +119,9 @@ class SourceMacroSpec extends Spec {
       mirrorSource.run(q).ast mustEqual q.ast
     }
   }
+
+  "can be used as a var" in {
+    var db = source(new MirrorSourceConfig(""))
+    "db.run(qr1)" must compile
+  }
 }


### PR DESCRIPTION
Fixes #252

### Problem

The code that looks for implicit encodings in the source's scope doesn't work when the source is defined as a `var`.

### Solution

Create a stable identifier to be able to import the implicit members and perform the implicit resolution correctly.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers