### PR TITLE
increase mysql pool size for mysql-async

### DIFF
--- a/quill-async/src/test/resources/application.conf
+++ b/quill-async/src/test/resources/application.conf
@@ -2,8 +2,8 @@ testMysqlDB.host=${?MYSQL_PORT_3306_TCP_ADDR}
 testMysqlDB.port=${?MYSQL_PORT_3306_TCP_PORT}
 testMysqlDB.user=root
 testMysqlDB.database=quill_test
-testMysqlDB.poolMaxQueueSize=4
-testMysqlDB.poolMaxObjects=4
+testMysqlDB.poolMaxQueueSize=10
+testMysqlDB.poolMaxObjects=10
 testMysqlDB.poolMaxIdle=999999999
 testMysqlDB.poolValidationInterval=100
 


### PR DESCRIPTION

### Problem

The build is failing a lot lately.

### Solution

Increase mysql async pool size

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

