### PR TITLE
encoder for java 8 LocalDate & LocalDateTime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ lazy val `quill-core` =
       "org.scala-lang"             %  "scala-reflect" % scalaVersion.value
     ))
     .jsSettings(
+      libraryDependencies += "org.scala-js" %%% "scalajs-java-time" % "0.2.0",
       coverageExcludedPackages := ".*"
     )
 

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
@@ -1,6 +1,9 @@
 package io.getquill.context.async.postgres
 
+import java.time.{ LocalDate, LocalDateTime }
+
 import io.getquill.context.sql.EncodingSpec
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -82,5 +85,27 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
       verifyBarcode(barCode)
     }
     success must not be empty
+  }
+
+  "encodes localdate type" in {
+    case class DateEncodingTestEntity(v1: LocalDate, v2: LocalDate)
+    val entity = new DateEncodingTestEntity(LocalDate.now, LocalDate.now)
+    val r = for {
+      _ <- testContext.run(query[DateEncodingTestEntity].delete)
+      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      result <- testContext.run(query[DateEncodingTestEntity])
+    } yield result
+    Await.result(r, Duration.Inf) must contain(entity)
+  }
+
+  "encodes localdatetime type" in {
+    case class DateEncodingTestEntity(v1: LocalDateTime, v2: LocalDateTime)
+    val entity = new DateEncodingTestEntity(LocalDateTime.now, LocalDateTime.now)
+    val r = for {
+      _ <- testContext.run(query[DateEncodingTestEntity].delete)
+      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      result <- testContext.run(query[DateEncodingTestEntity])
+    } yield result
+    Await.result(r, Duration.Inf)
   }
 }

--- a/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
@@ -1,17 +1,16 @@
 package io.getquill.context.async
 
-import com.github.mauricio.async.db.RowData
+import java.time.{ LocalDate, LocalDateTime, ZoneId }
 
+import com.github.mauricio.async.db.RowData
 import java.util.Date
 import java.util.UUID
 
-import org.joda.time.LocalDate
-import org.joda.time.LocalDateTime
+import org.joda.time.{ LocalDate => JodaLocalDate }
+import org.joda.time.{ LocalDateTime => JodaLocalDateTime }
 
-import scala.BigDecimal
 import scala.reflect.ClassTag
 import scala.reflect.classTag
