### PR TITLE
support mapped encoding definition without a context instance

### DIFF
--- a/CASSANDRA.md
+++ b/CASSANDRA.md
@@ -548,8 +548,8 @@ object Quill extends App {
 
   object Country {
 
-    implicit val decode: MappedEncoding[String, Country] = mappedEncoding[String, Country](Country(_))
-    implicit val encode: MappedEncoding[Country, String] = mappedEncoding[Country, String](_.code)
+    implicit val decode: MappedEncoding[String, Country] = MappedEncoding[String, Country](Country(_))
+    implicit val encode: MappedEncoding[Country, String] = MappedEncoding[Country, String](_.code)
   }
   case class WeatherStation(country: Country, city: String, stationId: String, entry: Int, value: Int)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# To be released
+
+### Migration notes
+
+- `mappedEncoding` has been renamed to `MappedEncoding`.
+
 # 0.9.0 - 22-Aug-2016
 
 **see migration notes below**

--- a/README.md
+++ b/README.md
@@ -862,13 +862,24 @@ Quill uses `Encoder`s to encode query inputs and `Decoder`s to read values retur
 Mapped Encoding
 ---------------
 
-If the correspondent database type is already supported, use `mappedEncoding`. In this example, `String` is already supported by Quill and the `UUID` encoding from/to `String` is defined through mapped encoding:
+If the correspondent database type is already supported, use `MappedEncoding`. In this example, `String` is already supported by Quill and the `UUID` encoding from/to `String` is defined through mapped encoding:
 
 ```scala
+import ctx._
 import java.util.UUID
 
-implicit val encodeUUID = mappedEncoding[UUID, String](_.toString)
-implicit val decodeUUID = mappedEncoding[String, UUID](UUID.fromString(_))
+implicit val encodeUUID = MappedEncoding[UUID, String](_.toString)
+implicit val decodeUUID = MappedEncoding[String, UUID](UUID.fromString(_))
+```
+
+A mapped encoding also can be defined without a context instance by importing `io.getquill.MappedEncoding`:
+
+```scala
+import io.getquill.MappedEncoding
+import java.util.UUID
+
+implicit val encodeUUID = MappedEncoding[UUID, String](_.toString)
+implicit val decodeUUID = MappedEncoding[String, UUID](UUID.fromString(_))
 ```
 
 Raw Encoding

--- a/quill-core/src/main/scala/io/getquill/MappedEncoding.scala
+++ b/quill-core/src/main/scala/io/getquill/MappedEncoding.scala
@@ -1,0 +1,3 @@
+package io.getquill
+
+case class MappedEncoding[I, O](f: I => O)

--- a/quill-core/src/main/scala/io/getquill/dsl/EncodingDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/EncodingDsl.scala
@@ -48,9 +48,8 @@ trait EncodingDsl {
 
   /* ************************************************************************** */
 
-  case class MappedEncoding[I, O](f: I => O)
-
-  def mappedEncoding[I, O](f: I => O) = MappedEncoding(f)
+  type MappedEncoding[I, O] = io.getquill.MappedEncoding[I, O]
+  val MappedEncoding = io.getquill.MappedEncoding
 
   implicit def mappedDecoder[I, O](implicit mapped: MappedEncoding[I, O], decoder: Decoder[I]): Decoder[O] =
     new Decoder[O] {

--- a/quill-core/src/test/scala/io/getquill/context/ContextInstanceSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/ContextInstanceSpec.scala
@@ -17,20 +17,40 @@ class ContextInstanceSpec extends Spec {
     case class StringValue(s: String)
     case class Entity(s: StringValue)
 
-    "encoding" in {
-      implicit val testToString = mappedEncoding[StringValue, String](_.s)
-      val q = quote {
-        query[Entity].insert(_.s -> lift(StringValue("s")))
+    "context-based" - {
+      "encoding" in {
+        implicit val testToString = MappedEncoding[StringValue, String](_.s)
+        val q = quote {
+          query[Entity].insert(_.s -> lift(StringValue("s")))
+        }
+        testContext.run(q).prepareRow mustEqual Row("s")
       }
-      testContext.run(q).prepareRow mustEqual Row("s")
-    }
 
-    "decoding" in {
-      implicit val stringToTest = mappedEncoding[String, StringValue](StringValue)
-      val q = quote {
-        query[Entity]
+      "decoding" in {
+        implicit val stringToTest = MappedEncoding[String, StringValue](StringValue)
+        val q = quote {
+          query[Entity]
+        }
+        testContext.run(q).extractor(Row("s")) mustEqual Entity(StringValue("s"))
       }
-      testContext.run(q).extractor(Row("s")) mustEqual Entity(StringValue("s"))
+    }
+    "package-based" - {
+      import io.getquill.MappedEncoding
+      "encoding" in {
+        implicit val testToString = MappedEncoding[StringValue, String](_.s)
+        val q = quote {
+          query[Entity].insert(_.s -> lift(StringValue("s")))
+        }
+        testContext.run(q).prepareRow mustEqual Row("s")
+      }
+
+      "decoding" in {
+        implicit val stringToTest = MappedEncoding[String, StringValue](StringValue)
+        val q = quote {
+          query[Entity]
+        }
+        testContext.run(q).extractor(Row("s")) mustEqual Entity(StringValue("s"))
+      }
     }
   }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/TestDecoders.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/TestDecoders.scala
@@ -3,5 +3,5 @@ package io.getquill.context.sql
 trait TestDecoders {
   this: SqlContext[_, _] =>
 
-  implicit val encodingTestTypeDecoder = mappedEncoding[String, EncodingTestType](EncodingTestType)
+  implicit val encodingTestTypeDecoder = MappedEncoding[String, EncodingTestType](EncodingTestType)
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/TestEncoders.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/TestEncoders.scala
@@ -3,5 +3,5 @@ package io.getquill.context.sql
 trait TestEncoders {
   this: SqlContext[_, _] =>
 
-  implicit val encodingTestTypeEncoder = mappedEncoding[EncodingTestType, String](_.value)
+  implicit val encodingTestTypeEncoder = MappedEncoding[EncodingTestType, String](_.value)
 }


### PR DESCRIPTION
Fixes #516 

### Problem

Mapped encoding can't be defined without a context instance.

### Solution

Move the mapped encoding case class to `io.getquill`

### Notes

I've also removed the `mappedEncoding` method to make the usage on both context-based or package-based mapped encodings equal.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

