### PR TITLE
reconfigure test coverage settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -140,7 +140,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
   ),
   fork in Test := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  scoverage.ScoverageKeys.coverageMinimum := 100,
+  scoverage.ScoverageKeys.coverageMinimum := 96,
   scoverage.ScoverageKeys.coverageFailOnMinimum := false,
   ScalariformKeys.preferences := ScalariformKeys.preferences.value
     .setPreference(AlignParameters, true)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default: {}
+comment: off


### PR DESCRIPTION
The project doesn't have 100% test coverage for a long time now. I'd like to lower the target to 96% because there's a lot to work on before the `1.0` release and it'll be difficult to maintain 100% coverage on every change. The plan is revisit this with https://github.com/getquill/quill/issues/75 after `1.0`.

This also disables the annoying codecov PR comments.

@getquill/maintainers
