### PR TITLE
only call the parent decoder when the row isn't null

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcDecoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcDecoders.scala
@@ -23,7 +23,7 @@ trait JdbcDecoders {
         // don't invoke the parent decoder before the value was null checked
         row.wasNull match {
           case true  => None
-          case false => Some(d(index, row))
+          case false => Option(d(index, row))
         }
       }
     }


### PR DESCRIPTION
### Problem

Actually on quill-jdbc the Option Decoder would call the parent decoder no matter if the row was null or not. After that it would discard the value of the parent decoder if the row is zero.
This is not good behavior since we probably don't want to call the parent decoder if the row is zero, if we have a option decoder.

### Solution

changed it like it was done in quill-async, quill-cassandra and quill-finagle-async.

### Checklist

- [ ] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

Couldn't test locally yet / can't install docker.