### PR TITLE
fix query generation for wrapped types

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,7 +801,7 @@ Quill's default operation mode is compile-time, but there are queries that have 
 ```scala
 import io.getquill._
 
-lazy val db = source(new MirrorSourceConfig("testSource"))
+lazy val db = source(new SqlMirrorSourceConfig("testSource"))
 
 sealed trait QueryType
 case object Minor extends QueryType

--- a/quill-core/src/main/scala/io/getquill/sources/EncodeParams.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/EncodeParams.scala
@@ -19,7 +19,7 @@ object EncodeParams {
         case (ident, (tpe, tree)) =>
           val encoder =
             Encoding.inferEncoder(c)(tpe)(s)
-              .getOrElse(c.fail(s"Source doesn't know how do encode '$ident: $tpe'"))
+              .getOrElse(c.fail(s"Source doesn't know how to encode '$ident: $tpe'"))
           (ident, (encoder, tree))
       }.toMap ++ raw
     }

--- a/quill-core/src/main/scala/io/getquill/sources/EncodingMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/EncodingMacro.scala
@@ -42,7 +42,12 @@ trait EncodingMacro {
     constructor.paramLists.map(_.map {
       param =>
         val paramType = param.typeSignature.asSeenFrom(typ, typ.typeSymbol)
-        encoding(Property(ast, param.name.decodedName.toString), paramType, inferEncoding)
+        val nestedAst =
+          if (typ.baseType(c.weakTypeOf[WrappedType].typeSymbol) != NoType)
+            ast
+          else
+            Property(ast, param.name.decodedName.toString)
+        encoding(nestedAst, paramType, inferEncoding)
     })
 
   private def caseClassConstructor(t: Type) =

--- a/quill-core/src/test/scala/io/getquill/sources/EncodeBindVariablesSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/EncodeBindVariablesSpec.scala
@@ -46,7 +46,9 @@ class EncodeBindVariablesSpec extends Spec {
       val q = quote {
         (x: WrappedEncodable) => query[Entity].filter(_.x == x)
       }
-      mirrorSource.run(q)(WrappedEncodable(1)).binds mustEqual Row(1)
+      val r = mirrorSource.run(q)(WrappedEncodable(1))
+      r.ast.toString mustEqual "query[Entity].filter(x3 => x3.x == p1).map(x3 => x3.x)"
+      r.binds mustEqual Row(1)
     }
 
     "encodes constructable `WrappedType` extended class" in {
@@ -58,7 +60,9 @@ class EncodeBindVariablesSpec extends Spec {
       val q = quote {
         (x: Wrapped) => query[Entity].filter(_.x == x)
       }
-      mirrorSource.run(q)(Wrapped(1)).binds mustEqual Row(1)
+      val r = mirrorSource.run(q)(Wrapped(1))
+      r.ast.toString mustEqual "query[Entity].filter(x4 => x4.x == p1).map(x4 => x4.x)"
+      r.binds mustEqual Row(1)
     }
 
     "fails for unwrapped class" in {

--- a/quill-core/src/test/scala/io/getquill/sources/SourceMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/sources/SourceMacroSpec.scala
@@ -113,7 +113,7 @@ class SourceMacroSpec extends Spec {
           (p1: WrappedEncodable) => query[Entity].filter(t => t.x == p1)
         }
         val r = mirrorSource.run(q)(WrappedEncodable(1))
-        r.ast.toString mustEqual "query[Entity].filter(t => t.x == p1).map(t => t.x.value)"
+        r.ast.toString mustEqual "query[Entity].filter(t => t.x == p1).map(t => t.x)"
         r.binds mustEqual Row(1)
       }
       "infix" in {


### PR DESCRIPTION
Fixes #338 

### Problem

The query generated for wrapped values is wrong:

```scala
case class UserId(value: Int) extends AnyVal with WrappedValue[Int]
  case class User(id: UserId, name: String)

  val q = quote {
    (id: UserId) => for {
      u <- query[User] if u.id == id
    } yield u
  }

  db.run(q)(UserId(1)) // SELECT u.idvalue, u.name FROM User u WHERE u.id = ?
```

Note `u.idvalue`.

### Solution

Do not create a nested property when expanding a wrapped type.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
