### PR TITLE
Fixes #306

### DIFF
--- a/quill-async/src/test/scala/io/getquill/sources/async/mysql/PeopleMysqlAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/mysql/PeopleMysqlAsyncSpec.scala
@@ -50,4 +50,12 @@ class PeopleMysqlAsyncSpec extends PeopleSpec {
   "Example 7 - predicate 1" in {
     await(testMysqlDB.run(satisfies(eval(`Ex 7 predicate`)))) mustEqual `Ex 7 expected result`
   }
+
+  "Example 8 - contains empty" in {
+    await(testMysqlDB.run(`Ex 8 and 9 contains`)(`Ex 8 param`)) mustEqual `Ex 8 expected result`
+  }
+
+  "Example 9 - contains non empty" in {
+    await(testMysqlDB.run(`Ex 8 and 9 contains`)(`Ex 9 param`)) mustEqual `Ex 9 expected result`
+  }
 }

--- a/quill-async/src/test/scala/io/getquill/sources/async/postgres/PeoplePostgresAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/postgres/PeoplePostgresAsyncSpec.scala
@@ -50,4 +50,12 @@ class PeoplePostgresAsyncSpec extends PeopleSpec {
   "Example 7 - predicate 1" in {
     await(testPostgresDB.run(satisfies(eval(`Ex 7 predicate`)))) mustEqual `Ex 7 expected result`
   }
+
+  "Example 8 - contains empty" in {
+    await(testPostgresDB.run(`Ex 8 and 9 contains`)(`Ex 8 param`)) mustEqual `Ex 8 expected result`
+  }
+
+  "Example 9 - contains non empty" in {
+    await(testPostgresDB.run(`Ex 8 and 9 contains`)(`Ex 9 param`)) mustEqual `Ex 9 expected result`
+  }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/PeopleCassandraSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/PeopleCassandraSpec.scala
@@ -1,0 +1,32 @@
+package io.getquill.sources.cassandra
+
+import io.getquill._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class PeopleCassandraSpec extends Spec {
+  case class Person(id: Int, name: String, age: Int)
+
+  override def beforeAll = {
+    val entries = List(
+      Person(1, "Bob", 30),
+      Person(2, "Gus", 40),
+      Person(3, "Pet", 20),
+      Person(4, "Don", 50),
+      Person(5, "Dre", 60)
+    )
+    testSyncDB.run(query[Person].delete)
+    testSyncDB.run(query[Person].insert)(entries)
+    ()
+  }
+
+  val q = quote {
+    (ids: Set[Int]) => query[Person].filter(p => ids.contains(p.id))
+  }
+
+  "Contains id" - {
+    "empty" in {
+      testSyncDB.run(q)(Set.empty[Int]) mustEqual List.empty[Person]
+    }
+
+  }
+}

--- a/quill-core/src/main/scala/io/getquill/sources/BindedStatementBuilder.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/BindedStatementBuilder.scala
@@ -36,7 +36,11 @@ class BindedStatementBuilder[S] {
         case ('?' :: qtail, (bind: SingleBinding[_, _]) :: btail) =>
           expand(qtail, btail, acc :+ '?')
         case ('?' :: qtail, (bind: SetBinding[_, _]) :: btail) =>
-          val expanded = List.fill(bind.values.size)('?').mkString(", ").toList
+          val expanded = if (bind.values.isEmpty) {
+            emptySet.toList
+          } else {
+            List.fill(bind.values.size)('?').mkString(", ").toList
+          }
           expand(qtail, btail, acc ++ expanded)
         case other =>
           throw new IllegalStateException("Number of bindings doesn't match the question marks.")
@@ -62,4 +66,6 @@ class BindedStatementBuilder[S] {
       }
     (expandedQuery.mkString, (setValues _).andThen(_._1))
   }
+
+  def emptySet = ""
 }

