### PR TITLE
Return type improve

### DIFF
--- a/quill-async/src/main/scala/io/getquill/sources/async/AsyncSource.scala
+++ b/quill-async/src/main/scala/io/getquill/sources/async/AsyncSource.scala
@@ -30,6 +30,7 @@ abstract class AsyncSource[D <: SqlIdiom, N <: NamingStrategy, C <: Connection](
     Logger(LoggerFactory.getLogger(classOf[AsyncSource[_, _, _]]))
 
   type QueryResult[T] = Future[List[T]]
+  type SingleQueryResult[T] = Future[T]
   type ActionResult[T] = Future[Long]
   type BatchedActionResult[T] = Future[List[Long]]
 
@@ -96,4 +97,9 @@ abstract class AsyncSource[D <: SqlIdiom, N <: NamingStrategy, C <: Connection](
       }
     }
   }
+
+  def querySingle[T](sql: String, bind: BindedStatementBuilder[List[Any]] => BindedStatementBuilder[List[Any]], extractor: RowData => T)(implicit ec: ExecutionContext) = {
+    query(sql, bind, extractor).map(handleSingleResult)
+  }
+
 }

--- a/quill-async/src/test/scala/io/getquill/sources/async/mysql/QueryResultTypeMysqlAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/mysql/QueryResultTypeMysqlAsyncSpec.scala
@@ -1,0 +1,103 @@
+package io.getquill.sources.async.mysql
+
+import io.getquill.sources.sql._
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.JavaConverters._
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class QueryResultTypeMysqlAsyncSpec extends QueryResultTypeSpec {
+  val db = testMysqlDB
+
+  def await[T](r: Future[T]) = Await.result(r, Duration.Inf)
+
+  val insertedProducts = new ConcurrentLinkedQueue[Product]
+
+  override def beforeAll = {
+    await(db.run(deleteAll))
+    val ids = await(db.run(productInsert)(productEntries))
+    val inserted = (ids zip productEntries).map {
+      case (id, prod) => prod.copy(id = id)
+    }
+    insertedProducts.addAll(inserted.asJava)
+    ()
+  }
+
+  def products = insertedProducts.asScala.toList
+
+  "return list" - {
+    "select" in {
+      await(db.run(selectAll)) must contain theSameElementsAs (products)
+    }
+    "map" in {
+      await(db.run(map)) must contain theSameElementsAs (products.map(_.id))
+    }
+    "filter" in {
+      await(db.run(filter)) must contain theSameElementsAs (products)
+    }
+    "withFilter" in {
+      await(db.run(withFilter)) must contain theSameElementsAs (products)
+    }
+    "sortBy" in {
+      await(db.run(sortBy)) must contain theSameElementsInOrderAs (products)
+    }
+    "take" in {
+      await(db.run(take)) must contain theSameElementsAs (products)
+    }
+    "drop" in {
+      await(db.run(drop)) must contain theSameElementsAs (products.drop(1))
+    }
+    "++" in {
+      await(db.run(`++`)) must contain theSameElementsAs (products ++ products)
+    }
+    "unionAll" in {
+      await(db.run(unionAll)) must contain theSameElementsAs (products ++ products)
+    }
+    "union" in {
+      await(db.run(union)) must contain theSameElementsAs (products)
+    }
+    "join" in {
+      await(db.run(join)) must contain theSameElementsAs (products zip products)
+    }
+    "distinct" in {
+      await(db.run(distinct)) must contain theSameElementsAs (products.map(_.id).distinct)
+    }
+  }
+
+  "return single result" - {
+    "min" - {
+      "some" in {
+        await(db.run(minExists)) mustEqual Some(products.map(_.sku).min)
+      }
+      "none" in {
+        await(db.run(minNonExists)) mustBe None
+      }
+    }
+    "max" - {
+      "some" in {
+        await(db.run(maxExists)) mustBe Some(products.map(_.sku).max)
+      }
+      "none" in {
+        await(db.run(maxNonExists)) mustBe None
+      }
+    }
+    "avg" - {
+      "some" in {
+        await(db.run(avgExists)) mustBe Some(BigDecimal(products.map(_.sku).sum) / products.size)
+      }
+      "none" in {
+        await(db.run(avgNonExists)) mustBe None
+      }
+    }
+    "size" in {
+      await(db.run(productSize)) mustEqual products.size
+    }
+    "nonEmpty" in {
+      await(db.run(nonEmpty)) mustEqual true
+    }
+    "isEmpty" in {
+      await(db.run(isEmpty)) mustEqual false
+    }
+  }
+}

