### PR TITLE
fix sbt configuration to publish the aggregate project `quill`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ lazy val quill =
 
 lazy val `quill-with-js` = 
   (project in file("."))
+    .settings(name := "quill")
     .settings(tutSettings ++ commonSettings)
     .settings(`tut-settings`:_*)
     .dependsOn(


### PR DESCRIPTION
Fixes #458 

### Problem

The sbt configuration to support Scala.js broke the publishing of the aggregate project [`quill`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22quill_2.11%22).

### Solution

Set the name of the project `quill-with-js` to `quill`

### Notes

I've just published it manually to maven central.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
