### PR TITLE
quill-jdbc: support nested `transaction` calls

### DIFF
--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/JdbcContextSpec.scala
@@ -28,5 +28,14 @@ class JdbcContextSpec extends Spec {
       }
       testContext.run(qr1).isEmpty mustEqual true
     }
+    "nested" in {
+      testContext.run(qr1.delete)
+      testContext.transaction {
+        testContext.transaction {
+          testContext.run(qr1.insert(_.i -> 33))
+        }
+      }
+      testContext.run(qr1).map(_.i) mustEqual List(33)
+    }
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/JdbcContextSpec.scala
@@ -36,5 +36,14 @@ class JdbcContextSpec extends Spec {
       }
       testContext.run(qr1).isEmpty mustEqual true
     }
+    "nested" in {
+      testContext.run(qr1.delete)
+      testContext.transaction {
+        testContext.transaction {
+          testContext.run(qr1.insert(_.i -> 33))
+        }
+      }
+      testContext.run(qr1).map(_.i) mustEqual List(33)
+    }
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcContextSpec.scala
@@ -36,5 +36,14 @@ class JdbcContextSpec extends Spec {
       }
       testContext.run(qr1).isEmpty mustEqual true
     }
+    "nested" in {
+      testContext.run(qr1.delete)
+      testContext.transaction {
+        testContext.transaction {
+          testContext.run(qr1.insert(_.i -> 33))
+        }
+      }
+      testContext.run(qr1).map(_.i) mustEqual List(33)
+    }
   }
 }


### PR DESCRIPTION
Fixes #402

### Problem

The jdbc context doesn't support nested `transaction`s because each `transactional` call creates a new transaction.

### Solution

Don't create a new transaction if the `transaction` call is already inside a transaction

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

