### PR TITLE
fail compilation if query is defined outside a `quote`

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/InfixDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/InfixDsl.scala
@@ -1,6 +1,7 @@
 package io.getquill.dsl
 
 import io.getquill.quotation.NonQuotedException
+import scala.annotation.compileTimeOnly
 
 private[dsl] trait InfixDsl {
 
@@ -9,6 +10,8 @@ private[dsl] trait InfixDsl {
   }
 
   implicit class InfixInterpolator(val sc: StringContext) {
+
+    @compileTimeOnly(NonQuotedException.message)
     def infix(args: Any*): InfixValue = NonQuotedException()
   }
 }

--- a/quill-core/src/main/scala/io/getquill/dsl/OrdDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/OrdDsl.scala
@@ -1,30 +1,60 @@
 package io.getquill.dsl
 
 import io.getquill.quotation.NonQuotedException
+import scala.annotation.compileTimeOnly
 
 private[dsl] trait OrdDsl {
 
-  implicit def implicitOrd[T]: Ord[T] = NonQuotedException()
-
   trait Ord[T]
+
+  @compileTimeOnly(NonQuotedException.message)
+  implicit def implicitOrd[T]: Ord[T] = NonQuotedException()
 
   object Ord {
 
+    @compileTimeOnly(NonQuotedException.message)
     def asc[T]: Ord[T] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def desc[T]: Ord[T] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def ascNullsFirst[T]: Ord[T] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def descNullsFirst[T]: Ord[T] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def ascNullsLast[T]: Ord[T] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def descNullsLast[T]: Ord[T] = NonQuotedException()
 
+    @compileTimeOnly(NonQuotedException.message)
     def apply[T1, T2](o1: Ord[T1], o2: Ord[T2]): Ord[(T1, T2)] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def apply[T1, T2, T3](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3]): Ord[(T1, T2, T3)] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def apply[T1, T2, T3, T4](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4]): Ord[(T1, T2, T3, T4)] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def apply[T1, T2, T3, T4, T5](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5]): Ord[(T1, T2, T3, T4, T5)] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def apply[T1, T2, T3, T4, T5, T6](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6]): Ord[(T1, T2, T3, T4, T5, T6)] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def apply[T1, T2, T3, T4, T5, T6, T7](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7]): Ord[(T1, T2, T3, T4, T5, T6, T7)] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def apply[T1, T2, T3, T4, T5, T6, T7, T8](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7], o8: Ord[T8]): Ord[(T1, T2, T3, T4, T5, T6, T7, T8)] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7], o8: Ord[T8], o9: Ord[T9]): Ord[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7], o8: Ord[T8], o9: Ord[T9], o10: Ord[T10]): Ord[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)] = NonQuotedException()
   }
 }

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -3,9 +3,11 @@ package io.getquill.dsl
 import scala.reflect.ClassTag
 
 import io.getquill.quotation.NonQuotedException
+import scala.annotation.compileTimeOnly
 
 private[dsl] trait QueryDsl {
 
+  @compileTimeOnly(NonQuotedException.message)
   def query[T](implicit ct: ClassTag[T]): EntityQuery[T] = NonQuotedException()
 
   sealed trait Query[+T] {

--- a/quill-core/src/main/scala/io/getquill/dsl/QuotationDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QuotationDsl.scala
@@ -7,6 +7,7 @@ import scala.reflect.macros.whitebox.Context
 import io.getquill.ast.Ast
 import io.getquill.quotation.NonQuotedException
 import io.getquill.quotation.Quotation
+import scala.annotation.compileTimeOnly
 
 private[dsl] trait QuotationDsl {
 
@@ -14,6 +15,7 @@ private[dsl] trait QuotationDsl {
     def ast: Ast
   }
 
+  @compileTimeOnly(NonQuotedException.message)
   def lift[T](v: T): T = NonQuotedException()
 
   def quote[T](body: Quoted[T]): Quoted[T] = macro QuotationMacro.doubleQuote[T]
@@ -29,6 +31,8 @@ private[dsl] trait QuotationDsl {
   def quote[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](func: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => Quoted[R]): Quoted[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R] = macro QuotationMacro.quotedFunctionBody
 
   implicit def quote[T](body: T): Quoted[T] = macro QuotationMacro.quote[T]
+
+  @compileTimeOnly(NonQuotedException.message)
   implicit def unquote[T](quoted: Quoted[T]): T = NonQuotedException()
 }
 

--- a/quill-core/src/main/scala/io/getquill/quotation/NonQuotedException.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/NonQuotedException.scala
@@ -1,8 +1,8 @@
 package io.getquill.quotation
 
-class NonQuotedException extends Exception("The query definition must happen inside a `quote` block.")
+class NonQuotedException extends Exception(NonQuotedException.message)
 
 object NonQuotedException {
-
+  final val message = "The query definition must happen within a `quote` block."
   def apply() = throw new NonQuotedException
 }

--- a/quill-core/src/test/scala/io/getquill/OpsSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/OpsSpec.scala
@@ -5,13 +5,10 @@ import io.getquill.ast.Entity
 import io.getquill.ast.Ident
 import io.getquill.ast.Infix
 import io.getquill.ast.Map
-import io.getquill.quotation.NonQuotedException
 import io.getquill.testContext.EntityQuery
 import io.getquill.testContext.InfixInterpolator
-import io.getquill.testContext.Ord
 import io.getquill.testContext.Query
 import io.getquill.testContext.TestEntity
-import io.getquill.testContext.implicitOrd
 import io.getquill.testContext.qr1
 import io.getquill.testContext.query
 import io.getquill.testContext.quote
@@ -87,36 +84,6 @@ class OpsSpec extends Spec {
           query[TestEntity].allowFiltering
       }
       q.toString mustEqual "(i, j, k) => infix\"" + "$" + "{query[TestEntity]} ALLOW FILTERING\""
-    }
-  }
-
-  "fails if the infix is used outside of a quotation" in {
-    val e = intercept[NonQuotedException] {
-      infix"true"
-    }
-  }
-
-  "fails if a query is used ouside of a quotation" in {
-    val e = intercept[NonQuotedException] {
-      query[TestEntity]
-    }
-  }
-
-  "fails if a quotation is unquoted ouside of a quotation" in {
-    val e = intercept[NonQuotedException] {
-      unquote(qr1)
-    }
-  }
-
-  "fails if ord is unquoted ouside of a quotation" in {
-    val e = intercept[NonQuotedException] {
-      Ord.asc[Int]
-    }
-  }
-
-  "fails if orderingToOrd is unquoted ouside of a quotation" in {
-    val e = intercept[NonQuotedException] {
-      implicitOrd[Int]
     }
   }
 }


### PR DESCRIPTION
## Problem

It's common to see users confused because they are defining queries outside of a `quote` block. Part of the problem is due to the fact that the feedback of the wrong usage happens only at run time with an exception.

### Solution

Use the `@compileTimeOnly` annotation to fail the compilation if quote-only methods are use outside of a `quote`. For reference, this is the documentation of the annotation:

```scala
/**
 * An annotation that designates that an annottee should not be referred to after
 * type checking (which includes macro expansion).
 *
 * Examples of potential use:
 *   1) The annottee can only appear in the arguments of some other macro
 *      that will eliminate it from the AST during expansion.
 *   2) The annottee is a macro and should have been expanded away,
 *      so if hasn't, something wrong has happened.
 *      (Comes in handy to provide better support for new macro flavors,
 *      e.g. macro annotations, that can't be expanded by the vanilla compiler).
 *
 * @param  message the error message to print during compilation if a reference remains
 *                 after type checking
 * @since  2.11.0
 */
@getter @setter @beanGetter @beanSetter @companionClass @companionMethod
final class compileTimeOnly(message: String) extends scala.annotation.StaticAnnotation
```

### Notes

- Unfortunately, it's not possible to unit test that the code won't compile. `"code" mustNot compile` doesn't fail for `compileTimeOnly`.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
