### PR TITLE
Upgraded to Monix 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import scalariform.formatter.preferences._
 import sbtrelease.ReleasePlugin
 
-lazy val `quill` = 
+lazy val `quill` =
   (project in file("."))
     .settings(tutSettings ++ commonSettings)
     .settings(`tut-settings`:_*)
@@ -28,7 +28,7 @@ lazy val superPure = new org.scalajs.sbtplugin.cross.CrossType {
     Some(projectBase.getParentFile / "src" / conf / "scala")
 }
 
-lazy val `quill-core` = 
+lazy val `quill-core` =
   crossProject.crossType(superPure)
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
@@ -44,7 +44,7 @@ lazy val `quill-core` =
 lazy val `quill-core-jvm` = `quill-core`.jvm
 lazy val `quill-core-js` = `quill-core`.js
 
-lazy val `quill-sql` = 
+lazy val `quill-sql` =
   crossProject.crossType(superPure)
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
@@ -56,7 +56,7 @@ lazy val `quill-sql` =
 lazy val `quill-sql-jvm` = `quill-sql`.jvm
 lazy val `quill-sql-js` = `quill-sql`.js
 
-lazy val `quill-jdbc` = 
+lazy val `quill-jdbc` =
   (project in file("quill-jdbc"))
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
@@ -72,7 +72,7 @@ lazy val `quill-jdbc` =
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
 
-lazy val `quill-finagle-mysql` = 
+lazy val `quill-finagle-mysql` =
   (project in file("quill-finagle-mysql"))
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
@@ -84,7 +84,7 @@ lazy val `quill-finagle-mysql` =
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
 
-lazy val `quill-finagle-postgres` = 
+lazy val `quill-finagle-postgres` =
   (project in file("quill-finagle-postgres"))
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
@@ -132,7 +132,7 @@ lazy val `quill-async-postgres` =
     )
     .dependsOn(`quill-async` % "compile->compile;test->test")
 
-lazy val `quill-cassandra` = 
+lazy val `quill-cassandra` =
   (project in file("quill-cassandra"))
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
@@ -140,7 +140,7 @@ lazy val `quill-cassandra` =
       fork in Test := true,
       libraryDependencies ++= Seq(
         "com.datastax.cassandra" %  "cassandra-driver-core" % "3.0.2",
-        "org.monifu"             %% "monifu"                % "1.2"
+        "io.monix"               %% "monix"                % "2.0.2"
       )
     )
     .dependsOn(`quill-core-jvm` % "compile->compile;test->test")
@@ -183,7 +183,7 @@ commands += Command.command("checkUnformattedFiles") { st =>
   st
 }
 
-def updateReadmeVersion(selectVersion: sbtrelease.Versions => String) = 
+def updateReadmeVersion(selectVersion: sbtrelease.Versions => String) =
   ReleaseStep(action = st => {
 
     val newVersion = selectVersion(st.get(ReleaseKeys.versions).get)
@@ -208,7 +208,7 @@ def updateReadmeVersion(selectVersion: sbtrelease.Versions => String) =
     st
   })
 
-def updateWebsiteTag = 
+def updateWebsiteTag =
   ReleaseStep(action = st => {
 
     val vcs = Project.extract(st).get(releaseVcs).get
@@ -238,9 +238,9 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     "-feature",
     "-unchecked",
     "-Xlint",
-    "-Yno-adapted-args",       
+    "-Yno-adapted-args",
     "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",   
+    "-Ywarn-numeric-widen",
     "-Ywarn-value-discard",
     "-Xfuture",
     "-Ywarn-unused-import"
@@ -315,4 +315,3 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
       </developer>
     </developers>)
 )
-

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraStreamSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraStreamSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.cassandra
 
-import monifu.concurrent.Implicits.globalScheduler
-import monifu.reactive.Observable
+import monix.execution.Scheduler.Implicits.global
+import monix.reactive.Observable
 
 class QueryResultTypeCassandraStreamSpec extends QueryResultTypeCassandraSpec {
 
@@ -10,7 +10,7 @@ class QueryResultTypeCassandraStreamSpec extends QueryResultTypeCassandraSpec {
   import context._
 
   def result[T](t: Observable[T]) =
-    await(t.foldLeft(List.empty[T])(_ :+ _).asFuture)
+    await(t.foldLeftL(List.empty[T])(_ :+ _).runAsync)
 
   override def beforeAll = {
     result(context.run(deleteAll))

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraStreamSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraStreamSpec.scala
@@ -19,15 +19,15 @@ class QueryResultTypeCassandraStreamSpec extends QueryResultTypeCassandraSpec {
   }
 
   "query" in {
-    result(context.run(selectAll)) mustEqual Some(entries)
+    result(context.run(selectAll)) mustEqual entries
   }
 
   "querySingle" - {
     "size" in {
-      result(context.run(entitySize)) mustEqual Some(List(3))
+      result(context.run(entitySize)) mustEqual List(3)
     }
     "parametrized size" in {
-      result(context.run(parametrizedSize(lift(10000)))) mustEqual Some(List(0))
+      result(context.run(parametrizedSize(lift(10000)))) mustEqual List(0)
     }
   }
 }


### PR DESCRIPTION
Fixes: no reported issue

### Problem

Upgrade Quill-Cassandra to use Monix 2.x from Monix (Monifu) 1.x. 

### Solution

1. Replaced the `monifu` package imports with `monix` package imports
2. The `page` method now returns a lazy `Task`
3. `fromStateAction` is replaced with `fromAsyncStateAction`
4. Updated tests: `Observable.asFuture` replaced with `Observable.headL.runAsync` 
5. Updated tests: `Observable.count` replaced with `Observable.fromTask(Observable.countL)` 
6. Updated tests: `Observable.fold` replaced with `Observable.foldL` 


### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
