### PR TITLE
add method to force dynamic quotations

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/QuotationDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QuotationDsl.scala
@@ -13,6 +13,7 @@ private[dsl] trait QuotationDsl {
 
   trait Quoted[+T] {
     def ast: Ast
+    def dynamic: Quoted[T] = this
   }
 
   @compileTimeOnly(NonQuotedException.message)

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -839,6 +839,10 @@ class QuotationSpec extends Spec {
           test[TestEntity].ast mustEqual Map(Entity("TestEntity"), Ident("t"), Constant(1))
         }
       }
+      "forced" in {
+        val q = quote(1).dynamic
+        "q.ast: Constant" mustNot compile
+      }
     }
     "if" - {
       "simple" in {


### PR DESCRIPTION
### Problem

When debugging problems with quill, it's common to have to force a dynamic quotation.

### Solution

Add a method to force a dynamic quotation.

### Notes

This will hardly be used by final users, but it's very handy for maintainers.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
