### PR TITLE
Longer example and quote usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,16 @@ val q: Quoted[Query[Circle]] = quote {
 ctx.run(q) // Dynamic query
 ```
 
-Quill falls back to runtime normalization and query generation if the quotation's AST can't be read at compile-time. Please refer to [dynamic queries](#dynamic-queries) for more information
+Quill falls back to runtime normalization and query generation if the quotation's AST can't be read at compile-time. Please refer to [dynamic queries](#dynamic-queries) for more information.
+
+#### Inline queries
+
+Quoting is implicit when writing a query in a `run` statement.
+
+```scala
+ctx.run(query[Circle].map(_.radius))
+// SELECT r.radius FROM Circle r
+```
 
 Bindings
 --------


### PR DESCRIPTION
### Problem

As suggested on Gitter, there should be a note in the readme about the redondant usage of `quote` inside `run`. Moreover providing a more concrete example could also be pleasant to first time Quill users.

### Solution

Add an example to `README.md`.

### Notes

One style of writing query should be chosen. Not sure whether this one correspond to everyone's opinions. 

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
