### PR TITLE
fix Option.{isEmpty, isDefined, nonEmpty} show on action.filter

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -283,7 +283,11 @@ trait SqlIdiom {
       assignments.map(a => s"${strategy.column(a.property)} = ${scopedShow(a.value)}").mkString(", ")
 
     implicit def propertyShow: Show[Property] = Show[Property] {
-      case Property(_, name) => strategy.column(name)
+      case Property(Property(_, name), "isEmpty")   => s"${strategy.column(name)} IS NULL"
+      case Property(Property(_, name), "isDefined") => s"${strategy.column(name)} IS NOT NULL"
+      case Property(Property(_, name), "nonEmpty")  => s"${strategy.column(name)} IS NOT NULL"
+      case Property(Property(_, name), prop)        => s"${strategy.column(name)}.$prop"
+      case Property(_, name)                        => strategy.column(name)
     }
 
     Show[Action] {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -770,26 +770,74 @@ class SqlIdiomSpec extends Spec {
         testContext.run(q).sql mustEqual
           "SELECT t.s FROM TestEntity t"
       }
-      "isEmpty" in {
-        val q = quote {
-          qr1.filter(t => t.o.isEmpty)
+      "isEmpty" - {
+        "query" in {
+          val q = quote {
+            qr1.filter(t => t.o.isEmpty)
+          }
+          testContext.run(q).sql mustEqual
+            "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NULL"
         }
-        testContext.run(q).sql mustEqual
-          "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NULL"
+        "update" in {
+          val q = quote {
+            qr1.filter(t => t.o.isEmpty).update(_.i -> 1)
+          }
+          testContext.run(q).sql mustEqual
+            "UPDATE TestEntity SET i = 1 WHERE o IS NULL"
+        }
+        "delete" in {
+          val q = quote {
+            qr1.filter(t => t.o.isEmpty).delete
+          }
+          testContext.run(q).sql mustEqual
+            "DELETE FROM TestEntity WHERE o IS NULL"
+        }
       }
-      "nonEmpty" in {
-        val q = quote {
-          qr1.filter(t => t.o.nonEmpty)
+      "nonEmpty" - {
+        "query" in {
+          val q = quote {
+            qr1.filter(t => t.o.nonEmpty)
+          }
+          testContext.run(q).sql mustEqual
+            "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NOT NULL"
         }
-        testContext.run(q).sql mustEqual
-          "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NOT NULL"
+        "update" in {
+          val q = quote {
+            qr1.filter(t => t.o.nonEmpty).update(_.i -> 1)
+          }
+          testContext.run(q).sql mustEqual
+            "UPDATE TestEntity SET i = 1 WHERE o IS NOT NULL"
+        }
+        "delete" in {
+          val q = quote {
+            qr1.filter(t => t.o.nonEmpty).delete
+          }
+          testContext.run(q).sql mustEqual
+            "DELETE FROM TestEntity WHERE o IS NOT NULL"
+        }
       }
-      "isDefined" in {
-        val q = quote {
-          qr1.filter(t => t.o.isDefined)
+      "isDefined" - {
+        "query" in {
+          val q = quote {
+            qr1.filter(t => t.o.isDefined)
+          }
+          testContext.run(q).sql mustEqual
+            "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NOT NULL"
         }
-        testContext.run(q).sql mustEqual
-          "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o IS NOT NULL"
+        "update" in {
+          val q = quote {
+            qr1.filter(t => t.o.isDefined).update(_.i -> 1)
+          }
+          testContext.run(q).sql mustEqual
+            "UPDATE TestEntity SET i = 1 WHERE o IS NOT NULL"
+        }
+        "delete" in {
+          val q = quote {
+            qr1.filter(t => t.o.isDefined).delete
+          }
+          testContext.run(q).sql mustEqual
+            "DELETE FROM TestEntity WHERE o IS NOT NULL"
+        }
       }
     }
     "infix" - {


### PR DESCRIPTION
Fixes #504 

### Problem

`propertyShow` inside `actionShow` treat all property as column

### Solution

show `isEmpty`, `isDefined`, ``


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

