### PR TITLE
create sub query if aggregation on distinct query

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/SqlQuery.scala
@@ -161,7 +161,7 @@ object SqlQuery {
       case Aggregation(op, q: Query) =>
         val b = flatten(q, alias)
         b.select match {
-          case head :: Nil =>
+          case head :: Nil if !b.distinct =>
             b.copy(select = List(head.copy(ast = Aggregation(op, head.ast))))
           case other =>
             FlattenSqlQuery(

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -80,6 +80,13 @@ class SqlIdiomSpec extends Spec {
           testContext.run(q).sql mustEqual
             "SELECT x + 1 FROM (SELECT DISTINCT i.i FROM TestEntity i) x"
         }
+        "distinct followed by aggregation" in {
+          val q = quote {
+            qr1.map(i => i.i).distinct.size
+          }
+          testContext.run(q).sql mustEqual
+            "SELECT COUNT(*) FROM (SELECT DISTINCT i.i FROM TestEntity i) x"
+        }
       }
       "sorted" - {
         "simple" in {


### PR DESCRIPTION
Fixes #436 
### Problem

Aggregation  on `distinct` query will break the `SELECT ` semantic
### Solution

Produce sub query if aggerate on distinct query

### Notes

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

