### PR TITLE
fix empty sql string

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/SqlBindedStatementBuilder.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/SqlBindedStatementBuilder.scala
@@ -3,5 +3,5 @@ package io.getquill.context.sql
 import io.getquill.context.BindedStatementBuilder
 
 class SqlBindedStatementBuilder[S] extends BindedStatementBuilder[S] {
-  override def emptySet: String = "SELECT 0 WHERE FALSE"
+  override def emptySet: String = "SELECT 0 FROM (SELECT 0) AS QUILL_EMPTY_SET WHERE FALSE"
 }


### PR DESCRIPTION
Fixes #442 
### Problem
```sql
SELECT 0 WHERE FALSE
```
is not valid in mysql 5.6
### Solution
change it to 
```sql
SELECT 0 FROM (SELECT 0) AS QUILL_EMPTY_SET WHERE FALSE
```

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

