### PR TITLE
support  contains for Traversable

### DIFF
--- a/quill-async/src/main/scala/io/getquill/sources/async/Encoders.scala
+++ b/quill-async/src/main/scala/io/getquill/sources/async/Encoders.scala
@@ -22,9 +22,9 @@ trait Encoders {
       }
     }
 
-  implicit def setEncoder[T](implicit e: Encoder[T]): Encoder[Set[T]] =
-    new Encoder[Set[T]] {
-      def apply(index: Int, values: Set[T], row: BindedStatementBuilder[List[Any]]) =
+  implicit def traversableEncoder[T](implicit e: Encoder[T]): Encoder[Traversable[T]] =
+    new Encoder[Traversable[T]] {
+      def apply(index: Int, values: Traversable[T], row: BindedStatementBuilder[List[Any]]) =
         row.coll[T](index, values, e)
     }
 

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
@@ -101,7 +101,7 @@ object CqlIdiom {
     case Constant(())        => s"1"
     case Constant(v)         => s"$v"
     case Tuple(values)       => s"${values.show}"
-    case Set(values)         => s"${values.show}"
+    case Collection(values)  => s"${values.show}"
     case NullValue           => fail("Cql doesn't support null values.")
   }
 

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -88,7 +88,7 @@ object NullValue extends Value
 
 case class Tuple(values: List[Ast]) extends Value
 
-case class Set(values: List[Ast]) extends Value
+case class Collection(values: List[Ast]) extends Value
 
 //************************************************************
 

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -141,7 +141,7 @@ object AstShow {
     case Constant(v)         => s"$v"
     case NullValue           => s"null"
     case Tuple(values)       => s"(${values.show})"
-    case Set(values)         => s"Set(${values.show})"
+    case Collection(values)  => s"Collection(${values.show})"
   }
 
   implicit val identShow: Show[Ident] = Show[Ident] {

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -123,9 +123,9 @@ trait StatefulTransformer[T] {
       case Tuple(a) =>
         val (at, att) = apply(a)(_.apply)
         (Tuple(at), att)
-      case Set(a) =>
+      case Collection(a) =>
         val (at, att) = apply(a)(_.apply)
-        (Set(at), att)
+        (Collection(at), att)
     }
 
   def apply(e: Action): (Action, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -51,10 +51,10 @@ trait StatelessTransformer {
 
   def apply(e: Value): Value =
     e match {
-      case e: Constant   => e
-      case NullValue     => NullValue
-      case Tuple(values) => Tuple(values.map(apply))
-      case Set(values)   => Set(values.map(apply))
+      case e: Constant        => e
+      case NullValue          => NullValue
+      case Tuple(values)      => Tuple(values.map(apply))
+      case Collection(values) => Collection(values.map(apply))
     }
 
   def apply(e: Action): Action =

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -119,10 +119,10 @@ trait Liftables {
   }
 
   implicit val valueLiftable: Liftable[Value] = Liftable[Value] {
-    case NullValue   => q"$pack.NullValue"
-    case Constant(a) => q"$pack.Constant(${Literal(c.universe.Constant(a))})"
-    case Tuple(a)    => q"$pack.Tuple($a)"
-    case Set(a)      => q"$pack.Set($a)"
+    case NullValue     => q"$pack.NullValue"
+    case Constant(a)   => q"$pack.Constant(${Literal(c.universe.Constant(a))})"
+    case Tuple(a)      => q"$pack.Tuple($a)"
+    case Collection(a) => q"$pack.Collection($a)"
   }
   implicit val identLiftable: Liftable[Ident] = Liftable[Ident] {
     case Ident(a) => q"$pack.Ident($a)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -131,7 +131,7 @@ trait Unliftables {
     case q"$pack.NullValue" => NullValue
     case q"$pack.Constant.apply(${ Literal(c.universe.Constant(a)) })" => Constant(a)
     case q"$pack.Tuple.apply(${ a: List[Ast] })" => Tuple(a)
-    case q"$pack.Set.apply(${ a: List[Ast] })" => Set(a)
+    case q"$pack.Collection.apply(${ a: List[Ast] })" => Collection(a)
   }
   implicit val identUnliftable: Unliftable[Ident] = Unliftable[Ident] {
     case q"$pack.Ident.apply(${ a: String })" => Ident(a)

--- a/quill-core/src/main/scala/io/getquill/sources/BindedStatementBuilder.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/BindedStatementBuilder.scala
@@ -8,7 +8,7 @@ sealed trait Binding[S] {
 }
 
 case class SingleBinding[S, T](index: Int, value: T, enc: Encoder[S, T]) extends Binding[S]
-case class SetBinding[S, T](index: Int, values: Set[T], enc: Encoder[BindedStatementBuilder[S], T]) extends Binding[S]
+case class SetBinding[S, T](index: Int, values: Traversable[T], enc: Encoder[BindedStatementBuilder[S], T]) extends Binding[S]
 
 class BindedStatementBuilder[S] {
 
@@ -19,7 +19,7 @@ class BindedStatementBuilder[S] {
     this
   }
 
-  def coll[T](idx: Int, values: Set[T], enc: Encoder[BindedStatementBuilder[S], T]) = {
+  def coll[T](idx: Int, values: Traversable[T], enc: Encoder[BindedStatementBuilder[S], T]) = {
     bindings += SetBinding[S, T](idx, values, enc)
     this
   }

--- a/quill-core/src/main/scala/io/getquill/sources/Encoding.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/Encoding.scala
@@ -8,7 +8,7 @@ trait Decoder[R, T] {
   def apply(index: Int, row: R): T
 }
 
-trait Encoder[S, T] {
+trait Encoder[S, -T] {
   def apply(index: Int, value: T, row: S): S
 }
 

--- a/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorEncoders.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorEncoders.scala
@@ -17,9 +17,9 @@ trait MirrorEncoders {
         row.add(value)
     }
 
-  implicit def setEncoder[T](implicit d: Encoder[T]): Encoder[Set[T]] =
-    new Encoder[Set[T]] {
-      def apply(index: Int, value: Set[T], row: Row) = row.add(value)
+  implicit def traversableEncoder[T](implicit d: Encoder[T]): Encoder[Traversable[T]] =
+    new Encoder[Traversable[T]] {
+      def apply(index: Int, value: Traversable[T], row: Row) = row.add(value)
     }
 
   implicit val stringEncoder = encoder[String]

--- a/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
@@ -409,12 +409,26 @@ class AstShowSpec extends Spec {
       (q.ast: Ast).show mustEqual
         """(null, 1, "a")"""
     }
-    "set" in {
-      val q = quote {
-        collection.Set(1, 2, 3)
+    "collection" - {
+      def verify(ast: Ast) = ast.show mustEqual "Collection(1, 2, 3)"
+      "set" in {
+        val q = quote {
+          Set(1, 2, 3)
+        }
+        verify(q.ast)
       }
-      (q.ast: Ast).show mustEqual
-        """Set(1, 2, 3)"""
+      "list" in {
+        val q = quote {
+          List(1, 2, 3)
+        }
+        verify(q.ast)
+      }
+      "seq" in {
+        val q = quote {
+          Seq(1, 2, 3)
+        }
+        verify(q.ast)
+      }
     }
   }
 

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -173,11 +173,11 @@ class StatefulTransformerSpec extends Spec {
             att.state mustEqual List(Ident("a"), Ident("b"), Ident("c"))
         }
       }
-      "set" in {
-        val ast: Ast = Set(List(Ident("a"), Ident("b")))
+      "Collection" in {
+        val ast: Ast = Collection(List(Ident("a"), Ident("b")))
         Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) match {
           case (at, att) =>
-            at mustEqual Set(List(Ident("a'"), Ident("b'")))
+            at mustEqual Collection(List(Ident("a'"), Ident("b'")))
             att.state mustEqual List(Ident("a"), Ident("b"))
         }
       }

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -111,10 +111,10 @@ class StatelessTransformerSpec extends Spec {
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
           Tuple(List(Ident("a'"), Ident("b'"), Ident("c'")))
       }
-      "set" in {
-        val ast: Ast = Set(List(Ident("a"), Ident("b")))
+      "collection" in {
+        val ast: Ast = Collection(List(Ident("a"), Ident("b")))
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) mustEqual
-          Set(List(Ident("a'"), Ident("b'")))
+          Collection(List(Ident("a'"), Ident("b'")))
       }
     }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -332,9 +332,20 @@ class QuotationSpec extends Spec {
           }
         }
       }
-      "set" in {
-        val q = quote(collection.Set(1, 2))
-        quote(unquote(q)).ast mustEqual Set(List(Constant(1), Constant(2)))
+      "collection" - {
+        val expectedAst = Collection(List(Constant(1), Constant(2)))
+        "seq" in {
+          val q = quote(Seq(1, 2))
+          quote(unquote(q)).ast mustEqual expectedAst
+        }
+        "list" in {
+          val q = quote(List(1, 2))
+          quote(unquote(q)).ast mustEqual expectedAst
+        }
+        "set" in {
+          val q = quote(Set(1, 2))
+          quote(unquote(q)).ast mustEqual expectedAst
+        }
       }
     }
     "ident" in {
@@ -505,28 +516,46 @@ class QuotationSpec extends Spec {
           }
           quote(unquote(q)).ast.body mustEqual BinaryOperation(Ident("a"), SetOperator.`contains`, Ident("b"))
         }
-        "set" in {
-          val q = quote {
-            (a: collection.Set[TestEntity], b: TestEntity) =>
-              a.contains(b)
+        "collections" - {
+          def verifyBody(body: Ast) = body mustEqual BinaryOperation(Ident("a"), SetOperator.`contains`, Ident("b"))
+          "Set" in {
+            val q = quote {
+              (a: Set[TestEntity], b: TestEntity) =>
+                a.contains(b)
+            }
+            verifyBody(q.ast.body)
           }
-          quote(unquote(q)).ast.body mustEqual BinaryOperation(Ident("a"), SetOperator.`contains`, Ident("b"))
+          "Seq" in {
+            val q = quote {
+              (a: Seq[TestEntity], b: TestEntity) =>
+                a.contains(b)
+            }
+            verifyBody(q.ast.body)
+          }
+          "List" in {
+            val q = quote {
+              (a: List[TestEntity], b: TestEntity) =>
+                a.contains(b)
+            }
+            verifyBody(q.ast.body)
+          }
+
         }
         "within option operation" - {
           "forall" in {
-            val q = quote { (a: collection.Set[Int], b: Option[Int]) =>
+            val q = quote { (a: Set[Int], b: Option[Int]) =>
               b.forall(a.contains)
             }
             quote(unquote(q)).ast.body mustBe an[OptionOperation]
           }
           "exists" in {
-            val q = quote { (a: collection.Set[Int], b: Option[Int]) =>
+            val q = quote { (a: Set[Int], b: Option[Int]) =>
               b.exists(a.contains)
             }
             quote(unquote(q)).ast.body mustBe an[OptionOperation]
           }
           "map" in {
-            val q = quote { (a: collection.Set[Int], b: Option[Int]) =>
+            val q = quote { (a: Set[Int], b: Option[Int]) =>
               b.map(a.contains)
             }
             quote(unquote(q)).ast.body mustBe an[OptionOperation]

--- a/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlEncoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlEncoders.scala
@@ -27,9 +27,9 @@ trait FinagleMysqlEncoders {
       }
     }
 
-  implicit def setEncoder[T](implicit e: Encoder[T]): Encoder[Set[T]] =
-    new Encoder[Set[T]] {
-      def apply(idx: Int, values: Set[T], row: BindedStatementBuilder[List[Parameter]]) =
+  implicit def traversableEncoder[T](implicit e: Encoder[T]): Encoder[Traversable[T]] =
+    new Encoder[Traversable[T]] {
+      def apply(idx: Int, values: Traversable[T], row: BindedStatementBuilder[List[Parameter]]) =
         row.coll[T](idx, values, e)
     }
 

--- a/quill-jdbc/src/main/scala/io/getquill/sources/jdbc/JdbcEncoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/sources/jdbc/JdbcEncoders.scala
@@ -26,9 +26,9 @@ trait JdbcEncoders {
       }
     }
 
-  implicit def setEncoder[T](implicit enc: Encoder[T]): Encoder[Set[T]] =
-    new Encoder[Set[T]] {
-      override def apply(index: Int, values: Set[T], row: BindedStatementBuilder[PreparedStatement]) =
+  implicit def traversableEncoder[T](implicit enc: Encoder[T]): Encoder[Traversable[T]] =
+    new Encoder[Traversable[T]] {
+      override def apply(index: Int, values: Traversable[T], row: BindedStatementBuilder[PreparedStatement]) =
         row.coll(index, values, enc)
     }
 

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/SqlSource.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/SqlSource.scala
@@ -21,7 +21,7 @@ abstract class SqlSource[D <: SqlIdiom, N <: NamingStrategy, R: ClassTag, S: Cla
 
   implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]]
   implicit def optionEncoder[T](implicit d: Encoder[T]): Encoder[Option[T]]
-  implicit def setEncoder[T](implicit d: Encoder[T]): Encoder[Set[T]]
+  implicit def traversableEncoder[T](implicit d: Encoder[T]): Encoder[Traversable[T]]
 
   implicit val stringDecoder: Decoder[String]
   implicit val bigDecimalDecoder: Decoder[BigDecimal]

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
@@ -195,7 +195,7 @@ trait SqlIdiom {
     case Constant(v)         => s"$v"
     case NullValue           => s"null"
     case Tuple(values)       => s"${values.show}"
-    case Set(values)         => s"${values.show}"
+    case Collection(values)  => s"${values.show}"
   }
 
   implicit def identShow(implicit strategy: NamingStrategy): Show[Ident] = Show[Ident] {

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/SqlSourceMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/SqlSourceMacroSpec.scala
@@ -58,7 +58,7 @@ class SqlSourceMacroSpec extends Spec {
 
       implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] = null
       implicit def optionEncoder[T](implicit d: Encoder[T]): Encoder[Option[T]] = null
-      implicit def setEncoder[T](implicit d: Encoder[T]): Encoder[Set[T]] = null
+      implicit def traversableEncoder[T](implicit d: Encoder[T]): Encoder[Traversable[T]] = null
 
       implicit val stringDecoder: Decoder[String] = null
       implicit val bigDecimalDecoder: Decoder[BigDecimal] = null


### PR DESCRIPTION
Fixes #261 

### Problem

Currently contains only support `Set`

### Solution

Support for all `Traversable` sub classes

### Notes

`Array` is not supported yet. Because it was not a `Traversable` but was implicitly convert to `ArrayOps`, which makes parsing very `ugly`. 
### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers