### PR TITLE
added handling for string lists in ClusterBuilder

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/cluster/ClusterBuilder.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/sources/cassandra/cluster/ClusterBuilder.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigValueType
 import java.lang.reflect.Method
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import com.datastax.driver.core.Cluster
 
 object ClusterBuilder {
@@ -58,10 +59,14 @@ object ClusterBuilder {
     instance
   }
 
+  val stringArrayClass = java.lang.reflect.Array.newInstance(classOf[String], 0).getClass()
+
   private def param(key: String, tpe: Class[_], cfg: Config) =
     Try {
       if (tpe == classOf[String])
         cfg.getString(key)
+      else if (tpe == stringArrayClass)
+        cfg.getStringList(key).asScala.toArray
       else if (tpe == classOf[Int] || tpe == classOf[Integer])
         cfg.getInt(key)
       else if (tpe.isEnum)

--- a/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/cluster/ClsuterBuilderSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/sources/cassandra/cluster/ClsuterBuilderSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.sources.cassandra.cluster
+
+import java.net.InetSocketAddress
+
+import com.datastax.driver.core.Cluster.Builder
+import com.typesafe.config.ConfigFactory
+import io.getquill.Spec
+
+class ClusterBuilderSpec extends Spec {
+
+  val hosts = List("127.0.0.1", "127.0.0.2", "127.0.0.3")
+  val contactPoints = hosts.map(new InetSocketAddress(_, 9042))
+
+  "creates Builder" - {
+
+    "with a single host" in {
+      val cfgString = s"contactPoint = ${hosts.head}"
+      val clusterBuilder: Builder = ClusterBuilder(ConfigFactory.parseString(cfgString))
+      clusterBuilder.getContactPoints must contain theSameElementsAs (contactPoints.take(1))
+    }
+
+    "with a single host in an array" in {
+      val cfgString = s"contactPoints = [${hosts.head}]"
+      val clusterBuilder: Builder = ClusterBuilder(ConfigFactory.parseString(cfgString))
+      clusterBuilder.getContactPoints must contain theSameElementsAs (contactPoints.take(1))
+    }
+
+    "with multiple hosts" in {
+      val cfgString = s"""contactPoints = [${hosts.mkString(",")}] """
+      val clusterBuilder: Builder = ClusterBuilder(ConfigFactory.parseString(cfgString))
+      clusterBuilder.getContactPoints must contain theSameElementsAs (contactPoints)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #388 

### Problem

configuration `contactPoints = ["127.0.0.1", "127.0.0.2"]` should create a valid `datastax.driver.core.Cluster#Builder` by using the `addContactPoints` method.

### Solution

added another `else if` block in `ClusterBuilder#param`

### Notes

`addContactPoints(String...)` is the only relevant varargs signature in `Builder`, so I only took care of adding and testing string lists

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

