### PR TITLE
update versions and use patched cqlsh

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,9 +32,9 @@ lazy val `quill-jdbc` =
     .settings(mimaSettings)
     .settings(
       libraryDependencies ++= Seq(
-        "com.zaxxer"     % "HikariCP"             % "2.4.5",
+        "com.zaxxer"     % "HikariCP"             % "2.4.6",
         "mysql"          % "mysql-connector-java" % "5.1.38"  % "test",
-        "com.h2database" % "h2"                   % "1.4.191" % "test",
+        "com.h2database" % "h2"                   % "1.4.192" % "test",
         "org.postgresql" % "postgresql"           % "9.4.1208" % "test"
       ),
       parallelExecution in Test := false
@@ -47,7 +47,7 @@ lazy val `quill-finagle-mysql` =
     .settings(mimaSettings)
     .settings(
       libraryDependencies ++= Seq(
-        "com.twitter" %% "finagle-mysql" % "6.34.0"
+        "com.twitter" %% "finagle-mysql" % "6.35.0"
       ),
       parallelExecution in Test := false
     )
@@ -59,9 +59,9 @@ lazy val `quill-async` =
     .settings(mimaSettings)
     .settings(
       libraryDependencies ++= Seq(
-        "com.github.mauricio" %% "db-async-common"  % "0.2.19",
-        "com.github.mauricio" %% "mysql-async"      % "0.2.19",
-        "com.github.mauricio" %% "postgresql-async" % "0.2.19"
+        "com.github.mauricio" %% "db-async-common"  % "0.2.20",
+        "com.github.mauricio" %% "mysql-async"      % "0.2.20",
+        "com.github.mauricio" %% "postgresql-async" % "0.2.20"
       ),
       parallelExecution in Test := false
     )
@@ -73,7 +73,7 @@ lazy val `quill-cassandra` =
     .settings(mimaSettings)
     .settings(
       libraryDependencies ++= Seq(
-        "com.datastax.cassandra" %  "cassandra-driver-core" % "3.0.1",
+        "com.datastax.cassandra" %  "cassandra-driver-core" % "3.0.2",
         "org.monifu"             %% "monifu"                % "1.2"
       ),
       parallelExecution in Test := false

--- a/build/Dockerfile-sbt
+++ b/build/Dockerfile-sbt
@@ -1,7 +1,7 @@
-FROM alpine:3.3
+FROM alpine:3.4
 MAINTAINER gustavo.amigo@gmail.com
 
-RUN apk update; apk add git openssh openjdk8 bash
+RUN apk update; apk add git openssh openjdk8 bash curl openssl
 
 ENV SBT_VERSION 0.13.11
 ENV SBT_HOME /usr/local/sbt

--- a/build/Dockerfile-setup
+++ b/build/Dockerfile-setup
@@ -1,11 +1,14 @@
-FROM alpine:3.3
+FROM alpine:3.4
 MAINTAINER gustavo.amigo@gmail.com
 
 RUN apk update; apk add postgresql-client mysql-client curl python tar
 
 RUN  mkdir /opt; \
      cd /opt ; \
-     curl http://archive.apache.org/dist/cassandra/3.3/apache-cassandra-3.3-bin.tar.gz | tar zx
+     curl http://archive.apache.org/dist/cassandra/3.7/apache-cassandra-3.7-bin.tar.gz | tar zx
 
-ENV PATH /opt/apache-cassandra-3.3/bin:$PATH
+RUN rm /opt/apache-cassandra-3.7/lib/cassandra-driver-internal-only*
 
+RUN curl https://raw.githubusercontent.com/stef1927/cassandra/ab6ba9568e7500be2e42ade2c158552dfc812ff5/lib/cassandra-driver-internal-only-3.4.0.zip > /opt/apache-cassandra-3.7/lib/cassandra-driver-internal-only-3.4.0.zip
+
+ENV PATH /opt/apache-cassandra-3.7/bin:$PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ mysql:
     - MYSQL_ALLOW_EMPTY_PASSWORD=yes
 
 cassandra:
-  image: cassandra:3.3
+  image: cassandra:3.7
   ports:
     - "19042:9042"
     - "19160:9160"


### PR DESCRIPTION
### Problem

The build is failing because the latest alpine uses a new python version that is incompatible with cqlsh (see https://github.com/getquill/quill/pull/409#issuecomment-230094882).

### Solution

This PR uses the patch that will be included in new versions of cassandra (> 3.7) to fix the incompatibility. I've also took the opportunity to update dependencies.

### Notes

![](http://play.thinkcube.com/images/2WxWmAh.jpg)

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
