### PR TITLE
Remove implicit from max and min since SQL is very flexiable regardin…

### DIFF
--- a/quill-core/src/main/scala/io/getquill/Query.scala
+++ b/quill-core/src/main/scala/io/getquill/Query.scala
@@ -17,8 +17,8 @@ sealed trait Query[+T] {
 
   def groupBy[R](f: T => R): Query[(R, Query[T])]
 
-  def min[U >: T](implicit o: Ordering[U]): Option[T]
-  def max[U >: T](implicit o: Ordering[U]): Option[T]
+  def min[U >: T]: Option[T]
+  def max[U >: T]: Option[T]
   def avg[U >: T](implicit n: Numeric[U]): Option[BigDecimal]
   def sum[U >: T](implicit n: Numeric[U]): Option[T]
   def size: Long

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -173,8 +173,8 @@ trait Parsing extends EntityConfigParsing {
     case q"$source.groupBy[$t](($alias) => $body)" if (is[QuillQuery[Any]](source)) =>
       GroupBy(astParser(source), identParser(alias), astParser(body))
 
-    case q"$a.min[$t]($o)" if (is[QuillQuery[Any]](a)) => Aggregation(AggregationOperator.`min`, astParser(a))
-    case q"$a.max[$t]($o)" if (is[QuillQuery[Any]](a)) => Aggregation(AggregationOperator.`max`, astParser(a))
+    case q"$a.min[$t]" if (is[QuillQuery[Any]](a)) => Aggregation(AggregationOperator.`min`, astParser(a))
+    case q"$a.max[$t]" if (is[QuillQuery[Any]](a)) => Aggregation(AggregationOperator.`max`, astParser(a))
     case q"$a.avg[$t]($n)" if (is[QuillQuery[Any]](a)) => Aggregation(AggregationOperator.`avg`, astParser(a))
     case q"$a.sum[$t]($n)" if (is[QuillQuery[Any]](a)) => Aggregation(AggregationOperator.`sum`, astParser(a))
     case q"$a.size" if (is[QuillQuery[Any]](a))        => Aggregation(AggregationOperator.`size`, astParser(a))


### PR DESCRIPTION
Remove implicit ordering from `max` and `min` since SQL is very flexible regarding types. 

### Problem

Implicit ordering makes it hard to adapt to SQL flexibility regarding types. In SQL you can use `max` and `min` with anything, so there is no point to limiting this with scala. 

### Solution

Just removed the implicit ordering

### Notes

Additional notes.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

…g types