### PR TITLE
don't consider `?` a binding if inside a quote

### DIFF
--- a/quill-core/src/main/scala/io/getquill/sources/BindedStatementBuilder.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/BindedStatementBuilder.scala
@@ -34,9 +34,10 @@ class BindedStatementBuilder[S] {
         case ('\'' :: qtail, b) => // skip quote
           @tailrec def extractQuote(q: List[Char], acc: List[Char]): (List[Char], List[Char]) =
             q match {
-              case '\'' :: tail => (acc :+ '\'', tail)
-              case head :: tail => extractQuote(tail, acc :+ head)
-              case Nil          => (acc, Nil)
+              case '\\' :: '\'' :: tail => extractQuote(tail, acc :+ '\\' :+ '\'')
+              case '\'' :: tail         => (acc :+ '\'', tail)
+              case head :: tail         => extractQuote(tail, acc :+ head)
+              case Nil                  => (acc, Nil)
             }
           val (quote, tail) = extractQuote(qtail, List('\''))
           expand(tail, b, acc ++ quote)

--- a/quill-core/src/main/scala/io/getquill/sources/BindedStatementBuilder.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/BindedStatementBuilder.scala
@@ -24,13 +24,22 @@ class BindedStatementBuilder[S] {
     this
   }
 
-  def build(query: String) = {
+  def build(query: String): (String, (S => S)) = {
 
     @tailrec
     def expand(q: List[Char], b: List[Binding[S]], acc: List[Char]): List[Char] =
       (q, b) match {
         case (Nil, Nil) =>
           acc
+        case ('\'' :: qtail, b) => // skip quote
+          @tailrec def extractQuote(q: List[Char], acc: List[Char]): (List[Char], List[Char]) =
+            q match {
+              case '\'' :: tail => (acc :+ '\'', tail)
+              case head :: tail => extractQuote(tail, acc :+ head)
+              case Nil          => (acc, Nil)
+            }
+          val (quote, tail) = extractQuote(qtail, List('\''))
+          expand(tail, b, acc ++ quote)
         case (c :: qtail, b) if (c != '?') =>
           expand(qtail, b, acc :+ c)
         case ('?' :: qtail, (bind: SingleBinding[_, _]) :: btail) =>
@@ -46,7 +55,7 @@ class BindedStatementBuilder[S] {
           throw new IllegalStateException("Number of bindings doesn't match the question marks.")
       }
 
-    val expandedQuery = expand(query.toList, bindings.toList.sortBy(_.index), List.empty)
+    def expandedQuery = expand(query.toList, bindings.toList.sortBy(_.index), List.empty)
 
     def setValues(p: S) =
       bindings.foldLeft((p, 0)) {
@@ -64,7 +73,11 @@ class BindedStatementBuilder[S] {
 
           }
       }
-    (expandedQuery.mkString, (setValues _).andThen(_._1))
+
+    if (bindings.isEmpty)
+      (query, identity[S] _)
+    else
+      (expandedQuery.mkString, (setValues _).andThen(_._1))
   }
 
   def emptySet = ""

--- a/quill-core/src/test/scala/io/getquill/sources/BindedStatementBuilderSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/BindedStatementBuilderSpec.scala
@@ -78,6 +78,18 @@ class BindedStatementBuilderSpec extends Spec {
     bind(List()) mustEqual List(1)
   }
 
+  "ignores quote within quote" in {
+    val subject = new Subject
+    val query = "SELECT '\\'?\\' \\'' FROM Test WHERE id = ?"
+
+    subject.single(0, 1, rawEnc)
+    val (expanded, bind) = subject.build(query)
+
+    expanded mustEqual query
+
+    bind(List()) mustEqual List(1)
+  }
+
   "invalid" - {
     "more ?" in {
       val subject = new Subject

--- a/quill-core/src/test/scala/io/getquill/sources/BindedStatementBuilderSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/BindedStatementBuilderSpec.scala
@@ -66,6 +66,18 @@ class BindedStatementBuilderSpec extends Spec {
     bind(List()) mustEqual List(1, 2, 3, 4)
   }
 
+  "ignores quote" in {
+    val subject = new Subject
+    val query = "SELECT '?' FROM Test WHERE id = ?"
+
+    subject.single(0, 1, rawEnc)
+    val (expanded, bind) = subject.build(query)
+
+    expanded mustEqual query
+
+    bind(List()) mustEqual List(1)
+  }
+
   "invalid" - {
     "more ?" in {
       val subject = new Subject


### PR DESCRIPTION
Fixes #330

### Problem

`?` inside a quote value is being considered as a binding value. For instance:

`select ' ? ' from Person`

Doesn't have a binding.

### Solution

Don't look for `?` inside a quote value.

### Notes

I'm not sure if there are other edge cases where `?` could be used.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
