### PR TITLE
introduce `finagle-postgres`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,6 +1282,46 @@ ctx.pool.bufferSize=0
 ctx.pool.maxWaiters=2147483647
 ```
 
+##### quill-finagle-postgres
+
+**Transactions**
+
+The finagle context provides transaction support through a `Local` value. See twitter util's [scaladoc](https://github.com/twitter/util/blob/ee8d3140ba0ecc16b54591bd9d8961c11b999c0d/util-core/src/main/scala/com/twitter/util/Local.scala#L96) for more details.
+
+```
+ctx.transaction {
+  ctx.run(query[Person].delete)
+  // other transactional code
+}
+```
+
+The body of `transaction` can contain calls to other methods and multiple `run` calls, since the transaction is automatically propagated through the `Local` value.
+
+sbt dependencies
+```
+libraryDependencies ++= Seq(
+  "io.getquill" %% "quill-finagle-postgres" % "0.10.1-SNAPSHOT"
+)
+```
+
+context definition
+```scala
+lazy val ctx = new FinaglePostgresContext[SnakeCase]("ctx")
+```
+
+application.properties
+```
+ctx.host=localhost:3306
+ctx.user=root
+ctx.password=root
+ctx.database=database
+ctx.useSsl=false
+ctx.hostConnectionLimit=1
+ctx.numRetries=4
+ctx.binaryResults=false
+ctx.binaryParams=false
+```
+
 Cassandra Contexts
 -----------------
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,12 +9,12 @@ lazy val `quill` =
     .settings(`tut-settings`:_*)
     .dependsOn(
       `quill-core-jvm`, `quill-core-js`, `quill-sql-jvm`, `quill-sql-js`,
-      `quill-jdbc`, `quill-finagle-mysql`, `quill-async`, `quill-async-mysql`,
-      `quill-async-postgres`, `quill-cassandra`
+      `quill-jdbc`, `quill-finagle-mysql`, `quill-finagle-postgres`, `quill-async`,
+      `quill-async-mysql`, `quill-async-postgres`, `quill-cassandra`
     ).aggregate(
       `quill-core-jvm`, `quill-core-js`, `quill-sql-jvm`, `quill-sql-js`,
-      `quill-jdbc`, `quill-finagle-mysql`, `quill-async`, `quill-async-mysql`,
-      `quill-async-postgres`, `quill-cassandra`
+      `quill-jdbc`, `quill-finagle-mysql`, `quill-finagle-postgres`, `quill-async`,
+      `quill-async-mysql`, `quill-async-postgres`, `quill-cassandra`
     )
 
 lazy val superPure = new org.scalajs.sbtplugin.cross.CrossType {
@@ -80,6 +80,18 @@ lazy val `quill-finagle-mysql` =
       fork in Test := true,
       libraryDependencies ++= Seq(
         "com.twitter" %% "finagle-mysql" % "6.37.0"
+      )
+    )
+    .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
+
+lazy val `quill-finagle-postgres` = 
+  (project in file("quill-finagle-postgres"))
+    .settings(commonSettings: _*)
+    .settings(mimaSettings: _*)
+    .settings(
+      fork in Test := true,
+      libraryDependencies ++= Seq(
+        "io.github.finagle" %% "finagle-postgres" % "0.2.0"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")

--- a/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresDialect.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresDialect.scala
@@ -1,0 +1,9 @@
+package io.getquill
+
+import io.getquill.context.sql.idiom.PositionalBindVariables
+
+trait FinaglePostgresDialect
+  extends PostgresDialect
+  with PositionalBindVariables
+
+object FinaglePostgresDialect extends FinaglePostgresDialect

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/FinaglePostgresContext.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/FinaglePostgresContext.scala
@@ -49,10 +49,13 @@ class FinaglePostgresContext[N <: NamingStrategy](client: Client) extends SqlCon
     withClient(_.prepareAndQuery(sql, prepare(Nil): _*)(extractor).map(_.toList))
   }
 
-  def executeQuerySingle[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[T] = executeQuery(sql, prepare, extractor).map(handleSingleResult)
+  def executeQuerySingle[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[T] =
+    executeQuery(sql, prepare, extractor).map(handleSingleResult)
 
-  def executeAction[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[Long] =
+  def executeAction[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[Long] = {
+    logger.info(sql)
     withClient(_.prepareAndExecute(sql, prepare(Nil): _*)).map(_.toLong)
+  }
 
   def executeBatchAction[B](groups: List[BatchGroup]): Future[List[Long]] = Future.collect {
     groups.map {

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/FinaglePostgresContext.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/FinaglePostgresContext.scala
@@ -1,0 +1,89 @@
+package io.getquill
+
+import com.twitter.util.{ Await, Future, Local }
+import com.twitter.finagle.postgres._
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.Logger
+import io.getquill.context.finagle.postgres._
+import io.getquill.context.sql.SqlContext
+import io.getquill.util.LoadConfig
+import org.slf4j.LoggerFactory
+import scala.util.Try
+
+class FinaglePostgresContext[N <: NamingStrategy](client: Client) extends SqlContext[FinaglePostgresDialect, N] with FinaglePostgresEncoders with FinaglePostgresDecoders {
+
+  def this(config: FinaglePostgresContextConfig) = this(config.client)
+  def this(config: Config) = this(FinaglePostgresContextConfig(config))
+  def this(configPrefix: String) = {
+    this(LoadConfig(configPrefix))
+  }
+
+  protected val logger: Logger =
+    Logger(LoggerFactory.getLogger(classOf[FinaglePostgresContext[_]]))
+
+  override type PrepareRow = List[Param[_]]
+  override type ResultRow = Row
+  override type RunQueryResult[T] = Future[List[T]]
+  override type RunQuerySingleResult[T] = Future[T]
+  override type RunActionResult = Future[Long]
+  override type RunActionReturningResult[T] = Future[T]
+  override type RunBatchActionResult = Future[List[Long]]
+  override type RunBatchActionReturningResult[T] = Future[List[T]]
+
+  private val currentClient = new Local[Client]
+
+  override def close = Await.result(client.close())
+
+  private def expandAction(sql: String, returningColumn: String): String =
+    s"$sql RETURNING $returningColumn"
+
+  def probe(sql: String) = Try(Await.result(client.query(sql)))
+
+  def transaction[T](f: => Future[T]) = client.inTransaction { c =>
+    currentClient.update(c)
+    f.ensure(currentClient.clear)
+  }
+
+  def executeQuery[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[List[T]] = {
+    logger.info(sql)
+    withClient(_.prepareAndQuery(sql, prepare(Nil): _*)(extractor).map(_.toList))
+  }
+
+  def executeQuerySingle[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[T] = executeQuery(sql, prepare, extractor).map(handleSingleResult)
+
+  def executeAction[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[Long] =
+    withClient(_.prepareAndExecute(sql, prepare(Nil): _*)).map(_.toLong)
+
+  def executeBatchAction[B](groups: List[BatchGroup]): Future[List[Long]] = Future.collect {
+    groups.map {
+      case BatchGroup(sql, prepare) =>
+        prepare.foldLeft(Future.value(List.empty[Long])) {
+          case (acc, prepare) =>
+            acc.flatMap { list =>
+              executeAction(sql, prepare).map(list :+ _)
+            }
+        }
+    }
+  }.map(_.flatten.toList)
+
+  def executeActionReturning[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T, returningColumn: String): Future[T] = {
+    logger.info(sql)
+    withClient(_.prepareAndQuery(expandAction(sql, returningColumn), prepare(List()): _*)(extractor)).map(v => handleSingleResult(v.toList))
+  }
+
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Row => T): Future[List[T]] =
+    Future.collect {
+      groups.map {
+        case BatchGroupReturning(sql, column, prepare) =>
+          prepare.foldLeft(Future.value(List.empty[T])) {
+            case (acc, prepare) =>
+              acc.flatMap { list =>
+                executeActionReturning(sql, prepare, extractor, column).map(list :+ _)
+              }
+          }
+      }
+    }.map(_.flatten.toList)
+
+  private def withClient[T](f: Client => T) =
+    currentClient().map(f).getOrElse(f(client))
+}

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/FinaglePostgresContextConfig.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/FinaglePostgresContextConfig.scala
@@ -1,0 +1,34 @@
+package io.getquill
+
+import com.typesafe.config.Config
+import com.twitter.finagle.postgres.Client
+import com.twitter.finagle.postgres.values._
+import scala.util.Try
+
+case class FinaglePostgresContextConfig(config: Config) {
+  def host: String = config.getString("host")
+  def username: String = config.getString("user")
+  def password: Option[String] = Try(config.getString("password")).toOption
+  def database: String = config.getString("database")
+  def useSsl: Boolean = Try(config.getBoolean("useSsl")).getOrElse(false)
+  def hostConnectionLimit: Int = Try(config.getInt("hostConnectionLimit")).getOrElse(1)
+  def numRetries: Int = Try(config.getInt("numRetries")).getOrElse(4)
+  def customTypes: Boolean = Try(config.getBoolean("customTypes")).getOrElse(false)
+  def customReceiveFunctions: PartialFunction[String, ValueDecoder[T] forSome { type T }] = { case "noop" => ValueDecoder.Unknown }
+  def binaryResults: Boolean = Try(config.getBoolean("binaryResults")).getOrElse(false)
+  def binaryParams: Boolean = Try(config.getBoolean("binaryParams")).getOrElse(false)
+
+  def client = Client(
+    host = host,
+    username = username,
+    password = password,
+    database = database,
+    useSsl = useSsl,
+    hostConnectionLimit = hostConnectionLimit,
+    numRetries = numRetries,
+    customTypes = customTypes,
+    customReceiveFunctions = customReceiveFunctions,
+    binaryResults = binaryResults,
+    binaryParams = binaryParams
+  )
+}

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
@@ -1,0 +1,66 @@
+package io.getquill.context.finagle.postgres
+
+import com.twitter.finagle.postgres._
+import io.getquill.FinaglePostgresContext
+import io.getquill.util.Messages.fail
+import java.time._
+import java.util.{ Date, UUID }
+import scala.reflect.ClassTag
+import scala.reflect.classTag
+
+trait FinaglePostgresDecoders {
+  this: FinaglePostgresContext[_] =>
+
+  def decoder[T: ClassTag](f: PartialFunction[Any, T]): Decoder[T] = new Decoder[T] {
+    def apply(idx: Int, row: Row) = {
+      val value = row.vals(idx).value
+      f.lift(value).getOrElse(fail(s"Value '$value' at index $idx can't be decoded to '${classTag[T].runtimeClass}'"))
+    }
+  }
+
+  def decoderDirectly[T: ClassTag] = new Decoder[T] {
+    def apply(idx: Int, row: Row) = row.vals(idx).value match {
+      case v: T => v
+      case v    => fail(s"Cannot decode value ${v} at index $idx to ${classTag[T]}")
+    }
+  }
+
+  implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] = new Decoder[Option[T]] {
+    def apply(idx: Int, row: Row) = {
+      if (row.vals == null || row.vals(idx) == null) None else Some(d.apply(idx, row))
+    }
+  }
+
+  implicit val stringDecoder: Decoder[String] = decoderDirectly[String]
+  implicit val bigDecimalDecoder: Decoder[BigDecimal] = decoderDirectly[BigDecimal]
+  implicit val booleanDecoder: Decoder[Boolean] = decoderDirectly[Boolean]
+  implicit val byteDecoder: Decoder[Byte] = decoder[Byte] {
+    case v: Short => v.toByte
+  }
+  implicit val shortDecoder: Decoder[Short] = decoderDirectly[Short]
+  implicit val intDecoder: Decoder[Int] =
+    decoder[Int] {
+      case v: Int  => v
+      case v: Long => v.toInt
+    }
+  implicit val longDecoder: Decoder[Long] =
+    decoder[Long] {
+      case v: Int  => v.toLong
+      case v: Long => v
+    }
+  implicit val floatDecoder: Decoder[Float] = decoder[Float] {
+    case v: Double => v.toFloat
+    case v: Float  => v
+  }
+  implicit val doubleDecoder: Decoder[Double] = decoder[Double] {
+    case v: Double => v
+    case v: Float  => v.toDouble
+  }
+  implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoderDirectly[Array[Byte]]
+  implicit val dateDecoder: Decoder[Date] =
+    decoder[Date] {
+      case d: LocalDateTime => Date.from(d.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+  implicit val uuidDecoder: Decoder[UUID] = decoderDirectly[UUID]
+}

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncoders.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncoders.scala
@@ -1,0 +1,50 @@
+package io.getquill.context.finagle.postgres
+
+import com.twitter.finagle.postgres._
+import com.twitter.finagle.postgres.values._
+import com.twitter.finagle.postgres.values.ValueEncoder._
+import io.getquill.FinaglePostgresContext
+import java.util.{ Date, UUID }
+import java.time._
+import org.jboss.netty.buffer.ChannelBuffers
+
+trait FinaglePostgresEncoders {
+  this: FinaglePostgresContext[_] =>
+
+  protected class ValueEncoderEncoder[T](val encoder: ValueEncoder[T]) extends Encoder[T] {
+    def apply(idx: Int, value: T, row: PrepareRow) = {
+      row :+ Param(value)(encoder)
+    }
+  }
+
+  protected def encoder[T](implicit e: ValueEncoder[T]): Encoder[T] = new ValueEncoderEncoder(e)
+  protected def encoder[T, U](f: U => T)(implicit e: ValueEncoder[T]): Encoder[U] = new ValueEncoderEncoder[U](e.contraMap(f))
+
+  override def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], e: Encoder[O]): Encoder[I] = e match {
+    case v: ValueEncoderEncoder[O] => encoder[O, I](mapped.f)(v.encoder)
+  }
+
+  def optionEncoder[T](implicit e: Encoder[T]): Encoder[Option[T]] = e match {
+    case v: ValueEncoderEncoder[T] => encoder[Option[T]](option(v.encoder))
+  }
+
+  //Workaround for https://github.com/finagle/finagle-postgres/pull/28
+  implicit val bytea: ValueEncoder[Array[Byte]] = instance(
+    "bytea",
+    bytes => "\\x" + bytes.map("%02x".format(_)).mkString,
+    (b, c) => Some(ChannelBuffers.copiedBuffer(b))
+  )
+
+  implicit val stringEncoder: Encoder[String] = encoder[String]
+  implicit val bigDecimalEncoder: Encoder[BigDecimal] = encoder[BigDecimal]
+  implicit val booleanEncoder: Encoder[Boolean] = encoder[Boolean]
+  implicit val byteEncoder: Encoder[Byte] = encoder[Short, Byte](_.toShort)
+  implicit val shortEncoder: Encoder[Short] = encoder[Short]
+  implicit val intEncoder: Encoder[Int] = encoder[Int]
+  implicit val longEncoder: Encoder[Long] = encoder[Long]
+  implicit val floatEncoder: Encoder[Float] = encoder[Float]
+  implicit val doubleEncoder: Encoder[Double] = encoder[Double]
+  implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder[Array[Byte]](bytea)
+  implicit val dateEncoder: Encoder[Date] = encoder[LocalDateTime, Date]((v: Date) => LocalDateTime.ofInstant(v.toInstant(), ZoneId.systemDefault()))
+  implicit val uuidEncoder: Encoder[UUID] = encoder[UUID]
+}

--- a/quill-finagle-postgres/src/test/resources/application.conf
+++ b/quill-finagle-postgres/src/test/resources/application.conf
@@ -1,0 +1,3 @@
+testPostgresDB.host=${?POSTGRES_PORT_5432_TCP_ADDR}":"${?POSTGRES_PORT_5432_TCP_PORT}
+testPostgresDB.user=postgres
+testPostgresDB.database=quill_test

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/DepartmentsFinaglePostgresSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/DepartmentsFinaglePostgresSpec.scala
@@ -1,0 +1,37 @@
+package io.getquill.context.finagle.postgres
+
+import com.twitter.util.Await
+import com.twitter.util.Future
+
+import io.getquill.context.sql.DepartmentsSpec
+
+class DepartmentsPostgresMysqlSpec extends DepartmentsSpec {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](future: Future[T]) = Await.result(future)
+
+  override def beforeAll =
+    await {
+      testContext.transaction {
+        for {
+          _ <- testContext.run(query[Department].delete)
+          _ <- testContext.run(query[Employee].delete)
+          _ <- testContext.run(query[Task].delete)
+
+          _ <- testContext.run(liftQuery(departmentEntries).foreach(e => departmentInsert(e)))
+          _ <- testContext.run(liftQuery(employeeEntries).foreach(e => employeeInsert(e)))
+          _ <- testContext.run(liftQuery(taskEntries).foreach(e => taskInsert(e)))
+        } yield {}
+      }
+    }
+
+  "Example 8 - nested naive" in {
+    await(testContext.run(`Example 8 expertise naive`(lift(`Example 8 param`)))) mustEqual `Example 8 expected result`
+  }
+
+  "Example 9 - nested db" in {
+    await(testContext.run(`Example 9 expertise`(lift(`Example 9 param`)))) mustEqual `Example 9 expected result`
+  }
+}

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresContextSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresContextSpec.scala
@@ -1,0 +1,19 @@
+package io.getquill.context.finagle.postgres
+
+import com.twitter.util._
+import io.getquill._
+
+class FinaglePostgresContextSpec extends Spec {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](f: Future[T]) = Await.result(f)
+
+  "run non-batched action" in {
+    val insert = quote { (i: Int) =>
+      qr1.insert(_.i -> i)
+    }
+    await(context.run(insert(lift(1)))) mustEqual 1
+  }
+}

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncodingSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncodingSpec.scala
@@ -1,0 +1,84 @@
+package io.getquill.context.finagle.postgres
+
+import io.getquill.context.sql.EncodingSpec
+import com.twitter.util.Await
+import java.util.Date
+import java.util.UUID
+
+class FinaglePostgresEncodingSpec extends EncodingSpec {
+
+  val context = testContext
+  import testContext._
+
+  "encodes and decodes types" in {
+    val r =
+      for {
+        _ <- testContext.run(delete)
+        _ <- testContext.run(liftQuery(insertValues).foreach(e => insert(e)))
+        result <- testContext.run(query[EncodingTestEntity])
+      } yield result
+    println(Await.result(r))
+    verify(Await.result(r).toList)
+  }
+
+  "encodes and decodes uuids" in {
+    case class EncodingUUIDTestEntity(v1: UUID)
+    val testUUID = UUID.fromString("e5240c08-6ee7-474a-b5e4-91f79c48338f")
+
+    //delete old values
+    val q0 = quote(query[EncodingUUIDTestEntity].delete)
+    val rez0 = Await.result(testContext.run(q0))
+
+    //insert new uuid
+    val rez1 = Await.result(testContext.run(query[EncodingUUIDTestEntity].insert(lift(EncodingUUIDTestEntity(testUUID)))))
+
+    //verify you can get the uuid back from the db
+    val q2 = quote(query[EncodingUUIDTestEntity].map(p => p.v1))
+    val rez2 = Await.result(testContext.run(q2))
+
+    rez2 mustEqual List(testUUID)
+  }
+
+  "fails if the column has the wrong type" - {
+    "numeric" in {
+      Await.result(testContext.run(liftQuery(insertValues).foreach(e => insert(e))))
+      case class EncodingTestEntity(v1: Int)
+      val e = intercept[IllegalStateException] {
+        Await.result(testContext.run(query[EncodingTestEntity]))
+      }
+    }
+    "non-numeric" in {
+      Await.result(testContext.run(liftQuery(insertValues).foreach(e => insert(e))))
+      case class EncodingTestEntity(v1: Date)
+      val e = intercept[IllegalStateException] {
+        Await.result(testContext.run(query[EncodingTestEntity]))
+      }
+    }
+  }
+
+  "encodes sets" in {
+    val q = quote {
+      (set: Query[Int]) =>
+        query[EncodingTestEntity].filter(t => set.contains(t.v6))
+    }
+    val fut =
+      for {
+        _ <- testContext.run(query[EncodingTestEntity].delete)
+        _ <- testContext.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+        r <- testContext.run(q(liftQuery(insertValues.map(_.v6))))
+      } yield {
+        r
+      }
+    verify(Await.result(fut))
+  }
+
+  "returning UUID" in {
+    val success = for {
+      uuid <- Await.result(testContext.run(insertBarCode(lift(barCodeEntry))))
+      barCode <- Await.result(testContext.run(findBarCodeByUuid(uuid))).headOption
+    } yield {
+      verifyBarcode(barCode)
+    }
+    success must not be empty
+  }
+}

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/PeopleFinaglePostgresSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/PeopleFinaglePostgresSpec.scala
@@ -1,0 +1,62 @@
+package io.getquill.context.finagle.postgres
+
+import com.twitter.util.Await
+import com.twitter.util.Future
+
+import io.getquill.context.sql.PeopleSpec
+
+class PeopleFinaglePostgresSpec extends PeopleSpec {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](future: Future[T]) = Await.result(future)
+
+  override def beforeAll =
+    await {
+      testContext.transaction {
+        for {
+          _ <- testContext.run(query[Couple].delete)
+          _ <- testContext.run(query[Person].filter(_.age > 0).delete)
+          _ <- testContext.run(liftQuery(peopleEntries).foreach(e => peopleInsert(e)))
+          _ <- testContext.run(liftQuery(couplesEntries).foreach(e => couplesInsert(e)))
+        } yield {}
+      }
+    }
+
+  "Example 1 - differences" in {
+    await(testContext.run(`Ex 1 differences`)) mustEqual `Ex 1 expected result`
+  }
+
+  "Example 2 - range simple" in {
+    await(testContext.run(`Ex 2 rangeSimple`(lift(`Ex 2 param 1`), lift(`Ex 2 param 2`)))) mustEqual `Ex 2 expected result`
+  }
+
+  "Examples 3 - satisfies" in {
+    await(testContext.run(`Ex 3 satisfies`)) mustEqual `Ex 3 expected result`
+  }
+
+  "Examples 4 - satisfies" in {
+    await(testContext.run(`Ex 4 satisfies`)) mustEqual `Ex 4 expected result`
+  }
+
+  "Example 5 - compose" in {
+    await(testContext.run(`Ex 5 compose`(lift(`Ex 5 param 1`), lift(`Ex 5 param 2`)))) mustEqual `Ex 5 expected result`
+  }
+
+  "Example 6 - predicate 0" in {
+    await(testContext.run(satisfies(eval(`Ex 6 predicate`)))) mustEqual `Ex 6 expected result`
+  }
+
+  "Example 7 - predicate 1" in {
+    await(testContext.run(satisfies(eval(`Ex 7 predicate`)))) mustEqual `Ex 7 expected result`
+  }
+
+  "Example 8 - contains empty" in {
+    await(testContext.run(`Ex 8 and 9 contains`(liftQuery(`Ex 8 param`)))) mustEqual `Ex 8 expected result`
+  }
+
+  "Example 9 - contains non empty" in {
+    await(testContext.run(`Ex 8 and 9 contains`(liftQuery(`Ex 9 param`)))) mustEqual `Ex 9 expected result`
+  }
+}

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/ProductFinaglePostgresSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/ProductFinaglePostgresSpec.scala
@@ -1,0 +1,97 @@
+package io.getquill.context.finagle.postgres
+
+import io.getquill.context.sql.ProductSpec
+import com.twitter.util.Await
+import com.twitter.util.Future
+import io.getquill.context.sql.Id
+
+class ProductFinaglePostgresSpec extends ProductSpec {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](r: Future[T]) = Await.result(r)
+
+  override def beforeAll = {
+    await(testContext.run(quote(query[Product].delete)))
+    ()
+  }
+
+  "Product" - {
+    "Insert multiple products" in {
+      val inserted = await(Future.collect(productEntries.map(product => testContext.run(productInsert(lift(product))))))
+      val product = await(testContext.run(productById(lift(inserted(2))))).head
+      product.description mustEqual productEntries(2).description
+      product.id mustEqual inserted(2)
+    }
+    "Single insert product" in {
+      val inserted = await(testContext.run(productSingleInsert))
+      val product = await(testContext.run(productById(lift(inserted)))).head
+      product.description mustEqual "Window"
+      product.id mustEqual inserted
+    }
+
+    "Single insert with inlined free variable" in {
+      val prd = Product(0L, "test1", 1L)
+      val inserted = await {
+        testContext.run {
+          product.insert(_.sku -> lift(prd.sku), _.description -> lift(prd.description)).returning(_.id)
+        }
+      }
+      val returnedProduct = await(testContext.run(productById(lift(inserted)))).head
+      returnedProduct.description mustEqual "test1"
+      returnedProduct.sku mustEqual 1L
+      returnedProduct.id mustEqual inserted
+    }
+
+    "Single insert with free variable and explicit quotation" in {
+      val prd = Product(0L, "test2", 2L)
+      val q1 = quote {
+        product.insert(_.sku -> lift(prd.sku), _.description -> lift(prd.description)).returning(_.id)
+      }
+      val inserted = await(testContext.run(q1))
+      val returnedProduct = await(testContext.run(productById(lift(inserted)))).head
+      returnedProduct.description mustEqual "test2"
+      returnedProduct.sku mustEqual 2L
+      returnedProduct.id mustEqual inserted
+    }
+
+    "Single product insert with a method quotation" in {
+      val prd = Product(0L, "test3", 3L)
+      val inserted = await(testContext.run(productInsert(lift(prd))))
+      val returnedProduct = await(testContext.run(productById(lift(inserted)))).head
+      returnedProduct.description mustEqual "test3"
+      returnedProduct.sku mustEqual 3L
+      returnedProduct.id mustEqual inserted
+    }
+
+    "Single insert with wrapped value" in {
+      case class Product(id: Id, description: String, sku: Long)
+      val prd = Product(Id(0L), "test2", 2L)
+      val q1 = quote {
+        query[Product].insert(_.sku -> lift(prd.sku), _.description -> lift(prd.description)).returning(_.id)
+      }
+      await(testContext.run(q1)) mustBe a[Id]
+    }
+
+    "supports casts from string to number" - {
+      "toInt" in {
+        case class Product(id: Long, description: String, sku: Int)
+        val queried = await {
+          testContext.run {
+            query[Product].filter(_.sku == lift("1004").toInt)
+          }
+        }.head
+        queried.sku mustEqual 1004L
+      }
+      "toLong" in {
+        val queried = await {
+          testContext.run {
+            query[Product].filter(_.sku == lift("1004").toLong)
+          }
+        }.head
+        queried.sku mustEqual 1004L
+      }
+    }
+  }
+}

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/QueryResultTypeFinaglePostgresSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/QueryResultTypeFinaglePostgresSpec.scala
@@ -1,0 +1,106 @@
+package io.getquill.context.finagle.postgres
+
+import io.getquill.context.sql._
+import com.twitter.util.{ Await, Future }
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.collection.JavaConverters._
+
+class QueryResultTypeFinaglePostgresSpec extends QueryResultTypeSpec {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](r: Future[T]) = Await.result(r)
+
+  val insertedProducts = new ConcurrentLinkedQueue[Product]
+
+  override def beforeAll = {
+    await(testContext.run(deleteAll))
+    val rs = await(testContext.run(liftQuery(productEntries).foreach(e => productInsert(e))))
+    val inserted = (rs zip productEntries).map {
+      case (r, prod) => prod.copy(id = r)
+    }
+    insertedProducts.addAll(inserted.asJava)
+    ()
+  }
+
+  def products = insertedProducts.asScala.toList
+
+  "return list" - {
+    "select" in {
+      await(testContext.run(selectAll)) must contain theSameElementsAs (products)
+    }
+    "map" in {
+      await(testContext.run(map)) must contain theSameElementsAs (products.map(_.id))
+    }
+    "filter" in {
+      await(testContext.run(filter)) must contain theSameElementsAs (products)
+    }
+    "withFilter" in {
+      await(testContext.run(withFilter)) must contain theSameElementsAs (products)
+    }
+    "sortBy" in {
+      await(testContext.run(sortBy)) must contain theSameElementsInOrderAs (products)
+    }
+    "take" in {
+      await(testContext.run(take)) must contain theSameElementsAs (products)
+    }
+    "drop" in {
+      await(testContext.run(drop)) must contain theSameElementsAs (products.drop(1))
+    }
+    "++" in {
+      await(testContext.run(`++`)) must contain theSameElementsAs (products ++ products)
+    }
+    "unionAll" in {
+      await(testContext.run(unionAll)) must contain theSameElementsAs (products ++ products)
+    }
+    "union" in {
+      await(testContext.run(union)) must contain theSameElementsAs (products)
+    }
+    "join" in {
+      await(testContext.run(join)) must contain theSameElementsAs (products zip products)
+    }
+    "distinct" in {
+      await(testContext.run(distinct)) must contain theSameElementsAs (products.map(_.id).distinct)
+    }
+  }
+
+  "return single result" - {
+    "min" - {
+      "some" in {
+        await(testContext.run(minExists)) mustEqual Some(products.map(_.sku).min)
+      }
+      "none" in {
+        await(testContext.run(minNonExists)) mustBe None
+      }
+    }
+    "max" - {
+      "some" in {
+        await(testContext.run(maxExists)) mustBe Some(products.map(_.sku).max)
+      }
+      "none" in {
+        await(testContext.run(maxNonExists)) mustBe None
+      }
+    }
+    "avg" - {
+      "some" in {
+        await(testContext.run(avgExists)) mustBe Some(BigDecimal(products.map(_.sku).sum) / products.size)
+      }
+      "none" in {
+        await(testContext.run(avgNonExists)) mustBe None
+      }
+    }
+    "size" in {
+      await(testContext.run(productSize)) mustEqual products.size
+    }
+    "parametrized size" in {
+      await(testContext.run(parametrizedSize(lift(10000)))) mustEqual 0
+    }
+    "nonEmpty" in {
+      await(testContext.run(nonEmpty)) mustEqual true
+    }
+    "isEmpty" in {
+      await(testContext.run(isEmpty)) mustEqual false
+    }
+  }
+}

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/TestContext.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/TestContext.scala
@@ -1,0 +1,6 @@
+package io.getquill.context.finagle.postgres
+
+import io.getquill._
+import io.getquill.context.sql.{ TestDecoders, TestEncoders }
+
+object testContext extends FinaglePostgresContext[Literal]("testPostgresDB") with TestEntities with TestEncoders with TestDecoders


### PR DESCRIPTION
Fixes #8 

Finagle-Postgres seems brought back to active development now


### Notes

`finagle-mysql`  and `finagle-postgres`  actually differs alot from each other! 

+ `finagle-mysql`  always follow latest finagle version.
+ They almost share nothing, including totaly different `Client`, and data types

So I haven't make an `comman` sub-project

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

