### PR TITLE
Fix different timezone issue.

### DIFF
--- a/quill-async/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncEncodingSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncEncodingSpec.scala
@@ -3,7 +3,7 @@ package io.getquill.context.async.mysql
 import io.getquill.context.sql.EncodingSpec
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import java.util.Date
 
 class MysqlAsyncEncodingSpec extends EncodingSpec {
@@ -71,6 +71,8 @@ class MysqlAsyncEncodingSpec extends EncodingSpec {
   }
 
   "decode date types" in {
+    def round(milliseconds: Long, duration: Duration): Long = Math.round(milliseconds / duration.toMillis.toDouble) * duration.toMillis
+
     case class DateEncodingTestEntity(v1: Date, v2: Date, v3: Date)
     val entity = new DateEncodingTestEntity(new Date, new Date, new Date)
     val delete = quote(query[DateEncodingTestEntity].delete)
@@ -80,8 +82,12 @@ class MysqlAsyncEncodingSpec extends EncodingSpec {
       _ <- testContext.run(insert)(List(entity))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
-    Await.result(r, Duration.Inf)
-    ()
+
+    val result = Await.result(r, Duration.Inf).head
+
+    round(result.v1.getTime, 24.hours) mustEqual round(entity.v1.getTime, 24.hours)
+    result.v2.getTime mustEqual round(entity.v2.getTime, 1.second)
+    result.v3.getTime mustEqual round(entity.v3.getTime, 1.second)
   }
 
   "fails if the column has the wrong type" - {

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -1,13 +1,11 @@
 package io.getquill
 
-import com.twitter.finagle.exp.mysql.Client
-import com.twitter.finagle.exp.mysql.Parameter
-import com.twitter.finagle.exp.mysql.Result
-import com.twitter.finagle.exp.mysql.Row
+import com.twitter.finagle.exp.mysql._
 import com.twitter.util.Future
 import com.twitter.util.Local
 import io.getquill.context.sql.{ SqlBindedStatementBuilder, SqlContext }
 import com.twitter.util.Await
+
 import scala.util.Try
 import io.getquill.context.BindedStatementBuilder
 import com.typesafe.scalalogging.Logger
@@ -41,6 +39,12 @@ class FinagleMysqlContext[N <: NamingStrategy](
   protected type SingleQueryResult[T] = Future[T]
   protected type ActionResult[T] = Future[Long]
   protected type BatchedActionResult[T] = Future[List[Long]]
+
+  protected val timestampValue =
+    new TimestampValue(
+      dateTimezone,
+      dateTimezone
+    )
 
   Await.result(client.ping)
 

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
@@ -1,33 +1,16 @@
 package io.getquill.context.finagle.mysql
 
 import java.util.Date
+
 import scala.reflect.ClassTag
 import scala.reflect.classTag
-import com.twitter.finagle.exp.mysql.BigDecimalValue
-import com.twitter.finagle.exp.mysql.ByteValue
-import com.twitter.finagle.exp.mysql.DoubleValue
-import com.twitter.finagle.exp.mysql.FloatValue
-import com.twitter.finagle.exp.mysql.IntValue
-import com.twitter.finagle.exp.mysql.LongValue
-import com.twitter.finagle.exp.mysql.RawValue
-import com.twitter.finagle.exp.mysql.Row
-import com.twitter.finagle.exp.mysql.ShortValue
-import com.twitter.finagle.exp.mysql.StringValue
-import com.twitter.finagle.exp.mysql.TimestampValue
-import com.twitter.finagle.exp.mysql.Type
-import com.twitter.finagle.exp.mysql.Value
+import com.twitter.finagle.exp.mysql._
 import io.getquill.util.Messages.fail
 import com.twitter.finagle.exp.mysql.NullValue
 import io.getquill.FinagleMysqlContext
 
 trait FinagleMysqlDecoders {
   this: FinagleMysqlContext[_] =>
-
-  protected val timestampValue =
-    new TimestampValue(
-      dateTimezone,
-      dateTimezone
-    )
 
   def decoder[T: ClassTag](f: PartialFunction[Value, T]): Decoder[T] =
     new Decoder[T] {
@@ -95,6 +78,7 @@ trait FinagleMysqlDecoders {
     }
   implicit val dateDecoder: Decoder[Date] =
     decoder[Date] {
+      case DateValue(v)        => v
       case `timestampValue`(v) => new Date(v.getTime)
     }
 }

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
@@ -1,6 +1,7 @@
 package io.getquill.context.finagle.mysql
 
 import java.util.Date
+
 import com.twitter.finagle.exp.mysql.BigDecimalValue
 import com.twitter.finagle.exp.mysql.CanBeParameter
 import com.twitter.finagle.exp.mysql.CanBeParameter._
@@ -56,5 +57,7 @@ trait FinagleMysqlEncoders {
   implicit val floatEncoder: Encoder[Float] = encoder[Float]
   implicit val doubleEncoder: Encoder[Double] = encoder[Double]
   implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder[Array[Byte]]
-  implicit val dateEncoder: Encoder[Date] = encoder[Date]
+  implicit val dateEncoder: Encoder[Date] = encoder[Date] { (value: Date) =>
+    timestampValue(new java.sql.Timestamp(value.getTime)): Parameter
+  }
 }

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
@@ -1,8 +1,13 @@
 package io.getquill.context.finagle.mysql
 
-import com.twitter.util.Await
+import java.util.{ Date, TimeZone }
 
+import com.twitter.util.Await
+import io.getquill.{ FinagleMysqlContext, FinagleMysqlContextConfig, Literal }
 import io.getquill.context.sql.EncodingSpec
+import io.getquill.util.LoadConfig
+
+import scala.concurrent.duration._
 
 class FinagleMysqlEncodingSpec extends EncodingSpec {
 
@@ -86,6 +91,57 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
       r.v5 mustEqual false
       r.v6 mustEqual false
       r.v7 mustEqual false
+    }
+
+  }
+
+  "decode date types" - {
+
+    case class DateEncodingTestEntity(
+      v1: Date,
+      v2: Date,
+      v3: Date
+    )
+
+    def round(milliseconds: Long, duration: Duration): Long = Math.round(milliseconds / duration.toMillis.toDouble) * duration.toMillis
+
+    val entity = DateEncodingTestEntity(new Date, new Date, new Date)
+
+    def verify(result: DateEncodingTestEntity) = {
+      round(result.v1.getTime, 24.hours) mustEqual round(entity.v1.getTime, 24.hours)
+      result.v2.getTime mustEqual round(entity.v2.getTime, 1.second)
+      result.v3.getTime mustEqual round(entity.v3.getTime, 1.second)
+    }
+
+    "default timezone" in {
+      val delete = quote(query[DateEncodingTestEntity].delete)
+      val insert = quote(query[DateEncodingTestEntity].insert)
+      val r = for {
+        _ <- testContext.run(delete)
+        _ <- testContext.run(insert)(List(entity))
+        result <- testContext.run(query[DateEncodingTestEntity])
+      } yield result
+
+      val result = Await.result(r).head
+      verify(result)
+    }
+
+    "different timezone" in {
+      val config = FinagleMysqlContextConfig(LoadConfig("testDB"))
+      val testTimezoneContext = new FinagleMysqlContext[Literal](config.client, TimeZone.getTimeZone("UTC"))
+      import testTimezoneContext._
+      TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+
+      val delete = quote(query[DateEncodingTestEntity].delete)
+      val insert = quote(query[DateEncodingTestEntity].insert)
+      val r = for {
+        _ <- testTimezoneContext.run(delete)
+        _ <- testTimezoneContext.run(insert)(List(entity))
+        result <- testTimezoneContext.run(query[DateEncodingTestEntity])
+      } yield result
+
+      val result = Await.result(r).head
+      verify(result)
     }
   }
 }


### PR DESCRIPTION
### Problem
1. Wrong encoding issue occured by differences between DB and `finagle-mysql` client timezone.
2. Mysql Date typecan't be decoded to `java.util.Date` in `finagle-mysql`.

```java
Value 'RawValue(10,63,true,[B@69c21295)' can't be decoded to 'class java.util.Date'
java.lang.IllegalStateException: Value 'RawValue(10,63,true,[B@69c21295)' can't be decoded to 'class java.util.Date'
```

### Solution
* Apply encoder using timestampValue

> Current
```scala
implicit val dateEncoder: Encoder[Date] = encoder[Date]
```

> Fixed
```scala
implicit val dateEncoder: Encoder[Date] = encoder[Date] { (value: Date) =>
 timestampValue(new java.sql.Timestamp(value.getTime)): Parameter
}
```

* Add `DateValue` in dateDecoder

> ```scala
implicit val dateDecoder: Decoder[Date] =
  decoder[Date] {
    case DateValue(v)        => v  // Add for Mysql Date
    case `timestampValue`(v) => new Date(v.getTime)
  }
```

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

…lient timezone.

- Add assert code related with Date in MysqlAsyncEncodingSpec.
- Add decoder for Date type of Mysql.