### PR TITLE
show ident instead of indent.toString

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
@@ -182,10 +182,10 @@ trait SqlIdiom {
 
   implicit def propertyShow(implicit valueShow: Show[Value], identShow: Show[Ident], strategy: NamingStrategy): Show[Property] =
     Show[Property] {
-      case Property(ident, "isEmpty")      => s"$ident IS NULL"
-      case Property(ident, "nonEmpty")     => s"$ident IS NOT NULL"
-      case Property(ident, "isDefined")    => s"$ident IS NOT NULL"
-      case Property(Property(ident, a), b) => s"$ident.$a$b"
+      case Property(ident, "isEmpty")      => s"${ident.show} IS NULL"
+      case Property(ident, "nonEmpty")     => s"${ident.show} IS NOT NULL"
+      case Property(ident, "isDefined")    => s"${ident.show} IS NOT NULL"
+      case Property(Property(ident, a), b) => s"${ident.show}.$a$b"
       case Property(ast, name)             => s"${scopedShow(ast)}.${strategy.column(name)}"
     }
 

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomNamingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/idiom/SqlIdiomNamingSpec.scala
@@ -47,8 +47,10 @@ class SqlIdiomNamingSpec extends Spec {
       (q.ast: Ast).show mustEqual
         "SELECT t.c_somecolumn FROM test_entity t"
     }
+
+    val db = source(new SqlMirrorSourceConfig[SnakeCase]("test"))
+
     "actions" - {
-      val db = source(new SqlMirrorSourceConfig[SnakeCase]("test"))
       "insert" in {
         db.run(query[TestEntity].insert)(List()).sql mustEqual
           "INSERT INTO test_entity (some_column) VALUES (?)"
@@ -60,6 +62,14 @@ class SqlIdiomNamingSpec extends Spec {
       "delete" in {
         db.run(query[TestEntity].delete).sql mustEqual
           "DELETE FROM test_entity"
+      }
+    }
+
+    "queries" - {
+      "property empty check" in {
+        case class TestEntity(optionValue: Option[Int])
+        db.run(query[TestEntity].filter(t => t.optionValue.isEmpty)).sql mustEqual
+          "SELECT t.option_value FROM test_entity t WHERE t.option_value IS NULL"
       }
     }
   }


### PR DESCRIPTION
Fix #305 
### Problem

`propertyShow` in `SqlIdiom`  use `indent.toString`

### Solution

Should be `ident.show`


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers