### PR TITLE
Update codec for resolve decoding error between `mysql bit(1)` and `s…

### DIFF
--- a/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlDecoders.scala
@@ -56,6 +56,7 @@ trait FinagleMysqlDecoders {
   implicit val booleanDecoder: Decoder[Boolean] =
     decoder[Boolean] {
       case ByteValue(byte) => byte == (1: Byte)
+      case v: RawValue     => v.bytes.head == (1: Byte)
     }
   implicit val byteDecoder: Decoder[Byte] =
     decoder[Byte] {

--- a/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/FinagleMysqlEncodingSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/FinagleMysqlEncodingSpec.scala
@@ -41,4 +41,31 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
       }
     }
   }
+
+  "decode boolean types" - {
+    case class BooleanEncodingTestEntity(v1: Boolean, v2: Boolean)
+    val decodeBoolean = (entity: BooleanEncodingTestEntity) => {
+      val delete = quote(query[BooleanEncodingTestEntity].delete)
+      val insert = quote(query[BooleanEncodingTestEntity].insert)
+      val r = for {
+        _ <- testDB.run(delete)
+        _ <- testDB.run(insert)(List(entity))
+        result <- testDB.run(query[BooleanEncodingTestEntity])
+      } yield result
+      Await.result(r).head
+    }
+    "true" in {
+      val entity = BooleanEncodingTestEntity(true, true)
+      val r = decodeBoolean(entity)
+      r.v1 mustEqual true
+      r.v2 mustEqual true
+    }
+
+    "false" in {
+      val entity = BooleanEncodingTestEntity(false, false)
+      val r = decodeBoolean(entity)
+      r.v1 mustEqual false
+      r.v2 mustEqual false
+    }
+  }
 }

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -54,6 +54,11 @@ Create TABLE DateEncodingTestEntity(
     v3 timestamp
 );
 
+Create TABLE BooleanEncodingTestEntity(
+    v1 BOOLEAN,
+    v2 BIT(1)
+);
+
 CREATE TABLE TestEntity(
     s VARCHAR(255),
     i INTEGER,

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -32,7 +32,7 @@ CREATE TABLE EncodingTestEntity(
     v6 INTEGER,
     v7 BIGINT,
     v8 FLOAT,
-    v9 DOUBLE PRECISIOn,
+    v9 DOUBLE PRECISION,
     v10 BYTEA,
     v11 TIMESTAMP,
     o1 VARCHAR(255),
@@ -43,7 +43,7 @@ CREATE TABLE EncodingTestEntity(
     o6 INTEGER,
     o7 BIGINT,
     o8 FLOAT,
-    o9 DOUBLE PRECISIOn,
+    o9 DOUBLE PRECISION,
     o10 BYTEA,
     o11 TIMESTAMP
 );


### PR DESCRIPTION
Fixes `Mysql BIT(1)` to `scala Boolean` decoding Error.

### Problem

**Entity** 
```scala
case class Items(id:Int, brandId: Int, isValid: Boolean)
```

**Table**
```sql
CREATE TABLE items(`id` int(11),  `brand_id` int(11), `is_valid` bit(1) DEFAULT b'1');
```

**Error**
```scala
java.lang.IllegalStateException: Value 'RawValue(16,63,true,[B@64697949)' can't be decoded to 'boolean'

	at io.getquill.util.Messages$.fail(Messages.scala:8)
	at io.getquill.sources.finagle.mysql.FinagleMysqlDecoders$$anon$1$$anonfun$apply$1.apply(FinagleMysqlDecoders.scala:34)
	at io.getquill.sources.finagle.mysql.FinagleMysqlDecoders$$anon$1$$anonfun$apply$1.apply(FinagleMysqlDecoders.scala:34)
	at scala.Option.getOrElse(Option.scala:121)
	at io.getquill.sources.finagle.mysql.FinagleMysqlDecoders$$anon$1.apply(FinagleMysqlDecoders.scala:34)
	at io.getquill.sources.finagle.mysql.FinagleMysqlDecoders$$anon$1.apply(FinagleMysqlDecoders.scala:31)
```

**Custom Decoder not working on predefined types**
```scala
implicit val bitToBooleanDecoder = db.decoder[Boolean] {
  case ByteValue(byte) => byte == (1: Byte)
  case v: RawValue => v.bytes.head == (1 : Byte)
}
val q = quote { (id: Int) =>
  query[Items].filter(i => i.id == id).take(1)
}
db.run(q)(id).map(_.headOption)
// Error:(29, 11) Source doesn't know how to decode 'i.isValid: Boolean'
//    db.run(q)(id).map(_.headOption)
//          ^
```

### Solution
Add RawValue into a `Decoder[Boolean] `

### Notes



### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
