### PR TITLE
enclose operand-queries of SetOperation in parentheses

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -152,7 +152,7 @@ trait SqlIdiom {
         case (None, Some(offset))        => withOrderBy + showOffsetWithoutLimit(offset)
       }
     case SetOperationSqlQuery(a, op, b) =>
-      s"${a.show} ${op.show} ${b.show}"
+      s"(${a.show}) ${op.show} (${b.show})"
     case UnaryOperationSqlQuery(op, q) =>
       s"SELECT ${op.show} (${q.show})"
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -339,14 +339,14 @@ class SqlQuerySpec extends Spec {
           qr1.union(qr1)
         }
         SqlQuery(q.ast).show mustEqual
-          "SELECT x.* FROM TestEntity x UNION SELECT x.* FROM TestEntity x"
+          "(SELECT x.* FROM TestEntity x) UNION (SELECT x.* FROM TestEntity x)"
       }
       "unionAll" in {
         val q = quote {
           qr1.unionAll(qr1)
         }
         SqlQuery(q.ast).show mustEqual
-          "SELECT x.* FROM TestEntity x UNION ALL SELECT x.* FROM TestEntity x"
+          "(SELECT x.* FROM TestEntity x) UNION ALL (SELECT x.* FROM TestEntity x)"
       }
     }
     "unary operation query" - {


### PR DESCRIPTION
Fixes #509 

### Problem
Queries being combined within _UNION_ or _UNION ALL_ are not enclosed in parentheses.
If one of the sub/ operand queries or the resulting one contains a _sortBy_ clause, the generated SQL thus is not correct.

### Solution
Enclose operand-queries of _SetOperation_ in parentheses.

### Notes
Currently ```io.getquill.context.jdbc.sqlite.JdbcEncodingSpec.scala```fails on the PR branch but that is also true for the current Quill master branch.


### Checklist

- [-] Unit test all changes
- [-] Update `README.md` if applicable
- [-] Add `[WIP]` to the pull request title if it's work in progress
- [-] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [-] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

