### PR TITLE
cql: support `+` operator

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
@@ -92,7 +92,7 @@ trait CqlIdiom extends Idiom {
 
   implicit val aggregationOperatorTokenizer: Tokenizer[AggregationOperator] = Tokenizer[AggregationOperator] {
     case AggregationOperator.`size` => stmt"COUNT"
-    case o                          => fail(s"Cql doesn't support '$o' aggregationstmt")
+    case o                          => fail(s"Cql doesn't support '$o' aggregations")
   }
 
   implicit val binaryOperatorTokenizer: Tokenizer[BinaryOperator] = Tokenizer[BinaryOperator] {
@@ -102,6 +102,7 @@ trait CqlIdiom extends Idiom {
     case NumericOperator.`>=`   => stmt">="
     case NumericOperator.`<`    => stmt"<"
     case NumericOperator.`<=`   => stmt"<="
+    case NumericOperator.`+`    => stmt"+"
     case SetOperator.`contains` => stmt"IN"
     case other                  => fail(s"Cql doesn't support the '$other' operator.")
   }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
@@ -194,6 +194,13 @@ class CqlIdiomSpec extends Spec {
       mirrorContext.run(q).string mustEqual
         "SELECT s, i, l, o FROM TestEntity WHERE i <= 1"
     }
+    "+" in {
+      val q = quote {
+        qr1.update(t => t.i -> (t.i + 1))
+      }
+      mirrorContext.run(q).string mustEqual
+        "UPDATE TestEntity SET i = i + 1"
+    }
     "invalid" in {
       val q = quote {
         qr1.filter(t => t.i * 2 == 4)


### PR DESCRIPTION
Fixes #465 

### Problem

`CqlIdiom` doesn't support `+`.

### Solution

Add pattern to support it.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

