### PR TITLE
support explicit `Predef.ArrowAssoc` call

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/EntityConfigParsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/EntityConfigParsing.scala
@@ -11,6 +11,7 @@ case class EntityConfig(
 )
 
 trait EntityConfigParsing extends UnicodeArrowParsing {
+  this: Parsing =>
   val c: Context
 
   import c.universe.{ Function => _, Ident => _, _ }
@@ -20,7 +21,7 @@ trait EntityConfigParsing extends UnicodeArrowParsing {
       case q"$e.entity(${ name: String })" =>
         parseEntityConfig(e).copy(alias = Some(name))
       case q"$e.columns(..$propertyAliases)" =>
-        parseEntityConfig(e).copy(properties = propertyAliases.map(parsePropertyAlias))
+        parseEntityConfig(e).copy(properties = propertyAliases.map(propertyAliasParser(_)))
       case q"$e.generated(($alias) => $body)" =>
         parseEntityConfig(e).copy(generated = Some(parseProperty(body)))
       case _ =>
@@ -32,9 +33,5 @@ trait EntityConfigParsing extends UnicodeArrowParsing {
       case q"$e.$property" => property.decodedName.toString
     }
 
-  private def parsePropertyAlias(t: Tree): PropertyAlias =
-    t match {
-      case q"(($x1) => scala.this.Predef.ArrowAssoc[$t]($x2.$prop).$arrow[$v](${ alias: String }))" =>
-        PropertyAlias(prop.decodedName.toString, alias)
-    }
+  val propertyAliasParser: Parser[PropertyAlias]
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -221,7 +221,7 @@ trait Parsing extends EntityConfigParsing {
   }
 
   implicit val propertyAliasParser: Parser[PropertyAlias] = Parser[PropertyAlias] {
-    case q"(($x1) => scala.this.Predef.ArrowAssoc[$t]($x2.$prop).->[$v](${ alias: String }))" =>
+    case q"(($x1) => $pack.Predef.ArrowAssoc[$t]($x2.$prop).$arrow[$v](${ alias: String }))" =>
       PropertyAlias(prop.decodedName.toString, alias)
   }
 
@@ -375,7 +375,7 @@ trait Parsing extends EntityConfigParsing {
     case Literal(c.universe.Constant(v)) => Constant(v)
     case q"((..$v))" if (v.size > 1) => Tuple(v.map(astParser(_)))
     case tree @ q"$pack.$coll.apply[..$t](..$v)" if isTraversable(tree) => Collection(v.map(astParser(_)))
-    case q"((scala.this.Predef.ArrowAssoc[$t1]($v1).$arrow[$t2]($v2)))" => Tuple(List(astParser(v1), astParser(v2)))
+    case q"(($pack.Predef.ArrowAssoc[$t1]($v1).$arrow[$t2]($v2)))" => Tuple(List(astParser(v1), astParser(v2)))
   }
 
   val actionParser: Parser[Ast] = Parser[Ast] {
@@ -392,7 +392,7 @@ trait Parsing extends EntityConfigParsing {
   }
 
   private val assignmentParser: Parser[Assignment] = Parser[Assignment] {
-    case q"((${ identParser(i1) }) => scala.this.Predef.ArrowAssoc[$t](${ identParser(i2) }.$prop).$arrow[$v]($value))" if (i1 == i2) =>
+    case q"((${ identParser(i1) }) => $pack.Predef.ArrowAssoc[$t](${ identParser(i2) }.$prop).$arrow[$v]($value))" if (i1 == i2) =>
       Assignment(i1, prop.decodedName.toString, astParser(value))
   }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -32,11 +32,17 @@ class QuotationSpec extends Spec {
           }
           quote(unquote(q)).ast mustEqual ConfiguredEntity(Entity("TestEntity"), Some("SomeAlias"), List(PropertyAlias("s", "theS"), PropertyAlias("i", "theI")))
         }
+        "explicit `Predef.ArrowAssoc`" in {
+          val q = quote {
+            query[TestEntity].schema(_.columns(e => Predef.ArrowAssoc(e.s). -> [String]("theS")))
+          }
+          quote(unquote(q)).ast mustEqual ConfiguredEntity(Entity("TestEntity"), properties = List(PropertyAlias("s", "theS")))
+        }
         "with property alias and unicode arrow" in {
-          """|quote {
-             |  query[TestEntity].schema(_.entity("SomeAlias").columns(_.s → "theS", _.i → "theI"))
-             |}
-          """.stripMargin must compile
+          val q = quote {
+            query[TestEntity].schema(_.entity("SomeAlias").columns(_.s → "theS", _.i → "theI"))
+          }
+          quote(unquote(q)).ast mustEqual ConfiguredEntity(Entity("TestEntity"), Some("SomeAlias"), List(PropertyAlias("s", "theS"), PropertyAlias("i", "theI")))
         }
       }
       "filter" in {
@@ -273,6 +279,12 @@ class QuotationSpec extends Spec {
           }
           quote(unquote(q)).ast mustEqual Function(List(Ident("x1")), Update(Entity("TestEntity")))
         }
+        "explicit `Predef.ArrowAssoc`" in {
+          val q = quote {
+            qr1.update(t => Predef.ArrowAssoc(t.s). -> [String]("s"))
+          }
+          quote(unquote(q)).ast mustEqual AssignedAction(Update(Entity("TestEntity")), List(Assignment(Ident("t"), "s", Constant("s"))))
+        }
         "unicode arrow must compile" in {
           """|quote {
              |  qr1.filter(t ⇒ t.i == 1).update(_.s → "new", _.i → 0)
@@ -330,6 +342,10 @@ class QuotationSpec extends Spec {
             val q = quote(1 -> "a" -> "b")
             quote(unquote(q)).ast mustEqual Tuple(List(Tuple(List(Constant(1), Constant("a"))), Constant("b")))
           }
+          "explicit `Predef.ArrowAssoc`" in {
+            val q = quote(Predef.ArrowAssoc("a"). -> [String]("b"))
+            quote(unquote(q)).ast mustEqual Tuple(List(Constant("a"), Constant("b")))
+          }
         }
       }
       "collection" - {
@@ -362,9 +378,9 @@ class QuotationSpec extends Spec {
     }
     "property anonymous" in {
       val q = quote {
-        qr1.map(_.s)
+        qr1.map(t => t.s)
       }
-      quote(unquote(q)).ast.body mustEqual Property(Ident("x8"), "s")
+      quote(unquote(q)).ast.body mustEqual Property(Ident("t"), "s")
     }
     "function" - {
       "anonymous function" in {


### PR DESCRIPTION
Fixes #385 

### Problem

The parsing of arrow tuples (`a -> b`) uses a fixed package prefix for `Predef.ArrowAssoc`.

### Solution

Support `Predef.ArrowAssoc` in any package prefix.

### Notes

I've also added unicode arrows support for schema definition.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
