### PR TITLE
don't reset pullapprove count on push

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,7 +1,7 @@
 approve_by_comment: true
 approve_regex: '^:\+1:'
 reject_regex: '^:\-1:'
-reset_on_push: true
+reset_on_push: false
 author_approval: default
 reviewers:
     -


### PR DESCRIPTION
### Problem

The pullapprove configuration requires new :+1:s after a push. I think it's not necessary. 

### Solution

Don't reset pullapprove count on push

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers