### PR TITLE
Build FinagleMysqlSource with existing finagle mysql client

### DIFF
--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlSourceConfig.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlSourceConfig.scala
@@ -2,12 +2,28 @@ package io.getquill
 
 import com.twitter.finagle.client.DefaultPool
 import com.twitter.finagle.exp.Mysql
+import com.twitter.finagle.exp.mysql.Transactions
+import com.twitter.finagle.exp.mysql.Client
 import com.twitter.util.Try
 import com.twitter.conversions.time._
 import io.getquill.sources.SourceConfig
 import io.getquill.naming.NamingStrategy
 import java.util.TimeZone
 import io.getquill.sources.finagle.mysql.FinagleMysqlSource
+
+object FinagleMysqlSourceConfig {
+
+  def apply[N <: NamingStrategy](
+    clnt: Client with Transactions,
+    dataTimeZone: TimeZone = TimeZone.getDefault) = {
+
+    new FinagleMysqlSourceConfig[N]("") {
+      override def client = clnt
+    }
+  }
+
+  def apply[N <: NamingStrategy](name: String) = new FinagleMysqlSourceConfig[N](name)
+}
 
 class FinagleMysqlSourceConfig[N <: NamingStrategy](val name: String) extends SourceConfig[FinagleMysqlSource[N]] {
 


### PR DESCRIPTION
### Problem

There's no way of customizing the creation of the finagle mysql client used by FinagleMysqlSource.

### Solution

Added a constructor to FinagleMysqlSource, so the client code can take the response of building the mysql client.

@getquill/maintainers
