### PR TITLE
add references to scalafiddle.io

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,12 +2,15 @@ This template isn't a strict requirement to open issues, but please try to provi
 
 **Version**: (e.g. `0.4.1-SNAPSHOT`)
 **Module**: (e.g. `quill-jdbc`)
+**Database**: (e.g. `mysql`)
 
 ### Expected behavior
 
 ### Actual behavior
 
 ### Steps to reproduce the behavior
+
+If the issue can be reproduced using a [mirror context](http://getquill.io/#contexts-mirror-context), please provide a scalafiddle that reproduces it. See https://scalafiddle.io/sf/pMg4JvY/1 as an example. Remember to select the correct Quill version in the left menu.
 
 ### Workaround
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ import io.getquill._
 val ctx = new SqlMirrorContext[MirrorSqlDialect, Literal]
 ```
 
+> ### **Note:** [Scalafiddle](http://scalafiddle.io) is a great tool to try out Quill without having to prepare a local environment. It works with [mirror contexts](#mirror-context), see [this](https://scalafiddle.io/sf/pMg4JvY/1) fiddle as an example.
+
 The context instance provides all types and methods to deal quotations:
 
 ```scala


### PR DESCRIPTION
### Problem

Users currently don't have an easy way to:

- Provide executable code to reproduce issues
- Try out Quill without preparing a local environment

### Solution

Use http://scalafiddle.io for these two use cases.

### Notes

- Scalafiddle only works with mirror sources since it executes in Javascript. I've also tried [scalakata](http://scalakata.com/gist/e95f3d32b68d05e0de5cbc529d283169), that executes on the server, but the absence of a feature to select the version of Quill makes it not usable for the first use case.
- Thanks @ochrons for accepting the pull request and for the quick fix!

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
