### PR TITLE
provide default values for plain-sql query execution

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraStreamSource.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/CassandraStreamSource.scala
@@ -29,7 +29,7 @@ class CassandraStreamSource[N <: NamingStrategy](config: CassandraSourceConfig[N
       Observable.fromFuture(rs.fetchMoreResults()).map(_ => page)
   }
 
-  def query[T](cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], extractor: Row => T): Observable[T] = {
+  def query[T](cql: String, extractor: Row => T = identity[Row] _, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement] = identity): Observable[T] = {
     Observable
       .fromFuture(session.executeAsync(prepare(cql, bind)))
       .flatMap(Observable.fromStateAction((rs: ResultSet) => (page(rs), rs)))
@@ -39,12 +39,13 @@ class CassandraStreamSource[N <: NamingStrategy](config: CassandraSourceConfig[N
       .map(extractor)
   }
 
-  def querySingle[T](cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], extractor: Row => T) = query(cql, bind, extractor)
+  def querySingle[T](cql: String, extractor: Row => T = identity[Row] _, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement] = identity) =
+    query(cql, extractor, bind)
 
-  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None): Observable[ResultSet] =
+  def execute(cql: String, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement] = identity, generated: Option[String] = None): Observable[ResultSet] =
     Observable.fromFuture(session.executeAsync(prepare(cql, bind)))
 
-  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement], generated: Option[String] = None): Observable[T] => Observable[ResultSet] =
+  def executeBatch[T](cql: String, bindParams: T => BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement] = (_: T) => identity[BindedStatementBuilder[BoundStatement]] _, generated: Option[String] = None): Observable[T] => Observable[ResultSet] =
     (values: Observable[T]) =>
       values.flatMap { value =>
         Observable.fromFuture(session.executeAsync(prepare(cql, bindParams(value))))

--- a/quill-core/src/main/scala/io/getquill/sources/QueryMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/QueryMacro.scala
@@ -45,8 +45,8 @@ trait QueryMacro extends SelectFlattening with SelectResultExtraction {
 
         ${c.prefix}.$queryMethod(
           sql,
-          $encodedParams(bindings.map(_.name)),
-          $extractor)
+          $extractor,
+          $encodedParams(bindings.map(_.name)))
       }
       """
     else
@@ -59,8 +59,8 @@ trait QueryMacro extends SelectFlattening with SelectResultExtraction {
         (..$inputs) =>
           ${c.prefix}.query(
             sql,
-            $encodedParams(bindings.map(_.name)),
-            $extractor)
+            $extractor,
+            $encodedParams(bindings.map(_.name)))
       }
       """
   }

--- a/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorSource.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/mirror/MirrorSource.scala
@@ -44,21 +44,21 @@ class MirrorSource(config: SourceConfig[MirrorSource])
 
   case class ActionMirror(ast: Ast, bind: Row)
 
-  def execute(ast: Ast, bindParams: Row => Row, generated: Option[String] = None) =
+  def execute(ast: Ast, bindParams: Row => Row = identity, generated: Option[String] = None) =
     ActionMirror(ast, bindParams(Row()))
 
   case class BatchActionMirror(ast: Ast, bindList: List[Row])
 
-  def executeBatch[T](ast: Ast, bindParams: T => Row => Row, generated: Option[String] = None) =
+  def executeBatch[T](ast: Ast, bindParams: T => Row => Row = (_: T) => identity[Row] _, generated: Option[String] = None) =
     (values: List[T]) =>
       BatchActionMirror(ast, values.map(bindParams).map(_(Row())))
 
   case class QueryMirror[T](ast: Ast, binds: Row, extractor: Row => T)
 
-  def querySingle[T](ast: Ast, bind: Row => Row, extractor: Row => T) =
+  def querySingle[T](ast: Ast, extractor: Row => T = identity[Row] _, bind: Row => Row = identity) =
     QueryMirror(ast, bind(Row()), extractor)
 
-  def query[T](ast: Ast, bind: Row => Row, extractor: Row => T) = QueryMirror(ast, bind(Row()), extractor)
+  def query[T](ast: Ast, extractor: Row => T = identity[Row] _, bind: Row => Row = identity) = QueryMirror(ast, bind(Row()), extractor)
 }
 
 class MirrorSourceMacro(val c: Context) extends SourceMacro {


### PR DESCRIPTION
Fixes #359 

### Problem

The `source.execute*` and `source.query*` methods require two parameters that aren't always useful when executing plain-sql queries.

### Solution

Provide default values for these parameters.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
