### PR TITLE
fix class cast exception for returned values

### DIFF
--- a/quill-async/src/main/scala/io/getquill/MysqlAsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/MysqlAsyncContext.scala
@@ -7,6 +7,7 @@ import com.github.mauricio.async.db.pool.PartitionedConnectionPool
 import com.typesafe.config.Config
 import io.getquill.context.async.AsyncContext
 import io.getquill.util.LoadConfig
+import com.github.mauricio.async.db.general.ArrayRowData
 
 class MysqlAsyncContext[N <: NamingStrategy](pool: PartitionedConnectionPool[MySQLConnection])
   extends AsyncContext[MySQLDialect, N, MySQLConnection](pool) {
@@ -17,8 +18,10 @@ class MysqlAsyncContext[N <: NamingStrategy](pool: PartitionedConnectionPool[MyS
 
   override protected def extractActionResult[O](returningColumn: String, returningExtractor: RowData => O)(result: DBQueryResult): O = {
     result match {
-      case r: MySQLQueryResult => r.lastInsertId.asInstanceOf[O]
-      case _                   => throw new IllegalStateException("This is a bug. Cannot extract returning value.")
+      case r: MySQLQueryResult =>
+        returningExtractor(new ArrayRowData(0, Map.empty, Array(r.lastInsertId)))
+      case _ =>
+        throw new IllegalStateException("This is a bug. Cannot extract returning value.")
     }
   }
 }

--- a/quill-async/src/test/scala/io/getquill/context/async/mysql/ProductMysqlAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/context/async/mysql/ProductMysqlAsyncSpec.scala
@@ -6,6 +6,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import io.getquill.context.sql.ProductSpec
+import io.getquill.context.sql.Id
 
 class ProductMysqlAsyncSpec extends ProductSpec {
 
@@ -57,6 +58,15 @@ class ProductMysqlAsyncSpec extends ProductSpec {
       returnedProduct.description mustEqual "test2"
       returnedProduct.sku mustEqual 2L
       returnedProduct.id mustEqual inserted
+    }
+
+    "Single insert with wrapped value" in {
+      case class Product(id: Id, description: String, sku: Long)
+      val prd = Product(Id(0L), "test2", 2L)
+      val q1 = quote {
+        query[Product].insert(_.sku -> lift(prd.sku), _.description -> lift(prd.description)).returning(_.id)
+      }
+      await(testContext.run(q1)) mustBe a[Id]
     }
 
     "Single product insert with a method quotation" in {

--- a/quill-async/src/test/scala/io/getquill/context/async/postgres/ProductPostgresAsyncSpec.scala
+++ b/quill-async/src/test/scala/io/getquill/context/async/postgres/ProductPostgresAsyncSpec.scala
@@ -6,6 +6,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
 import io.getquill.context.sql.ProductSpec
+import io.getquill.context.sql.Id
 
 class ProductPostgresAsyncSpec extends ProductSpec {
 
@@ -65,6 +66,15 @@ class ProductPostgresAsyncSpec extends ProductSpec {
       returnedProduct.description mustEqual "test3"
       returnedProduct.sku mustEqual 3L
       returnedProduct.id mustEqual inserted
+    }
+
+    "Single insert with wrapped value" in {
+      case class Product(id: Id, description: String, sku: Long)
+      val prd = Product(Id(0L), "test2", 2L)
+      val q1 = quote {
+        query[Product].insert(_.sku -> lift(prd.sku), _.description -> lift(prd.description)).returning(_.id)
+      }
+      await(testContext.run(q1)) mustBe a[Id]
     }
 
     "supports casts from string to number" - {

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/SingleValueRow.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/SingleValueRow.scala
@@ -1,0 +1,10 @@
+package io.getquill.context.finagle.mysql
+
+import com.twitter.finagle.exp.mysql.Row
+import com.twitter.finagle.exp.mysql.Value
+
+case class SingleValueRow(value: Value) extends Row {
+  override val values = IndexedSeq(value)
+  override val fields = IndexedSeq.empty
+  override def indexOf(columnName: String) = None
+}

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/ProductFinagleMysqlSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/ProductFinagleMysqlSpec.scala
@@ -3,6 +3,7 @@ package io.getquill.context.finagle.mysql
 import io.getquill.context.sql.ProductSpec
 import com.twitter.util.Await
 import com.twitter.util.Future
+import io.getquill.context.sql.Id
 
 class ProductFinagleMysqlSpec extends ProductSpec {
 
@@ -62,6 +63,15 @@ class ProductFinagleMysqlSpec extends ProductSpec {
       returnedProduct.description mustEqual "test3"
       returnedProduct.sku mustEqual 3L
       returnedProduct.id mustEqual inserted
+    }
+
+    "Single insert with wrapped value" in {
+      case class Product(id: Id, description: String, sku: Long)
+      val prd = Product(Id(0L), "test2", 2L)
+      val q1 = quote {
+        query[Product].insert(_.sku -> lift(prd.sku), _.description -> lift(prd.description)).returning(_.id)
+      }
+      await(testContext.run(q1)) mustBe a[Id]
     }
 
     "supports casts from string to number" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/ProductSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/ProductSpec.scala
@@ -1,6 +1,9 @@
 package io.getquill.context.sql
 
 import io.getquill.Spec
+import io.getquill.WrappedValue
+
+case class Id(value: Long) extends AnyVal with WrappedValue[Long]
 
 trait ProductSpec extends Spec {
 


### PR DESCRIPTION
Fixes #533 

### Problem

Drivers that don't support reading arbitrary returning types from action executions don't use the `extractor` instance, producing a class cast exception if the id is a `WrappedValue`.

### Solution

Create single-element rows and use the extractor instance.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
