### PR TITLE
add naming strategy for pluralized table names

### DIFF
--- a/quill-core/src/main/scala/io/getquill/naming/NamingStrategy.scala
+++ b/quill-core/src/main/scala/io/getquill/naming/NamingStrategy.scala
@@ -80,6 +80,14 @@ trait CamelCase extends NamingStrategy {
 }
 object CamelCase extends CamelCase
 
+trait PluralizedTableNames extends NamingStrategy {
+  override def default(s: String) = s
+  override def table(s: String) =
+    if (s.endsWith("s")) s
+    else s + "s"
+}
+object PluralizedTableNames extends PluralizedTableNames
+
 trait PostgresEscape extends Escape {
   override def column(s: String) = if (s.startsWith("$")) s else super.column(s)
 }

--- a/quill-core/src/test/scala/io/getquill/naming/NamingStrategySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/naming/NamingStrategySpec.scala
@@ -86,6 +86,18 @@ class NamingStrategySpec extends Spec {
     }
   }
 
+  "pluralized table names" - {
+    val s = new NamingStrategy with PluralizedTableNames
+
+    "ending with s" in {
+      s.table("kittens") mustEqual "kittens"
+    }
+
+    "ending with something other than s" in {
+      s.table("kitten") mustEqual "kittens"
+    }
+  }
+
   "postgres quote" - {
     val s = new NamingStrategy with PostgresEscape
 


### PR DESCRIPTION
### Problem

Some conventions have the table name be a plural word. The simple changes in this pull request allows for this convention to be mixed into another `NamingStrategy`

### Solution

Added PluralizedTableNames trait, which simply adds an "s" to the end of a table name if the name doesn't already end with one.

### Notes

There may be some edge cases for words like "sheep", where the plural version of the word doesn't end with "s". The changes do not take these edge cases into account.

### Checklist

- [X] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

