### PR TITLE
pass ssl settings to async driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,6 +1258,8 @@ ctx.poolMaxQueueSize=4
 ctx.poolMaxObjects=4
 ctx.poolMaxIdle=999999999
 ctx.poolValidationInterval=100
+ctx.sslmode=disable # optional, one of [disable|prefer|require|verify-ca|verify-full]
+ctx.sslrootcert="./path/to/cert/file" # optional, required for sslmode=verify-ca or verify-full
 ```
 
 **Postgres Async**
@@ -1285,6 +1287,8 @@ ctx.poolMaxQueueSize=4
 ctx.poolMaxObjects=4
 ctx.poolMaxIdle=999999999
 ctx.poolValidationInterval=100
+ctx.sslmode=disable # optional, one of [disable|prefer|require|verify-ca|verify-full]
+ctx.sslrootcert="./path/to/cert/file" # optional, required for sslmode=verify-ca or verify-full
 ```
 
 ##### quill-finagle-mysql

--- a/quill-async-postgres/src/test/scala/io/getquill/PostgresAsyncContextConfigSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/PostgresAsyncContextConfigSpec.scala
@@ -1,0 +1,21 @@
+package io.getquill
+
+import java.io.File
+
+import com.github.mauricio.async.db.SSLConfiguration
+import com.github.mauricio.async.db.SSLConfiguration.Mode
+import com.typesafe.config.{ ConfigFactory, ConfigValueFactory }
+
+class PostgresAsyncContextConfigSpec extends Spec {
+
+  "parses ssl config" in {
+    val config = ConfigFactory.empty()
+      .withValue("user", ConfigValueFactory.fromAnyRef("user"))
+      .withValue("port", ConfigValueFactory.fromAnyRef(5432))
+      .withValue("host", ConfigValueFactory.fromAnyRef("host"))
+      .withValue("sslmode", ConfigValueFactory.fromAnyRef("require"))
+      .withValue("sslrootcert", ConfigValueFactory.fromAnyRef("./file.crt"))
+    val context = new PostgresAsyncContextConfig(config)
+    context.configuration.ssl mustEqual SSLConfiguration(Mode.Require, Some(new File("./file.crt")))
+  }
+}

--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContextConfig.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContextConfig.scala
@@ -2,6 +2,7 @@ package io.getquill.context.async
 
 import com.github.mauricio.async.db.Configuration
 import com.github.mauricio.async.db.Connection
+import com.github.mauricio.async.db.SSLConfiguration
 import com.github.mauricio.async.db.pool.ObjectFactory
 import com.github.mauricio.async.db.pool.PartitionedConnectionPool
 import com.github.mauricio.async.db.pool.PoolConfiguration
@@ -19,6 +20,10 @@ abstract class AsyncContextConfig[C <: Connection](
   def database = Try(config.getString("database")).toOption
   def port = config.getInt("port")
   def host = config.getString("host")
+  def sslProps = Map(
+    "sslmode" -> Try(config.getString("sslmode")).toOption,
+    "sslrootcert" -> Try(config.getString("sslrootcert")).toOption
+  ).collect { case (key, Some(value)) => key -> value }
 
   def configuration =
     new Configuration(
@@ -26,7 +31,8 @@ abstract class AsyncContextConfig[C <: Connection](
       password = password,
       database = database,
       port = port,
-      host = host
+      host = host,
+      ssl = SSLConfiguration(sslProps)
     )
 
   private val defaultPoolConfig = PoolConfiguration.Default


### PR DESCRIPTION
Fixes #586

### Problem

It's impossible to use the async driver with postgresql or mysql that require secure connection

### Solution

Pass ssl properties to async conext config

### Notes

I am not sure how can this change be unit tested

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

