### PR TITLE
fail build on any error

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e # Any subsequent(*) commands which fail will cause the shell script to exit immediately
 chown root ~/.ssh/config
 chmod 644 ~/.ssh/config
 
@@ -24,7 +25,8 @@ then
 		git push --delete origin release
 	elif [[ $TRAVIS_BRANCH == "master" ]]
 	then
-		sbt clean coverage test tut coverageAggregate release-vcs-checks && sbt coverageOff publish
+		sbt clean coverage test tut coverageAggregate release-vcs-checks
+		sbt coverageOff publish
 	else
 		sbt clean coverage test tut coverageAggregate release-vcs-checks
 		echo "version in ThisBuild := \"$TRAVIS_BRANCH-SNAPSHOT\"" > version.sbt


### PR DESCRIPTION
Fixes #339 

### Problem

`build.sh` should fail if any of the commands fails.

### Solution

use `set -e`. See http://stackoverflow.com/questions/2870992/automatic-exit-from-bash-shell-script-on-error.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
