### PR TITLE
Make decoder function public

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
@@ -10,7 +10,7 @@ import io.getquill.context.BindedStatementBuilder
 trait Decoders {
   this: CassandraContext[_, Row, BindedStatementBuilder[BoundStatement]] =>
 
-  private def decoder[T](f: Row => Int => T): Decoder[T] =
+  def decoder[T](f: Row => Int => T): Decoder[T] =
     new Decoder[T] {
       def apply(index: Int, row: Row) =
         f(row)(index)


### PR DESCRIPTION
Fixes #481

### Problem

decoder function in io.getquill.context.cassandra.encoding was private in contrast to encoder function from the same package

### Solution

Make decoder public

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

