### PR TITLE
Update finagle-mysql

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val `quill-finagle-mysql` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "com.twitter" %% "finagle-mysql" % "6.36.0"
+        "com.twitter" %% "finagle-mysql" % "6.37.0"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -6,12 +6,13 @@ import scala.util.Try
 
 import org.slf4j.LoggerFactory
 
-import com.twitter.finagle.exp.mysql.Client
-import com.twitter.finagle.exp.mysql.OK
-import com.twitter.finagle.exp.mysql.Parameter
-import com.twitter.finagle.exp.mysql.Result
-import com.twitter.finagle.exp.mysql.Row
-import com.twitter.finagle.exp.mysql.Transactions
+import com.twitter.finagle.mysql.Client
+import com.twitter.finagle.mysql.LongValue
+import com.twitter.finagle.mysql.OK
+import com.twitter.finagle.mysql.Parameter
+import com.twitter.finagle.mysql.Result
+import com.twitter.finagle.mysql.Row
+import com.twitter.finagle.mysql.Transactions
 import com.twitter.util.Await
 import com.twitter.util.Future
 import com.twitter.util.Local
@@ -20,11 +21,10 @@ import com.typesafe.scalalogging.Logger
 
 import io.getquill.context.finagle.mysql.FinagleMysqlDecoders
 import io.getquill.context.finagle.mysql.FinagleMysqlEncoders
+import io.getquill.context.finagle.mysql.SingleValueRow
 import io.getquill.context.sql.SqlContext
 import io.getquill.util.LoadConfig
 import io.getquill.util.Messages.fail
-import io.getquill.context.finagle.mysql.SingleValueRow
-import com.twitter.finagle.exp.mysql.LongValue
 
 class FinagleMysqlContext[N <: NamingStrategy](
   client:                             Client with Transactions,

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContextConfig.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContextConfig.scala
@@ -2,7 +2,7 @@ package io.getquill
 
 import java.util.TimeZone
 import com.twitter.finagle.client.DefaultPool
-import com.twitter.finagle.exp.Mysql
+import com.twitter.finagle.Mysql
 import com.twitter.util.Try
 import com.typesafe.config.Config
 import com.twitter.util.TimeConversions._

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
@@ -3,21 +3,21 @@ package io.getquill.context.finagle.mysql
 import java.util.Date
 import scala.reflect.ClassTag
 import scala.reflect.classTag
-import com.twitter.finagle.exp.mysql.BigDecimalValue
-import com.twitter.finagle.exp.mysql.ByteValue
-import com.twitter.finagle.exp.mysql.DoubleValue
-import com.twitter.finagle.exp.mysql.FloatValue
-import com.twitter.finagle.exp.mysql.IntValue
-import com.twitter.finagle.exp.mysql.LongValue
-import com.twitter.finagle.exp.mysql.RawValue
-import com.twitter.finagle.exp.mysql.Row
-import com.twitter.finagle.exp.mysql.ShortValue
-import com.twitter.finagle.exp.mysql.StringValue
-import com.twitter.finagle.exp.mysql.TimestampValue
-import com.twitter.finagle.exp.mysql.Type
-import com.twitter.finagle.exp.mysql.Value
+import com.twitter.finagle.mysql.BigDecimalValue
+import com.twitter.finagle.mysql.ByteValue
+import com.twitter.finagle.mysql.DoubleValue
+import com.twitter.finagle.mysql.FloatValue
+import com.twitter.finagle.mysql.IntValue
+import com.twitter.finagle.mysql.LongValue
+import com.twitter.finagle.mysql.NullValue
+import com.twitter.finagle.mysql.RawValue
+import com.twitter.finagle.mysql.Row
+import com.twitter.finagle.mysql.ShortValue
+import com.twitter.finagle.mysql.StringValue
+import com.twitter.finagle.mysql.TimestampValue
+import com.twitter.finagle.mysql.Type
+import com.twitter.finagle.mysql.Value
 import io.getquill.util.Messages.fail
-import com.twitter.finagle.exp.mysql.NullValue
 import io.getquill.FinagleMysqlContext
 
 trait FinagleMysqlDecoders {

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
@@ -1,11 +1,11 @@
 package io.getquill.context.finagle.mysql
 
 import java.util.Date
-import com.twitter.finagle.exp.mysql.BigDecimalValue
-import com.twitter.finagle.exp.mysql.CanBeParameter
-import com.twitter.finagle.exp.mysql.CanBeParameter._
-import com.twitter.finagle.exp.mysql.Parameter
-import com.twitter.finagle.exp.mysql.Parameter.wrap
+import com.twitter.finagle.mysql.BigDecimalValue
+import com.twitter.finagle.mysql.CanBeParameter
+import com.twitter.finagle.mysql.CanBeParameter._
+import com.twitter.finagle.mysql.Parameter
+import com.twitter.finagle.mysql.Parameter.wrap
 import io.getquill.FinagleMysqlContext
 
 trait FinagleMysqlEncoders {

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/SingleValueRow.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/SingleValueRow.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.finagle.mysql
 
-import com.twitter.finagle.exp.mysql.Row
-import com.twitter.finagle.exp.mysql.Value
+import com.twitter.finagle.mysql.Row
+import com.twitter.finagle.mysql.Value
 
 case class SingleValueRow(value: Value) extends Row {
   override val values = IndexedSeq(value)


### PR DESCRIPTION
Fixes #544 

### Problem

The lib finagle-mysql was released from experimental. The project should use this version.

### Solution

This PR updates the lib and references to the latest version.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [This PR updates the lib and references.
] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

