### PR TITLE
JdbcContext: Optimize extractResult

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
@@ -142,7 +142,7 @@ class JdbcContext[D <: SqlIdiom, N <: NamingStrategy](dataSource: DataSource wit
   @tailrec
   private def extractResult[T](rs: ResultSet, extractor: ResultSet => T, acc: List[T] = List()): List[T] =
     if (rs.next)
-      extractResult(rs, extractor, acc :+ extractor(rs))
+      extractResult(rs, extractor, extractor(rs) :: acc)
     else
-      acc
+      acc.reverse
 }


### PR DESCRIPTION
### Problem

Append operation is known to be expensive in scala's `List` ([see](http://docs.scala-lang.org/overviews/collections/performance-characteristics.html)). Changing `JdbcContext.extractResult` to use `prepend` instead and reversing the list in the end, which should be lead to better performance for larger number of rows extracted from the database. 

### Solution

Changing `append` to `prepend` in `JdbcContext.extractResult`

### Notes

Additional notes.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

