### PR TITLE
transform quoted reference

### DIFF
--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -36,11 +36,13 @@ trait StatefulTransformer[T] {
         val (ct, ctt) = btt.apply(c)
         (If(at, bt, ct), ctt)
 
-      case l: Dynamic            => (l, this)
+      case l: Dynamic => (l, this)
 
-      case l: Binding            => (l, this)
+      case l: Binding => (l, this)
 
-      case l: QuotedReference[_] => (l, this)
+      case QuotedReference(a, b) =>
+        val (bt, btt) = apply(b)
+        (QuotedReference(a, bt), btt)
 
       case Block(a) =>
         val (at, att) = apply(a)(_.apply)

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -265,6 +265,15 @@ class StatefulTransformerSpec extends Spec {
       }
     }
 
+    "quotedReference" in {
+      val ast: Ast = QuotedReference(1, RuntimeBinding("a"))
+      Subject(Nil, RuntimeBinding("a") -> RuntimeBinding("a'"))(ast) match {
+        case (at, att) =>
+          at mustEqual QuotedReference(1, RuntimeBinding("a'"))
+          att.state mustEqual List(RuntimeBinding("a"))
+      }
+    }
+
     "infix" in {
       val ast: Ast = Infix(List("test"), List(Ident("a")))
       Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {


### PR DESCRIPTION
### Problem

`QuotedRefrence` is not transformed

### Solution

Transform it

### Notes

I think this will fix #370, I've test a custom `date` type like this against `mysql-async`
```scala
case class MDate(t: Long)
  object MDate {
    def now() = {
      MDate(System.currentTimeMillis)
    }
  }

  implicit val mencoding = mappedEncoding[MDate, java.util.Date](d => new java.util.Date(d.t))
  implicit val menDeoding = mappedEncoding[java.util.Date, MDate](d => new MDate(d.getTime()))
  implicit class MDateOps(d: MDate) {
    def <(b: MDate) = quote(infix"$d > $b".as[Boolean])
  }

 testMysqlDB.run(query[DateEncodingTestEntity].filter(_.v1 < lift(now)))

```

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