--- a/quill-async/src/test/scala/io/getquill/sources/async/postgres/QueryResultTypePostgresAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/postgres/QueryResultTypePostgresAsyncSpec.scala
@@ -1,0 +1,103 @@
+package io.getquill.sources.async.postgres
+
+import io.getquill.sources.sql._
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.JavaConverters._
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class QueryResultTypePostgresAsyncSpec extends QueryResultTypeSpec {
+  val db = testPostgresDB
+
+  def await[T](r: Future[T]) = Await.result(r, Duration.Inf)
+
+  val insertedProducts = new ConcurrentLinkedQueue[Product]
+
+  override def beforeAll = {
+    await(db.run(deleteAll))
+    val ids = await(db.run(productInsert)(productEntries))
+    val inserted = (ids zip productEntries).map {
+      case (id, prod) => prod.copy(id = id)
+    }
+    insertedProducts.addAll(inserted.asJava)
+    ()
+  }
+
+  def products = insertedProducts.asScala.toList
+
+  "return list" - {
+    "select" in {
+      await(db.run(selectAll)) must contain theSameElementsAs (products)
+    }
+    "map" in {
+      await(db.run(map)) must contain theSameElementsAs (products.map(_.id))
+    }
+    "filter" in {
+      await(db.run(filter)) must contain theSameElementsAs (products)
+    }
+    "withFilter" in {
+      await(db.run(withFilter)) must contain theSameElementsAs (products)
+    }
+    "sortBy" in {
+      await(db.run(sortBy)) must contain theSameElementsInOrderAs (products)
+    }
+    "take" in {
+      await(db.run(take)) must contain theSameElementsAs (products)
+    }
+    "drop" in {
+      await(db.run(drop)) must contain theSameElementsAs (products.drop(1))
+    }
+    "++" in {
+      await(db.run(`++`)) must contain theSameElementsAs (products ++ products)
+    }
+    "unionAll" in {
+      await(db.run(unionAll)) must contain theSameElementsAs (products ++ products)
+    }
+    "union" in {
+      await(db.run(union)) must contain theSameElementsAs (products)
+    }
+    "join" in {
+      await(db.run(join)) must contain theSameElementsAs (products zip products)
+    }
+    "distinct" in {
+      await(db.run(distinct)) must contain theSameElementsAs (products.map(_.id).distinct)
+    }
+  }
+
+  "return single result" - {
+    "min" - {
+      "some" in {
+        await(db.run(minExists)) mustEqual Some(products.map(_.sku).min)
+      }
+      "none" in {
+        await(db.run(minNonExists)) mustBe None
+      }
+    }
+    "max" - {
+      "some" in {
+        await(db.run(maxExists)) mustBe Some(products.map(_.sku).max)
+      }
+      "none" in {
+        await(db.run(maxNonExists)) mustBe None
+      }
+    }
+    "avg" - {
+      "some" in {
+        await(db.run(avgExists)) mustBe Some(BigDecimal(products.map(_.sku).sum) / products.size)
+      }
+      "none" in {
+        await(db.run(avgNonExists)) mustBe None
+      }
+    }
+    "size" in {
+      await(db.run(productSize)) mustEqual products.size
+    }
+    "nonEmpty" in {
+      await(db.run(nonEmpty)) mustEqual true
+    }
+    "isEmpty" in {
+      await(db.run(isEmpty)) mustEqual false
+    }
+  }
+}

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSource.scala
@@ -16,6 +16,7 @@ trait CassandraSource[N <: NamingStrategy, R, S]
   def probe(cql: String): Try[Unit]
 
   type QueryResult[T]
+  type SingleQueryResult[T]
   type ActionResult[T]
   type BatchedActionResult[T]
   type Params[T]