-
 import io.getquill.util.Messages.fail
 
 trait Decoders {
@@ -106,10 +105,26 @@ trait Decoders {
 
   implicit val dateDecoder: Decoder[Date] =
     decoder[Date] {
-      case localDateTime: LocalDateTime =>
+      case localDateTime: JodaLocalDateTime =>
         localDateTime.toDate
-      case localDate: LocalDate =>
+      case localDate: JodaLocalDate =>
         localDate.toDate
+    }
+
+  implicit val localDateDecoder: Decoder[LocalDate] =
+    decoder[LocalDate] {
+      case localDateTime: JodaLocalDateTime => LocalDate.of(
+        localDateTime.getYear,
+        localDateTime.getMonthOfYear,
+        localDateTime.getDayOfMonth
+      )
+      case localDate: JodaLocalDate => LocalDate.of(localDate.getYear, localDate.getMonthOfYear, localDate.getDayOfMonth)
+    }
+
+  implicit val localDateTimeDecoder: Decoder[LocalDateTime] =
+    decoder[LocalDateTime] {
+      case localDateTime: JodaLocalDateTime => LocalDateTime.ofInstant(localDateTime.toDate.toInstant, ZoneId.systemDefault())
+      case localDate: JodaLocalDate         => LocalDateTime.ofInstant(localDate.toDate.toInstant, ZoneId.systemDefault())
     }
 
   implicit val uuidDecoder: Decoder[UUID] = new Decoder[UUID] {

--- a/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
@@ -1,8 +1,9 @@
 package io.getquill.context.async
 
+import java.time.{ LocalDate, LocalDateTime, ZoneId }
 import java.util.{ Date, UUID }
 
-import org.joda.time.LocalDateTime
+import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
 
 trait Encoders {
   this: AsyncContext[_, _, _] =>
@@ -40,7 +41,15 @@ trait Encoders {
   implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder[Array[Byte]]
   implicit val dateEncoder: Encoder[Date] =
     encoder[Date] { (value: Date) =>
-      new LocalDateTime(value)
+      new JodaLocalDateTime(value)
     }
   implicit val uuidEncoder: Encoder[UUID] = encoder[UUID]
+  implicit val localDateEncoder: Encoder[LocalDate] =
+    encoder[LocalDate] { (value: LocalDate) =>
+      new JodaLocalDate(value.getYear, value.getMonthValue, value.getDayOfMonth)
+    }
+  implicit val localDateTimeEncoder: Encoder[LocalDateTime] =
+    encoder[LocalDateTime] { (value: LocalDateTime) =>
+      new JodaLocalDateTime(value.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli)
+    }
 }

--- a/quill-core/src/main/scala/io/getquill/context/mirror/MirrorDecoders.scala
+++ b/quill-core/src/main/scala/io/getquill/context/mirror/MirrorDecoders.scala
@@ -1,5 +1,6 @@
 package io.getquill.context.mirror
 
+import java.time.LocalDate
 import java.util.Date
 
 import io.getquill.context.Context
@@ -36,4 +37,5 @@ trait MirrorDecoders {
   implicit val doubleDecoder: Decoder[Double] = decoder[Double]
   implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoder[Array[Byte]]
   implicit val dateDecoder: Decoder[Date] = decoder[Date]
+  implicit val localDateDecoder: Decoder[LocalDate] = decoder[LocalDate]
 }

--- a/quill-core/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
+++ b/quill-core/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
@@ -1,5 +1,6 @@
 package io.getquill.context.mirror
 
+import java.time.LocalDate
 import java.util.Date
 
 import io.getquill.context.Context
@@ -35,4 +36,5 @@ trait MirrorEncoders {
   implicit val doubleEncoder = encoder[Double]
   implicit val byteArrayEncoder = encoder[Array[Byte]]
   implicit val dateEncoder = encoder[Date]
+  implicit val localDateEncoder = encoder[LocalDate]
 }

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
@@ -1,22 +1,11 @@
 package io.getquill.context.finagle.mysql
 
+import java.time.{ LocalDate, LocalDateTime }
 import java.util.Date
+
 import scala.reflect.ClassTag
 import scala.reflect.classTag
-import com.twitter.finagle.mysql.BigDecimalValue
-import com.twitter.finagle.mysql.ByteValue
-import com.twitter.finagle.mysql.DoubleValue
-import com.twitter.finagle.mysql.FloatValue
-import com.twitter.finagle.mysql.IntValue
-import com.twitter.finagle.mysql.LongValue
-import com.twitter.finagle.mysql.NullValue
-import com.twitter.finagle.mysql.RawValue
-import com.twitter.finagle.mysql.Row
-import com.twitter.finagle.mysql.ShortValue
-import com.twitter.finagle.mysql.StringValue
-import com.twitter.finagle.mysql.TimestampValue
-import com.twitter.finagle.mysql.Type
-import com.twitter.finagle.mysql.Value
+import com.twitter.finagle.mysql._
 import io.getquill.util.Messages.fail
 import io.getquill.FinagleMysqlContext
 
@@ -98,4 +87,13 @@ trait FinagleMysqlDecoders {
     decoder[Date] {
       case `timestampValue`(v) => new Date(v.getTime)
     }
+
+  implicit val localDateDecoder: Decoder[LocalDate] = decoder[LocalDate] {
+    case `timestampValue`(v) => v.toLocalDateTime.toLocalDate
+    case DateValue(d)        => d.toLocalDate
+  }
+
+  implicit val localDateTimeDecoder: Decoder[LocalDateTime] = decoder[LocalDateTime] {
+    case `timestampValue`(v) => v.toLocalDateTime
+  }
 }

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
@@ -1,10 +1,11 @@
 package io.getquill.context.finagle.mysql
 
+import java.sql.Timestamp
+import java.time.{ LocalDate, LocalDateTime }
 import java.util.Date
-import com.twitter.finagle.mysql.BigDecimalValue
-import com.twitter.finagle.mysql.CanBeParameter
+
+import com.twitter.finagle.mysql._
 import com.twitter.finagle.mysql.CanBeParameter._
-import com.twitter.finagle.mysql.Parameter
 import com.twitter.finagle.mysql.Parameter.wrap
 import io.getquill.FinagleMysqlContext
 
@@ -46,4 +47,10 @@ trait FinagleMysqlEncoders {
   implicit val doubleEncoder: Encoder[Double] = encoder[Double]
   implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder[Array[Byte]]
   implicit val dateEncoder: Encoder[Date] = encoder[Date]
+  implicit val localDateEncoder: Encoder[LocalDate] = encoder[LocalDate] {
+    (d: LocalDate) => DateValue(java.sql.Date.valueOf(d)): Parameter
+  }
+  implicit val localDateTimeEncoder: Encoder[LocalDateTime] = encoder[LocalDateTime] {
+    (d: LocalDateTime) => new TimestampValue(dateTimezone, dateTimezone).apply(Timestamp.valueOf(d)): Parameter
+  }
 }

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
@@ -61,6 +61,14 @@ trait FinaglePostgresDecoders {
     decoder[Date] {
       case d: LocalDateTime => Date.from(d.atZone(ZoneId.systemDefault()).toInstant());
     }
+  implicit val localDateDecoder: Decoder[LocalDate] = decoder[LocalDate] {
+    case d: LocalDateTime => d.toLocalDate
+    case d: LocalDate     => d
+  }
+  implicit val localDateTimeDecoder: Decoder[LocalDateTime] = decoder[LocalDateTime] {
+    case d: LocalDateTime => d
+    case d: LocalDate     => d.atStartOfDay()
+  }
 
   implicit val uuidDecoder: Decoder[UUID] = decoderDirectly[UUID]
 }

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncoders.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncoders.scala
@@ -47,5 +47,7 @@ trait FinaglePostgresEncoders {
   implicit val doubleEncoder: Encoder[Double] = encoder[Double]
   implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder[Array[Byte]](bytea)
   implicit val dateEncoder: Encoder[Date] = encoder[LocalDateTime, Date]((v: Date) => LocalDateTime.ofInstant(v.toInstant(), ZoneId.systemDefault()))
+  implicit val localDateEncoder: Encoder[LocalDate] = encoder[LocalDate]
+  implicit val localDateTimeEncoder: Encoder[LocalDateTime] = encoder[LocalDateTime]
   implicit val uuidEncoder: Encoder[UUID] = encoder[UUID]
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcDecoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcDecoders.scala
@@ -1,6 +1,7 @@
 package io.getquill.context.jdbc
 
 import java.sql.ResultSet
+import java.time.{ LocalDate, LocalDateTime }
 import java.util
 import java.util.Calendar
 
@@ -55,6 +56,26 @@ trait JdbcDecoders {
           new util.Date(0)
         else
           new util.Date(v.getTime)
+      }
+    }
+  implicit val localDateDecoder: Decoder[LocalDate] =
+    new Decoder[LocalDate] {
+      def apply(index: Int, row: ResultSet) = {
+        val v = row.getDate(index + 1, Calendar.getInstance(dateTimeZone))
+        if (v == null)
+          LocalDate.ofEpochDay(0)
+        else
+          v.toLocalDate
+      }
+    }
+  implicit val localDateTimeDecoder: Decoder[LocalDateTime] =
+    new Decoder[LocalDateTime] {
+      def apply(index: Int, row: ResultSet) = {
+        val v = row.getTimestamp(index + 1, Calendar.getInstance(dateTimeZone))
+        if (v == null)
+          LocalDate.ofEpochDay(0).atStartOfDay()
+        else
+          v.toLocalDateTime
       }
     }
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcEncoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcEncoders.scala
@@ -1,6 +1,7 @@
 package io.getquill.context.jdbc
 
-import java.sql.{ PreparedStatement, Types }
+import java.sql.{ Date, PreparedStatement, Timestamp, Types }
+import java.time.{ LocalDate, LocalDateTime }
 import java.util.{ Calendar, TimeZone }
 import java.{ sql, util }
 
@@ -69,4 +70,14 @@ trait JdbcEncoders {
         row.setTimestamp(idx, new sql.Timestamp(value.getTime), Calendar.getInstance(dateTimeZone)),
       Types.TIMESTAMP
     )
+  implicit val localDateEncoder: Encoder[LocalDate] = encoder[LocalDate](
+    row => (idx, value) =>
+      row.setDate(idx, Date.valueOf(value), Calendar.getInstance(dateTimeZone)),
+    Types.DATE
+  )
+  implicit val localDateTimeEncoder: Encoder[LocalDateTime] = encoder[LocalDateTime](
+    row => (idx, value) =>
+      row.setTimestamp(idx, Timestamp.valueOf(value), Calendar.getInstance(dateTimeZone)),
+    Types.TIMESTAMP
+  )
 }

--- a/quill-jdbc/src/test/resources/sql/h2-schema.sql
+++ b/quill-jdbc/src/test/resources/sql/h2-schema.sql
@@ -36,6 +36,8 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     v10 BYTEA,
     v11 TIMESTAMP,
     v12 VARCHAR(255),
+    v13 DATE,
+    v14 TIMESTAMP,
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -47,7 +49,9 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     o9 DOUBLE PRECISIOn,
     o10 BYTEA,
     o11 TIMESTAMP,
-    o12 VARCHAR(255)
+    o12 VARCHAR(255),
+    o13 DATE,
+    o14 TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS TestEntity(

--- a/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
+++ b/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
@@ -36,6 +36,8 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     v10 BLOB,
     v11 BIGINT,
     v12 VARCHAR(255),
+    v13 BIGINT,
+    v14 BIGINT,
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -47,7 +49,9 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     o9 DOUBLE PRECISIOn,
     o10 BLOB,
     o11 BIGINT,
-    o12 VARCHAR(255)
+    o12 VARCHAR(255),
+    o13 BIGINT,
+    o14 BIGINT
 );
 
 CREATE TABLE IF NOT EXISTS TestEntity(

--- a/quill-sql/src/main/scala/io/getquill/context/sql/SqlContext.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/SqlContext.scala
@@ -1,5 +1,7 @@
 package io.getquill.context.sql
 
+import java.time.LocalDate
+
 import io.getquill.idiom.{ Idiom => BaseIdiom }
 import java.util.Date
 
@@ -25,6 +27,7 @@ trait SqlContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
   implicit val doubleDecoder: Decoder[Double]
   implicit val byteArrayDecoder: Decoder[Array[Byte]]
   implicit val dateDecoder: Decoder[Date]
+  implicit val localDateDecoder: Decoder[LocalDate]
 
   implicit val stringEncoder: Encoder[String]
   implicit val bigDecimalEncoder: Encoder[BigDecimal]
@@ -37,4 +40,5 @@ trait SqlContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
   implicit val doubleEncoder: Encoder[Double]
   implicit val byteArrayEncoder: Encoder[Array[Byte]]
   implicit val dateEncoder: Encoder[Date]
+  implicit val localDateEncoder: Encoder[LocalDate]
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
@@ -1,5 +1,6 @@
 package io.getquill.context.sql
 
+import java.time.LocalDate
 import java.util.{ Date, UUID }
 
 import scala.BigDecimal
@@ -26,6 +27,7 @@ trait EncodingSpec extends Spec {
     v10: Array[Byte],
     v11: Date,
     v12: EncodingTestType,
+    v13: LocalDate,
     o1:  Option[String],
     o2:  Option[BigDecimal],
     o3:  Option[Boolean],
@@ -37,7 +39,8 @@ trait EncodingSpec extends Spec {
     o9:  Option[Double],
     o10: Option[Array[Byte]],
     o11: Option[Date],
-    o12: Option[EncodingTestType]
+    o12: Option[EncodingTestType],
+    o13: Option[LocalDate]
   )
 
   val delete = quote {
@@ -63,6 +66,7 @@ trait EncodingSpec extends Spec {
         Array(1.toByte, 2.toByte),
         new Date(31200000),
         EncodingTestType("s"),
+        LocalDate.of(2013, 11, 23),
         Some("s"),
         Some(BigDecimal(1.1)),
         Some(true),
@@ -74,7 +78,8 @@ trait EncodingSpec extends Spec {
         Some(42d),
         Some(Array(1.toByte, 2.toByte)),
         Some(new Date(31200000)),
-        Some(EncodingTestType("s"))
+        Some(EncodingTestType("s")),
+        Some(LocalDate.of(2013, 11, 23))
       ),
       EncodingTestEntity(
         "",
@@ -89,6 +94,8 @@ trait EncodingSpec extends Spec {
         Array(),
         new Date(0),
         EncodingTestType(""),
+        LocalDate.ofEpochDay(0),
+        None,
         None,
         None,
         None,
@@ -120,6 +127,7 @@ trait EncodingSpec extends Spec {
         e1.v10.toList mustEqual List(1.toByte, 2.toByte)
         e1.v11 mustEqual new Date(31200000)
         e1.v12 mustEqual EncodingTestType("s")
+        e1.v13 mustEqual LocalDate.of(2013, 11, 23)
 
         e1.o1 mustEqual Some("s")
         e1.o2 mustEqual Some(BigDecimal(1.1))
@@ -133,6 +141,7 @@ trait EncodingSpec extends Spec {
         e1.o10.map(_.toList) mustEqual Some(List(1.toByte, 2.toByte))
         e1.o11 mustEqual Some(new Date(31200000))
         e1.o12 mustEqual Some(EncodingTestType("s"))
+        e1.o13 mustEqual Some(LocalDate.of(2013, 11, 23))
 
         e2.v1 mustEqual ""
         e2.v2 mustEqual BigDecimal(0)
@@ -146,6 +155,7 @@ trait EncodingSpec extends Spec {
         e2.v10.toList mustEqual Nil
         e2.v11 mustEqual new Date(0)
         e2.v12 mustEqual EncodingTestType("")
+        e2.v13 mustEqual LocalDate.ofEpochDay(0)
 
         e2.o1 mustEqual None
         e2.o2 mustEqual None
@@ -159,6 +169,7 @@ trait EncodingSpec extends Spec {
         e2.o10 mustEqual None
         e2.o11 mustEqual None
         e2.o12 mustEqual None
+        e2.o13 mustEqual None
     }
 
   case class BarCode(description: String, uuid: Option[UUID] = None)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlContextSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlContextSpec.scala
@@ -1,9 +1,9 @@
 package io.getquill.context.sql
 
+import java.time.LocalDate
 import java.util.Date
 
 import scala.util.Try
-
 import io.getquill.Spec
 import io.getquill.context.mirror.Row
 import io.getquill.context.sql.idiom.SqlIdiom
@@ -73,8 +73,9 @@ class SqlContextSpec extends Spec {
       implicit val floatDecoder: Decoder[Float] = null
       implicit val doubleDecoder: Decoder[Double] = null
       implicit val byteArrayDecoder: Decoder[Array[Byte]] = null
-      implicit val dateDecoder: Decoder[Date] = null
+      implicit val localDateDecoder: Decoder[LocalDate] = null
 
+      implicit val dateDecoder: Decoder[Date] = null
       implicit val stringEncoder: Encoder[String] = null
       implicit val bigDecimalEncoder: Encoder[BigDecimal] = null
       implicit val booleanEncoder: Encoder[Boolean] = null
@@ -86,6 +87,7 @@ class SqlContextSpec extends Spec {
       implicit val doubleEncoder: Encoder[Double] = null
       implicit val byteArrayEncoder: Encoder[Array[Byte]] = null
       implicit val dateEncoder: Encoder[Date] = null
+      implicit val localDateEncoder: Encoder[LocalDate] = null
     }
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/mirror/MirrorContextEncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/mirror/MirrorContextEncodingSpec.scala
@@ -11,8 +11,8 @@ class MirrorContextEncodingSpec extends EncodingSpec {
 
   "encodes and decodes types" in {
     val rows = insertValues.map(v =>
-      Row(v.v1, v.v2, v.v3, v.v4, v.v5, v.v6, v.v7, v.v8, v.v9, v.v10, v.v11, v.v12.value,
-        v.o1, v.o2, v.o3, v.o4, v.o5, v.o6, v.o7, v.o8, v.o9, v.o10, v.o11, v.o12.map(_.value)))
+      Row(v.v1, v.v2, v.v3, v.v4, v.v5, v.v6, v.v7, v.v8, v.v9, v.v10, v.v11, v.v12.value, v.v13,
+        v.o1, v.o2, v.o3, v.o4, v.o5, v.o6, v.o7, v.o8, v.o9, v.o10, v.o11, v.o12.map(_.value), v.o13))
     context.run(liftQuery(insertValues).foreach(p => insert(p))).groups.map(_._2).flatten mustEqual rows
 
     val mirror = context.run(query[EncodingTestEntity])

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -36,6 +36,8 @@ CREATE TABLE EncodingTestEntity(
     v10 VARBINARY(255),
     v11 DATETIME,
     v12 VARCHAR(255),
+    v13 DATE,
+    v14 DATETIME,
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -47,7 +49,9 @@ CREATE TABLE EncodingTestEntity(
     o9 DOUBLE,
     o10 VARBINARY(255),
     o11 DATETIME,
-    o12 VARCHAR(255)
+    o12 VARCHAR(255),
+    o13 DATE,
+    o14 DATETIME
 );
 
 Create TABLE DateEncodingTestEntity(

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -36,6 +36,8 @@ CREATE TABLE EncodingTestEntity(
     v10 BYTEA,
     v11 TIMESTAMP,
     v12 VARCHAR(255),
+    v13 DATE,
+    v14 TIMESTAMP,
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -47,7 +49,9 @@ CREATE TABLE EncodingTestEntity(
     o9 DOUBLE PRECISION,
     o10 BYTEA,
     o11 TIMESTAMP,
-    o12 VARCHAR(255)
+    o12 VARCHAR(255),
+    o13 DATE,
+    o14 TIMESTAMP
 );
 
 CREATE TABLE EncodingUUIDTestEntity(
@@ -84,4 +88,9 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE TABLE Barcode(
     uuid UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     description TEXT
+);
+
+CREATE TABLE DateEncodingTestEntity (
+    v1 DATE,
+    v2 TIMESTAMP
 );


### PR DESCRIPTION
Fixes #111

### Problem

Missing native support for java 8 date apis

### Solution
Add relevant encoders/decoders for `java.time.LocalDate` 

### Notes

1. At the moment I've only added support for LocalDate, if the proposed approach is acceptable I'll add LocalDateTime as well
2. Mauricio's driver doesn't support java 8 date apis yet see mauricio/postgresql-async#189. However, it does support Joda's out of the box, so the async encoders transform java 8 date to joda date.
3. scala-js doesn't support java 8 date as well, see here scala-js/scala-js#1618 so I need your advice on how to get the scalajs compiled.

First time here, so appreciate your kind review 😄 

- [x] Support LocalDateTime
- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

