### PR TITLE
[WIP]: Removed Closeable from dataSource type in JdbcContext constructor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,7 +188,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
   scalaVersion := "2.11.8",
   libraryDependencies ++= Seq(
     "org.scalamacros" %% "resetallattrs"  % "1.0.0",
-    "org.scalatest"   %%% "scalatest"     % "3.0.0-RC2" % "test",
+    "org.scalamock" % "scalamock-scalatest-support_2.11" % "3.2.2",
     "ch.qos.logback"  % "logback-classic" % "1.1.7"     % "test",
     "com.google.code.findbugs" % "jsr305" % "3.0.1"     % "provided" // just to avoid warnings during compilation
   ),

--- a/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
@@ -52,7 +52,7 @@ class JdbcContext[D <: SqlIdiom, N <: NamingStrategy](dataSource: DataSource)
     }
 
   def close = dataSource match {
-    case _: DataSource with Closeable =>
+    case _: Closeable =>
       dataSource.asInstanceOf[DataSource with Closeable].close()
     case _ => ()
   }

--- a/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
@@ -25,7 +25,7 @@ import scala.reflect.runtime.universe._
 
 //import io.getquill.context.jdbc.ActionApply
 
-class JdbcContext[D <: SqlIdiom, N <: NamingStrategy](dataSource: DataSource with Closeable)
+class JdbcContext[D <: SqlIdiom, N <: NamingStrategy](dataSource: DataSource)
   extends SqlContext[D, N, ResultSet, BindedStatementBuilder[PreparedStatement]]
   with JdbcEncoders
   with JdbcDecoders {
@@ -51,7 +51,11 @@ class JdbcContext[D <: SqlIdiom, N <: NamingStrategy](dataSource: DataSource wit
       finally conn.close
     }
 
-  def close = dataSource.close()
+  def close = dataSource match {
+    case _: DataSource with Closeable =>
+      dataSource.asInstanceOf[DataSource with Closeable].close()
+    case _ => ()
+  }
 
   def probe(sql: String) =
     Try {

--- a/quill-jdbc/src/test/scala/io/getquill/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/JdbcContextSpec.scala
@@ -1,0 +1,22 @@
+package io.getquill
+
+import java.io.Closeable
+import javax.sql.DataSource
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.FlatSpec
+import org.scalatest.MustMatchers
+
+class JdbcContextSpec extends FlatSpec with MustMatchers with MockFactory {
+
+  abstract class DataSourceWithCloseable extends DataSource with Closeable
+
+  "JdbcContextSpec" should "call close when extends Closable" in {
+    val dataSourceMock = mock[DataSourceWithCloseable]
+    (dataSourceMock.close _).expects().once()
+
+    val ctx = new JdbcContext[PostgresDialect, SnakeCase](dataSourceMock)
+    ctx.close()
+  }
+
+}


### PR DESCRIPTION
### Problem
In documentation it stated that context can be initialized as follows.

```
def createDataSource: javax.sql.DataSource with java.io.Closeable = ???
lazy val ctx = new JdbcContext[MySQLDialect, SnakeCase](createDataSource)
```

Currently, `javax.sql.DataSource` does not implement `java.io.Closeable`. Thus for this functionality to work, we must wrap `javax.sql.DataSource` to implement `java.io.Closeable`.

In this pull request we remove this type `java.io.Closeable` constraint but keep the close functionality if `javax.sql.DataSource` indeed implements `java.io.Closeable`.

@getquill/maintainers
