### PR TITLE
Allow finagle-mysql to use Long with INT columns

### DIFF
--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
@@ -79,6 +79,7 @@ trait FinagleMysqlDecoders {
     }
   implicit val longDecoder: Decoder[Long] =
     decoder[Long] {
+      case IntValue(v)  => v.toLong
       case LongValue(v) => v
     }
   implicit val floatDecoder: Decoder[Float] =

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
@@ -44,6 +44,19 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
     }
   }
 
+  "Integer type with Long" in {
+    case class IntLong(o6: Long)
+    val entity = quote { query[IntLong].schema(_.entity("EncodingTestEntity")) }
+    val insert = quote {
+      entity.insert(_.o6 -> 5589)
+    }
+    val q = quote {
+      entity.filter(_.o6 == 5589)
+    }
+    Await.result(testContext.run(insert))
+    Await.result(testContext.run(q)).nonEmpty mustEqual true
+  }
+
   "decode boolean types" - {
     case class BooleanEncodingTestEntity(
       v1: Boolean,


### PR DESCRIPTION
### Problem

quill-finagle-mysql does not allow using INT column with Long type. 

### Solution

Add a new case in `Decoder[Long]` to allow mixing INT columns with Long types.

### Notes

N/A

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

