### PR TITLE
`blockParser` off-by-one error

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -52,7 +52,7 @@ trait Parsing extends SchemaConfigParsing {
   }
 
   val blockParser: Parser[Block] = Parser[Block] {
-    case q"{..$exprs}" if exprs.size > 0 => Block(exprs.map(astParser(_)))
+    case q"{..$exprs}" if exprs.size > 1 => Block(exprs.map(astParser(_)))
   }
 
   val valParser: Parser[Val] = Parser[Val] {


### PR DESCRIPTION
Fixes #289 

### Problem

When a quotation block contains a non-parsable AST type a StackOverflowError occurs due to `blockParser` only checking for a non-empty expression list.

### Solution

Make sure matched `blockParser` expression list has at least *two* entries (i.e. `Val` and a return type).

> There are two hard things in computer science: cache invalidation, naming things, and off-by-one errors

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers