### PR TITLE
fix pom to point to getquill

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     pushChanges
   ),
   pomExtra := (
-    <url>http://github.com/fwbrasil/quill</url>
+    <url>http://github.com/getquill/quill</url>
     <licenses>
       <license>
         <name>Apache License 2.0</name>
@@ -195,8 +195,8 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
       </license>
     </licenses>
     <scm>
-      <url>git@github.com:fwbrasil/quill.git</url>
-      <connection>scm:git:git@github.com:fwbrasil/quill.git</connection>
+      <url>git@github.com:getquill/quill.git</url>
+      <connection>scm:git:git@github.com:getquill/quill.git</connection>
     </scm>
     <developers>
       <developer>


### PR DESCRIPTION
### Problem

http://index.scala-lang.org/ doesn't list quill properly.

### Solution

Fix `pomExtra` to point to the correct repository.

### Notes

It'll be listed by scaladex only after the next release to maven central.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
