### PR TITLE
quotation: allow lifting of `AnyVal`s

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -98,6 +98,13 @@ trait Parsing extends EntityConfigParsing {
   }
 
   val bindingParser: Parser[Binding] = Parser[Binding] {
+    case q"$pack.lift[$t]($value)" if(t.tpe <:< c.weakTypeOf[AnyVal]) => 
+      t.tpe.members.collect {
+        case m: MethodSymbol if (m.isPrimaryConstructor) => m.paramLists.flatten
+      }.flatten.headOption match {
+        case Some(param) => CompileTimeBinding(c.typecheck(q"$value.${param.name.toTermName}"))
+        case None => CompileTimeBinding(value)
+      }
     case q"$pack.lift[$t]($value)" => CompileTimeBinding(value)
   }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -75,6 +75,9 @@ import io.getquill.testContext.query
 import io.getquill.testContext.quote
 import io.getquill.testContext.Quoted
 import io.getquill.testContext.unquote
+import io.getquill.context.WrappedEncodable
+
+case class CustomAnyValue(i: Int) extends AnyVal
 
 class QuotationSpec extends Spec {
 
@@ -893,6 +896,20 @@ class QuotationSpec extends Spec {
         q3.bindings.`q2.b` mustEqual b
         q3.bindings.c mustEqual c
       }
+    }
+
+    "supports WrappedValue" in {
+      def q(v: WrappedEncodable) = quote {
+        lift(v)
+      }
+      q(WrappedEncodable(1)).bindings.`v.value` mustEqual 1
+    }
+
+    "supports custom anyval" in {
+      def q(v: CustomAnyValue) = quote {
+        lift(v)
+      }
+      q(CustomAnyValue(1)).bindings.`v.i` mustEqual 1
     }
   }
 


### PR DESCRIPTION
Fixes #366 

### Problem

Scala doesn't allow a custom `AnyVal` to be part of the signature of a type refinement (see #366) that's used to hold the lifted values (bindings)

### Solution

Automatically transform a lifting of an `AnyVal` to the underlying value.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
