### PR TITLE
set the scope of all cassandra context type definitions to public

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -20,11 +20,11 @@ class CassandraAsyncContext[N <: NamingStrategy](config: CassandraContextConfig)
   def this(config: Config) = this(CassandraContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 
-  override protected type QueryResult[T] = Future[List[T]]
-  override protected type SingleQueryResult[T] = Future[T]
-  override protected type ActionResult[T] = Future[ResultSet]
-  override protected type BatchedActionResult[T] = Future[List[ResultSet]]
-  override protected type Params[T] = List[T]
+  override type QueryResult[T] = Future[List[T]]
+  override type SingleQueryResult[T] = Future[T]
+  override type ActionResult[T] = Future[ResultSet]
+  override type BatchedActionResult[T] = Future[List[ResultSet]]
+  override type Params[T] = List[T]
 
   def executeQuery[T](cql: String, extractor: Row => T = identity[Row] _, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement] = identity)(implicit ec: ExecutionContext): Future[List[T]] =
     session.executeAsync(prepare(cql, bind))

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
@@ -18,11 +18,11 @@ class CassandraSyncContext[N <: NamingStrategy](config: CassandraContextConfig)
   def this(config: Config) = this(CassandraContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 
-  override protected type QueryResult[T] = List[T]
-  override protected type SingleQueryResult[T] = T
-  override protected type ActionResult[T] = ResultSet
-  override protected type BatchedActionResult[T] = List[ResultSet]
-  override protected type Params[T] = List[T]
+  override type QueryResult[T] = List[T]
+  override type SingleQueryResult[T] = T
+  override type ActionResult[T] = ResultSet
+  override type BatchedActionResult[T] = List[ResultSet]
+  override type Params[T] = List[T]
 
   def executeQuery[T](cql: String, extractor: Row => T = identity[Row] _, bind: BindedStatementBuilder[BoundStatement] => BindedStatementBuilder[BoundStatement] = identity): List[T] =
     session.execute(prepare(cql, bind))


### PR DESCRIPTION
Fixes #480 

### Problem
Type definitions in CassandraSyncContext and CassandraAsyncContext being defined as 'protected' causes IDEs to incorrectly report compile errors.

### Solution
Set their scope to public.


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

