### PR TITLE
make type aliases for `run` results public

### DIFF
--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
@@ -28,10 +28,10 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
   private val logger: Logger =
     Logger(LoggerFactory.getLogger(classOf[AsyncContext[_, _, _]]))
 
-  protected type QueryResult[T] = Future[List[T]]
-  protected type SingleQueryResult[T] = Future[T]
-  protected type ActionResult[T] = Future[Long]
-  protected type BatchedActionResult[T] = Future[List[Long]]
+  type QueryResult[T] = Future[List[T]]
+  type SingleQueryResult[T] = Future[T]
+  type ActionResult[T] = Future[Long]
+  type BatchedActionResult[T] = Future[List[Long]]
 
   override def close = {
     Await.result(pool.close, Duration.Inf)

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -37,10 +37,10 @@ class FinagleMysqlContext[N <: NamingStrategy](
   protected val logger: Logger =
     Logger(LoggerFactory.getLogger(classOf[FinagleMysqlContext[_]]))
 
-  protected type QueryResult[T] = Future[List[T]]
-  protected type SingleQueryResult[T] = Future[T]
-  protected type ActionResult[T] = Future[Long]
-  protected type BatchedActionResult[T] = Future[List[Long]]
+  type QueryResult[T] = Future[List[T]]
+  type SingleQueryResult[T] = Future[T]
+  type ActionResult[T] = Future[Long]
+  type BatchedActionResult[T] = Future[List[Long]]
 
   Await.result(client.ping)
 

--- a/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
@@ -33,10 +33,10 @@ class JdbcContext[D <: SqlIdiom, N <: NamingStrategy](dataSource: DataSource wit
   private val logger: Logger =
     Logger(LoggerFactory.getLogger(classOf[JdbcContext[_, _]]))
 
-  protected type QueryResult[T] = List[T]
-  protected type SingleQueryResult[T] = T
-  protected type ActionResult[T] = Long
-  protected type BatchedActionResult[T] = List[Long]
+  type QueryResult[T] = List[T]
+  type SingleQueryResult[T] = T
+  type ActionResult[T] = Long
+  type BatchedActionResult[T] = List[Long]
 
   private val currentConnection = new DynamicVariable[Option[Connection]](None)
 

--- a/quill-sql/src/main/scala/io/getquill/context/sql/SqlContext.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/SqlContext.scala
@@ -16,10 +16,10 @@ abstract class SqlContext[D <: SqlIdiom, N <: NamingStrategy, R: ClassTag, S: Cl
   extends Context[R, S]
   with SqlDsl {
 
-  protected type QueryResult[T]
-  protected type SingleQueryResult[T]
-  protected type ActionResult[T]
-  protected type BatchedActionResult[T]
+  type QueryResult[T]
+  type SingleQueryResult[T]
+  type ActionResult[T]
+  type BatchedActionResult[T]
 
   def probe(sql: String): Try[Any]
 


### PR DESCRIPTION
### Problem

IntelliJ doesn't give autocomplete for `run` results.

### Solution

Remove `protected` from the type aliases.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

