### PR TITLE
simplify `finagle-mysql` action result type

### DIFF
--- a/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/FinagleMysqlSourceSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/FinagleMysqlSourceSpec.scala
@@ -1,6 +1,5 @@
 package io.getquill.sources.finagle.mysql
 
-import com.twitter.finagle.exp.mysql._
 import com.twitter.util._
 import io.getquill._
 
@@ -8,10 +7,10 @@ class MysqlAsyncSourceSpec extends Spec {
 
   def await[T](f: Future[T]) = Await.result(f)
 
-  "run non-batched action" - {
+  "run non-batched action" in {
     val insert = quote { (i: Int) =>
       qr1.insert(_.i -> i)
     }
-    await(testDB.run(insert)(1)) mustBe an[OK]
+    await(testDB.run(insert)(1)) mustEqual 1
   }
 }

--- a/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/QueryResultFinagleMysqlSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/QueryResultFinagleMysqlSpec.scala
@@ -1,7 +1,6 @@
 package io.getquill.sources.finagle.mysql
 
 import io.getquill.sources.sql._
-import com.twitter.finagle.exp.mysql.OK
 import com.twitter.util.{ Await, Future }
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.collection.JavaConverters._
@@ -17,7 +16,7 @@ class QueryResultTypeFinagleMysqlSpec extends QueryResultTypeSpec {
     await(db.run(deleteAll))
     val rs = await(db.run(productInsert)(productEntries))
     val inserted = (rs zip productEntries).map {
-      case (r, prod) => prod.copy(id = r.asInstanceOf[OK].insertId)
+      case (r, prod) => prod.copy(id = r)
     }
     insertedProducts.addAll(inserted.asJava)
     ()


### PR DESCRIPTION
Fixes #316 

### Problem

`quill-finagle-mysql` returns `com.twitter.finagle.exp.mysql.Result` for actions. It should return a `Long`, as the other modules.

### Solution

Return `Long`.

### Notes

I've created https://github.com/getquill/quill/issues/357 to write tests covering the returned generated column.

### Checklist

- [x] Unit test all changes (**tech debt**)
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers