### PR TITLE
quotation: fix binding conflict

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -49,8 +49,9 @@ trait Quotation extends Liftables with Unliftables with Parsing {
     val bindings =
       CollectAst(ast) {
         case CompileTimeBinding(tree: Tree) =>
-          q"val ${bindingName(tree.toString)} = $tree"
-      }
+          val name = bindingName(tree.toString)
+          name -> q"val $name = $tree"
+      }.toMap.values
 
     val id = TermName(s"id${ast.hashCode}")
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -782,6 +782,11 @@ class QuotationSpec extends Spec {
         val q = quote(lift(String.valueOf(1)))
         q.bindings.`java.this.lang.String.valueOf(1)` mustEqual String.valueOf(1)
       }
+      "duplicate" in {
+        val i = 1
+        val q = quote(lift(i) + lift(i))
+        q.bindings.i mustEqual i
+      }
     }
 
     "aggregates bindings of nested quotations" - {


### PR DESCRIPTION
### Problem

As pointed out by @gustavoamigo, two `lift` calls with the same runtime value generate a binding name conflict. For instance, `quote(lift(i) + lift(i))` fails to compile

### Solution

Deduplicate bindings when generating the quotation.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
