### PR TITLE
fix unformatted files error message for pull requests

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -33,5 +33,5 @@ then
 		sbt "project quill-with-js" coverageOff publish
 	fi
 else
-	sbt "project quill-with-js" clean coverage test tut coverageAggregate release-vcs-checks
+	sbt "project quill-with-js" clean coverage test tut coverageAggregate checkUnformattedFiles
 fi


### PR DESCRIPTION
### Problem

The build still shows a cryptic message for unformatted files if it's building a pull request. Example: https://travis-ci.org/getquill/quill/builds/151474134#L10802

### Solution

Fix sbt command.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
