### PR TITLE
scala.js support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,11 @@ After that, just run the command bellow to build and test the project.
 
 `docker-compose run --rm sbt sbt test`
 
+## Building Scala.js targets
+
+The Scala.js targets are disabled by default, use `sbt "project quill-with-js"` to enable them.
+The CI build also sets this `project quill-with-js` to force the Scala.js compilation.
+
 ## Changing database schema
 
 If you have changed any file that creates a database schema, you will
@@ -41,9 +46,7 @@ In order to contribute to the project, just do as follows:
 
 ### Improve build performance with Docker *(for Mac users only)*
 
-Please, install and run [docker-machine-nfs](https://github.com/adlogix/docker-machine-nfs).
-It will change the default file sharing of your [docker-machine](https://docs.docker.com/machine/)
-from Virtual Box Shared Folders to NFS, which is a lot faster. 
+Use [docker for mac](https://docs.docker.com/engine/installation/mac/#/docker-for-mac).
 
 ## File Formatting 
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -24,13 +24,13 @@ then
 		sbt tut 'release with-defaults'
 	elif [[ $TRAVIS_BRANCH == "master" ]]
 	then
-		sbt clean coverage test tut coverageAggregate checkUnformattedFiles
-		sbt coverageOff publish
+		sbt "project quill-with-js" clean coverage test tut coverageAggregate checkUnformattedFiles
+		sbt "project quill-with-js" coverageOff publish
 	else
-		sbt clean coverage test tut coverageAggregate checkUnformattedFiles
+		sbt "project quill-with-js" clean coverage test tut coverageAggregate checkUnformattedFiles
 		echo "version in ThisBuild := \"$TRAVIS_BRANCH-SNAPSHOT\"" > version.sbt
-		sbt coverageOff publish
+		sbt "project quill-with-js" coverageOff publish
 	fi
 else
-	sbt clean coverage test tut coverageAggregate release-vcs-checks
+	sbt "project quill-with-js" clean coverage test tut coverageAggregate release-vcs-checks
 fi

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,3 +22,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.9")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.10")

--- a/quill-async/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncContextSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncContextSpec.scala
@@ -13,7 +13,7 @@ class MysqlAsyncContextSpec extends Spec {
 
   def await[T](f: Future[T]) = Await.result(f, Duration.Inf)
 
-  "run non-batched action" - {
+  "run non-batched action" in {
     val insert = quote { (i: Int) =>
       qr1.insert(_.i -> i)
     }

--- a/quill-async/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncContextSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncContextSpec.scala
@@ -13,7 +13,7 @@ class PostgresAsyncContextSpec extends Spec {
 
   def await[T](f: Future[T]) = Await.result(f, Duration.Inf)
 
-  "run non-batched action" - {
+  "run non-batched action" in {
     val insert = quote { (i: Int) =>
       qr1.insert(_.i -> i)
     }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlQuerySpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlQuerySpec.scala
@@ -142,49 +142,49 @@ class CqlQuerySpec extends Spec {
       val q = quote {
         qr1.flatMap(r1 => qr2.filter(_.i == r1.i))
       }
-      trap(CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support flatMap."
+      intercept[IllegalStateException](CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support flatMap."
     }
     "groupBy not supported" in {
       val q = quote {
         qr1.groupBy(t => t.i)
       }
-      trap(CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support groupBy."
+      intercept[IllegalStateException](CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support groupBy."
     }
     "union not supported" in {
       val q = quote {
         qr1.filter(_.i == 0).union(qr1.filter(_.i == 1))
       }
-      trap(CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support union/unionAll."
+      intercept[IllegalStateException](CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support union/unionAll."
     }
     "unionAll not supported" in {
       val q = quote {
         qr1.filter(_.i == 0).unionAll(qr1.filter(_.i == 1))
       }
-      trap(CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support union/unionAll."
+      intercept[IllegalStateException](CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support union/unionAll."
     }
     "join not supported" in {
       val q = quote {
         qr1.join(qr2).on((a, b) => a.i == b.i)
       }
-      trap(CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support join."
+      intercept[IllegalStateException](CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support join."
     }
     "leftJoin not supported" in {
       val q = quote {
         qr1.leftJoin(qr2).on((a, b) => a.i == b.i)
       }
-      trap(CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support leftJoin."
+      intercept[IllegalStateException](CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support leftJoin."
     }
     "rightJoin not supported" in {
       val q = quote {
         qr1.rightJoin(qr2).on((a, b) => a.i == b.i)
       }
-      trap(CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support rightJoin."
+      intercept[IllegalStateException](CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support rightJoin."
     }
     "fullJoin not supported" in {
       val q = quote {
         qr1.fullJoin(qr2).on((a, b) => a.i == b.i)
       }
-      trap(CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support fullJoin."
+      intercept[IllegalStateException](CqlQuery(q.ast)).getMessage mustEqual "Cql doesn't support fullJoin."
     }
     "sortBy after take" in {
       val q = quote {

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/EncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/EncodingSpec.scala
@@ -126,6 +126,8 @@ class EncodingSpec extends Spec {
     e.o7 mustEqual a.o7
     e.o8.map(_.toList) mustEqual a.o8.map(_.toList)
     e.o9 mustEqual a.o9
+
+    ()
   }
 
   case class EncodingTestEntity(

--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -53,7 +53,7 @@ trait Quotation extends Liftables with Unliftables with Parsing {
           name -> q"val $name = $tree"
       }.toMap.values
 
-    val id = TermName(s"id${ast.hashCode}")
+    val id = TermName(s"id${ast.hashCode.abs}")
 
     val reifiedAst =
       Transform(ast) {

--- a/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/AstShowSpec.scala
@@ -557,11 +557,11 @@ class AstShowSpec extends Spec {
     }
   }
 
-  "shows dynamic asts" - {
+  "shows dynamic asts" in {
     (Dynamic(1): Ast).show mustEqual "1"
   }
 
-  "shows if" - {
+  "shows if" in {
     val q = quote {
       (i: Int) =>
         if (i > 10) "a" else "b"
@@ -570,7 +570,7 @@ class AstShowSpec extends Spec {
       """if(i > 10) "a" else "b""""
   }
 
-  "shows distinct" - {
+  "shows distinct" in {
     val q = quote {
       query[TestEntity].distinct
     }

--- a/quill-core/src/test/scala/io/getquill/norm/NormalizeNestedStructuresSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/NormalizeNestedStructuresSpec.scala
@@ -129,7 +129,7 @@ class NormalizeNestedStructuresSpec extends Spec {
         NormalizeNestedStructures.unapply(q.ast) mustEqual Some(n.ast)
       }
     }
-    "distinct" - {
+    "distinct" in {
       val q = quote {
         qr1.filter(t => t.s == ("a", "b")._1).distinct
       }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -956,23 +956,25 @@ class QuotationSpec extends Spec {
     }
   }
 
-  "unquotes referenced quotations" - {
+  "unquotes referenced quotations" in {
     val q = quote(1)
     val q2 = quote(q + 1)
     quote(unquote(q2)).ast mustEqual BinaryOperation(Constant(1), NumericOperator.`+`, Constant(1))
   }
 
-  "ignores the ifrefutable call" - {
+  "ignores the ifrefutable call" in {
     val q = quote {
       qr1.map(t => (t.i, t.l))
     }
-    val n = quote {
-      for {
-        (a, b) <- q
-      } yield {
-        a + b
+    """
+      quote {
+        for {
+          (a, b) <- q
+        } yield {
+          a + b
+        }
       }
-    }
+    """ must compile
   }
 
   "supports implicit quotations" - {

--- a/quill-core/src/test/scala/io/getquill/util/CacheSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/util/CacheSpec.scala
@@ -54,9 +54,8 @@ class CacheSpec extends Spec {
       Some(value)
     }
 
-    cache.getOrElseUpdate(1, _value, 100.milliseconds)
-
-    Thread.sleep(3000)
+    cache.getOrElseUpdate(1, _value, -1.milliseconds)
+    cache.getOrElseUpdate(2, None, -1.milliseconds)
 
     calls mustEqual 1
     value.closes mustEqual 1

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/JdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/JdbcEncodingSpec.scala
@@ -11,6 +11,7 @@ class JdbcEncodingSpec extends EncodingSpec {
     testContext.run(delete)
     testContext.run(insert)(insertValues)
     verify(testContext.run(query[EncodingTestEntity]))
+    ()
   }
 
   // Remove this workaround once the issue is fixed


### PR DESCRIPTION
Fixes #18 

### Problem

Quill's core and its sql extension are basically "pure" Scala code. They could be used by Scala.js applications. See https://github.com/slick/slick/issues/1313 for some examples of use cases.

### Solution

Cross-compile `quill-core` and `quill-sql` to Scala.js. 

### Notes

- We'd need to create a new module to integrate database access from Scala.js. The [Slick issue](https://github.com/slick/slick/issues/1313) suggests using Node.js. I'd like to try and find someone familiar with Scala.js to work on this new module as a separate pull request.

- This increases the build time from ~13m to ~26m. We might have to look into parallel module builds in the future, but for now I think it's manageable.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
