### PR TITLE
Add quill-cassandra dependency to build.sbt

### DIFF
--- a/CASSANDRA.md
+++ b/CASSANDRA.md
@@ -41,6 +41,17 @@ db.session.contactPoint=127.0.0.1
 db.session.queryOptions.consistencyLevel=ONE
 ```
 
+Be sure to also update your project's `build.sbt`.
+e.g.
+
+```
+val quillV = "0.10.0"
+
+libraryDependencies ++= Seq(
+  "io.getquill"               %% "quill-async"                 % quillV,
+  "io.getquill"               %% "quill-cassandra"             % quillV)
+```
+
 ## Abstraction level ##
 
 The Datastax Java driver provides simple abstractions that let you either write you queries as plain strings or to use a declarative Query Builder. It also provides a higher level [Object Mapper](https://github.com/datastax/java-driver/tree/2.1/manual/object_mapper). For this comparison we will only use the Query Builder.


### PR DESCRIPTION
### Problem

When looking for instructions of how to set quill with Cassandra there is no instructions of how to set the project properly.

### Solution

Modify CASSANDRA.cmd to  indicate the dependencies needed in build.sbt besides other requirements to make the examples run.

@getquill/maintainers

