### PR TITLE
Made return statements with inserts return AnyVal instead of Long so …

### DIFF
--- a/quill-async/src/main/scala/io/getquill/PostgresAsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/PostgresAsyncContext.scala
@@ -1,10 +1,11 @@
 package io.getquill
 
+import java.util.UUID
+
 import com.github.mauricio.async.db.{ QueryResult => DBQueryResult }
 import com.github.mauricio.async.db.pool.PartitionedConnectionPool
 import com.github.mauricio.async.db.postgresql.PostgreSQLConnection
 import com.typesafe.config.Config
-
 import io.getquill.context.async.AsyncContext
 import io.getquill.util.LoadConfig
 
@@ -15,13 +16,14 @@ class PostgresAsyncContext[N <: NamingStrategy](pool: PartitionedConnectionPool[
   def this(config: Config) = this(PostgresAsyncContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 
-  override protected def extractActionResult(generated: Option[String])(result: DBQueryResult): Long = (generated, result) match {
+  override protected def extractActionResult(generated: Option[String])(result: DBQueryResult): Any = (generated, result) match {
     case (None, r) =>
       r.rowsAffected
     case (Some(col), r) =>
       r.rows.get(0)(col) match {
-        case l: Long => l
-        case i: Int  => i.toLong
+        case l: Long    => l
+        case i: Int     => i.toLong
+        case uuid: UUID => uuid
         case other =>
           throw new IllegalArgumentException(s"Type ${other.getClass.toString} of column $col is not supported for returning values")
       }

--- a/quill-async/src/main/scala/io/getquill/context/async/ActionApply.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/ActionApply.scala
@@ -3,8 +3,8 @@ package io.getquill.context.async
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-class ActionApply[T](f: List[T] => Future[List[Long]])(implicit ec: ExecutionContext)
-  extends Function1[List[T], Future[List[Long]]] {
+class ActionApply[T](f: List[T] => Future[List[Any]])(implicit ec: ExecutionContext)
+  extends Function1[List[T], Future[List[Any]]] {
   def apply(params: List[T]) = f(params)
   def apply(param: T) = f(List(param)).map(_.head)
 }

--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
@@ -30,8 +30,8 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
 
   protected type QueryResult[T] = Future[List[T]]
   protected type SingleQueryResult[T] = Future[T]
-  protected type ActionResult[T] = Future[Long]
-  protected type BatchedActionResult[T] = Future[List[Long]]
+  protected type ActionResult[T] = Future[Any]
+  protected type BatchedActionResult[T] = Future[List[Any]]
 
   override def close = {
     Await.result(pool.close, Duration.Inf)
@@ -44,7 +44,7 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
       case other                                   => f(pool)
     }
 
-  protected def extractActionResult(generated: Option[String])(result: DBQueryResult): Long
+  protected def extractActionResult(generated: Option[String])(result: DBQueryResult): Any
 
   protected def expandAction(sql: String, generated: Option[String]) = sql
 
@@ -65,7 +65,7 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
   }
 
   def executeActionBatch[T](sql: String, bindParams: T => BindedStatementBuilder[List[Any]] => BindedStatementBuilder[List[Any]] = (_: T) => identity[BindedStatementBuilder[List[Any]]] _, generated: Option[String] = None)(implicit ec: ExecutionContext): ActionApply[T] = {
-    def run(values: List[T]): Future[List[Long]] =
+    def run(values: List[T]): Future[List[Any]] =
       values match {
         case Nil =>
           Future.successful(List())


### PR DESCRIPTION
Fixes #427 

### Problem

The problem is that currently there is a restriction where when you do inserts and you specify a column to be ignored (usually the ID column that gets auto generated on the database), that column can only be of type Long

### Solution

The solution in this pull request is kind of a dumb solution, it removes the restriction by changing the type from `Long` to `Any`. I don't really expect this to get merged, its just an indication of what I have done to remedy the problem in the short term.

### Notes

As I said before I don't expect this to get merged. The real solution to this problem would involve separate `ActionResult` to `InsertResult` and then `UpdateResult`. `InsertResult` would then need to be modified (with other changes in the database) to carry over type information (i.e. we need to get the type from `_.generated(_.id)` to carry over to our `extractActionResult`/`executeAction`). 

This is probably done better as a separate pull request, as the methodology to this is going to be completely different and will require more work.

Also the tests will fail with this, unless this solution has a change of getting merged I will put my time into doing a proper solution

@getquill/maintainers