### PR TITLE
quilll-sql: support value queries

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/sources/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/SqlQuery.scala
@@ -34,7 +34,7 @@ case class UnaryOperationSqlQuery(
 case class SelectValue(ast: Ast, alias: Option[String] = None)
 
 case class FlattenSqlQuery(
-  from:     List[Source],
+  from:     List[Source]          = List(),
   where:    Option[Ast]           = None,
   groupBy:  List[Property]        = Nil,
   orderBy:  List[OrderByCriteria] = Nil,
@@ -52,6 +52,7 @@ object SqlQuery {
       case Union(a, b)                  => SetOperationSqlQuery(apply(a), UnionOperation, apply(b))
       case UnionAll(a, b)               => SetOperationSqlQuery(apply(a), UnionAllOperation, apply(b))
       case UnaryOperation(op, q: Query) => UnaryOperationSqlQuery(op, apply(q))
+      case _: Operation | _: Value      => FlattenSqlQuery(select = List(SelectValue(query)))
       case q: Query                     => flatten(q, "x")
       case other                        => fail(s"Query not properly normalized. Please open a bug report. Ast: '$other'")
     }

--- a/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/sources/sql/idiom/SqlIdiom.scala
@@ -55,14 +55,20 @@ trait SqlIdiom {
 
       val selectClause =
         select match {
-          case Nil => s"SELECT$distinctShow * FROM ${from.show}"
-          case _   => s"SELECT$distinctShow ${select.show} FROM ${from.show}"
+          case Nil => s"SELECT$distinctShow *"
+          case _   => s"SELECT$distinctShow ${select.show}"
+        }
+
+      val withFrom =
+        from match {
+          case Nil  => selectClause
+          case from => selectClause + s" FROM ${from.show}"
         }
 
       val withWhere =
         where match {
-          case None        => selectClause
-          case Some(where) => selectClause + s" WHERE ${where.show}"
+          case None        => withFrom
+          case Some(where) => withFrom + s" WHERE ${where.show}"
         }
       val withGroupBy =
         groupBy match {

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/SqlQuerySpec.scala
@@ -49,6 +49,22 @@ class SqlQuerySpec extends Spec {
       SqlQuery(q.ast).show mustEqual
         "SELECT a.i, b.i FROM TestEntity a, TestEntity2 b WHERE (a.s IS NOT NULL) AND (b.i > a.i)"
     }
+
+    "value query" - {
+      "operation" in {
+        val q = quote {
+          qr1.map(_.i).contains(1)
+        }
+        SqlQuery(q.ast).show mustEqual
+          "SELECT 1 IN (SELECT x1.i FROM TestEntity x1)"
+      }
+      "simple value" in {
+        val q = quote(1)
+        SqlQuery(q.ast).show mustEqual
+          "SELECT 1"
+      }
+    }
+
     "nested infix query" - {
       "as source" in {
         val q = quote {
@@ -349,15 +365,6 @@ class SqlQuerySpec extends Spec {
       }
       SqlQuery(q.ast).show mustEqual
         "SELECT MIN(q2.i) FROM TestEntity q1, TestEntity2 q2"
-    }
-  }
-
-  "fails if the query is not normalized" in {
-    val q = quote {
-      ((s: String) => qr1.filter(_.s == s))("s")
-    }
-    val e = intercept[IllegalStateException] {
-      val a = SqlQuery(q.ast)
     }
   }
 }


### PR DESCRIPTION
Fixes #341 

### Problem

Quill doesn't support selecting values or operations.
```scala
db.run(qr1.map(_.i).contains(1))
db.run(1)
```

### Solution

Change `SqlQuery` to support this kind of quotations.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