@@ -90,35 +91,35 @@ trait CassandraSource[N <: NamingStrategy, R, S]
 
   def run[T](
     quoted: Quoted[T]
-  ): QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, T](
     quoted: Quoted[P1 => T]
-  ): P1 => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): P1 => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, P2, T](
     quoted: Quoted[(P1, P2) => T]
-  ): (P1, P2) => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): (P1, P2) => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, T](
     quoted: Quoted[(P1, P2, P3) => T]
-  ): (P1, P2, P3) => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): (P1, P2, P3) => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, T](
     quoted: Quoted[(P1, P2, P3, P4) => T]
-  ): (P1, P2, P3, P4) => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4) => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, T](
     quoted: Quoted[(P1, P2, P3, P4, P5) => T]
-  ): (P1, P2, P3, P4, P5) => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5) => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6) => T]
-  ): (P1, P2, P3, P4, P5, P6) => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6) => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, P7, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6, P7) => T]
-  ): (P1, P2, P3, P4, P5, P6, P7) => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6, P7) => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, P7, P8, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6, P7, P8) => T]
-  ): (P1, P2, P3, P4, P5, P6, P7, P8) => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6, P7, P8) => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, P7, P8, P9, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6, P7, P8, P9) => T]
-  ): (P1, P2, P3, P4, P5, P6, P7, P8, P9) => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6, P7, P8, P9) => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) => T]
-  ): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) => QueryResult[T] = macro CassandraSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) => SingleQueryResult[T] = macro CassandraSourceMacro.runSingle[R, S]
 }

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraStreamSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraStreamSource.scala
@@ -14,6 +14,7 @@ class CassandraStreamSource[N <: NamingStrategy](config: CassandraSourceConfig[N
   extends CassandraSourceSession[N](config) {
 
   override type QueryResult[T] = Observable[T]
+  override type SingleQueryResult[T] = Observable[T]
   override type ActionResult[T] = Observable[ResultSet]
   override type BatchedActionResult[T] = Observable[ResultSet]
   override type Params[T] = Observable[T]
@@ -37,6 +38,8 @@ class CassandraStreamSource[N <: NamingStrategy](config: CassandraSourceConfig[N
       .flatMap(Observable.fromIterable)
       .map(extractor)
   }
+
+  def querySingle[T](cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], extractor: Row => T) = query(cql, bind, extractor)
 
   def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None): Observable[ResultSet] =
     Observable.fromFuture(session.executeAsync(prepare(cql, bind)))

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSyncSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraSyncSource.scala
@@ -15,6 +15,7 @@ class CassandraSyncSource[N <: NamingStrategy](config: CassandraSourceConfig[N, 
   extends CassandraSourceSession[N](config) {
 
   override type QueryResult[T] = List[T]
+  override type SingleQueryResult[T] = T
   override type ActionResult[T] = ResultSet
   override type BatchedActionResult[T] = List[ResultSet]
   override type Params[T] = List[T]
@@ -27,6 +28,8 @@ class CassandraSyncSource[N <: NamingStrategy](config: CassandraSourceConfig[N, 
   def query[T](cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], extractor: Row => T): List[T] =
     session.execute(prepare(cql, bind))
       .all.toList.map(extractor)
+
+  def querySingle[T](cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], extractor: Row => T): T = handleSingleResult(query(cql, bind, extractor))
 
   def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None): ResultSet =
     session.execute(prepare(cql, bind))

--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/mirror/CassandraMirrorSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/mirror/CassandraMirrorSource.scala
@@ -15,6 +15,7 @@ class CassandraMirrorSource(config: CassandraMirrorSourceConfig)
   with MirrorDecoders {
 
   override type QueryResult[T] = QueryMirror[T]
+  override type SingleQueryResult[T] = QueryMirror[T]
   override type ActionResult[T] = ActionMirror
   override type BatchedActionResult[T] = BatchActionMirror
   override type Params[T] = List[T]
@@ -49,4 +50,7 @@ class CassandraMirrorSource(config: CassandraMirrorSourceConfig)
 
   def query[T](cql: String, bind: Row => Row, extractor: Row => T) =
     QueryMirror(cql, bind(Row()), extractor)
+
+  def querySingle[T](cql: String, bind: Row => Row, extractor: Row => T) =
+    query(cql, bind, extractor)
 }

--- a/quill-cassandra/src/test/cql/cassandra-schema.cql
+++ b/quill-cassandra/src/test/cql/cassandra-schema.cql
@@ -1,36 +1,36 @@
 CREATE TABLE Person(
     id INT PRIMARY KEY,
-	name VARCHAR,
-	age INT
+    name VARCHAR,
+    age INT
 );
 
 CREATE TABLE Couple(
     id INT PRIMARY KEY,
-	her VARCHAR,
-	him VARCHAR
+    her VARCHAR,
+    him VARCHAR
 );
 
 CREATE TABLE Department(
     id INT PRIMARY KEY,
-	dpt VARCHAR
+    dpt VARCHAR
 );
 
 CREATE TABLE Employee(
     id INT PRIMARY KEY,
-	emp VARCHAR,
-	dpt VARCHAR,
-	salary INT
+    emp VARCHAR,
+    dpt VARCHAR,
+    salary INT
 );
 
 CREATE TABLE Task(
     id INT PRIMARY KEY,
-	emp VARCHAR,
-	tsk VARCHAR
+    emp VARCHAR,
+    tsk VARCHAR
 );
 
 CREATE TABLE EncodingTestEntity(
     id INT,
-	v1 VARCHAR,
+    v1 VARCHAR,
     v2 DECIMAL,
     v3 BOOLEAN,
     v4 INT,
@@ -52,9 +52,15 @@ CREATE TABLE EncodingTestEntity(
     PRIMARY KEY(id, v1)
 );
 
+CREATE TABLE OrderTestEntity(
+    id INT,
+    i Int,
+    PRIMARY KEY(id, i)
+) WITH CLUSTERING ORDER BY (i ASC);
+
 CREATE TABLE TestEntity(
     id INT PRIMARY KEY,
-	s VARCHAR,
+    s VARCHAR,
     i INT,
     l BIGINT,
     o INT
@@ -62,14 +68,14 @@ CREATE TABLE TestEntity(
 
 CREATE TABLE TestEntity2(
     id INT PRIMARY KEY,
-	s VARCHAR,
+    s VARCHAR,
     i INT,
     l BIGINT
 );
 
 CREATE TABLE TestEntity3(
     id INT PRIMARY KEY,
-	s VARCHAR,
+    s VARCHAR,
     i INT,
     l BIGINT
 );

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/QueryResultTypeCassandraSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/QueryResultTypeCassandraSpec.scala
@@ -1,0 +1,114 @@
+package io.getquill.sources.cassandra
+
+import io.getquill._
+import monifu.reactive.Observable
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class QueryResultTypeCassandraSpec extends FreeSpec with BeforeAndAfterAll with MustMatchers {
+
+  case class OrderTestEntity(id: Int, i: Int)
+
+  val entries = List(
+    OrderTestEntity(1, 1),
+    OrderTestEntity(2, 2),
+    OrderTestEntity(3, 3)
+  )
+
+  val insert = quote(query[OrderTestEntity].insert)
+  val deleteAll = quote(query[OrderTestEntity].delete)
+  val selectAll = quote(query[OrderTestEntity])
+  val map = quote(query[OrderTestEntity].map(_.id))
+  val filter = quote(query[OrderTestEntity].filter(_.id == 1))
+  val withFilter = quote(query[OrderTestEntity].withFilter(_.id == 1))
+  val sortBy = quote(query[OrderTestEntity].filter(_.id == 1).sortBy(_.i)(Ord.asc))
+  val take = quote(query[OrderTestEntity].take(10))
+  val entitySize = quote(query[OrderTestEntity].size)
+  val distinct = quote(query[OrderTestEntity].map(_.id).distinct)
+
+  override def beforeAll = {
+    val r1 = testSyncDB.run(deleteAll)
+    val r2 = testSyncDB.run(insert)(entries)
+  }
+
+  "async" - {
+    val db = testAsyncDB
+    def await[T](r: Future[T]) = Await.result(r, Duration.Inf)
+    "return list" - {
+      "select" in {
+        await(db.run(selectAll)) must contain theSameElementsAs (entries)
+      }
+      "map" in {
+        await(db.run(map)) must contain theSameElementsAs (entries.map(_.id))
+      }
+      "filter" in {
+        await(db.run(filter)) mustEqual entries.take(1)
+      }
+      "withFilter" in {
+        await(db.run(withFilter)) mustEqual entries.take(1)
+      }
+      "sortBy" in {
+        await(db.run(sortBy)) mustEqual entries.take(1)
+      }
+      "take" in {
+        await(db.run(take)) must contain theSameElementsAs (entries)
+      }
+    }
+
+    "return single result" - {
+      "size" in {
+        await(db.run(entitySize)) mustEqual entries.size
+      }
+    }
+  }
+
+  "sync" - {
+    val db = testSyncDB
+    def await[T](r: T) = r
+    "return list" - {
+      "select" in {
+        await(db.run(selectAll)) must contain theSameElementsAs (entries)
+      }
+      "map" in {
+        await(db.run(map)) must contain theSameElementsAs (entries.map(_.id))
+      }
+      "filter" in {
+        await(db.run(filter)) mustEqual entries.take(1)
+      }
+      "withFilter" in {
+        await(db.run(withFilter)) mustEqual entries.take(1)
+      }
+      "sortBy" in {
+        await(db.run(sortBy)) mustEqual entries.take(1)
+      }
+      "take" in {
+        await(db.run(take)) must contain theSameElementsAs (entries)
+      }
+    }
+
+    "return single result" - {
+      "size" in {
+        await(db.run(entitySize)) mustEqual entries.size
+      }
+    }
+  }
+  "stream" - {
+    import monifu.concurrent.Implicits.globalScheduler
+    val db = testStreamDB
+    def await[T](t: Observable[T]) = {
+      val f = t.foldLeft(List.empty[T])(_ :+ _).asFuture
+      Await.result(f, Duration.Inf)
+    }
+    "query" in {
+      await(db.run(selectAll)) mustEqual Some(entries)
+    }
+
+    "querySingle" in {
+      await(db.run(entitySize)) mustEqual Some(List(3))
+    }
+  }
+}

--- a/quill-core/src/main/scala/io/getquill/Query.scala
+++ b/quill-core/src/main/scala/io/getquill/Query.scala
@@ -19,7 +19,7 @@ sealed trait Query[+T] {
 
   def min[U >: T](implicit o: Ordering[U]): Option[T]
   def max[U >: T](implicit o: Ordering[U]): Option[T]
-  def avg[U >: T](implicit n: Numeric[U]): Option[T]
+  def avg[U >: T](implicit n: Numeric[U]): Option[BigDecimal]
   def sum[U >: T](implicit n: Numeric[U]): Option[T]
   def size: Long
 

--- a/quill-core/src/main/scala/io/getquill/sources/Source.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/Source.scala
@@ -23,6 +23,12 @@ abstract class Source[R: ClassTag, S: ClassTag] extends Closeable {
 
   implicit def wrappedTypeDecoder[T <: WrappedType] =
     MappedEncoding[T, T#Type](_.value)
+
+  protected def handleSingleResult[T](list: List[T]) =
+    list match {
+      case value :: Nil => value
+      case other        => throw new IllegalStateException(s"Expected a single result but got $other")
+    }
 }
 
 object Source {

--- a/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorSource.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorSource.scala
@@ -55,8 +55,10 @@ class MirrorSource(config: SourceConfig[MirrorSource])
 
   case class QueryMirror[T](ast: Ast, binds: Row, extractor: Row => T)
 
-  def query[T](ast: Ast, bind: Row => Row, extractor: Row => T) =
+  def querySingle[T](ast: Ast, bind: Row => Row, extractor: Row => T) =
     QueryMirror(ast, bind(Row()), extractor)
+
+  def query[T](ast: Ast, bind: Row => Row, extractor: Row => T) = QueryMirror(ast, bind(Row()), extractor)
 }
 
 class MirrorSourceMacro(val c: Context) extends SourceMacro {

--- a/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlDecoders.scala
@@ -14,7 +14,9 @@ import com.twitter.finagle.exp.mysql.Row
 import com.twitter.finagle.exp.mysql.ShortValue
 import com.twitter.finagle.exp.mysql.StringValue
 import com.twitter.finagle.exp.mysql.TimestampValue
+import com.twitter.finagle.exp.mysql.Type
 import com.twitter.finagle.exp.mysql.Value
+import com.twitter.finagle.exp.mysql.transport.BufferReader
 import io.getquill.util.Messages.fail
 import com.twitter.finagle.exp.mysql.NullValue
 
@@ -55,8 +57,11 @@ trait FinagleMysqlDecoders {
     }
   implicit val booleanDecoder: Decoder[Boolean] =
     decoder[Boolean] {
-      case ByteValue(byte) => byte == (1: Byte)
-      case v: RawValue     => v.bytes.head == (1: Byte)
+      case ByteValue(v)                     => v == (1: Byte)
+      case ShortValue(v)                    => v == (1: Short)
+      case IntValue(v)                      => v == 1
+      case LongValue(v)                     => v == 1L
+      case v: RawValue if v.typ == Type.Bit => v.bytes.head == (1: Byte)
     }
   implicit val byteDecoder: Decoder[Byte] =
     decoder[Byte] {

--- a/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlSource.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/sources/finagle/mysql/FinagleMysqlSource.scala
@@ -34,6 +34,7 @@ class FinagleMysqlSource[N <: NamingStrategy](config: FinagleMysqlSourceConfig[N
     Logger(LoggerFactory.getLogger(classOf[FinagleMysqlSource[_]]))
 
   type QueryResult[T] = Future[List[T]]
+  type SingleQueryResult[T] = Future[T]
   type ActionResult[T] = Future[Result]
   type BatchedActionResult[T] = Future[List[Result]]
 
@@ -88,6 +89,8 @@ class FinagleMysqlSource[N <: NamingStrategy](config: FinagleMysqlSourceConfig[N
     logger.info(expanded)
     withClient(_.prepare(expanded).select(params(List()): _*)(extractor)).map(_.toList)
   }
+
+  def querySingle[T](sql: String, bind: BindedStatementBuilder[List[Parameter]] => BindedStatementBuilder[List[Parameter]], extractor: Row => T): Future[T] = query(sql, bind, extractor).map(handleSingleResult)
 
   private def withClient[T](f: Client => T) =
     currentClient().map {

--- a/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/FinagleMysqlEncodingSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/FinagleMysqlEncodingSpec.scala
@@ -43,7 +43,15 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
   }
 
   "decode boolean types" - {
-    case class BooleanEncodingTestEntity(v1: Boolean, v2: Boolean)
+    case class BooleanEncodingTestEntity(
+      v1: Boolean,
+      v2: Boolean,
+      v3: Boolean,
+      v4: Boolean,
+      v5: Boolean,
+      v6: Boolean,
+      v7: Boolean
+    )
     val decodeBoolean = (entity: BooleanEncodingTestEntity) => {
       val delete = quote(query[BooleanEncodingTestEntity].delete)
       val insert = quote(query[BooleanEncodingTestEntity].insert)
@@ -55,17 +63,27 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
       Await.result(r).head
     }
     "true" in {
-      val entity = BooleanEncodingTestEntity(true, true)
+      val entity = BooleanEncodingTestEntity(true, true, true, true, true, true, true)
       val r = decodeBoolean(entity)
       r.v1 mustEqual true
       r.v2 mustEqual true
+      r.v3 mustEqual true
+      r.v4 mustEqual true
+      r.v5 mustEqual true
+      r.v6 mustEqual true
+      r.v7 mustEqual true
     }
 
     "false" in {
-      val entity = BooleanEncodingTestEntity(false, false)
+      val entity = BooleanEncodingTestEntity(false, false, false, false, false, false, false)
       val r = decodeBoolean(entity)
       r.v1 mustEqual false
       r.v2 mustEqual false
+      r.v3 mustEqual false
+      r.v4 mustEqual false
+      r.v5 mustEqual false
+      r.v6 mustEqual false
+      r.v7 mustEqual false
     }
   }
 }

--- a/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/QueryResultFinagleMysqlSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/QueryResultFinagleMysqlSpec.scala
@@ -1,0 +1,102 @@
+package io.getquill.sources.finagle.mysql
+
+import io.getquill.sources.sql._
+import com.twitter.finagle.exp.mysql.OK
+import com.twitter.util.{ Await, Future }
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.JavaConverters._
+
+class QueryResultTypeFinagleMysqlSpec extends QueryResultTypeSpec {
+  val db = testDB
+
+  def await[T](r: Future[T]) = Await.result(r)
+
+  val insertedProducts = new ConcurrentLinkedQueue[Product]
+
+  override def beforeAll = {
+    await(db.run(deleteAll))
+    val rs = await(db.run(productInsert)(productEntries))
+    val inserted = (rs zip productEntries).map {
+      case (r, prod) => prod.copy(id = r.asInstanceOf[OK].insertId)
+    }
+    insertedProducts.addAll(inserted.asJava)
+    ()
+  }
+
+  def products = insertedProducts.asScala.toList
+
+  "return list" - {
+    "select" in {
+      await(db.run(selectAll)) must contain theSameElementsAs (products)
+    }
+    "map" in {
+      await(db.run(map)) must contain theSameElementsAs (products.map(_.id))
+    }
+    "filter" in {
+      await(db.run(filter)) must contain theSameElementsAs (products)
+    }
+    "withFilter" in {
+      await(db.run(withFilter)) must contain theSameElementsAs (products)
+    }
+    "sortBy" in {
+      await(db.run(sortBy)) must contain theSameElementsInOrderAs (products)
+    }
+    "take" in {
+      await(db.run(take)) must contain theSameElementsAs (products)
+    }
+    "drop" in {
+      await(db.run(drop)) must contain theSameElementsAs (products.drop(1))
+    }
+    "++" in {
+      await(db.run(`++`)) must contain theSameElementsAs (products ++ products)
+    }
+    "unionAll" in {
+      await(db.run(unionAll)) must contain theSameElementsAs (products ++ products)
+    }
+    "union" in {
+      await(db.run(union)) must contain theSameElementsAs (products)
+    }
+    "join" in {
+      await(db.run(join)) must contain theSameElementsAs (products zip products)
+    }
+    "distinct" in {
+      await(db.run(distinct)) must contain theSameElementsAs (products.map(_.id).distinct)
+    }
+  }
+
+  "return single result" - {
+    "min" - {
+      "some" in {
+        await(db.run(minExists)) mustEqual Some(products.map(_.sku).min)
+      }
+      "none" in {
+        await(db.run(minNonExists)) mustBe None
+      }
+    }
+    "max" - {
+      "some" in {
+        await(db.run(maxExists)) mustBe Some(products.map(_.sku).max)
+      }
+      "none" in {
+        await(db.run(maxNonExists)) mustBe None
+      }
+    }
+    "avg" - {
+      "some" in {
+        await(db.run(avgExists)) mustBe Some(BigDecimal(products.map(_.sku).sum) / products.size)
+      }
+      "none" in {
+        await(db.run(avgNonExists)) mustBe None
+      }
+    }
+    "size" in {
+      await(db.run(productSize)) mustEqual products.size
+    }
+    "nonEmpty" in {
+      await(db.run(nonEmpty)) mustEqual true
+    }
+    "isEmpty" in {
+      await(db.run(isEmpty)) mustEqual false
+    }
+  }
+}

--- a/quill-jdbc/src/main/scala/io/getquill/sources/jdbc/JdbcSource.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/sources/jdbc/JdbcSource.scala
@@ -27,6 +27,7 @@ class JdbcSource[D <: SqlIdiom, N <: NamingStrategy](config: JdbcSourceConfig[D,
     Logger(LoggerFactory.getLogger(classOf[JdbcSource[_, _]]))
 
   type QueryResult[T] = List[T]
+  type SingleQueryResult[T] = T
   type ActionResult[T] = Long
   type BatchedActionResult[T] = List[Long]
 
@@ -119,6 +120,9 @@ class JdbcSource[D <: SqlIdiom, N <: NamingStrategy](config: JdbcSourceConfig[D,
       extractResult(rs, extractor)
     }
   }
+
+  def querySingle[T](sql: String, bind: BindedStatementBuilder[PreparedStatement] => BindedStatementBuilder[PreparedStatement], extractor: ResultSet => T): T =
+    handleSingleResult(query(sql, bind, extractor))
 
   @tailrec
   private def extractResult[T](rs: ResultSet, extractor: ResultSet => T, acc: List[T] = List()): List[T] =

--- a/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/QueryResultTypeJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/QueryResultTypeJdbcSpec.scala
@@ -1,0 +1,101 @@
+package io.getquill.sources.jdbc
+
+import io.getquill.sources.sql._
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.JavaConverters._
+
+class QueryResultTypeJdbcSpec extends QueryResultTypeSpec {
+
+  val db = mysql.testMysqlDB
+
+  def await[T](r: T) = r
+
+  val insertedProducts = new ConcurrentLinkedQueue[Product]
+
+  override def beforeAll = {
+    db.run(deleteAll)
+    val ids = db.run(productInsert)(productEntries)
+    val inserted = (ids zip productEntries).map {
+      case (id, prod) => prod.copy(id = id)
+    }
+    insertedProducts.addAll(inserted.asJava)
+    ()
+  }
+
+  def products = insertedProducts.asScala.toList
+
+  "return list" - {
+    "select" in {
+      await(db.run(selectAll)) must contain theSameElementsAs (products)
+    }
+    "map" in {
+      await(db.run(map)) must contain theSameElementsAs (products.map(_.id))
+    }
+    "filter" in {
+      await(db.run(filter)) must contain theSameElementsAs (products)
+    }
+    "withFilter" in {
+      await(db.run(withFilter)) must contain theSameElementsAs (products)
+    }
+    "sortBy" in {
+      await(db.run(sortBy)) must contain theSameElementsInOrderAs (products)
+    }
+    "take" in {
+      await(db.run(take)) must contain theSameElementsAs (products)
+    }
+    "drop" in {
+      await(db.run(drop)) must contain theSameElementsAs (products.drop(1))
+    }
+    "++" in {
+      await(db.run(`++`)) must contain theSameElementsAs (products ++ products)
+    }
+    "unionAll" in {
+      await(db.run(unionAll)) must contain theSameElementsAs (products ++ products)
+    }
+    "union" in {
+      await(db.run(union)) must contain theSameElementsAs (products)
+    }
+    "join" in {
+      await(db.run(join)) must contain theSameElementsAs (products zip products)
+    }
+    "distinct" in {
+      await(db.run(distinct)) must contain theSameElementsAs (products.map(_.id).distinct)
+    }
+  }
+
+  "return single result" - {
+    "min" - {
+      "some" in {
+        await(db.run(minExists)) mustEqual Some(products.map(_.sku).min)
+      }
+      "none" in {
+        await(db.run(minNonExists)) mustBe None
+      }
+    }
+    "max" - {
+      "some" in {
+        await(db.run(maxExists)) mustBe Some(products.map(_.sku).max)
+      }
+      "none" in {
+        await(db.run(maxNonExists)) mustBe None
+      }
+    }
+    "avg" - {
+      "some" in {
+        await(db.run(avgExists)) mustBe Some(BigDecimal(products.map(_.sku).sum) / products.size)
+      }
+      "none" in {
+        await(db.run(avgNonExists)) mustBe None
+      }
+    }
+    "size" in {
+      await(db.run(productSize)) mustEqual products.size
+    }
+    "nonEmpty" in {
+      await(db.run(nonEmpty)) mustEqual true
+    }
+    "isEmpty" in {
+      await(db.run(isEmpty)) mustEqual false
+    }
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/SqlSource.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/SqlSource.scala
@@ -14,6 +14,7 @@ import io.getquill.sources.sql.idiom.SqlIdiom
 abstract class SqlSource[D <: SqlIdiom, N <: NamingStrategy, R: ClassTag, S: ClassTag] extends io.getquill.sources.Source[R, S] {
 
   type QueryResult[T]
+  type SingleQueryResult[T]
   type ActionResult[T]
   type BatchedActionResult[T]
 
@@ -117,35 +118,35 @@ abstract class SqlSource[D <: SqlIdiom, N <: NamingStrategy, R: ClassTag, S: Cla
 
   def run[T](
     quoted: Quoted[T]
-  ): QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, T](
     quoted: Quoted[P1 => T]
-  ): P1 => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): P1 => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, P2, T](
     quoted: Quoted[(P1, P2) => T]
-  ): (P1, P2) => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): (P1, P2) => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, T](
     quoted: Quoted[(P1, P2, P3) => T]
-  ): (P1, P2, P3) => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): (P1, P2, P3) => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, T](
     quoted: Quoted[(P1, P2, P3, P4) => T]
-  ): (P1, P2, P3, P4) => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4) => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, T](
     quoted: Quoted[(P1, P2, P3, P4, P5) => T]
-  ): (P1, P2, P3, P4, P5) => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5) => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6) => T]
-  ): (P1, P2, P3, P4, P5, P6) => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6) => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, P7, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6, P7) => T]
-  ): (P1, P2, P3, P4, P5, P6, P7) => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6, P7) => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, P7, P8, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6, P7, P8) => T]
-  ): (P1, P2, P3, P4, P5, P6, P7, P8) => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6, P7, P8) => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, P7, P8, P9, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6, P7, P8, P9) => T]
-  ): (P1, P2, P3, P4, P5, P6, P7, P8, P9) => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6, P7, P8, P9) => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
   def run[P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, T](
     quoted: Quoted[(P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) => T]
-  ): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) => QueryResult[T] = macro SqlSourceMacro.run[R, S]
+  ): (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) => SingleQueryResult[T] = macro SqlSourceMacro.runSingle[R, S]
 }

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/mirror/SqlMirrorSource.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/mirror/SqlMirrorSource.scala
@@ -18,9 +18,11 @@ class SqlMirrorSource[N <: NamingStrategy](config: SqlMirrorSourceConfig[N])
 
   override def close = ()
 