--- a/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/PeopleFinagleMysqlSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/PeopleFinagleMysqlSpec.scala
@@ -49,4 +49,12 @@ class PeopleFinagleMysqlSpec extends PeopleSpec {
   "Example 7 - predicate 1" in {
     await(testDB.run(satisfies(eval(`Ex 7 predicate`)))) mustEqual `Ex 7 expected result`
   }
+
+  "Example 8 - contains empty" in {
+    await(testDB.run(`Ex 8 and 9 contains`)(`Ex 8 param`)) mustEqual `Ex 8 expected result`
+  }
+
+  "Example 9 - contains non empty" in {
+    await(testDB.run(`Ex 8 and 9 contains`)(`Ex 9 param`)) mustEqual `Ex 9 expected result`
+  }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/h2/PeopleJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/h2/PeopleJdbcSpec.scala
@@ -41,4 +41,12 @@ class PeopleJdbcSpec extends PeopleSpec {
   "Example 7 - predicate 1" in {
     testH2DB.run(satisfies(eval(`Ex 7 predicate`))) mustEqual `Ex 7 expected result`
   }
+
+  "Example 8 - contains empty" in {
+    testH2DB.run(`Ex 8 and 9 contains`)(`Ex 8 param`) mustEqual `Ex 8 expected result`
+  }
+
+  "Example 9 - contains non empty" in {
+    testH2DB.run(`Ex 8 and 9 contains`)(`Ex 9 param`) mustEqual `Ex 9 expected result`
+  }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/mysql/PeopleJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/mysql/PeopleJdbcSpec.scala
@@ -43,4 +43,12 @@ class PeopleJdbcSpec extends PeopleSpec {
   "Example 7 - predicate 1" in {
     testMysqlDB.run(satisfies(eval(`Ex 7 predicate`))) mustEqual `Ex 7 expected result`
   }
+
+  "Example 8 - contains empty" in {
+    testMysqlDB.run(`Ex 8 and 9 contains`)(`Ex 8 param`) mustEqual `Ex 8 expected result`
+  }
+
+  "Example 9 - contains non empty" in {
+    testMysqlDB.run(`Ex 8 and 9 contains`)(`Ex 9 param`) mustEqual `Ex 9 expected result`
+  }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/postgres/PeopleJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/postgres/PeopleJdbcSpec.scala
@@ -43,4 +43,12 @@ class PeopleJdbcSpec extends PeopleSpec {
   "Example 7 - predicate 1" in {
     testPostgresDB.run(satisfies(eval(`Ex 7 predicate`))) mustEqual `Ex 7 expected result`
   }
+
+  "Example 8 - contains empty" in {
+    testPostgresDB.run(`Ex 8 and 9 contains`)(`Ex 8 param`) mustEqual `Ex 8 expected result`
+  }
+
+  "Example 9 - contains non empty" in {
+    testPostgresDB.run(`Ex 8 and 9 contains`)(`Ex 9 param`) mustEqual `Ex 9 expected result`
+  }
 }

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/SqlBindedStatementBuilder.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/SqlBindedStatementBuilder.scala
@@ -1,0 +1,7 @@
+package io.getquill.sources.sql
+
+import io.getquill.sources.BindedStatementBuilder
+
+class SqlBindedStatementBuilder[S] extends BindedStatementBuilder[S] {
+  override def emptySet: String = "SELECT 0 WHERE FALSE"
+}

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/PeopleSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/PeopleSpec.scala
@@ -120,4 +120,16 @@ trait PeopleSpec extends Spec {
 
   val `Ex 7 predicate` = Not(Or(Below(20), Above(30)))
   val `Ex 7 expected result` = List(Person("Edna", 21))
+
+  val `Ex 8 and 9 contains` =
+    quote {
+      (set: Set[Int]) =>
+        query[Person].filter(p => set.contains(p.age))
+    }
+
+  val `Ex 8 param` = Set.empty[Int]
+  val `Ex 8 expected result` = List.empty[Person]
+
+  val `Ex 9 param` = Set(55, 33)
+  val `Ex 9 expected result` = List(Person("Bert", 55), Person("Cora", 33))
 }


### PR DESCRIPTION
Fixes #306

### Problem

Empty set produces wrong SQL query. 

### Solution

Added an SQL clause that's equivalent to an empty set. 

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted
- [x] Need to add one more test for Cassandra

@getquill/maintainers