### PR TITLE
disable parallel execution of tests globally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,7 @@ lazy val `quill-jdbc` =
         "mysql"          % "mysql-connector-java" % "5.1.38"  % "test",
         "com.h2database" % "h2"                   % "1.4.192" % "test",
         "org.postgresql" % "postgresql"           % "9.4.1208" % "test"
-      ),
-      parallelExecution in Test := false
+      )
     )
     .dependsOn(`quill-sql` % "compile->compile;test->test")
 
@@ -48,8 +47,7 @@ lazy val `quill-finagle-mysql` =
     .settings(
       libraryDependencies ++= Seq(
         "com.twitter" %% "finagle-mysql" % "6.35.0"
-      ),
-      parallelExecution in Test := false
+      )
     )
     .dependsOn(`quill-sql` % "compile->compile;test->test")
 
@@ -62,8 +60,7 @@ lazy val `quill-async` =
         "com.github.mauricio" %% "db-async-common"  % "0.2.20",
         "com.github.mauricio" %% "mysql-async"      % "0.2.20",
         "com.github.mauricio" %% "postgresql-async" % "0.2.20"
-      ),
-      parallelExecution in Test := false
+      )
     )
     .dependsOn(`quill-sql` % "compile->compile;test->test")
 
@@ -75,8 +72,7 @@ lazy val `quill-cassandra` =
       libraryDependencies ++= Seq(
         "com.datastax.cassandra" %  "cassandra-driver-core" % "3.0.2",
         "org.monifu"             %% "monifu"                % "1.2"
-      ),
-      parallelExecution in Test := false
+      )
     )
     .dependsOn(`quill-core` % "compile->compile;test->test")
 
@@ -139,6 +135,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     "-Ywarn-unused-import"
   ),
   fork in Test := true,
+  concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   scoverage.ScoverageKeys.coverageMinimum := 96,
   scoverage.ScoverageKeys.coverageFailOnMinimum := false,


### PR DESCRIPTION
Fixes #288 

### Problem

The build continues flaky. For instance, [this one](https://travis-ci.org/getquill/quill/builds/143760677#L6195) failed because the `quill-jdbc` tests were running in parallel to `quill-finagle-mysql`.

### Solution

Use `concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)`, that seems to be the only effective way to limit the tests concurrency.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
