### PR TITLE
trigger 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.6.0 / 9-May-2016
+
+* [explicit bindings using `lift`](https://github.com/getquill/quill/pull/335/files#diff-04c6e90faac2675aa89e2176d2eec7d8R157)
+* [Code Of Conduct](https://github.com/getquill/quill/pull/296)
+* [dynamic type parameters](https://github.com/getquill/quill/pull/351)
+* [support contains for Traversable](https://github.com/getquill/quill/pull/290)
+* [`equals` support](https://github.com/getquill/quill/pull/328)
+* [Always return List for any type of query](https://github.com/getquill/quill/pull/324)
+* [quilll-sql: support value queries](https://github.com/getquill/quill/pull/354)
+* [quill-sql: `in`/`contains` - support empty sets](https://github.com/getquill/quill/pull/329)
+* [Support `Ord` quotation](https://github.com/getquill/quill/pull/301)
+* [`blockParser` off-by-one error](https://github.com/getquill/quill/pull/292)
+* [show ident instead of indent.toString](https://github.com/getquill/quill/pull/307)
+* [decode bit as boolean](https://github.com/getquill/quill/pull/308)
+
 # 0.5.0 / 17-Mar-2016
 
 * [Schema mini-DSL and generated values](https://github.com/getquill/quill/pull/226/files#diff-04c6e90faac2675aa89e2176d2eec7d8R212)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Quill provides a Quoted Domain Specific Language ([QDSL](http://homepages.inf.ed
 * [Quotation](#quotation)
 * [Mirror sources](#mirror-sources)
 * [Compile-time quotations](#compile-time-quotations)
-* [Parametrized quotations](#parametrized-quotations)
+* [Bindings](#bindings)
 * [Schema](#schema)
 * [Queries](#queries)
 * [Query probing](#query-probing)
@@ -1006,7 +1006,7 @@ sbt dependencies
 ```
 libraryDependencies ++= Seq(
   "mysql" % "mysql-connector-java" % "5.1.36",
-  "io.getquill" %% "quill-jdbc" % "0.5.1-SNAPSHOT"
+  "io.getquill" %% "quill-jdbc" % "0.6.0"
 )
 ```
 
@@ -1037,7 +1037,7 @@ sbt dependencies
 ```
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.4-1206-jdbc41",
-  "io.getquill" %% "quill-jdbc" % "0.5.1-SNAPSHOT"
+  "io.getquill" %% "quill-jdbc" % "0.6.0"
 )
 ```
 
@@ -1068,7 +1068,7 @@ db.connectionTimeout=30000
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-async" % "0.5.1-SNAPSHOT"
+  "io.getquill" %% "quill-async" % "0.6.0"
 )
 ```
 
@@ -1098,7 +1098,7 @@ db.poolValidationInterval=100
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-async" % "0.5.1-SNAPSHOT"
+  "io.getquill" %% "quill-async" % "0.6.0"
 )
 ```
 
@@ -1128,7 +1128,7 @@ db.poolValidationInterval=100
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-finagle-mysql" % "0.5.1-SNAPSHOT"
+  "io.getquill" %% "quill-finagle-mysql" % "0.6.0"
 )
 ```
 
@@ -1158,7 +1158,7 @@ db.pool.maxWaiters=2147483647
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-cassandra" % "0.5.1-SNAPSHOT"
+  "io.getquill" %% "quill-cassandra" % "0.6.0"
 )
 ```
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1-SNAPSHOT"
+version in ThisBuild := "0.6.0"


### PR DESCRIPTION
I think this could be the last release before the `1.0` release candidates cycle.

I've also fixed a wrong README link.

@getquill/maintainers

