### PR TITLE
Add link to scala-db-codegen in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,6 +1355,10 @@ ScalaDays Berlin 2016 - [Scylla, Charybdis, and the mystery of Quill](https://ww
 
 Scalac.io blog - [Compile-time Queries with Quill](http://blog.scalac.io/2016/07/21/compile-time-queries-with-quill.html)
 
+**Tools**
+
+Code/boilerplate generator from db schema - [scala-db-codegen](https://github.com/olafurpg/scala-db-codegen)
+
 Code of Conduct
 ---------------
 


### PR DESCRIPTION
Related #265, see [this comment](https://github.com/getquill/quill/issues/265#issuecomment-242616238).

### Problem

Writing case classes from a db schema is tedious and error prone.

### Solution

scala-db-codegen can automatically generate classes/boilerplate from a db schema.

@getquill/maintainers
