### PR TITLE
introduce option property

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
@@ -23,7 +23,7 @@ object CqlIdiom {
       case Infix(parts, params) =>
         StringContext(parts: _*).s(params.map(_.show): _*)
       case a @ (
-        _: Function | _: FunctionApply | _: Dynamic | _: If | _: OptionOperation |
+        _: Function | _: FunctionApply | _: Dynamic | _: If | _: OptionOperation | _: OptionProperty |
         _: Query | _: Block | _: Val | _: Ordering | _: Binding | _: QuotedReference[_]
         ) =>
         fail(s"Invalid cql: '$a'")

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -83,6 +83,8 @@ case class Property(ast: Ast, name: String) extends Ast
 
 case class OptionOperation(t: OptionOperationType, ast: Ast, alias: Ident, body: Ast) extends Ast
 
+case class OptionProperty(ast: Ast, property: String) extends Ast
+
 case class If(condition: Ast, `then`: Ast, `else`: Ast) extends Ast
 
 //************************************************************

--- a/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstShow.scala
@@ -16,6 +16,7 @@ object AstShow {
     case ast: Property         => ast.show
     case ast: Infix            => ast.show
     case ast: OptionOperation  => ast.show
+    case ast: OptionProperty   => ast.show
     case ast: Dynamic          => ast.show
     case ast: Binding          => ast.show
     case ast: If               => ast.show
@@ -115,6 +116,10 @@ object AstShow {
         case OptionExists => "exists"
       }
       s"${q.ast}.$method((${q.alias.show}) => ${q.body.show})"
+  }
+
+  implicit val optionPropertyShow: Show[OptionProperty] = Show[OptionProperty] {
+    case OptionProperty(ast, prop) => s"${ast.show}.${prop}"
   }
 
   implicit val joinTypeShow: Show[JoinType] = Show[JoinType] {

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -30,6 +30,9 @@ trait StatefulTransformer[T] {
         val (ct, ctt) = att.apply(c)
         (OptionOperation(t, at, b, ct), ctt)
 
+      case OptionProperty(a, b) =>
+        val (at, att) = apply(a)
+        (OptionProperty(at, b), att)
       case If(a, b, c) =>
         val (at, att) = apply(a)
         val (bt, btt) = att.apply(b)

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -14,6 +14,7 @@ trait StatelessTransformer {
       case Property(a, name)           => Property(apply(a), name)
       case Infix(a, b)                 => Infix(a, b.map(apply))
       case OptionOperation(t, a, b, c) => OptionOperation(t, apply(a), b, apply(c))
+      case OptionProperty(a, b)        => OptionProperty(apply(a), b)
       case If(a, b, c)                 => If(apply(a), apply(b), apply(c))
       case e: Dynamic                  => e
       case e: Binding                  => e

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -26,6 +26,7 @@ trait Liftables {
     case UnaryOperation(a, b) => q"$pack.UnaryOperation($a, $b)"
     case Infix(a, b) => q"$pack.Infix($a, $b)"
     case OptionOperation(a, b, c, d) => q"$pack.OptionOperation($a, $b, $c, $d)"
+    case OptionProperty(a, b) => q"$pack.OptionProperty($a, $b)"
     case If(a, b, c) => q"$pack.If($a, $b, $c)"
     case Dynamic(tree: Tree) if (tree.tpe <:< c.weakTypeOf[CoreDsl#Quoted[Any]]) => q"$tree.ast"
     case Dynamic(tree: Tree) => q"$pack.Constant($tree)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -42,6 +42,7 @@ trait Parsing extends EntityConfigParsing {
     case `orderingParser`(value)            => value
     case `operationParser`(value)           => value
     case `identParser`(ident)               => ident
+    case `optionPropertyParser`(value)      => value
     case `propertyParser`(value)            => value
     case `stringInterpolationParser`(value) => value
     case `optionOperationParser`(value)     => value
@@ -277,6 +278,14 @@ trait Parsing extends EntityConfigParsing {
       OptionOperation(OptionForall, astParser(o), identParser(alias), astParser(body))
     case q"$o.exists({($alias) => $body})" if (is[Option[Any]](o)) =>
       OptionOperation(OptionExists, astParser(o), identParser(alias), astParser(body))
+  }
+
+  val optionPropertyParser: Parser[OptionProperty] = {
+    val props = Set("get", "isEmpty", "isDefined", "nonEmpty")
+    Parser[OptionProperty] {
+      case q"$o.$p" if (is[Option[Any]](o)) && props.contains(p.decodedName.toString) =>
+        OptionProperty(astParser(o), p.decodedName.toString)
+    }
   }
 
   val propertyParser: Parser[Ast] = Parser[Ast] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -23,6 +23,7 @@ trait Unliftables {
     case q"$pack.Aggregation.apply(${ a: AggregationOperator }, ${ b: Ast })" => Aggregation(a, b)
     case q"$pack.Infix.apply(${ a: List[String] }, ${ b: List[Ast] })" => Infix(a, b)
     case q"$pack.OptionOperation.apply(${ a: OptionOperationType }, ${ b: Ast }, ${ c: Ident }, ${ d: Ast })" => OptionOperation(a, b, c, d)
+    case q"$pack.OptionProperty.apply(${ a: Ast }, ${ b: String })" => OptionProperty(a, b)
     case q"$pack.If.apply(${ a: Ast }, ${ b: Ast }, ${ c: Ast })" => If(a, b, c)
     case q"$tree.ast" => Dynamic(tree)
     case q"$pack.RuntimeBinding.apply(${ a: String })" => RuntimeBinding(a)

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -292,6 +292,15 @@ class StatefulTransformerSpec extends Spec {
       }
     }
 
+    "option property" in {
+      val ast = OptionProperty(Ident("a"), "b")
+      Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {
+        case (at, att) =>
+          at mustEqual OptionProperty(Ident("a'"), "b")
+          att.state mustEqual List(Ident("a"))
+      }
+    }
+
     "if" in {
       val ast: Ast = If(Ident("a"), Ident("b"), Ident("c"))
       Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -49,6 +49,7 @@ import io.getquill.ast.OptionExists
 import io.getquill.ast.OptionForall
 import io.getquill.ast.OptionMap
 import io.getquill.ast.OptionOperation
+import io.getquill.ast.OptionProperty
 import io.getquill.ast.Property
 import io.getquill.ast.PropertyAlias
 import io.getquill.ast.RightJoin
@@ -722,6 +723,24 @@ class QuotationSpec extends Spec {
             infix"$a || $b".as[String]
         }
         quote(unquote(q)).ast.body mustEqual Infix(List("", " || ", ""), List(Ident("a"), Ident("b")))
+      }
+    }
+    "option property" - {
+      "get" in {
+        val q = quote { (o: Option[Int]) => o.get }
+        quote(unquote(q)).ast.body mustEqual OptionProperty(Ident("o"), "get")
+      }
+      "isEmpty" in {
+        val q = quote { (o: Option[Int]) => o.isEmpty }
+        quote(unquote(q)).ast.body mustEqual OptionProperty(Ident("o"), "isEmpty")
+      }
+      "nonEmpty" in {
+        val q = quote { (o: Option[Int]) => o.nonEmpty }
+        quote(unquote(q)).ast.body mustEqual OptionProperty(Ident("o"), "nonEmpty")
+      }
+      "isDefined" in {
+        val q = quote { (o: Option[Int]) => o.isDefined }
+        quote(unquote(q)).ast.body mustEqual OptionProperty(Ident("o"), "isDefined")
       }
     }
     "option operation" - {

--- a/quill-sql/src/main/scala/io/getquill/context/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/SqlQuery.scala
@@ -14,6 +14,7 @@ import io.getquill.ast.Join
 import io.getquill.ast.JoinType
 import io.getquill.ast.Map
 import io.getquill.ast.Operation
+import io.getquill.ast.OptionProperty
 import io.getquill.ast.Property
 import io.getquill.ast.PropertyOrdering
 import io.getquill.ast.Query
@@ -76,6 +77,7 @@ object SqlQuery {
       case Union(a, b)                  => SetOperationSqlQuery(apply(a), UnionOperation, apply(b))
       case UnionAll(a, b)               => SetOperationSqlQuery(apply(a), UnionAllOperation, apply(b))
       case UnaryOperation(op, q: Query) => UnaryOperationSqlQuery(op, apply(q))
+      case OptionProperty(a, "get")     => apply(a)
       case _: Operation | _: Value      => FlattenSqlQuery(select = List(SelectValue(query)))
       case q: Query                     => flatten(q, "x")
       case other                        => fail(s"Query not properly normalized. Please open a bug report. Ast: '$other'")

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -39,6 +39,7 @@ import io.getquill.ast.NullValue
 import io.getquill.ast.NumericOperator
 import io.getquill.ast.Operation
 import io.getquill.ast.OptionOperation
+import io.getquill.ast.OptionProperty
 import io.getquill.ast.Ordering
 import io.getquill.ast.Property
 import io.getquill.ast.Query
@@ -84,6 +85,7 @@ trait SqlIdiom {
       case Infix(parts, params) => StringContext(parts: _*).s(params.map(_.show): _*)
       case a: Action            => a.show
       case a: Ident             => a.show
+      case a: OptionProperty    => a.show
       case a: Property          => a.show
       case a: Value             => a.show
       case a: If                => a.show
@@ -257,12 +259,16 @@ trait SqlIdiom {
 
   implicit def propertyShow(implicit valueShow: Show[Value], identShow: Show[Ident], strategy: NamingStrategy): Show[Property] =
     Show[Property] {
-      case Property(ident, "isEmpty")      => s"${ident.show} IS NULL"
-      case Property(ident, "nonEmpty")     => s"${ident.show} IS NOT NULL"
-      case Property(ident, "isDefined")    => s"${ident.show} IS NOT NULL"
       case Property(Property(ident, a), b) => s"${ident.show}.$a$b"
       case Property(ast, name)             => s"${scopedShow(ast)}.${strategy.column(name)}"
     }
+
+  implicit def optionPropertyShow(implicit strategy: NamingStrategy): Show[OptionProperty] = Show[OptionProperty] {
+    case OptionProperty(ast, "get")       => ast.show
+    case OptionProperty(ast, "isEmpty")   => s"${ast.show} IS NULL"
+    case OptionProperty(ast, "nonEmpty")  => s"${ast.show} IS NOT NULL"
+    case OptionProperty(ast, "isDefined") => s"${ast.show} IS NOT NULL"
+  }
 
   implicit def valueShow(implicit strategy: NamingStrategy): Show[Value] = Show[Value] {
     case Constant(v: String) => s"'$v'"

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -762,13 +762,14 @@ class SqlIdiomSpec extends Spec {
           "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE (1, 2) = t.i"
       }
     }
-    "property" - {
-      "column" in {
-        val q = quote {
-          qr1.map(t => t.s)
-        }
-        testContext.run(q).sql mustEqual
-          "SELECT t.s FROM TestEntity t"
+    "option property" - {
+      "get option column" in {
+        val q = quote(qr1.map(t => t.o.get))
+        testContext.run(q).sql mustEqual "SELECT t.o FROM TestEntity t"
+      }
+      "get sum" in {
+        val q = quote(qr1.map(t => t.i).sum.get)
+        testContext.run(q).sql mustEqual "SELECT x.* FROM (SELECT SUM(t.i) FROM TestEntity t) x"
       }
       "isEmpty" in {
         val q = quote {
@@ -790,6 +791,15 @@ class SqlIdiomSpec extends Spec {
         }
         testContext.run(q).sql mustEqual
           "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NOT NULL"
+      }
+    }
+    "property" - {
+      "column" in {
+        val q = quote {
+          qr1.map(t => t.s)
+        }
+        testContext.run(q).sql mustEqual
+          "SELECT t.s FROM TestEntity t"
       }
     }
     "infix" - {


### PR DESCRIPTION
Fixes #248,  add `option.get`
### Problem

Currently `Option.{isEmpty, nonEmpty, isDefined}` have no ast

### Solution

Create Ast

### Notes

***`option.get` will cause runtime error while called on `NULL`  sql values, I don't know whether we should support it***

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

