### PR TITLE
Introduce MiMa

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val quill =
 lazy val `quill-core` = 
   (project in file("quill-core"))
     .settings(commonSettings: _*)
+    .settings(mimaSettings)
     .settings(libraryDependencies ++= Seq(
       "com.typesafe"               %  "config"        % "1.3.0",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
@@ -24,11 +25,13 @@ lazy val `quill-core` =
 lazy val `quill-sql` = 
   (project in file("quill-sql"))
     .settings(commonSettings: _*)
+    .settings(mimaSettings)
     .dependsOn(`quill-core` % "compile->compile;test->test")
 
 lazy val `quill-jdbc` = 
   (project in file("quill-jdbc"))
     .settings(commonSettings: _*)
+    .settings(mimaSettings)
     .settings(
       libraryDependencies ++= Seq(
         "com.zaxxer"     % "HikariCP"             % "2.3.9",
@@ -43,6 +46,7 @@ lazy val `quill-jdbc` =
 lazy val `quill-finagle-mysql` = 
   (project in file("quill-finagle-mysql"))
     .settings(commonSettings: _*)
+    .settings(mimaSettings)
     .settings(
       libraryDependencies ++= Seq(
         "com.twitter" %% "finagle-mysql" % "6.31.0"
@@ -54,6 +58,7 @@ lazy val `quill-finagle-mysql` =
 lazy val `quill-async` = 
   (project in file("quill-async"))
     .settings(commonSettings: _*)
+    .settings(mimaSettings)
     .settings(
       libraryDependencies ++= Seq(
         "com.github.mauricio" %% "db-async-common"  % "0.2.18",
@@ -67,6 +72,7 @@ lazy val `quill-async` =
 lazy val `quill-cassandra` = 
   (project in file("quill-cassandra"))
     .settings(commonSettings: _*)
+    .settings(mimaSettings)
     .settings(
       libraryDependencies ++= Seq(
         "com.datastax.cassandra" %  "cassandra-driver-core" % "3.0.0",
@@ -93,6 +99,17 @@ lazy val `tut-settings` = Seq(
       IO.write(file, str)
     }
     Seq()
+  }
+)
+
+lazy val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
+  previousArtifact := {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, scalaMajor)) if scalaMajor <= 11 =>
+        Some(organization.value % s"${name.value}_${scalaBinaryVersion.value}" % "0.5.0")
+      case _ =>
+        None
+    }
   }
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,6 +19,8 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.0")
 
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.9")
+
 // Scalariform
 //
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")


### PR DESCRIPTION
Fixes #198

### Problem

We should add the MiMa plugin to ensure binary compatibility of minor versions and patches.

### Notes

I'm not sure if this enough, but I could call it not finished since right now current master show binary incompabilities with 0.5.

To test it just run 

    sbt mimaReportBinaryIssues

Also I tested with v0.4.0 vs v.0.4.1 and I also found binary compatibilies. I guess quill is going under a lot of changes and refactorings right now and we are not following [semantic versioning](http://semver.org/) yet.

Maybe we should wait until 1.0 to apply this?

We also could filter modules or classes going under a lot of recfatoring with 

https://github.com/typesafehub/migration-manager/wiki/Sbt-plugin#advanced-usage-filtering-binary-incompatibilities

In my research, I found out people usually do this for classes/features marked as experimental.

We also have to discuss how we should integrate this in the build process.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers