### PR TITLE
fix free variables detection for the rhs of joins

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
@@ -48,7 +48,7 @@ case class FreeVariables(state: State)
       case q @ GroupBy(a, b, c)   => (q, free(a, b, c))
       case q @ Join(t, a, b, iA, iB, on) =>
         val (_, freeA) = apply(a)
-        val (_, freeB) = apply(a)
+        val (_, freeB) = apply(b)
         val (_, freeOn) = FreeVariables(State(state.seen + iA + iB, collection.Set.empty))(on)
         (q, FreeVariables(State(state.seen, state.free ++ freeA.state.free ++ freeB.state.free ++ freeOn.state.free)))
       case _: Entity | _: Take | _: Drop | _: Union | _: UnionAll | _: Aggregation | _: Distinct =>

--- a/quill-core/src/test/scala/io/getquill/quotation/FreeVariablesSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/FreeVariablesSpec.scala
@@ -80,6 +80,14 @@ class FreeVariablesSpec extends Spec {
       }
       FreeVariables(q.ast) mustEqual Set(Ident("i"))
     }
+    "join" in {
+      val i = 1
+      val q = quote {
+        qr1.join(qr2.filter(_.i == i))
+          .on((t1, t2) => t1.i == t2.i)
+      }
+      FreeVariables(q.ast) mustEqual Set(Ident("i"))
+    }
   }
 
   "takes in consideration variables defined in the quotation" - {


### PR DESCRIPTION
Fixes #464 

### Problem

Quill doesn't detect free variables on the right hand side of joins.

### Solution

Fix it!

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

