### PR TITLE
Use different empty query for mysql and postgres

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/MySQLDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/MySQLDialect.scala
@@ -21,6 +21,8 @@ trait MySQLDialect
   with OffsetWithoutLimitWorkaround
   with QuestionMarkBindVariables {
 
+  override def emptyQuery = "SELECT 0 FROM DUAL WHERE FALSE"
+
   override def prepareForProbing(string: String) = {
     val quoted = string.replace("'", "\\'")
     s"PREPARE p${quoted.hashCode.abs.toString.token} FROM '$quoted'"

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -29,7 +29,7 @@ trait SqlIdiom extends Idiom {
 
   override def prepareForProbing(string: String): String
 
-  override def emptyQuery = "SELECT 0 FROM (SELECT 0) AS QUILL_EMPTY_SET WHERE 1 = 0"
+  override def emptyQuery = "SELECT 0 LIMIT 0"
 
   override def translate(ast: Ast)(implicit naming: NamingStrategy) = {
     val normalizedAst = SqlNormalize(ast)


### PR DESCRIPTION
### Problem

The `emptyQuery` introduced previously is too complicated.
And mysql has very poor optimise for such queries
Before
```
mysql> select * from xxx where id in(SELECT 0 FROM (SELECT 0) AS QUILL_EMPTY_SET WHERE 1 = 0);
Empty set (8.54 sec)

```
After
```
mysql> select * from xxx where id in(select 0 from dual where false);
Empty set (0.01 sec)
```

### Solution

use different `emptyQuery` for different dialect

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

