### PR TITLE
0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.7.0 / 2-Jul-2016
+
+* [transform quoted reference](https://github.com/getquill/quill/pull/416)
+* [simplify `finagle-mysql` action result type](https://github.com/getquill/quill/pull/358)
+* [provide default values for plain-sql query execution](https://github.com/getquill/quill/pull/360)
+* [quotation: fix binding conflict](https://github.com/getquill/quill/pull/363)
+* [don't consider `?` a binding if inside a quote](https://github.com/getquill/quill/pull/361)
+* [fix query generation for wrapped types](https://github.com/getquill/quill/pull/364)
+* [use querySingle/query for parametrized query according to return type](https://github.com/getquill/quill/pull/375)
+* [remove implicit ordering](https://github.com/getquill/quill/pull/378)
+* [remove implicit from max and min](https://github.com/getquill/quill/pull/384)
+* [support explicit `Predef.ArrowAssoc` call](https://github.com/getquill/quill/pull/386)
+* [added handling for string lists in ClusterBuilder](https://github.com/getquill/quill/pull/395)
+* [add naming strategy for pluralized table names](https://github.com/getquill/quill/pull/396)
+* [transform ConfiguredEntity](https://github.com/getquill/quill/pull/409)
+
 # 0.6.0 / 9-May-2016
 
 * [explicit bindings using `lift`](https://github.com/getquill/quill/pull/335/files#diff-04c6e90faac2675aa89e2176d2eec7d8R157)

--- a/README.md
+++ b/README.md
@@ -1014,7 +1014,7 @@ sbt dependencies
 ```
 libraryDependencies ++= Seq(
   "mysql" % "mysql-connector-java" % "5.1.36",
-  "io.getquill" %% "quill-jdbc" % "0.6.1-SNAPSHOT"
+  "io.getquill" %% "quill-jdbc" % "0.7.0"
 )
 ```
 
@@ -1045,7 +1045,7 @@ sbt dependencies
 ```
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.4-1206-jdbc41",
-  "io.getquill" %% "quill-jdbc" % "0.6.1-SNAPSHOT"
+  "io.getquill" %% "quill-jdbc" % "0.7.0"
 )
 ```
 
@@ -1076,7 +1076,7 @@ db.connectionTimeout=30000
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-async" % "0.6.1-SNAPSHOT"
+  "io.getquill" %% "quill-async" % "0.7.0"
 )
 ```
 
@@ -1106,7 +1106,7 @@ db.poolValidationInterval=100
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-async" % "0.6.1-SNAPSHOT"
+  "io.getquill" %% "quill-async" % "0.7.0"
 )
 ```
 
@@ -1136,7 +1136,7 @@ db.poolValidationInterval=100
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-finagle-mysql" % "0.6.1-SNAPSHOT"
+  "io.getquill" %% "quill-finagle-mysql" % "0.7.0"
 )
 ```
 
@@ -1167,7 +1167,7 @@ Cassandra Sources
 sbt dependencies
 ```
 libraryDependencies ++= Seq(
-  "io.getquill" %% "quill-cassandra" % "0.6.1-SNAPSHOT"
+  "io.getquill" %% "quill-cassandra" % "0.7.0"
 )
 ```
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.1-SNAPSHOT"
+version in ThisBuild := "0.7.0"


### PR DESCRIPTION
We've accumulated a number of fixes over the last month. The initial plan was that the next release would be `1.0-RC1`, but we shouldn't hold fixes because of it.

@getquill/maintainers

