### PR TITLE
transform ConfiguredEntity

### DIFF
--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -55,6 +55,9 @@ trait StatefulTransformer[T] {
 
   def apply(e: Query): (Query, StatefulTransformer[T]) =
     e match {
+      case ConfiguredEntity(a, b, c, d) =>
+        val (at, att) = apply(a)
+        (ConfiguredEntity(at, b, c, d), att)
       case e: Entity => (e, this)
       case Filter(a, b, c) =>
         val (at, att) = apply(a)

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -23,6 +23,14 @@ class StatefulTransformerSpec extends Spec {
             att.state mustEqual Nil
         }
       }
+      "configuredEntity" in {
+        val ast: Ast = ConfiguredEntity(Entity("a"))
+        Subject(Nil, Entity("a") -> Entity("a'"))(ast) match {
+          case (at, att) =>
+            at mustEqual ConfiguredEntity(Entity("a'"))
+            att.state mustEqual List(Entity("a"))
+        }
+      }
       "filter" in {
         val ast: Ast = Filter(Ident("a"), Ident("b"), Ident("c"))
         Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {


### PR DESCRIPTION

### Problem
`StatefulTransformer`  won't transform ast in `ConfiguredEntity`

### Solution
transform it
### Notes

I met this while doing some trick to change table name dynamically (for simple sharding), currently this is not a good test case. So I haven't add any test case

This may also avoid some potential bug

```scala
implicit class WithSuffix[T](table: Quoted[EntityQuery[T]]) {
    def suffix(suffix: String) = {
      val entity = table.ast.asInstanceOf[SimpleEntity]
      val withSuffix = entity.copy(name = entity.name + suffix)
      new Quoted[EntityQuery[T]] {
        @QuotedAst(withSuffix)
        def quoted = withSuffix
        override def ast = withSuffix
        override def toString = withSuffix.toString
      }
    }
  }
```

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

