### PR TITLE
Add a default value to generated parameter

### DIFF
--- a/quill-async/src/main/scala/io/getquill/sources/async/AsyncSource.scala
+++ b/quill-async/src/main/scala/io/getquill/sources/async/AsyncSource.scala
@@ -65,13 +65,13 @@ abstract class AsyncSource[D <: SqlIdiom, N <: NamingStrategy, C <: Connection](
       f(TransactionalExecutionContext(ec, c))
     }
 
-  def execute(sql: String, bind: BindedStatementBuilder[List[Any]] => BindedStatementBuilder[List[Any]], generated: Option[String])(implicit ec: ExecutionContext) = {
+  def execute(sql: String, bind: BindedStatementBuilder[List[Any]] => BindedStatementBuilder[List[Any]], generated: Option[String] = None)(implicit ec: ExecutionContext) = {
     logger.info(sql)
     val (expanded, params) = bind(new BindedStatementBuilder).build(sql)
     withConnection(_.sendPreparedStatement(expandAction(expanded, generated), params(List()))).map(extractActionResult(generated))
   }
 
-  def executeBatch[T](sql: String, bindParams: T => BindedStatementBuilder[List[Any]] => BindedStatementBuilder[List[Any]], generated: Option[String])(implicit ec: ExecutionContext): ActionApply[T] = {
+  def executeBatch[T](sql: String, bindParams: T => BindedStatementBuilder[List[Any]] => BindedStatementBuilder[List[Any]], generated: Option[String] = None)(implicit ec: ExecutionContext): ActionApply[T] = {
     def run(values: List[T]): Future[List[Long]] =
       values match {
         case Nil =>

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraAsyncSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraAsyncSource.scala
@@ -30,10 +30,10 @@ class CassandraAsyncSource[N <: NamingStrategy](config: CassandraSourceConfig[N,
     session.executeAsync(prepare(cql, bind))
       .map(_.all.toList.map(extractor))
 
-  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String])(implicit ec: ExecutionContext): Future[ResultSet] =
+  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None)(implicit ec: ExecutionContext): Future[ResultSet] =
     session.executeAsync(prepare(cql, bind))
 
-  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String])(implicit ec: ExecutionContext): ActionApply[T] = {
+  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None)(implicit ec: ExecutionContext): ActionApply[T] = {
     def run(values: List[T]): Future[List[ResultSet]] =
       values match {
         case Nil => Future.successful(List())

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraStreamSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraStreamSource.scala
@@ -38,10 +38,10 @@ class CassandraStreamSource[N <: NamingStrategy](config: CassandraSourceConfig[N
       .map(extractor)
   }
 
-  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): Observable[ResultSet] =
+  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None): Observable[ResultSet] =
     Observable.fromFuture(session.executeAsync(prepare(cql, bind)))
 
-  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): Observable[T] => Observable[ResultSet] =
+  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None): Observable[T] => Observable[ResultSet] =
     (values: Observable[T]) =>
       values.flatMap { value =>
         Observable.fromFuture(session.executeAsync(prepare(cql, bindParams(value))))

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSyncSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSyncSource.scala
@@ -28,10 +28,10 @@ class CassandraSyncSource[N <: NamingStrategy](config: CassandraSourceConfig[N, 
     session.execute(prepare(cql, bind))
       .all.toList.map(extractor)
 
-  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): ResultSet =
+  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None): ResultSet =
     session.execute(prepare(cql, bind))
 
-  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String]): ActionApply[T] = {
+  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None): ActionApply[T] = {
     val func = { (values: List[T]) =>
       @tailrec
       def run(values: List[T], acc: List[ResultSet]): List[ResultSet] =

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/mirror/CassandraMirrorSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/mirror/CassandraMirrorSource.scala
@@ -34,12 +34,12 @@ class CassandraMirrorSource(config: CassandraMirrorSourceConfig)
 
   case class ActionMirror(cql: String, bind: Row)
 
-  def execute(cql: String, bind: Row => Row, generated: Option[String]) =
+  def execute(cql: String, bind: Row => Row, generated: Option[String] = None) =
     ActionMirror(cql, bind(Row()))
 
   case class BatchActionMirror(cql: String, bindList: List[Row])
 
-  def executeBatch[T](cql: String, bindParams: T => Row => Row, generated: Option[String]) = {
+  def executeBatch[T](cql: String, bindParams: T => Row => Row, generated: Option[String] = None) = {
     val f = (values: List[T]) =>
       BatchActionMirror(cql, values.map(bindParams).map(_(Row())))
     new ActionApply[T](f)

--- a/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorSource.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorSource.scala
@@ -44,12 +44,12 @@ class MirrorSource(config: SourceConfig[MirrorSource])
 
   case class ActionMirror(ast: Ast, bind: Row)
 
-  def execute(ast: Ast, bindParams: Row => Row, generated: Option[String]) =
+  def execute(ast: Ast, bindParams: Row => Row, generated: Option[String] = None) =
     ActionMirror(ast, bindParams(Row()))
 
   case class BatchActionMirror(ast: Ast, bindList: List[Row])
 
-  def executeBatch[T](ast: Ast, bindParams: T => Row => Row, generated: Option[String]) =
+  def executeBatch[T](ast: Ast, bindParams: T => Row => Row, generated: Option[String] = None) =
     (values: List[T]) =>
       BatchActionMirror(ast, values.map(bindParams).map(_(Row())))
 

--- a/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlSource.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlSource.scala
@@ -60,13 +60,13 @@ class FinagleMysqlSource[N <: NamingStrategy](config: FinagleMysqlSourceConfig[N
         f.ensure(currentClient.clear)
     }
 
-  def execute(sql: String, bind: BindedStatementBuilder[List[Parameter]] => BindedStatementBuilder[List[Parameter]], generated: Option[String]): Future[Result] = {
+  def execute(sql: String, bind: BindedStatementBuilder[List[Parameter]] => BindedStatementBuilder[List[Parameter]], generated: Option[String] = None): Future[Result] = {
     val (expanded, params) = bind(new BindedStatementBuilder).build(sql)
     logger.info(expanded)
     withClient(_.prepare(expanded)(params(List()): _*))
   }
 
-  def executeBatch[T](sql: String, bindParams: T => BindedStatementBuilder[List[Parameter]] => BindedStatementBuilder[List[Parameter]], generated: Option[String]): ActionApply[T] = {
+  def executeBatch[T](sql: String, bindParams: T => BindedStatementBuilder[List[Parameter]] => BindedStatementBuilder[List[Parameter]], generated: Option[String] = None): ActionApply[T] = {
     def run(values: List[T]): Future[List[Result]] =
       values match {
         case Nil =>

--- a/quill-jdbc/src/main/scala/io/getquill/sources/jdbc/JdbcSource.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/sources/jdbc/JdbcSource.scala
@@ -69,7 +69,7 @@ class JdbcSource[D <: SqlIdiom, N <: NamingStrategy](config: JdbcSourceConfig[D,
       }
     }
 
-  def execute(sql: String, bind: BindedStatementBuilder[PreparedStatement] => BindedStatementBuilder[PreparedStatement], generated: Option[String]): Long = {
+  def execute(sql: String, bind: BindedStatementBuilder[PreparedStatement] => BindedStatementBuilder[PreparedStatement], generated: Option[String] = None): Long = {
     logger.info(sql)
     val (expanded, setValues) = bind(new BindedStatementBuilder[PreparedStatement]).build(sql)
     logger.info(expanded)
@@ -87,7 +87,7 @@ class JdbcSource[D <: SqlIdiom, N <: NamingStrategy](config: JdbcSourceConfig[D,
   }
 
   def executeBatch[T](sql: String, bindParams: T => BindedStatementBuilder[PreparedStatement] => BindedStatementBuilder[PreparedStatement],
-                      generated: Option[String]): ActionApply[T] = {
+                      generated: Option[String] = None): ActionApply[T] = {
     val func = { (values: List[T]) =>
       val groups = values.map(bindParams(_)(new BindedStatementBuilder[PreparedStatement]).build(sql)).groupBy(_._1)
       (for ((sql, setValues) <- groups.toList) yield {

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/mirror/SqlMirrorSource.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/mirror/SqlMirrorSource.scala
@@ -38,12 +38,12 @@ class SqlMirrorSource[N <: NamingStrategy](config: SqlMirrorSourceConfig[N])
 
   case class ActionMirror(sql: String, bind: Row, generated: Option[String])
 
-  def execute(sql: String, bind: Row => Row, generated: Option[String]) =
+  def execute(sql: String, bind: Row => Row, generated: Option[String] = None) =
     ActionMirror(sql, bind(Row()), generated)
 
   case class BatchActionMirror(sql: String, bindList: List[Row], generated: Option[String])
 
-  def executeBatch[T](sql: String, bindParams: T => Row => Row, generated: Option[String]) = {
+  def executeBatch[T](sql: String, bindParams: T => Row => Row, generated: Option[String] = None) = {
     val func = (values: List[T]) =>
       BatchActionMirror(sql, values.map(bindParams).map(_(Row())), generated)
     new ActionApply(func)


### PR DESCRIPTION
Improve execute methods by providing a default value for generated methods (None)

### Problem

An user used to execute run just plain queries in my database (like schema creation), just calling `execute("Sql string)`. Now this user has to call `execute("Sql string", None)`

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers