### PR TITLE
check types when parsing assignments and equality operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,17 +541,6 @@ ctx.run(a)
 // INSERT INTO Contact (personId,phone) VALUES (?, ?)
 ```
 
-Or column queries:
-
-```scala
-val a = quote {
-  query[Person].insert(_.id -> lift(999), _.age -> query[Person].map(p => p.age).max)
-}
-
-ctx.run(a)
-// INSERT INTO Person (id,age) VALUES (?, (SELECT MAX(p.age) FROM Person p))
-```
-
 **batch insert**
 
 ```scala
@@ -593,17 +582,6 @@ val a = quote {
 
 ctx.run(a)
 // UPDATE Person SET age = (age + 1) WHERE id = ?
-```
-
-Using column a query:
-
-```scala
-val a = quote {
-  query[Person].filter(p => p.id == lift(999)).update(_.age -> query[Person].map(p => p.age).max)
-}
-
-ctx.run(a)
-// UPDATE Person SET age = (SELECT MAX(p.age) FROM Person p) WHERE id = ?
 ```
 
 **batch update**

--- a/quill-async/src/test/scala/io/getquill/context/async/mysql/ProductMysqlAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/context/async/mysql/ProductMysqlAsyncSpec.scala
@@ -70,6 +70,7 @@ class ProductMysqlAsyncSpec extends ProductSpec {
 
     "supports casts from string to number" - {
       "toInt" in {
+        case class Product(id: Long, description: String, sku: Int)
         val queried = await {
           testContext.run {
             query[Product].filter(_.sku == lift("1004").toInt)

--- a/quill-async/src/test/scala/io/getquill/context/async/postgres/ProductPostgresAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/context/async/postgres/ProductPostgresAsyncSpec.scala
@@ -69,6 +69,7 @@ class ProductPostgresAsyncSpec extends ProductSpec {
 
     "supports casts from string to number" - {
       "toInt" in {
+        case class Product(id: Long, description: String, sku: Int)
         val queried = await {
           testContext.run {
             query[Product].filter(_.sku == lift("1004").toInt)

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
@@ -218,11 +218,12 @@ class CqlIdiomSpec extends Spec {
         "SELECT s, i, l, o FROM TestEntity WHERE s = 's'"
     }
     "unit" in {
+      case class Test(u: Unit)
       val q = quote {
-        qr1.filter(t => t.i == (()))
+        query[Test].filter(t => t.u == (())).size
       }
       mirrorContext.run(q).string mustEqual
-        "SELECT s, i, l, o FROM TestEntity WHERE i = 1"
+        "SELECT COUNT(1) FROM Test WHERE u = 1"
     }
     "int" in {
       val q = quote {

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/norm/RenamePropertiesSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/norm/RenamePropertiesSpec.scala
@@ -27,10 +27,10 @@ class RenamePropertiesSpec extends Spec {
 
       "insert assigned" in {
         val q = quote {
-          e.insert(_.i -> 1, _.l -> 1L, _.o -> 1, _.s -> "test")
+          e.insert(_.i -> lift(1), _.l -> lift(1L), _.o -> lift(Option(1)), _.s -> lift("test"))
         }
         mirrorContext.run(q).string mustEqual
-          "INSERT INTO test_entity (field_i,l,o,field_s) VALUES (1, 1, 1, 'test')"
+          "INSERT INTO test_entity (field_i,l,o,field_s) VALUES (?, ?, ?, ?)"
       }
       "update" in {
         val q = quote {

--- a/quill-core/src/test/scala/io/getquill/context/EncodeBindVariablesSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/EncodeBindVariablesSpec.scala
@@ -29,7 +29,7 @@ class EncodeBindVariablesSpec extends Spec {
 
   "fails if there isn't an encoder for the binded value" in {
     val q = quote {
-      (i: Thread) => qr1.filter(_.i == i)
+      (i: Thread) => qr1.map(t => i)
     }
     "testContext.run(q)(new Thread)" mustNot compile
   }
@@ -41,7 +41,7 @@ class EncodeBindVariablesSpec extends Spec {
     }
     val d = 1D
     val q = quote {
-      qr1.filter(_.i == lift(d))
+      qr1.map(t => lift(d))
     }
     testContext.run(q).prepareRow mustEqual Row(1D)
   }
@@ -51,10 +51,10 @@ class EncodeBindVariablesSpec extends Spec {
     "encodes `WrappedValue` extended value class" in {
       case class Entity(x: WrappedEncodable)
       val q = quote {
-        query[Entity].filter(_.x == lift(WrappedEncodable(1)))
+        query[Entity].filter(t => t.x == lift(WrappedEncodable(1)))
       }
       val r = testContext.run(q)
-      r.string mustEqual "query[Entity].filter(x3 => x3.x == ?).map(x3 => x3.x)"
+      r.string mustEqual "query[Entity].filter(t => t.x == ?).map(t => t.x)"
       r.prepareRow mustEqual Row(1)
     }
 
@@ -65,10 +65,10 @@ class EncodeBindVariablesSpec extends Spec {
       case class Entity(x: Wrapped)
 
       val q = quote {
-        query[Entity].filter(_.x == lift(Wrapped(1)))
+        query[Entity].filter(t => t.x == lift(Wrapped(1)))
       }
       val r = testContext.run(q)
-      r.string mustEqual "query[Entity].filter(x4 => x4.x == ?).map(x4 => x4.x)"
+      r.string mustEqual "query[Entity].filter(t => t.x == ?).map(t => t.x)"
       r.prepareRow mustEqual Row(1)
     }
 

--- a/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
@@ -393,10 +393,10 @@ class MirrorIdiomSpec extends Spec {
     }
     "null" in {
       val q = quote {
-        1 != null
+        "a" != null
       }
       stmt"${(q.ast: Ast).token}" mustEqual
-        stmt"""1 != null"""
+        stmt""""a" != null"""
     }
     "tuple" in {
       val q = quote {

--- a/quill-core/src/test/scala/io/getquill/norm/NormalizeNestedStructuresSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/NormalizeNestedStructuresSpec.scala
@@ -10,11 +10,11 @@ import io.getquill.testContext.unquote
 class NormalizeNestedStructuresSpec extends Spec {
 
   val unormalized = quote {
-    qr1.map(x => x.i).take(1).max
+    qr1.map(x => x.i).take(1).size
   }
 
   val normalized = quote {
-    qr1.take(1).map(x => x.i).max
+    qr1.take(1).map(x => x.i).size
   }
 
   "returns Some if a nested structure changes" - {
@@ -92,57 +92,57 @@ class NormalizeNestedStructuresSpec extends Spec {
     }
     "union" in {
       val q = quote {
-        qr1.filter(t => unormalized == 1).union(qr1)
+        qr1.filter(t => unormalized == 1L).union(qr1)
       }
       val n = quote {
-        qr1.filter(t => normalized == 1).union(qr1)
+        qr1.filter(t => normalized == 1L).union(qr1)
       }
       NormalizeNestedStructures.unapply(q.ast) mustEqual Some(n.ast)
     }
     "unionAll" in {
       val q = quote {
-        qr1.filter(t => unormalized == 1).unionAll(qr1)
+        qr1.filter(t => unormalized == 1L).unionAll(qr1)
       }
       val n = quote {
-        qr1.filter(t => normalized == 1).unionAll(qr1)
+        qr1.filter(t => normalized == 1L).unionAll(qr1)
       }
       NormalizeNestedStructures.unapply(q.ast) mustEqual Some(n.ast)
     }
     "outer join" - {
       "left" in {
         val q = quote {
-          qr1.filter(t => unormalized == 1).rightJoin(qr1).on((a, b) => a.s == b.s)
+          qr1.filter(t => unormalized == 1L).rightJoin(qr1).on((a, b) => a.s == b.s)
         }
         val n = quote {
-          qr1.filter(t => normalized == 1).rightJoin(qr1).on((a, b) => a.s == b.s)
+          qr1.filter(t => normalized == 1L).rightJoin(qr1).on((a, b) => a.s == b.s)
         }
         NormalizeNestedStructures.unapply(q.ast) mustEqual Some(n.ast)
       }
       "right" in {
         val q = quote {
-          qr1.rightJoin(qr1.filter(t => unormalized == 1)).on((a, b) => a.s == b.s)
+          qr1.rightJoin(qr1.filter(t => unormalized == 1L)).on((a, b) => a.s == b.s)
         }
         val n = quote {
-          qr1.rightJoin(qr1.filter(t => normalized == 1)).on((a, b) => a.s == b.s)
+          qr1.rightJoin(qr1.filter(t => normalized == 1L)).on((a, b) => a.s == b.s)
         }
         NormalizeNestedStructures.unapply(q.ast) mustEqual Some(n.ast)
       }
       "on" in {
         val q = quote {
-          qr1.rightJoin(qr1).on((a, b) => unormalized == 1)
+          qr1.rightJoin(qr1).on((a, b) => unormalized == 1L)
         }
         val n = quote {
-          qr1.rightJoin(qr1).on((a, b) => normalized == 1)
+          qr1.rightJoin(qr1).on((a, b) => normalized == 1L)
         }
         NormalizeNestedStructures.unapply(q.ast) mustEqual Some(n.ast)
       }
     }
     "distinct" in {
       val q = quote {
-        qr1.filter(t => unormalized == 1).distinct
+        qr1.filter(t => unormalized == 1L).distinct
       }
       val n = quote {
-        qr1.filter(t => normalized == 1).distinct
+        qr1.filter(t => normalized == 1L).distinct
       }
       NormalizeNestedStructures.unapply(q.ast) mustEqual Some(n.ast)
     }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -259,9 +259,9 @@ class QuotationSpec extends Spec {
 
         "fails if not followed by 'on'" in {
           """
-          quote {
-            qr1.fullJoin(qr2)
-          }
+            quote {
+              qr1.fullJoin(qr2)
+            }
           """ mustNot compile
         }
       }
@@ -352,10 +352,17 @@ class QuotationSpec extends Spec {
         }
         quote(unquote(q)).ast mustEqual Delete(Entity("TestEntity"))
       }
+      "fails if the assignment types don't match" in {
+        """
+          quote {
+            qr1.update(t => t.i -> "s")
+          }
+        """ mustNot compile
+      }
     }
     "value" - {
       "null" in {
-        val q = quote(1 != null)
+        val q = quote("s" != null)
         quote(unquote(q)).ast.b mustEqual NullValue
       }
       "constant" in {
@@ -435,11 +442,20 @@ class QuotationSpec extends Spec {
       }
     }
     "binary operation" - {
-      "==" in {
-        val q = quote {
-          (a: Int, b: Int) => a == b
+      "==" - {
+        "normal" in {
+          val q = quote {
+            (a: Int, b: Int) => a == b
+          }
+          quote(unquote(q)).ast.body mustEqual BinaryOperation(Ident("a"), EqualityOperator.`==`, Ident("b"))
         }
-        quote(unquote(q)).ast.body mustEqual BinaryOperation(Ident("a"), EqualityOperator.`==`, Ident("b"))
+        "fails if the types don't match" in {
+          """
+            quote {
+              (a: Int, b: String) => a == b
+            }
+          """ mustNot compile
+        }
       }
       "equals" in {
         val q = quote {

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/ProductFinagleMysqlSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/ProductFinagleMysqlSpec.scala
@@ -66,6 +66,7 @@ class ProductFinagleMysqlSpec extends ProductSpec {
 
     "supports casts from string to number" - {
       "toInt" in {
+        case class Product(id: Long, description: String, sku: Int)
         val queried = await {
           testContext.run {
             query[Product].filter(_.sku == lift("1004").toInt)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/ProductJdbcSpec.scala
@@ -65,6 +65,7 @@ class ProductJdbcSpec extends ProductSpec {
 
     "supports casts from string to number" - {
       "toInt" in {
+        case class Product(id: Long, description: String, sku: Int)
         val queried = testContext.run {
           query[Product].filter(_.sku == lift("1004").toInt)
         }.head

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/ProductJdbcSpec.scala
@@ -59,6 +59,7 @@ class ProductJdbcSpec extends ProductSpec {
 
     "supports casts from string to number" - {
       "toInt" in {
+        case class Product(id: Long, description: String, sku: Int)
         val queried = testContext.run {
           query[Product].filter(_.sku == lift("1004").toInt)
         }.head

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ProductJdbcSpec.scala
@@ -61,6 +61,7 @@ class ProductJdbcSpec extends ProductSpec {
 
     "supports casts from string to number" - {
       "toInt" in {
+        case class Product(id: Long, description: String, sku: Int)
         val queried = testContext.run {
           query[Product].filter(_.sku == lift("1004").toInt)
         }.head

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/ProductJdbcSpec.scala
@@ -61,6 +61,7 @@ class ProductJdbcSpec extends ProductSpec {
 
     "supports casts from string to number" - {
       "toInt" in {
+        case class Product(id: Long, description: String, sku: Int)
         val queried = testContext.run {
           query[Product].filter(_.sku == lift("1004").toInt)
         }.head

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
@@ -166,7 +166,7 @@ trait EncodingSpec extends Spec {
   val insertBarCode = quote((b: BarCode) => query[BarCode].insert(b).returning(_.uuid))
   val barCodeEntry = BarCode("returning UUID")
 
-  def findBarCodeByUuid(uuid: UUID)(implicit enc: Encoder[UUID]) = quote(query[BarCode].filter(_.uuid == lift(uuid)))
+  def findBarCodeByUuid(uuid: UUID)(implicit enc: Encoder[UUID]) = quote(query[BarCode].filter(_.uuid == lift(Option(uuid))))
 
   def verifyBarcode(barCode: BarCode) = barCode.description mustEqual "returning UUID"
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -356,10 +356,10 @@ class SqlQuerySpec extends Spec {
       }
       "filter + map" in {
         val q = quote {
-          qr1.filter(t => t == 1).nested.map(t => t.i)
+          qr1.filter(t => t.i == 1).nested.map(t => t.i)
         }
         testContext.run(q).string mustEqual
-          "SELECT t.i FROM (SELECT t.i FROM TestEntity t WHERE t = 1) t"
+          "SELECT t.i FROM (SELECT t.i FROM TestEntity t WHERE t.i = 1) t"
       }
     }
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -26,10 +26,10 @@ class RenamePropertiesSpec extends Spec {
 
       "insert assigned" in {
         val q = quote {
-          e.insert(_.i -> 1, _.l -> 1L, _.o -> 1, _.s -> "test")
+          e.insert(_.i -> lift(1), _.l -> lift(1L), _.o -> lift(Option(1)), _.s -> lift("test"))
         }
         testContext.run(q).string mustEqual
-          "INSERT INTO test_entity (field_i,l,o,field_s) VALUES (1, 1, 1, 'test')"
+          "INSERT INTO test_entity (field_i,l,o,field_s) VALUES (?, ?, ?, ?)"
       }
       "update" in {
         val q = quote {


### PR DESCRIPTION
Fixes #446, #200 

### Problem

Assignments and equality operations don't check the types of the terms.

### Solution

Check types during parsing.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers