### PR TITLE
support decoding of optional single-value case classes

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/select/SelectResultExtraction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/select/SelectResultExtraction.scala
@@ -50,10 +50,17 @@ trait SelectResultExtraction extends EncodingMacro {
           if (tpe.typeSymbol.fullName.startsWith("scala.Tuple"))
             joinOptions(decodedParams.map(joinOptions(_)))
           else
-            q"""
-            val tuple = ${joinOptions(decodedParams.map(joinOptions(_)))}
-            tuple.map((${tpe.typeSymbol.companion}.apply _).tupled)
-          """
+            decodedParams match {
+              case (param :: Nil) :: Nil =>
+                q"""
+                  ${param}.map(${tpe.typeSymbol.companion})
+                """
+              case _ =>
+                q"""
+                  val tuple = ${joinOptions(decodedParams.map(joinOptions(_)))}
+                  tuple.map((${tpe.typeSymbol.companion}.apply _).tupled)
+                """
+            }
         (tree, paramsIndex)
     }
 

--- a/quill-core/src/test/scala/io/getquill/norm/select/SelectResultExtractionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/select/SelectResultExtractionSpec.scala
@@ -38,6 +38,14 @@ class SelectResultExtractionSpec extends Spec {
         testContext.run(q)
           .extractor(Row("a", 1L)) mustEqual Outer("a", Inner(1L))
       }
+      "one param" in {
+        case class OneParam(i: Int)
+        val q = quote {
+          query[OneParam]
+        }
+        testContext.run(q)
+          .extractor(Row(1)) mustEqual OneParam(1)
+      }
     }
     "tuple" - {
       "simple" in {


### PR DESCRIPTION
Fixes #337 and #408 

### Problem

The decoding macro for optional values tries to create a tupled function for single-value case classes.

### Solution

Call the constructor directly if there's only one parameter.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
