### PR TITLE
support forced nested queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,16 @@ ctx.run(q)
 // SELECT DISTINCT p.age FROM Person p
 ```
 
+**nested**
+```scala
+val q = quote {
+  query[Person].filter(p => p.name == "John").nested.map(p => p.age)
+}
+
+ctx.run(q)
+// SELECT p.age FROM (SELECT p.age FROM Person p WHERE p.name = 'John') p
+```
+
 **joins**
 
 In addition to applicative joins Quill also supports explicit joins (both inner and left/right/full outer joins).

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -97,6 +97,9 @@ class MirrorIdiom extends Idiom {
 
     case Distinct(a) =>
       stmt"${a.token}.distinct"
+
+    case Nested(a) =>
+      stmt"${a.token}.nested"
   }
 
   implicit val entityTokenizer: Tokenizer[Entity] = Tokenizer[Entity] {

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -73,6 +73,8 @@ case class Join(typ: JoinType, a: Ast, b: Ast, aliasA: Ident, aliasB: Ident, on:
 
 case class Distinct(a: Ast) extends Query
 
+case class Nested(a: Ast) extends Query
+
 //************************************************************
 
 case class Infix(parts: List[String], params: List[Ast]) extends Ast

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -109,6 +109,9 @@ trait StatefulTransformer[T] {
       case Distinct(a) =>
         val (at, att) = apply(a)
         (Distinct(at), att)
+      case Nested(a) =>
+        val (at, att) = apply(a)
+        (Nested(at), att)
     }
 
   def apply(e: Assignment): (Assignment, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -40,6 +40,7 @@ trait StatelessTransformer {
       case Join(t, a, b, iA, iB, on) =>
         Join(t, apply(a), apply(b), iA, iB, apply(on))
       case Distinct(a) => Distinct(apply(a))
+      case Nested(a)   => Nested(apply(a))
     }
 
   def apply(e: Assignment): Assignment =

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -50,6 +50,8 @@ private[dsl] trait QueryDsl {
 
     def distinct: Query[T]
 
+    def nested: Query[T]
+
     def foreach[A <: Action[_]](f: T => A): BatchAction[A]
   }
 

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -64,7 +64,7 @@ case class BetaReduction(map: collection.Map[Ast, Ast])
         GroupBy(apply(a), b, BetaReduction(map - b)(c))
       case Join(t, a, b, iA, iB, on) =>
         Join(t, apply(a), apply(b), iA, iB, BetaReduction(map - iA - iB)(on))
-      case _: Take | _: Entity | _: Drop | _: Union | _: UnionAll | _: Aggregation | _: Distinct =>
+      case _: Take | _: Entity | _: Drop | _: Union | _: UnionAll | _: Aggregation | _: Distinct | _: Nested =>
         super.apply(query)
     }
 }

--- a/quill-core/src/main/scala/io/getquill/norm/NormalizeNestedStructures.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/NormalizeNestedStructures.scala
@@ -1,20 +1,6 @@
 package io.getquill.norm
 
-import io.getquill.ast.Aggregation
-import io.getquill.ast.Ast
-import io.getquill.ast.Distinct
-import io.getquill.ast.Drop
-import io.getquill.ast.Entity
-import io.getquill.ast.Filter
-import io.getquill.ast.FlatMap
-import io.getquill.ast.GroupBy
-import io.getquill.ast.Join
-import io.getquill.ast.Map
-import io.getquill.ast.Query
-import io.getquill.ast.SortBy
-import io.getquill.ast.Take
-import io.getquill.ast.Union
-import io.getquill.ast.UnionAll
+import io.getquill.ast._
 
 object NormalizeNestedStructures {
 
@@ -32,6 +18,7 @@ object NormalizeNestedStructures {
       case Union(a, b)        => apply(a, b)(Union)
       case UnionAll(a, b)     => apply(a, b)(UnionAll)
       case Distinct(a)        => apply(a)(Distinct)
+      case Nested(a)          => apply(a)(Nested)
       case Join(t, a, b, iA, iB, on) =>
         (Normalize(a), Normalize(b), Normalize(on)) match {
           case (`a`, `b`, `on`) => None

--- a/quill-core/src/main/scala/io/getquill/norm/capture/Dealias.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/Dealias.scala
@@ -39,7 +39,7 @@ case class Dealias(state: Option[Ident]) extends StatefulTransformer[Option[Iden
         val ((an, iAn, on), ont) = dealias(a, iA, o)((_, _, _))
         val ((bn, iBn, onn), _) = ont.dealias(b, iB, on)((_, _, _))
         (Join(t, an, bn, iAn, iBn, onn), Dealias(None))
-      case _: Entity | _: Distinct | _: Aggregation =>
+      case _: Entity | _: Distinct | _: Aggregation | _: Nested =>
         (q, Dealias(None))
     }
 

--- a/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
@@ -51,7 +51,7 @@ case class FreeVariables(state: State)
         val (_, freeB) = apply(a)
         val (_, freeOn) = FreeVariables(State(state.seen + iA + iB, collection.Set.empty))(on)
         (q, FreeVariables(State(state.seen, state.free ++ freeA.state.free ++ freeB.state.free ++ freeOn.state.free)))
-      case _: Entity | _: Take | _: Drop | _: Union | _: UnionAll | _: Aggregation | _: Distinct =>
+      case _: Entity | _: Take | _: Drop | _: Union | _: UnionAll | _: Aggregation | _: Distinct | _: Nested =>
         super.apply(query)
     }
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -91,6 +91,7 @@ trait Liftables {
     case UnionAll(a, b)         => q"$pack.UnionAll($a, $b)"
     case Join(a, b, c, d, e, f) => q"$pack.Join($a, $b, $c, $d, $e, $f)"
     case Distinct(a)            => q"$pack.Distinct($a)"
+    case Nested(a)              => q"$pack.Nested($a)"
   }
 
   implicit val entityLiftable: Liftable[Entity] = Liftable[Entity] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -225,6 +225,9 @@ trait Parsing extends EntityConfigParsing {
     case q"$source.distinct" if (is[CoreDsl#Query[Any]](source)) =>
       Distinct(astParser(source))
 
+    case q"$source.nested" if (is[CoreDsl#Query[Any]](source)) =>
+      Nested(astParser(source))
+
   }
 
   implicit val orderingParser: Parser[Ordering] = Parser[Ordering] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -91,6 +91,7 @@ trait Unliftables {
       Join(t, a, b, iA, iB, on)
 
     case q"$pack.Distinct.apply(${ a: Ast })" => Distinct(a)
+    case q"$pack.Nested.apply(${ a: Ast })"   => Nested(a)
   }
 
   implicit val entityUnliftable: Unliftable[Entity] = Unliftable[Entity] {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -189,7 +189,12 @@ class QuotationSpec extends Spec {
         }
         quote(unquote(q)).ast mustEqual Distinct(Entity("TestEntity"))
       }
-
+      "nested" in {
+        val q = quote {
+          qr1.nested
+        }
+        quote(unquote(q)).ast mustEqual Nested(Entity("TestEntity"))
+      }
       "take" in {
         val q = quote {
           qr1.take(10)


### PR DESCRIPTION
Fixes #520 

### Problem

Quill doesn't allow the user to explicit nest queries.

### Solution

Add the new `query.nested` method API that forces nested queries.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

