### PR TITLE
use querySingle/query for paralized query according to return type

### DIFF
--- a/quill-async/src/test/scala/io/getquill/sources/async/mysql/QueryResultTypeMysqlAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/mysql/QueryResultTypeMysqlAsyncSpec.scala
@@ -93,8 +93,8 @@ class QueryResultTypeMysqlAsyncSpec extends QueryResultTypeSpec {
     "size" in {
       await(db.run(productSize)) mustEqual products.size
     }
-    "paramlized size" in {
-      await(db.run(paramlizedSize)(10000)) mustEqual 0
+    "parametrized size" in {
+      await(db.run(parametrizedSize)(10000)) mustEqual 0
     }
     "nonEmpty" in {
       await(db.run(nonEmpty)) mustEqual true

--- a/quill-async/src/test/scala/io/getquill/sources/async/mysql/QueryResultTypeMysqlAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/mysql/QueryResultTypeMysqlAsyncSpec.scala
@@ -93,6 +93,9 @@ class QueryResultTypeMysqlAsyncSpec extends QueryResultTypeSpec {
     "size" in {
       await(db.run(productSize)) mustEqual products.size
     }
+    "paramlized size" in {
+      await(db.run(paramlizedSize)(10000)) mustEqual 0
+    }
     "nonEmpty" in {
       await(db.run(nonEmpty)) mustEqual true
     }

--- a/quill-async/src/test/scala/io/getquill/sources/async/postgres/QueryResultTypePostgresAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/postgres/QueryResultTypePostgresAsyncSpec.scala
@@ -93,8 +93,8 @@ class QueryResultTypePostgresAsyncSpec extends QueryResultTypeSpec {
     "size" in {
       await(db.run(productSize)) mustEqual products.size
     }
-    "paramlized size" in {
-      await(db.run(paramlizedSize)(10000)) mustEqual 0
+    "parametrized size" in {
+      await(db.run(parametrizedSize)(10000)) mustEqual 0
     }
     "nonEmpty" in {
       await(db.run(nonEmpty)) mustEqual true

--- a/quill-async/src/test/scala/io/getquill/sources/async/postgres/QueryResultTypePostgresAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/sources/async/postgres/QueryResultTypePostgresAsyncSpec.scala
@@ -93,6 +93,9 @@ class QueryResultTypePostgresAsyncSpec extends QueryResultTypeSpec {
     "size" in {
       await(db.run(productSize)) mustEqual products.size
     }
+    "paramlized size" in {
+      await(db.run(paramlizedSize)(10000)) mustEqual 0
+    }
     "nonEmpty" in {
       await(db.run(nonEmpty)) mustEqual true
     }

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/QueryResultTypeCassandraSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/QueryResultTypeCassandraSpec.scala
@@ -28,7 +28,7 @@ class QueryResultTypeCassandraSpec extends FreeSpec with BeforeAndAfterAll with 
   val sortBy = quote(query[OrderTestEntity].filter(_.id == 1).sortBy(_.i)(Ord.asc))
   val take = quote(query[OrderTestEntity].take(10))
   val entitySize = quote(query[OrderTestEntity].size)
-  val paramlizedSize = quote { (id: Int) =>
+  val parametrizedSize = quote { (id: Int) =>
     query[OrderTestEntity].filter(_.id == id).size
   }
   val distinct = quote(query[OrderTestEntity].map(_.id).distinct)
@@ -67,7 +67,7 @@ class QueryResultTypeCassandraSpec extends FreeSpec with BeforeAndAfterAll with 
         await(db.run(entitySize)) mustEqual entries.size
       }
       "paramlize size" in {
-        await(db.run(paramlizedSize)(10000)) mustEqual 0
+        await(db.run(parametrizedSize)(10000)) mustEqual 0
       }
     }
   }
@@ -101,7 +101,7 @@ class QueryResultTypeCassandraSpec extends FreeSpec with BeforeAndAfterAll with 
         await(db.run(entitySize)) mustEqual entries.size
       }
       "paramlize size" in {
-        await(db.run(paramlizedSize)(10000)) mustEqual 0
+        await(db.run(parametrizedSize)(10000)) mustEqual 0
       }
     }
   }
@@ -120,8 +120,8 @@ class QueryResultTypeCassandraSpec extends FreeSpec with BeforeAndAfterAll with 
       "size" in {
         await(db.run(entitySize)) mustEqual Some(List(3))
       }
-      "paramlized size" in {
-        await(db.run(paramlizedSize)(10000)) mustEqual Some(List(0))
+      "parametrized size" in {
+        await(db.run(parametrizedSize)(10000)) mustEqual Some(List(0))
       }
     }
   }

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/QueryResultTypeCassandraSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/QueryResultTypeCassandraSpec.scala
@@ -28,6 +28,9 @@ class QueryResultTypeCassandraSpec extends FreeSpec with BeforeAndAfterAll with 
   val sortBy = quote(query[OrderTestEntity].filter(_.id == 1).sortBy(_.i)(Ord.asc))
   val take = quote(query[OrderTestEntity].take(10))
   val entitySize = quote(query[OrderTestEntity].size)
+  val paramlizedSize = quote { (id: Int) =>
+    query[OrderTestEntity].filter(_.id == id).size
+  }
   val distinct = quote(query[OrderTestEntity].map(_.id).distinct)
 
   override def beforeAll = {
@@ -63,6 +66,9 @@ class QueryResultTypeCassandraSpec extends FreeSpec with BeforeAndAfterAll with 
       "size" in {
         await(db.run(entitySize)) mustEqual entries.size
       }
+      "paramlize size" in {
+        await(db.run(paramlizedSize)(10000)) mustEqual 0
+      }
     }
   }
 
@@ -94,6 +100,9 @@ class QueryResultTypeCassandraSpec extends FreeSpec with BeforeAndAfterAll with 
       "size" in {
         await(db.run(entitySize)) mustEqual entries.size
       }
+      "paramlize size" in {
+        await(db.run(paramlizedSize)(10000)) mustEqual 0
+      }
     }
   }
   "stream" - {
@@ -107,8 +116,13 @@ class QueryResultTypeCassandraSpec extends FreeSpec with BeforeAndAfterAll with 
       await(db.run(selectAll)) mustEqual Some(entries)
     }
 
-    "querySingle" in {
-      await(db.run(entitySize)) mustEqual Some(List(3))
+    "querySingle" - {
+      "size" in {
+        await(db.run(entitySize)) mustEqual Some(List(3))
+      }
+      "paramlized size" in {
+        await(db.run(paramlizedSize)(10000)) mustEqual Some(List(0))
+      }
     }
   }
 }

--- a/quill-core/src/main/scala/io/getquill/sources/QueryMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/sources/QueryMacro.scala
@@ -57,7 +57,7 @@ trait QueryMacro extends SelectFlattening with SelectResultExtraction {
             ${prepare(flattenQuery, allParamIdents)}
 
         (..$inputs) =>
-          ${c.prefix}.query(
+          ${c.prefix}.$queryMethod(
             sql,
             $extractor,
             $encodedParams(bindings.map(_.name)))

--- a/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/QueryResultTypeFinagleMysqlSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/QueryResultTypeFinagleMysqlSpec.scala
@@ -91,8 +91,8 @@ class QueryResultTypeFinagleMysqlSpec extends QueryResultTypeSpec {
     "size" in {
       await(db.run(productSize)) mustEqual products.size
     }
-    "paramlized size" in {
-      await(db.run(paramlizedSize)(10000)) mustEqual 0
+    "parametrized size" in {
+      await(db.run(parametrizedSize)(10000)) mustEqual 0
     }
     "nonEmpty" in {
       await(db.run(nonEmpty)) mustEqual true

--- a/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/QueryResultTypeFinagleMysqlSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/sources/finagle/mysql/QueryResultTypeFinagleMysqlSpec.scala
@@ -91,6 +91,9 @@ class QueryResultTypeFinagleMysqlSpec extends QueryResultTypeSpec {
     "size" in {
       await(db.run(productSize)) mustEqual products.size
     }
+    "paramlized size" in {
+      await(db.run(paramlizedSize)(10000)) mustEqual 0
+    }
     "nonEmpty" in {
       await(db.run(nonEmpty)) mustEqual true
     }

--- a/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/QueryResultTypeJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/QueryResultTypeJdbcSpec.scala
@@ -91,6 +91,9 @@ class QueryResultTypeJdbcSpec extends QueryResultTypeSpec {
     "size" in {
       await(db.run(productSize)) mustEqual products.size
     }
+    "paramlized size" in {
+      await(db.run(paramlizedSize)(10000)) mustEqual 0
+    }
     "nonEmpty" in {
       await(db.run(nonEmpty)) mustEqual true
     }

--- a/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/QueryResultTypeJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/sources/jdbc/QueryResultTypeJdbcSpec.scala
@@ -91,8 +91,8 @@ class QueryResultTypeJdbcSpec extends QueryResultTypeSpec {
     "size" in {
       await(db.run(productSize)) mustEqual products.size
     }
-    "paramlized size" in {
-      await(db.run(paramlizedSize)(10000)) mustEqual 0
+    "parametrized size" in {
+      await(db.run(parametrizedSize)(10000)) mustEqual 0
     }
     "nonEmpty" in {
       await(db.run(nonEmpty)) mustEqual true

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/QueryResultTypeSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/QueryResultTypeSpec.scala
@@ -22,7 +22,7 @@ trait QueryResultTypeSpec extends ProductSpec {
   val avgExists = quote(query[Product].map(_.sku).avg)
   val avgNonExists = quote(query[Product].filter(_.id > 1000).map(_.sku).avg)
   val productSize = quote(query[Product].size)
-  val paramlizedSize = quote { (id: Long) =>
+  val parametrizedSize = quote { (id: Long) =>
     query[Product].filter(_.id == id).size
   }
 

--- a/quill-sql/src/test/scala/io/getquill/sources/sql/QueryResultTypeSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/sources/sql/QueryResultTypeSpec.scala
@@ -22,6 +22,9 @@ trait QueryResultTypeSpec extends ProductSpec {
   val avgExists = quote(query[Product].map(_.sku).avg)
   val avgNonExists = quote(query[Product].filter(_.id > 1000).map(_.sku).avg)
   val productSize = quote(query[Product].size)
+  val paramlizedSize = quote { (id: Long) =>
+    query[Product].filter(_.id == id).size
+  }
 
   val join = quote(query[Product].join(query[Product]).on(_.id == _.id))
 


### PR DESCRIPTION
Fixes #374 

### Problem

`QueryMacro` always use `query` for paramlized query, regardless of the expr return type

### Solution

use query/querySingle according to return type

### Notes


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

