### PR TITLE
quill-cassandra: replace Encoder[Set] with Encoder[Traversable]

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/encoding/Encoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/encoding/Encoders.scala
@@ -21,9 +21,9 @@ trait Encoders {
       }
     }
 
-  implicit def setEncoder[T](implicit e: Encoder[T]): Encoder[Set[T]] =
-    new Encoder[Set[T]] {
-      override def apply(idx: Int, values: Set[T], row: BindedStatementBuilder[BoundStatement]) =
+  implicit def traversableEncoder[T](implicit e: Encoder[T]): Encoder[Traversable[T]] =
+    new Encoder[Traversable[T]] {
+      override def apply(idx: Int, values: Traversable[T], row: BindedStatementBuilder[BoundStatement]) =
         row.coll(idx, values, e)
     }
 

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/CqlIdiomSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/CqlIdiomSpec.scala
@@ -230,9 +230,9 @@ class CqlIdiomSpec extends Spec {
       mirrorSource.run(q).cql mustEqual
         "SELECT i, s FROM TestEntity"
     }
-    "set" in {
+    "collection" in {
       val q = quote {
-        qr1.filter(t => Set(1, 2).contains(t.i))
+        qr1.filter(t => List(1, 2).contains(t.i))
       }
       mirrorSource.run(q).cql mustEqual
         "SELECT s, i, l, o FROM TestEntity WHERE i IN (1, 2)"

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/EncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/EncodingSpec.scala
@@ -46,16 +46,16 @@ class EncodingSpec extends Spec {
     }
   }
 
-  "encodes sets" - {
+  "encodes collections" - {
     val q = quote {
-      (set: Set[Int]) =>
-        query[EncodingTestEntity].filter(t => set.contains(t.id))
+      (list: List[Int]) =>
+        query[EncodingTestEntity].filter(t => list.contains(t.id))
     }
 
     "sync" in {
       testSyncDB.run(query[EncodingTestEntity])
       testSyncDB.run(query[EncodingTestEntity].insert)(insertValues)
-      verify(testSyncDB.run(q)(insertValues.map(_.id).toSet))
+      verify(testSyncDB.run(q)(insertValues.map(_.id)))
     }
 
     "async" in {
@@ -64,7 +64,7 @@ class EncodingSpec extends Spec {
         for {
           _ <- testAsyncDB.run(query[EncodingTestEntity].delete)
           _ <- testAsyncDB.run(query[EncodingTestEntity].insert)(insertValues)
-          r <- testAsyncDB.run(q)(insertValues.map(_.id).toSet)
+          r <- testAsyncDB.run(q)(insertValues.map(_.id))
         } yield {
           verify(r)
         }
@@ -78,7 +78,7 @@ class EncodingSpec extends Spec {
           _ <- testStreamDB.run(query[EncodingTestEntity].delete)
           inserts = Observable.from(insertValues: _*)
           _ <- testStreamDB.run(query[EncodingTestEntity].insert)(inserts).count
-          result <- testStreamDB.run(q)(insertValues.map(_.id).toSet)
+          result <- testStreamDB.run(q)(insertValues.map(_.id))
         } yield {
           result
         }


### PR DESCRIPTION
Closes #293 

### Problem

PR #290 missed the `Traversable` encoder for Cassandra.

### Solution

Replace `setEncoder` with `traversableEncoder`.

### Notes

n/a

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers