### PR TITLE
make the cassandra decoder fail when encountering a column with value null

### DIFF
--- a/quill-cassandra/src/test/cql/cassandra-schema.cql
+++ b/quill-cassandra/src/test/cql/cassandra-schema.cql
@@ -28,6 +28,11 @@ CREATE TABLE Task(
     tsk VARCHAR
 );
 
+CREATE TABLE DecodeNullTestEntity(
+    id INT PRIMARY KEY,
+    value INT
+);
+
 CREATE TABLE EncodingTestEntity(
     id INT,
     v1 VARCHAR,

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/DecodeNullSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/DecodeNullSpec.scala
@@ -1,0 +1,69 @@
+package io.getquill.context.cassandra
+
+import io.getquill._
+import monifu.reactive.Observable
+
+class DecodeNullSpec extends Spec {
+
+  "no default values when reading null" - {
+
+    "sync" in {
+      import testSyncDB._
+      val writeEntities = quote(query[DecodeNullTestWriteEntity].schema(_.entity("DecodeNullTestEntity")))
+
+      testSyncDB.run(writeEntities.delete)
+      testSyncDB.run(writeEntities.insert)(insertValue)
+      intercept[IllegalStateException] {
+        testSyncDB.run(query[DecodeNullTestEntity])
+      }
+    }
+
+    "async" in {
+      import testAsyncDB._
+      import scala.concurrent.ExecutionContext.Implicits.global
+      val writeEntities = quote(query[DecodeNullTestWriteEntity].schema(_.entity("DecodeNullTestEntity")))
+
+      val result =
+        for {
+          _ <- testAsyncDB.run(writeEntities.delete)
+          _ <- testAsyncDB.run(writeEntities.insert)(insertValue)
+          result <- testAsyncDB.run(query[DecodeNullTestEntity])
+        } yield {
+          result
+        }
+      intercept[IllegalStateException] {
+        await {
+          result
+        }
+      }
+    }
+
+    "stream" in {
+      import testStreamDB._
+      import monifu.concurrent.Implicits.globalScheduler
+      val writeEntities = quote(query[DecodeNullTestWriteEntity].schema(_.entity("DecodeNullTestEntity")))
+
+      val result =
+        for {
+          _ <- testStreamDB.run(writeEntities.delete)
+          inserts = Observable.from(insertValue)
+          _ <- testStreamDB.run(writeEntities.insert)(inserts).count
+          result <- testStreamDB.run(query[DecodeNullTestEntity])
+        } yield {
+          result
+        }
+      intercept[IllegalStateException] {
+        await {
+          result.asFuture
+        }
+      }
+    }
+  }
+
+  case class DecodeNullTestEntity(id: Int, value: Int)
+
+  case class DecodeNullTestWriteEntity(id: Int, value: Option[Int])
+
+  val insertValue = DecodeNullTestWriteEntity(0, None)
+
+}


### PR DESCRIPTION
Fixes #477 

### Problem
The Datastax driver row extractor methods return _null_ if the value at the respective column is _null_. Given that there is an explicit _optionDecoder_, using _decoder_ for _null_ indicates a mismatch which is why the operation should fail.
In case of extracting a Java Primitive value, the default value of the respective type is returned (which "silently forwards" the mismatch into client code and thus is even worse).

### Solution
Make the decoder fail when encountering _null_.

### Notes
As demonstrated by the test, the problem requires some sort of mismatch (or implementation error) between code which writes and code which reads the respective column.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers