### PR TITLE
readme: add config key for cassandra port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1294,6 +1294,7 @@ application.properties
 ctx.keyspace=quill_test
 ctx.preparedStatementCacheSize=1000
 ctx.session.contactPoint=127.0.0.1
+ctx.session.withPort=9042
 ctx.session.queryOptions.consistencyLevel=LOCAL_QUORUM
 ctx.session.withoutMetrics=true
 ctx.session.withoutJMXReporting=false


### PR DESCRIPTION
### Problem

It's common to see people asking on gitter how to set the cassandra port.

### Solution

Add the config key to the readme

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
