### PR TITLE
fix #299 - Support `Ord` quotation

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
@@ -24,7 +24,7 @@ object CqlIdiom {
         StringContext(parts: _*).s(params.map(_.show): _*)
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: If | _: OptionOperation |
-        _: Query | _: Block | _: Val
+        _: Query | _: Block | _: Val | _: Ordering
         ) =>
         fail(s"Invalid cql: '$a'")
     }

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlQuery.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlQuery.scala
@@ -88,7 +88,7 @@ object CqlQuery {
       case other          => fail(s"Cql supports only properties as select elements. Found: $other")
     }
 
-  private def orderByCriterias(ast: Ast, ordering: Ordering): List[OrderByCriteria] =
+  private def orderByCriterias(ast: Ast, ordering: Ast): List[OrderByCriteria] =
     (ast, ordering) match {
       case (Tuple(properties), ord: PropertyOrdering) => properties.flatMap(orderByCriterias(_, ord))
       case (Tuple(properties), TupleOrdering(ord))    => properties.zip(ord).flatMap { case (a, o) => orderByCriterias(a, o) }

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -27,9 +27,9 @@ case class Map(query: Ast, alias: Ident, body: Ast) extends Query
 
 case class FlatMap(query: Ast, alias: Ident, body: Ast) extends Query
 
-case class SortBy(query: Ast, alias: Ident, criterias: Ast, ordering: Ordering) extends Query
+case class SortBy(query: Ast, alias: Ident, criterias: Ast, ordering: Ast) extends Query
 
-sealed trait Ordering
+sealed trait Ordering extends Ast
 case class TupleOrdering(elems: List[Ordering]) extends Ordering
 
 sealed trait PropertyOrdering extends Ordering

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -21,6 +21,7 @@ object AstShow {
     case ast: If              => ast.show
     case ast: Block           => ast.show
     case ast: Val             => ast.show
+    case ast: Ordering        => ast.show
   }
 
   implicit val ifShow: Show[If] = Show[If] {

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -47,6 +47,8 @@ trait StatefulTransformer[T] {
       case Val(a, b) =>
         val (at, att) = apply(b)
         (Val(a, at), att)
+
+      case o: Ordering => (o, this)
     }
 
   def apply(e: Query): (Query, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -17,11 +17,10 @@ trait StatelessTransformer {
       case Infix(a, b)                 => Infix(a, b.map(apply))
       case OptionOperation(t, a, b, c) => OptionOperation(t, apply(a), b, apply(c))
       case If(a, b, c)                 => If(apply(a), apply(b), apply(c))
-
       case e: Dynamic                  => e
-
       case Block(statements)           => Block(statements.map(apply))
       case Val(name, body)             => Val(name, apply(body))
+      case o: Ordering                 => o
     }
 
   def apply(e: Query): Query =

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -15,6 +15,7 @@ trait Liftables {
     case ast: Action => actionLiftable(ast)
     case ast: Value => valueLiftable(ast)
     case ast: Ident => identLiftable(ast)
+    case ast: Ordering => orderingLiftable(ast)
     case Val(name, body) => q"$pack.Val($name, $body)"
     case Block(statements) => q"$pack.Block($statements)"
     case Property(a, b) => q"$pack.Property($a, $b)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -37,6 +37,7 @@ trait Parsing extends SchemaConfigParsing {
     case `functionParser`(function)         => function
     case `actionParser`(action)             => action
     case `infixParser`(value)               => value
+    case `orderingParser`(value)            => value
     case `operationParser`(value)           => value
     case `identParser`(ident)               => ident
     case `propertyParser`(value)            => value
@@ -155,7 +156,7 @@ trait Parsing extends SchemaConfigParsing {
       FlatMap(astParser(source), identParser(alias), astParser(body))
 
     case q"$source.sortBy[$t](($alias) => $body)($ord)" if (is[QuillQuery[Any]](source)) =>
-      SortBy(astParser(source), identParser(alias), astParser(body), orderingParser(ord))
+      SortBy(astParser(source), identParser(alias), astParser(body), astParser(ord))
 
     case q"$source.groupBy[$t](($alias) => $body)" if (is[QuillQuery[Any]](source)) =>
       GroupBy(astParser(source), identParser(alias), astParser(body))

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -14,6 +14,7 @@ trait Unliftables {
     case actionUnliftable(ast) => ast
     case valueUnliftable(ast) => ast
     case identUnliftable(ast) => ast
+    case orderingUnliftable(ast) => ast
     case q"$pack.Property.apply(${ a: Ast }, ${ b: String })" => Property(a, b)
     case q"$pack.Function.apply(${ a: List[Ident] }, ${ b: Ast })" => Function(a, b)
     case q"$pack.FunctionApply.apply(${ a: Ast }, ${ b: List[Ast] })" => FunctionApply(a, b)
@@ -78,7 +79,7 @@ trait Unliftables {
     case q"$pack.Filter.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Filter(a, b, c)
     case q"$pack.Map.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Map(a, b, c)
     case q"$pack.FlatMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => FlatMap(a, b, c)
-    case q"$pack.SortBy.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast }, ${ d: Ordering })" => SortBy(a, b, c, d)
+    case q"$pack.SortBy.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast }, ${ d: Ast })" => SortBy(a, b, c, d)
     case q"$pack.GroupBy.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => GroupBy(a, b, c)
     case q"$pack.Take.apply(${ a: Ast }, ${ b: Ast })" => Take(a, b)
     case q"$pack.Drop.apply(${ a: Ast }, ${ b: Ast })" => Drop(a, b)

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -736,14 +736,23 @@ class QuotationSpec extends Spec {
         val q = quote {
           (c: Boolean) => if (c) 1 else 2
         }
-        q.ast.body mustEqual If(Ident("c"), Constant(1), Constant(2))
+        quote(unquote(q)).ast.body mustEqual If(Ident("c"), Constant(1), Constant(2))
       }
       "nested" in {
         val q = quote {
           (c1: Boolean, c2: Boolean) => if (c1) 1 else if (c2) 2 else 3
         }
-        q.ast.body mustEqual If(Ident("c1"), Constant(1), If(Ident("c2"), Constant(2), Constant(3)))
+        quote(unquote(q)).ast.body mustEqual If(Ident("c1"), Constant(1), If(Ident("c2"), Constant(2), Constant(3)))
       }
+    }
+    "ord" in {
+      val o = quote {
+        Ord.desc[Int]
+      }
+      val q = quote {
+        qr1.sortBy(_.i)(o)
+      }
+      quote(unquote(q)).ast.ordering mustEqual o.ast
     }
   }
 

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/SqlQuery.scala
@@ -198,7 +198,7 @@ object SqlQuery {
       case other             => fail(s"Invalid group by criteria $ast")
     }
 
-  private def orderByCriterias(ast: Ast, ordering: Ordering): List[OrderByCriteria] =
+  private def orderByCriterias(ast: Ast, ordering: Ast): List[OrderByCriteria] =
     (ast, ordering) match {
       case (Tuple(properties), ord: PropertyOrdering) => properties.map(orderByCriterias(_, ord)).flatten
       case (Tuple(properties), TupleOrdering(ord))    => properties.zip(ord).map { case (a, o) => orderByCriterias(a, o) }.flatten

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
@@ -23,7 +23,7 @@ trait SqlIdiom {
       case a: Property          => a.show
       case a: Value             => a.show
       case a: If                => a.show
-      case a @ (_: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block | _: Val) =>
+      case a @ (_: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block | _: Val | _: Ordering) =>
         fail(s"Malformed query $a.")
     }
 


### PR DESCRIPTION
Fixes #299

### Problem

`Ord` currently only can be quoted as a `sortBy` parameter.

### Solution

Make `Ord` an AST.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers