### PR TITLE
Allow Free Variables anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ val areas = quote {
 }
 ```
 
+Quotations can contain values defined outside of the quotation:
+```scala
+val pi = 3.14159
+val areas = quote {
+  query[Circle].map(c => pi * c.radius * c.radius)
+}
+```
+
 Quill's normalization engine applies reduction steps before translating the quotation to the target language. The correspondent normalized quotation for both versions of the `areas` query is:
 
 ```scala

--- a/quill-async/src/test/scala/io/getquill/sources/async/mysql/ProductAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/mysql/ProductAsyncSpec.scala
@@ -20,13 +20,13 @@ class ProductAsyncSpec extends ProductSpec {
   "Product" - {
     "Insert multiple products" in {
       val inserted = await(testMysqlDB.run(productInsert)(productEntries))
-      val product = await(testMysqlDB.run(productById)(inserted(2))).head
+      val product = await(testMysqlDB.run(productById(inserted(2)))).head
       product.description mustEqual productEntries(2).description
       product.id mustEqual inserted(2)
     }
     "Single insert product" in {
       val inserted = await(testMysqlDB.run(productSingleInsert))
-      val product = await(testMysqlDB.run(productById)(inserted)).head
+      val product = await(testMysqlDB.run(productById(inserted))).head
       product.description mustEqual "Window"
       product.id mustEqual inserted
     }

--- a/quill-async/src/test/scala/io/getquill/sources/async/postgres/ProductAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/postgres/ProductAsyncSpec.scala
@@ -20,13 +20,13 @@ class ProductAsyncSpec extends ProductSpec {
   "Product" - {
     "Insert multiple products" in {
       val inserted = await(testPostgresDB.run(productInsert)(productEntries))
-      val product = await(testPostgresDB.run(productById)(inserted(2))).head
+      val product = await(testPostgresDB.run(productById(inserted(2)))).head
       product.description mustEqual productEntries(2).description
       product.id mustEqual inserted(2)
     }
     "Single insert product" in {
       val inserted = await(testPostgresDB.run(productSingleInsert))
-      val product = await(testPostgresDB.run(productById)(inserted)).head
+      val product = await(testPostgresDB.run(productById(inserted))).head
       product.description mustEqual "Window"
       product.id mustEqual inserted
     }

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CqlIdiom.scala
@@ -24,7 +24,7 @@ object CqlIdiom {
         StringContext(parts: _*).s(params.map(_.show): _*)
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: If | _: OptionOperation |
-        _: Query | _: Block | _: Val | _: Ordering
+        _: Query | _: Block | _: Val | _: Ordering | _: Binding | _: QuotedReference[_]
         ) =>
         fail(s"Invalid cql: '$a'")
     }

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/ops/CassandraOpsSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/ops/CassandraOpsSpec.scala
@@ -73,6 +73,7 @@ class CassandraOpsSpec extends Spec {
       }
     }
     "if" in {
+
       val q = quote {
         query[TestEntity].update(t => t.s -> "b").ifCond(t => t.s == "a")
       }

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -111,3 +111,10 @@ case class Assignment(input: Ident, property: String, value: Ast)
 //************************************************************
 
 case class Dynamic(tree: Any) extends Ast
+
+sealed trait Binding extends Ast
+
+case class RuntimeBinding(key: String, override val toString: String) extends Binding
+case class CompileTimeBinding[T](key: String, tree: T) extends Binding
+
+case class QuotedReference[T](tree: T, ast: Ast) extends Ast

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -8,20 +8,22 @@ import io.getquill.util.Show.listShow
 object AstShow {
 
   implicit val astShow: Show[Ast] = Show[Ast] {
-    case ast: Query           => ast.show
-    case ast: Function        => ast.show
-    case ast: Value           => ast.show
-    case ast: Operation       => ast.show
-    case ast: Action          => ast.show
-    case ast: Ident           => ast.show
-    case ast: Property        => ast.show
-    case ast: Infix           => ast.show
-    case ast: OptionOperation => ast.show
-    case ast: Dynamic         => ast.show
-    case ast: If              => ast.show
-    case ast: Block           => ast.show
-    case ast: Val             => ast.show
-    case ast: Ordering        => ast.show
+    case ast: Query            => ast.show
+    case ast: Function         => ast.show
+    case ast: Value            => ast.show
+    case ast: Operation        => ast.show
+    case ast: Action           => ast.show
+    case ast: Ident            => ast.show
+    case ast: Property         => ast.show
+    case ast: Infix            => ast.show
+    case ast: OptionOperation  => ast.show
+    case ast: Dynamic          => ast.show
+    case ast: Binding          => ast.show
+    case ast: If               => ast.show
+    case ast: Block            => ast.show
+    case ast: Val              => ast.show
+    case ast: Ordering         => ast.show
+    case q: QuotedReference[_] => q.ast.show
   }
 
   implicit val ifShow: Show[If] = Show[If] {
@@ -30,6 +32,11 @@ object AstShow {
 
   implicit val dynamicShow: Show[Dynamic] = Show[Dynamic] {
     case Dynamic(tree) => tree.toString
+  }
+
+  implicit val bindingShow: Show[Binding] = Show[Binding] {
+    case RuntimeBinding(_, toString) => toString
+    case b: CompileTimeBinding[_]    => b.tree.toString
   }
 
   implicit val blockShow: Show[Block] = Show[Block] {

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -38,7 +38,11 @@ trait StatefulTransformer[T] {
         val (ct, ctt) = btt.apply(c)
         (If(at, bt, ct), ctt)
 
-      case l: Dynamic => (l, this)
+      case l: Dynamic            => (l, this)
+
+      case l: Binding            => (l, this)
+
+      case l: QuotedReference[_] => (l, this)
 
       case Block(a) =>
         val (at, att) = apply(a)(_.apply)

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -18,6 +18,8 @@ trait StatelessTransformer {
       case OptionOperation(t, a, b, c) => OptionOperation(t, apply(a), b, apply(c))
       case If(a, b, c)                 => If(apply(a), apply(b), apply(c))
       case e: Dynamic                  => e
+      case e: Binding                  => e
+      case e: QuotedReference[_]       => e
       case Block(statements)           => Block(statements.map(apply))
       case Val(name, body)             => Val(name, apply(body))
       case o: Ordering                 => o

--- a/quill-core/src/main/scala/io/getquill/quotation/CompileTimeBindings.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/CompileTimeBindings.scala
@@ -1,0 +1,24 @@
+package io.getquill.quotation
+
+import io.getquill.ast.{ Ast, CompileTimeBinding, StatefulTransformer }
+
+import scala.reflect.macros.whitebox.Context
+
+case class CompileTimeBindings[T](state: List[CompileTimeBinding[T]])
+  extends StatefulTransformer[List[CompileTimeBinding[T]]] {
+
+  override def apply(ast: Ast): (Ast, StatefulTransformer[List[CompileTimeBinding[T]]]) =
+    ast match {
+      case binding: CompileTimeBinding[T] => (binding, CompileTimeBindings(binding :: state))
+      case other =>
+        super.apply(other)
+    }
+}
+
+object CompileTimeBindings {
+  def apply(c: Context)(ast: Ast): List[CompileTimeBinding[c.Tree]] =
+    new CompileTimeBindings[c.Tree](List.empty[CompileTimeBinding[c.Tree]])(ast) match {
+      case (_, transformer) =>
+        transformer.state.reverse
+    }
+}

--- a/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
@@ -9,6 +9,8 @@ case class FreeVariables(state: State)
 
   override def apply(ast: Ast): (Ast, StatefulTransformer[State]) =
     ast match {
+      case binding: RuntimeBinding =>
+        (binding, FreeVariables(State(state.seen, state.free + Ident(binding.toString))))
       case ident: Ident if (!state.seen.contains(ident)) =>
         (ident, FreeVariables(State(state.seen, state.free + ident)))
       case f @ Function(params, body) =>

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -1,8 +1,7 @@
 package io.getquill.quotation
 
 import scala.reflect.macros.whitebox.Context
-
-import io.getquill.ast._
+import io.getquill.ast.{ CompileTimeBinding, _ }
 
 trait Liftables {
   val c: Context
@@ -28,6 +27,9 @@ trait Liftables {
     case If(a, b, c) => q"$pack.If($a, $b, $c)"
     case Dynamic(tree: Tree) if (tree.tpe <:< c.weakTypeOf[Quoted[Any]]) => q"$tree.ast"
     case Dynamic(tree: Tree) => q"$pack.Constant($tree)"
+    case RuntimeBinding(key: String, toString: String) => q"$pack.RuntimeBinding($key, $toString)"
+    case CompileTimeBinding(key: String, tree: Tree) => q"$pack.RuntimeBinding($key, ${tree.toString})"
+    case QuotedReference(_, ast) => astLiftable(ast)
   }
 
   implicit val optionOperationTypeLiftable: Liftable[OptionOperationType] = Liftable[OptionOperationType] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -1,11 +1,14 @@
 package io.getquill.quotation
 
 import io.getquill.util.Messages._
+
 import scala.annotation.StaticAnnotation
 import scala.reflect.ClassTag
 import scala.reflect.macros.whitebox.Context
 import io.getquill.ast._
-import java.util.concurrent.atomic.AtomicInteger
+import scala.reflect.internal.Symbols
+
+import scala.collection.mutable
 
 trait Quoted[+T] {
   def ast: Ast
@@ -13,21 +16,48 @@ trait Quoted[+T] {
 
 case class QuotedAst(ast: Ast) extends StaticAnnotation
 
-trait Quotation extends Parsing with Liftables with Unliftables {
+trait Quotation extends Liftables with Unliftables {
 
   val c: Context
   import c.universe._
 
   def quote[T: WeakTypeTag](body: Expr[T]) = {
-    val ast = astParser(body.tree)
+
+    val freeVars = extractFreeVars(body.tree)
+
+    val ast = Parsing(c)(freeVars).astParser(body.tree)
+
+    val runtimeBindings = RuntimeBindings(c)(ast).map {
+      case (quoted, RuntimeBinding(key, _)) =>
+        val binding = TermName(s"binding_$key")
+        q"def $binding = ${quoted}.$binding"
+    }
+
+    val importReflectiveCalls = runtimeBindings.map {
+      _ => q"import scala.language.reflectiveCalls"
+    }.headOption.getOrElse(EmptyTree)
+
+    val compileTimeBindings = CompileTimeBindings(c)(ast).map {
+      case CompileTimeBinding(key, tree: Tree) =>
+        val binding = TermName(s"binding_$key")
+        q"def $binding = $tree"
+    }
+
     val id = TermName(s"id${ast.hashCode}")
+
     q"""
       new ${c.weakTypeOf[Quoted[T]]} {
+        $importReflectiveCalls
+
         @${c.weakTypeOf[QuotedAst]}($ast)
         def quoted = ast
+
         override def ast = $ast
         override def toString = ast.toString
+
         def $id() = ()
+        ..$runtimeBindings
+        ..$compileTimeBindings
       }
     """
   }
@@ -54,4 +84,32 @@ trait Quotation extends Parsing with Liftables with Unliftables {
       annotation <- method.annotations.headOption
       astTree <- annotation.tree.children.lastOption
     } yield (astTree)
+
+  private class FreeVarTraverser extends Traverser {
+    val freeVars = mutable.LinkedHashSet[Symbol]()
+    val declared = mutable.LinkedHashSet[Symbol]()
+    def isLocalToBlock(sym: Symbol) = sym.owner.isTerm
+    override def traverse(tree: Tree) = {
+      tree match {
+        case Function(args, _) =>
+          args foreach { arg => declared += arg.symbol }
+        case ValDef(_, _, _, _) =>
+          declared += tree.symbol
+        case _: Bind =>
+          declared += tree.symbol
+        case Ident(_) =>
+          val sym = tree.symbol
+          if ((sym != NoSymbol) && isLocalToBlock(sym) && sym.isTerm && !declared.contains(sym)) freeVars += sym
+        case _ =>
+      }
+      super.traverse(tree)
+    }
+  }
+
+  private def extractFreeVars(tree: Tree) = {
+    val freeVarsTraverser = new FreeVarTraverser
+    freeVarsTraverser.traverse(tree)
+    freeVarsTraverser.freeVars.toList
+  }
+
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/RuntimeBindings.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/RuntimeBindings.scala
@@ -1,0 +1,36 @@
+package io.getquill.quotation
+
+import io.getquill.ast.{ Ast, QuotedReference, RuntimeBinding, StatefulTransformer }
+
+import scala.reflect.macros.whitebox.Context
+import scala.collection.immutable.ListMap
+import io.getquill.util.Messages._
+
+case class Bindings[T](current: Option[T], bindings: ListMap[T, RuntimeBinding])
+
+case class RuntimeBindings[T](c: Context, state: Bindings[T])
+  extends StatefulTransformer[Bindings[T]] {
+
+  override def apply(ast: Ast): (Ast, StatefulTransformer[Bindings[T]]) =
+    ast match {
+      case quoted: QuotedReference[T] =>
+        RuntimeBindings(c, Bindings(Some(quoted.tree), state.bindings)).apply(quoted.ast)
+      case binding: RuntimeBinding =>
+        state.current match {
+          case None => c.fail(s"Please report a bug. The binding '${binding.toString}' expected a Quoted Reference")
+          case Some(current) =>
+            val bindings = Bindings(state.current, state.bindings + ((current, binding)))
+            (binding, RuntimeBindings(c, bindings))
+        }
+      case other =>
+        super.apply(other)
+    }
+}
+
+object RuntimeBindings {
+  def apply(c: Context)(ast: Ast): ListMap[c.Tree, RuntimeBinding] =
+    RuntimeBindings(c, Bindings(None, ListMap.empty[c.Tree, RuntimeBinding]))(ast) match {
+      case (_, transformer) =>
+        transformer.state.bindings
+    }
+}

--- a/quill-core/src/main/scala/io/getquill/quotation/SchemaConfigParsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/SchemaConfigParsing.scala
@@ -2,10 +2,12 @@ package io.getquill.quotation
 
 import io.getquill.ast.PropertyAlias
 
+import scala.reflect.macros.whitebox.Context
+
 case class SchemaConfig(alias: Option[String] = None, properties: List[PropertyAlias] = List(), generated: Option[String] = None)
 
 trait SchemaConfigParsing extends UnicodeArrowParsing {
-  this: Quotation =>
+  val c: Context
 
   import c.universe.{ Function => _, Ident => _, _ }
 

--- a/quill-core/src/main/scala/io/getquill/quotation/UnicodeArrowParsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/UnicodeArrowParsing.scala
@@ -1,7 +1,9 @@
 package io.getquill.quotation
 
+import scala.reflect.macros.whitebox.Context
+
 trait UnicodeArrowParsing {
-  this: Quotation =>
+  val c: Context
 
   import c.universe.Quasiquote
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -26,6 +26,7 @@ trait Unliftables {
     case q"$pack.If.apply(${ a: Ast }, ${ b: Ast }, ${ c: Ast })" => If(a, b, c)
     case q"$tree.ast" => Dynamic(tree)
     case q"$pack.lift($tree)" => Dynamic(tree)
+    case q"$pack.RuntimeBinding.apply(${ a: String }, ${ b: String })" => RuntimeBinding(a, b)
   }
 
   implicit val optionOperationTypeUnliftable: Unliftable[OptionOperationType] = Unliftable[OptionOperationType] {

--- a/quill-core/src/main/scala/io/getquill/sources/QueryMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/QueryMacro.scala
@@ -13,6 +13,7 @@ trait QueryMacro extends SelectFlattening with SelectResultExtraction {
   import c.universe.{ Ident => _, _ }
 
   def runQuery[R, S, T](
+    quotedTree:     Tree,
     ast:            Ast,
     inPlaceParams:  collection.Map[Ident, (Type, Tree)],
     functionParams: List[(Ident, Type)]
@@ -37,6 +38,8 @@ trait QueryMacro extends SelectFlattening with SelectResultExtraction {
     if (inputs.isEmpty)
       q"""
       {
+        import scala.language.reflectiveCalls
+        val quoted = $quotedTree
         val (sql, bindings: List[io.getquill.ast.Ident], _) =
             ${prepare(flattenQuery, allParamIdents)}
 
@@ -49,6 +52,8 @@ trait QueryMacro extends SelectFlattening with SelectResultExtraction {
     else
       q"""
       {
+        import scala.language.reflectiveCalls
+        val quoted = $quotedTree
         val (sql, bindings: List[io.getquill.ast.Ident], _) =
             ${prepare(flattenQuery, allParamIdents)}
 

--- a/quill-core/src/main/scala/io/getquill/sources/SourceMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/SourceMacro.scala
@@ -2,12 +2,9 @@ package io.getquill.sources
 
 import scala.reflect.macros.whitebox.Context
 import io.getquill._
-import io.getquill.ast.{ Query => _, Action => _, _ }
-import io.getquill.norm.Normalize
+import io.getquill.ast.{ Action => _, Query => _, _ }
 import io.getquill.quotation.Quotation
 import io.getquill.quotation.Quoted
-import io.getquill.util.Messages.RichContext
-import io.getquill.quotation.FreeVariables
 
 trait SourceMacro extends Quotation with ActionMacro with QueryMacro with ResolveSourceMacro {
   val c: Context
@@ -20,38 +17,34 @@ trait SourceMacro extends Quotation with ActionMacro with QueryMacro with Resolv
 
     val ast = this.ast(quoted)
 
-    val inPlaceParams =
-      FreeVariables(ast).toList.map {
-        case i @ Ident(name) =>
-          i -> {
-            val tree =
-              c.typecheck(q"${TermName(name)}", silent = true) match {
-                case EmptyTree => c.fail(s"Runtime value binded outside of `source.run`: $name")
-                case tree      => tree
-              }
-            (tree.tpe, tree)
-          }
-      }.toMap
+    val inPlaceParams = bindingsTree(quoted.tree)
 
     t.tpe.typeSymbol.fullName.startsWith("scala.Function") match {
 
       case true =>
         val bodyType = c.WeakTypeTag(t.tpe.typeArgs.takeRight(1).head)
         val params = (1 until t.tpe.typeArgs.size).map(i => Ident(s"p$i")).toList
-        run(FunctionApply(ast, params), inPlaceParams, params.zip(paramsTypes(t)))(r, s, bodyType)
+        run(quoted.tree, FunctionApply(ast, params), inPlaceParams, params.zip(paramsTypes(t)))(r, s, bodyType)
 
       case false =>
-        run(ast, inPlaceParams, Nil)(r, s, t)
+        run(quoted.tree, ast, inPlaceParams, Nil)(r, s, t)
     }
   }
 
-  private def run[R, S, T](ast: Ast, inPlaceParams: collection.Map[Ident, (Type, Tree)], params: List[(Ident, Type)])(implicit r: WeakTypeTag[R], s: WeakTypeTag[S], t: WeakTypeTag[T]): Tree =
+  private def bindingsTree(tree: Tree) =
+    tree.tpe.decls
+      .filter(_.name.decodedName.toString.startsWith("binding_"))
+      .map { symbol =>
+        (Ident(symbol.name.decodedName.toString.replace("binding_", "")), (symbol.typeSignature.resultType, q"quoted.$symbol"))
+      }.toMap
+
+  private def run[R, S, T](quotedTree: Tree, ast: Ast, inPlaceParams: collection.Map[Ident, (Type, Tree)], params: List[(Ident, Type)])(implicit r: WeakTypeTag[R], s: WeakTypeTag[S], t: WeakTypeTag[T]): Tree =
     ast match {
       case ast if ((t.tpe.erasure <:< c.weakTypeTag[Action[Any]].tpe.erasure)) =>
-        runAction[S, T](ast, inPlaceParams, params)
+        runAction[S, T](quotedTree, ast, inPlaceParams, params)
 
       case ast =>
-        runQuery(ast, inPlaceParams, params)(r, s, queryType(t.tpe))
+        runQuery(quotedTree, ast, inPlaceParams, params)(r, s, queryType(t.tpe))
     }
 
   private def queryType(tpe: Type) =
@@ -68,9 +61,4 @@ trait SourceMacro extends Quotation with ActionMacro with QueryMacro with Resolv
   private def paramsTypes[T](implicit t: WeakTypeTag[T]) =
     t.tpe.typeArgs.dropRight(1)
 
-  private def verifyFreeVariables(ast: Ast) =
-    FreeVariables(ast).toList match {
-      case Nil  => ast
-      case vars => c.fail(s"A quotation must not have references to variables outside its scope. Found: '${vars.mkString(", ")}' in '$ast'.")
-    }
 }

--- a/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
@@ -537,11 +537,34 @@ class AstShowSpec extends Spec {
     }
   }
 
-  "shows dynamic asts" in {
+  "shows bindings" - {
+    "quotedReference" in {
+      val ast: Ast = QuotedReference("ignore", Filter(Ident("a"), Ident("b"), Ident("c")))
+      ast.show mustEqual
+        """a.filter(b => c)"""
+    }
+
+    "compileTimeBinding" in {
+      val ast: Ast = Filter(Ident("a"), Ident("b"), CompileTimeBinding("ignore", "c"))
+      ast.show mustEqual
+        """a.filter(b => c)"""
+    }
+
+    "runtimeBindings" in {
+      val i = 1
+      val q = quote {
+        qr1.filter(x => x.i == i)
+      }
+      (q.ast: Ast).show mustEqual
+        """query[TestEntity].filter(x => x.i == i)"""
+    }
+  }
+
+  "shows dynamic asts" - {
     (Dynamic(1): Ast).show mustEqual "1"
   }
 
-  "shows if" in {
+  "shows if" - {
     val q = quote {
       (i: Int) =>
         if (i > 10) "a" else "b"
@@ -550,7 +573,7 @@ class AstShowSpec extends Spec {
       """if(i > 10) "a" else "b""""
   }
 
-  "shows distinct" in {
+  "shows distinct" - {
     val q = quote {
       query[TestEntity].distinct
     }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -820,19 +820,23 @@ class QuotationSpec extends Spec {
       }
       quote(unquote(q)).ast mustEqual n.ast
     }
-    "with additional param" in {
-      implicit class GreaterThan[T](q: Query[Int]) {
-        def greaterThan(j: Int) = quote(q.filter(i => i > j))
-      }
+  }
 
-      val q = quote {
-        query[TestEntity].map(t => t.i).greaterThan(1)
-      }
-      val n = quote {
-        query[TestEntity].map(t => t.i).filter(i => i > 1)
-      }
-      quote(unquote(q)).ast mustEqual n.ast
+  "with additional param" in {
+    implicit class GreaterThan[T](q: Query[Int]) {
+      def greaterThan(j: Int) = quote(q.filter(i => i > j))
     }
+
+    val j = 1
+    val q = quote {
+      query[TestEntity].map(t => t.i).greaterThan(j)
+    }
+
+    val n = quote {
+      query[TestEntity].map(t => t.i).filter(i => i > j)
+    }
+
+    quote(unquote(q)).ast.toString mustEqual n.ast.toString
   }
 
   "doesn't double quote" in {

--- a/quill-core/src/test/scala/io/getquill/sources/QueryMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/QueryMacroSpec.scala
@@ -37,7 +37,6 @@ class QueryMacroSpec extends Spec {
       }
       val p1 = 1
       val r = mirrorSource.run(q(p1))
-      r.ast mustEqual q.ast.body
       r.binds mustEqual Row(p1)
     }
     "in-place param and function param" in {

--- a/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/h2/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/h2/ProductJdbcSpec.scala
@@ -17,15 +17,43 @@ class ProductJdbcSpec extends ProductSpec {
       So we have to insert one entry at a time in order to get the generated values.
      */
       val inserted = productEntries.map(product => testH2DB.run(productInsert)(product))
-      val product = testH2DB.run(productById)(inserted(2)).head
+      val product = testH2DB.run(productById(inserted(2))).head
       product.description mustEqual productEntries(2).description
       product.id mustEqual inserted(2)
     }
     "Single insert product" in {
       val inserted = testH2DB.run(productSingleInsert)
-      val product = testH2DB.run(productById)(inserted).head
+      val product = testH2DB.run(productById(inserted)).head
       product.description mustEqual "Window"
       product.id mustEqual inserted
+    }
+
+    "Single insert with inlined free variable" in {
+      val prd = Product(0L, "test1", 1L)
+      val inserted = testH2DB.run(product.insert(_.sku -> prd.sku, _.description -> prd.description))
+      val returnedProduct = testH2DB.run(productById(inserted)).head
+      returnedProduct.description mustEqual "test1"
+      returnedProduct.sku mustEqual 1L
+      returnedProduct.id mustEqual inserted
+    }
+
+    "Single insert with free variable and explicit quotation" in {
+      val prd = Product(0L, "test2", 2L)
+      val q1 = quote { product.insert(_.sku -> prd.sku, _.description -> prd.description) }
+      val inserted = testH2DB.run(q1)
+      val returnedProduct = testH2DB.run(productById(inserted)).head
+      returnedProduct.description mustEqual "test2"
+      returnedProduct.sku mustEqual 2L
+      returnedProduct.id mustEqual inserted
+    }
+
+    "Single product insert with a method quotation" in {
+      val prd = Product(0L, "test3", 3L)
+      val inserted = testH2DB.run(productInsert(prd))
+      val returnedProduct = testH2DB.run(productById(inserted)).head
+      returnedProduct.description mustEqual "test3"
+      returnedProduct.sku mustEqual 3L
+      returnedProduct.id mustEqual inserted
     }
   }
 

--- a/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/mysql/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/mysql/ProductJdbcSpec.scala
@@ -13,15 +13,42 @@ class ProductJdbcSpec extends ProductSpec {
   "Product" - {
     "Insert multiple products" in {
       val inserted = testMysqlDB.run(productInsert)(productEntries)
-      val product = testMysqlDB.run(productById)(inserted(2)).head
+      val product = testMysqlDB.run(productById(inserted(2))).head
       product.description mustEqual productEntries(2).description
       product.id mustEqual inserted(2)
     }
     "Single insert product" in {
       val inserted = testMysqlDB.run(productSingleInsert)
-      val product = testMysqlDB.run(productById)(inserted).head
+      val product = testMysqlDB.run(productById(inserted)).head
       product.description mustEqual "Window"
       product.id mustEqual inserted
+    }
+    "Single insert with inlined free variable" in {
+      val prd = Product(0L, "test1", 1L)
+      val inserted = testMysqlDB.run(product.insert(_.sku -> prd.sku, _.description -> prd.description))
+      val returnedProduct = testMysqlDB.run(productById(inserted)).head
+      returnedProduct.description mustEqual "test1"
+      returnedProduct.sku mustEqual 1L
+      returnedProduct.id mustEqual inserted
+    }
+
+    "Single insert with free variable and explicit quotation" in {
+      val prd = Product(0L, "test2", 2L)
+      val q1 = quote { product.insert(_.sku -> prd.sku, _.description -> prd.description) }
+      val inserted = testMysqlDB.run(q1)
+      val returnedProduct = testMysqlDB.run(productById(inserted)).head
+      returnedProduct.description mustEqual "test2"
+      returnedProduct.sku mustEqual 2L
+      returnedProduct.id mustEqual inserted
+    }
+
+    "Single product insert with a method quotation" in {
+      val prd = Product(0L, "test3", 3L)
+      val inserted = testMysqlDB.run(productInsert(prd))
+      val returnedProduct = testMysqlDB.run(productById(inserted)).head
+      returnedProduct.description mustEqual "test3"
+      returnedProduct.sku mustEqual 3L
+      returnedProduct.id mustEqual inserted
     }
   }
 

--- a/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/postgres/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/postgres/ProductJdbcSpec.scala
@@ -13,17 +13,44 @@ class ProductJdbcSpec extends ProductSpec {
   "Product" - {
     "Insert multiple products" in {
       val inserted = testPostgresDB.run(productInsert)(productEntries)
-      val product = testPostgresDB.run(productById)(inserted(2)).head
+      val product = testPostgresDB.run(productById(inserted(2))).head
       product.description mustEqual productEntries(2).description
       product.id mustEqual inserted(2)
     }
 
     "Single insert product" in {
       val inserted = testPostgresDB.run(productSingleInsert)
-      val product = testPostgresDB.run(productById)(inserted).head
+      val product = testPostgresDB.run(productById(inserted)).head
       product.description mustEqual "Window"
       product.id mustEqual inserted
     }
-  }
 
+    "Single insert with inlined free variable" in {
+      val prd = Product(0L, "test1", 1L)
+      val inserted = testPostgresDB.run(product.insert(_.sku -> prd.sku, _.description -> prd.description))
+      val returnedProduct = testPostgresDB.run(productById(inserted)).head
+      returnedProduct.description mustEqual "test1"
+      returnedProduct.sku mustEqual 1L
+      returnedProduct.id mustEqual inserted
+    }
+
+    "Single insert with free variable and explicit quotation" in {
+      val prd = Product(0L, "test2", 2L)
+      val q1 = quote { product.insert(_.sku -> prd.sku, _.description -> prd.description) }
+      val inserted = testPostgresDB.run(q1)
+      val returnedProduct = testPostgresDB.run(productById(inserted)).head
+      returnedProduct.description mustEqual "test2"
+      returnedProduct.sku mustEqual 2L
+      returnedProduct.id mustEqual inserted
+    }
+
+    "Single product insert with a method quotation" in {
+      val prd = Product(0L, "test3", 3L)
+      val inserted = testPostgresDB.run(productInsert(prd))
+      val returnedProduct = testPostgresDB.run(productById(inserted)).head
+      returnedProduct.description mustEqual "test3"
+      returnedProduct.sku mustEqual 3L
+      returnedProduct.id mustEqual inserted
+    }
+  }
 }

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/BindVariables.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/BindVariables.scala
@@ -13,6 +13,9 @@ private[sources] case class BindVariables(state: (List[Ident], List[Ident]))
           case true  => (Ident("?"), BindVariables((vars, bindings :+ i)))
           case false => (i, this)
         }
+      case (b: RuntimeBinding) =>
+        val (vars, bindings) = state
+        (Ident("?"), BindVariables((vars, bindings :+ Ident(b.key))))
       case other => super.apply(ast)
     }
 

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
@@ -23,7 +23,10 @@ trait SqlIdiom {
       case a: Property          => a.show
       case a: Value             => a.show
       case a: If                => a.show
-      case a @ (_: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block | _: Val | _: Ordering) =>
+      case a @ (
+        _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
+        _: Val | _: Ordering | _: Binding | _: QuotedReference[_]
+        ) =>
         fail(s"Malformed query $a.")
     }
 

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/ProductSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/ProductSpec.scala
@@ -14,8 +14,8 @@ trait ProductSpec extends Spec {
     query[Product](_.generated(_.id)).insert
   }
 
-  val productById = quote {
-    (id: Long) => product.filter(_.id == id)
+  def productById(id: Long) = quote {
+    product.filter(_.id == id)
   }
 
   val productEntries = List(
@@ -26,6 +26,10 @@ trait ProductSpec extends Spec {
 
   val productSingleInsert = quote {
     product.insert(_.id -> 0, _.description -> "Window", _.sku -> 1004L)
+  }
+
+  def productInsert(prd: Product) = quote {
+    product.insert(_.description -> prd.description, _.sku -> prd.sku)
   }
 
 }


### PR DESCRIPTION
### ~~DON'T PANIC - ALPHA QUALITY CODE~~

This is a refactor to allow free variable to be defined anywhere outside the quoted blocked. ~~The code is a little bit messy yet and there are a few things to do. But I want your opinion before moving forward.~~

Fixes #302

### Problem

We should be able to use free variables as free as possible. 

Examples:
With inlined quotation
```scala
val freeVariable = Product(0L, "test1", 1L)
db.run(quote { product.insert(_.sku -> freeVariable.sku, _.description -> freeVariable.description) })
```
With quotetaion defined outside of `run`
```scala
val freeVariable = Product(0L, "test1", 1L)
val q = quote { product.insert(_.sku -> freeVariable.sku, _.description -> freeVariable.description) }
db.run(q)
```
Or with method
```scala
def productInsert(prd: Product) = quote {
    product.insert(_.description -> prd.description, _.sku -> prd.sku)
}
val freeVariable = Product(0L, "test1", 1L)
val q = quote { productInsert(freeVariable) }
db.run(q)
```

### Solution

- Extract the free variable from the quoted block using Traverser [see](https://github.com/getquill/quill/blob/free-vars-anywhere/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala#L99)
- Refactor `Parsing` to allow passing a free variable list [see] (https://github.com/getquill/quill/blob/free-vars-anywhere/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala#L29)
- During parsing, create `CompileTimeBinding` with the tree reference to the free variable 
- Convert `CompileTimeBinding` to `Binding` during Lifting. [see](https://github.com/getquill/quill/blob/free-vars-anywhere/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala#L31)
- In `Quotation.quote`, define binding methods (`def binding_$key`) to the Free Variables. [see](https://github.com/getquill/quill/blob/free-vars-anywhere/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala#L50)
- In `SourceMacro.run`, extract bindings defined during quotation through reflection [see](https://github.com/getquill/quill/blob/free-vars-anywhere/quill-core/src/main/scala/io/getquill/sources/SourceMacro.scala#L34)

### Notes

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
