### PR TITLE
cassandra context constructor with ready-made Cluster

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -9,10 +9,16 @@ import io.getquill.util.LoadConfig
 import com.typesafe.config.Config
 import scala.collection.JavaConverters._
 import io.getquill.context.cassandra.CassandraSessionContext
+import com.datastax.driver.core.Cluster
 
-class CassandraAsyncContext[N <: NamingStrategy](config: CassandraContextConfig)
-  extends CassandraSessionContext[N](config) {
+class CassandraAsyncContext[N <: NamingStrategy](
+  cluster:                    Cluster,
+  keyspace:                   String,
+  preparedStatementCacheSize: Long
+)
+  extends CassandraSessionContext[N](cluster, keyspace, preparedStatementCacheSize) {
 
+  def this(config: CassandraContextConfig) = this(config.cluster, config.keyspace, config.preparedStatementCacheSize)
   def this(config: Config) = this(CassandraContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
@@ -11,10 +11,16 @@ import io.getquill.context.cassandra.CassandraSessionContext
 import io.getquill.context.cassandra.util.FutureConversions.toScalaFuture
 import monifu.reactive.Observable
 import io.getquill.util.LoadConfig
+import com.datastax.driver.core.Cluster
 
-class CassandraStreamContext[N <: NamingStrategy](config: CassandraContextConfig)
-  extends CassandraSessionContext[N](config) {
+class CassandraStreamContext[N <: NamingStrategy](
+  cluster:                    Cluster,
+  keyspace:                   String,
+  preparedStatementCacheSize: Long
+)
+  extends CassandraSessionContext[N](cluster, keyspace, preparedStatementCacheSize) {
 
+  def this(config: CassandraContextConfig) = this(config.cluster, config.keyspace, config.preparedStatementCacheSize)
   def this(config: Config) = this(CassandraContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
@@ -6,10 +6,16 @@ import com.typesafe.config.Config
 import io.getquill.util.LoadConfig
 import io.getquill.context.cassandra.CassandraSessionContext
 import scala.collection.JavaConverters._
+import com.datastax.driver.core.Cluster
 
-class CassandraSyncContext[N <: NamingStrategy](config: CassandraContextConfig)
-  extends CassandraSessionContext[N](config) {
+class CassandraSyncContext[N <: NamingStrategy](
+  cluster:                    Cluster,
+  keyspace:                   String,
+  preparedStatementCacheSize: Long
+)
+  extends CassandraSessionContext[N](cluster, keyspace, preparedStatementCacheSize) {
 
+  def this(config: CassandraContextConfig) = this(config.cluster, config.keyspace, config.preparedStatementCacheSize)
   def this(config: Config) = this(CassandraContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 


### PR DESCRIPTION
Fixes #488

### Problem

It's necessary to override the cassandra config in order to use a readr-made `Cluster` instance.

### Solution

Provide constructor that receives a `Cluster

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
