### PR TITLE
fix bind order for take/drop with extra param

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/BindVariables.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/BindVariables.scala
@@ -35,10 +35,10 @@ private[context] case class BindVariables(state: (List[Ident], List[Ident]))
   override def apply(e: Query) =
     e match {
       case Take(Drop(a, b), c) =>
-        val (ct, ctt) = apply(c)
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
         val (bt, btt) = ctt.apply(b)
-        val (at, att) = btt.apply(a)
-        (Take(Drop(at, bt), ct), att)
+        (Take(Drop(at, bt), ct), btt)
       case Map(a, b, c) =>
         val (ct, ctt) = apply(c)
         val (at, att) = ctt.apply(a)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/BindVariablesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/BindVariablesSpec.scala
@@ -18,5 +18,14 @@ class BindVariablesSpec extends Spec {
       mirror.sql mustEqual "SELECT x.s, x.i, x.l, x.o FROM TestEntity x LIMIT ? OFFSET ?"
       mirror.binds mustEqual Row(2, 1)
     }
+    "drop.take with extra param" in {
+      val q =
+        quote { (offset: Int, size: Int, i: Int) =>
+          query[TestEntity].filter(_.i == i).drop(offset).take(size)
+        }
+      val mirror = testContext.run(q)(1, 2, 3)
+      mirror.sql mustEqual "SELECT x1.s, x1.i, x1.l, x1.o FROM TestEntity x1 WHERE x1.i = ? LIMIT ? OFFSET ?"
+      mirror.binds mustEqual Row(3, 2, 1)
+    }
   }
 }


### PR DESCRIPTION
Fixes #391

### Problem

The mechanism that reorders bindings for take/drop isn't ordering correctly additional params before the take/drop call.

### Solution

Fix order.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