+  type SingleQueryResult[T] = QueryMirror[T]
   type QueryResult[T] = QueryMirror[T]
   type ActionResult[T] = ActionMirror
   type BatchedActionResult[T] = BatchActionMirror
+
   class ActionApply[T](f: List[T] => BatchActionMirror)
     extends Function1[List[T], BatchActionMirror] {
     def apply(params: List[T]) = f(params)
@@ -53,4 +55,6 @@ class SqlMirrorSource[N <: NamingStrategy](config: SqlMirrorSourceConfig[N])
 
   def query[T](sql: String, bind: Row => Row, extractor: Row => T) =
     QueryMirror(sql, bind(Row()), extractor)
+
+  def querySingle[T](sql: String, bind: Row => Row, extractor: Row => T) = query(sql, bind, extractor)
 }

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/QueryResultTypeSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/QueryResultTypeSpec.scala
@@ -1,0 +1,32 @@
+package io.getquill.sources.sql
+
+import io.getquill._
+
+trait QueryResultTypeSpec extends ProductSpec {
+  val deleteAll = quote(query[Product].delete)
+  val selectAll = quote(query[Product])
+  val map = quote(query[Product].map(_.id))
+  val filter = quote(query[Product].filter(_ => true))
+  val withFilter = quote(query[Product].withFilter(_ => true))
+  val sortBy = quote(query[Product].sortBy(_.id)(Ord.asc))
+  val take = quote(query[Product].take(10))
+  val drop = quote(query[Product].drop(1))
+  val `++` = quote(query[Product] ++ query[Product])
+  val unionAll = quote(query[Product].unionAll(query[Product]))
+  val union = quote(query[Product].union(query[Product]))
+
+  val minExists = quote(query[Product].map(_.sku).min)
+  val minNonExists = quote(query[Product].filter(_.id > 1000).map(_.sku).min)
+  val maxExists = quote(query[Product].map(_.sku).max)
+  val maxNonExists = quote(query[Product].filter(_.id > 1000).map(_.sku).max)
+  val avgExists = quote(query[Product].map(_.sku).avg)
+  val avgNonExists = quote(query[Product].filter(_.id > 1000).map(_.sku).avg)
+  val productSize = quote(query[Product].size)
+
+  val join = quote(query[Product].join(query[Product]).on(_.id == _.id))
+
+  val nonEmpty = quote(query[Product].nonEmpty)
+  val isEmpty = quote(query[Product].isEmpty)
+  val distinct = quote(query[Product].map(_.id).distinct)
+
+}

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -56,7 +56,12 @@ Create TABLE DateEncodingTestEntity(
 
 Create TABLE BooleanEncodingTestEntity(
     v1 BOOLEAN,
-    v2 BIT(1)
+    v2 BIT(1),
+    v3 TINYINT,
+    v4 SMALLINT,
+    v5 MEDIUMINT,
+    v6 INT,
+    v7 BIGINT
 );
 
 CREATE TABLE TestEntity(
@@ -80,7 +85,7 @@ CREATE TABLE TestEntity3(
 
 CREATE TABLE Product(
     description VARCHAR(255),
-    id INTEGER NOT NULL AUTO_INCREMENT,
+    id BIGINT NOT NULL AUTO_INCREMENT,
     sku BIGINT,
     PRIMARY KEY (id)
 );


### PR DESCRIPTION
Fix #172 Fix #340 
### Problem
Always return `List`  for any type of query

### Solution

If `expr`  returns `io.getquill.Query[T]` then return `List` otherwise return `expr`'s tree type.

### Notes



### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers