### PR TITLE
Remove Implicit Ordering

### DIFF
--- a/quill-core/src/main/scala/io/getquill/Ord.scala
+++ b/quill-core/src/main/scala/io/getquill/Ord.scala
@@ -4,12 +4,12 @@ trait Ord[T]
 
 trait OrdOps {
 
-  def asc[T](implicit ord: Ordering[T]): Ord[T]
-  def desc[T](implicit ord: Ordering[T]): Ord[T]
-  def ascNullsFirst[T](implicit ord: Ordering[T]): Ord[T]
-  def descNullsFirst[T](implicit ord: Ordering[T]): Ord[T]
-  def ascNullsLast[T](implicit ord: Ordering[T]): Ord[T]
-  def descNullsLast[T](implicit ord: Ordering[T]): Ord[T]
+  def asc[T]: Ord[T]
+  def desc[T]: Ord[T]
+  def ascNullsFirst[T]: Ord[T]
+  def descNullsFirst[T]: Ord[T]
+  def ascNullsLast[T]: Ord[T]
+  def descNullsLast[T]: Ord[T]
 
   def apply[T1, T2](o1: Ord[T1], o2: Ord[T2]): Ord[(T1, T2)]
   def apply[T1, T2, T3](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3]): Ord[(T1, T2, T3)]

--- a/quill-core/src/main/scala/io/getquill/package.scala
+++ b/quill-core/src/main/scala/io/getquill/package.scala
@@ -39,5 +39,5 @@ package object getquill {
 
   def Ord: OrdOps = NonQuotedException()
 
-  implicit def orderingToOrd[T](implicit o: Ordering[T]): Ord[T] = NonQuotedException()
+  implicit def implicitOrd[T]: Ord[T] = NonQuotedException()
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -210,14 +210,14 @@ trait Parsing extends EntityConfigParsing {
   }
 
   implicit val orderingParser: Parser[Ordering] = Parser[Ordering] {
-    case q"$pack.orderingToOrd[$t]($o)"      => AscNullsFirst
+    case q"$pack.implicitOrd[$t]"            => AscNullsFirst
     case q"$pack.Ord.apply[..$t](..$elems)"  => TupleOrdering(elems.map(orderingParser(_)))
-    case q"$pack.Ord.asc[$t]($o)"            => Asc
-    case q"$pack.Ord.desc[$t]($o)"           => Desc
-    case q"$pack.Ord.ascNullsFirst[$t]($o)"  => AscNullsFirst
-    case q"$pack.Ord.descNullsFirst[$t]($o)" => DescNullsFirst
-    case q"$pack.Ord.ascNullsLast[$t]($o)"   => AscNullsLast
-    case q"$pack.Ord.descNullsLast[$t]($o)"  => DescNullsLast
+    case q"$pack.Ord.asc[$t]"                => Asc
+    case q"$pack.Ord.desc[$t]"               => Desc
+    case q"$pack.Ord.ascNullsFirst[$t]"      => AscNullsFirst
+    case q"$pack.Ord.descNullsFirst[$t]"     => DescNullsFirst
+    case q"$pack.Ord.ascNullsLast[$t]"       => AscNullsLast
+    case q"$pack.Ord.descNullsLast[$t]"      => DescNullsLast
   }
 
   implicit val propertyAliasParser: Parser[PropertyAlias] = Parser[PropertyAlias] {

--- a/quill-core/src/test/scala/io/getquill/PackageSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/PackageSpec.scala
@@ -103,7 +103,7 @@ class PackageSpec extends Spec {
 
   "fails if orderingToOrd is unquoted ouside of a quotation" in {
     val e = intercept[NonQuotedException] {
-      orderingToOrd[Int]
+      implicitOrd[Int]
     }
   }
 }


### PR DESCRIPTION
### Problem

The sortBy relied on Ord class that was restricting ordering based on `scala.math.Ordering`, but it is not used anywhere else.

### Solution

Remove it

### Notes



### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

