### PR TITLE
apply intermediate map before take/drop

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/ApplyIntermediateMap.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/ApplyIntermediateMap.scala
@@ -9,6 +9,8 @@ import io.getquill.ast.Ident
 import io.getquill.ast.Map
 import io.getquill.ast.Query
 import io.getquill.ast.SortBy
+import io.getquill.ast.Drop
+import io.getquill.ast.Take
 
 object ApplyIntermediateMap {
 
@@ -21,6 +23,8 @@ object ApplyIntermediateMap {
       case FlatMap(Map(a: GroupBy, b, c), d, e)   => None
       case Filter(Map(a: GroupBy, b, c), d, e)    => None
       case SortBy(Map(a: GroupBy, b, c), d, e, f) => None
+      case Take(Map(a: GroupBy, b, c), d)         => None
+      case Drop(Map(a: GroupBy, b, c), d)         => None
       case Map(a: GroupBy, b, c) if (b == c)      => None
 
       //  map(i => (i.i, i.l)).distinct.map(x => (x._1, x._2)) =>
@@ -56,6 +60,16 @@ object ApplyIntermediateMap {
       case SortBy(Map(a, b, c), d, e, f) =>
         val er = BetaReduction(e, d -> c)
         Some(Map(SortBy(a, b, er, f), b, c))
+
+      // a.map(b => c).drop(d) =>
+      //    a.drop(d).map(b => c)
+      case Drop(Map(a, b, c), d) =>
+        Some(Map(Drop(a, d), b, c))
+
+      // a.map(b => c).take(d) =>
+      //    a.drop(d).map(b => c)
+      case Take(Map(a, b, c), d) =>
+        Some(Map(Take(a, d), b, c))
 
       case other => None
     }

--- a/quill-core/src/test/scala/io/getquill/norm/ApplyIntermediateMapSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ApplyIntermediateMapSpec.scala
@@ -36,6 +36,18 @@ class ApplyIntermediateMapSpec extends Spec {
       }
       ApplyIntermediateMap.unapply(q.ast) mustEqual None
     }
+    "take" in {
+      val q = quote {
+        qr1.groupBy(t => t.i).map(y => y._1).take(1)
+      }
+      ApplyIntermediateMap.unapply(q.ast) mustEqual None
+    }
+    "drop" in {
+      val q = quote {
+        qr1.groupBy(t => t.i).map(y => y._1).drop(1)
+      }
+      ApplyIntermediateMap.unapply(q.ast) mustEqual None
+    }
     "identity map" in {
       val q = quote {
         qr1.groupBy(t => t.i).map(y => y)
@@ -96,6 +108,24 @@ class ApplyIntermediateMapSpec extends Spec {
       }
       val n = quote {
         query[TestEntity].map(i => (i.i, i.l)).distinct
+      }
+      ApplyIntermediateMap.unapply(q.ast) mustEqual Some(n.ast)
+    }
+    "take" in {
+      val q = quote {
+        qr1.map(y => y.s).take(1)
+      }
+      val n = quote {
+        qr1.take(1).map(y => y.s)
+      }
+      ApplyIntermediateMap.unapply(q.ast) mustEqual Some(n.ast)
+    }
+    "drop" in {
+      val q = quote {
+        qr1.map(y => y.s).drop(1)
+      }
+      val n = quote {
+        qr1.drop(1).map(y => y.s)
       }
       ApplyIntermediateMap.unapply(q.ast) mustEqual Some(n.ast)
     }


### PR DESCRIPTION
Fixes #317 

### Problem

Intermediate maps before take/drop aren't being applied, generating the error reported by #317.

### Solution

Apply them.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
