### PR TITLE
fix #275 - quotation: add identifier method to avoid wrong type refinement inference

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -4,8 +4,8 @@ import io.getquill.util.Messages._
 import scala.annotation.StaticAnnotation
 import scala.reflect.ClassTag
 import scala.reflect.macros.whitebox.Context
-
 import io.getquill.ast._
+import java.util.concurrent.atomic.AtomicInteger
 
 trait Quoted[+T] {
   def ast: Ast
@@ -20,12 +20,14 @@ trait Quotation extends Parsing with Liftables with Unliftables {
 
   def quote[T: WeakTypeTag](body: Expr[T]) = {
     val ast = astParser(body.tree)
+    val id = TermName(s"id${ast.hashCode}")
     q"""
       new ${c.weakTypeOf[Quoted[T]]} {
         @${c.weakTypeOf[QuotedAst]}($ast)
         def quoted = ast
         override def ast = $ast
         override def toString = ast.toString
+        def $id() = ()
       }
     """
   }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -802,11 +802,22 @@ class QuotationSpec extends Spec {
     val dq: Quoted[Int] = quote(q)
   }
 
-  "doean't a allow quotation of null" in {
+  "doesn't a allow quotation of null" in {
     "quote(null)" mustNot compile
   }
 
   "fails if the tree is not valid" in {
     """quote("s".getBytes)""" mustNot compile
+  }
+
+  "infers the correct dynamic tree" in {
+    val i = -1
+    val q1 = quote(qr1.filter(_.s == "aa"))
+    val q2 = quote(qr1.filter(_.s == "bb"))
+    val q =
+      if (i > 0) q1
+      else q2
+
+    quote(unquote(q)).ast mustEqual q2.ast
   }
 }


### PR DESCRIPTION
Fixes #275 

### Problem

The quotation mechanism uses a type refinement with an annotation to store the AST. The scala compiler considers two type refinements equal if they have the same signature, which doesn't include annotations. This makes the quotation infer the wrong AST for some dynamic query compositions.

### Solution

Add an identifier method to the quotation to make the type refinements different from the scala compiler's perspective.

### Notes

The method name will have up to 12 characters, so we shouldn't hit any method name limit.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers