### PR TITLE
support `AnyVal` self lifting

### DIFF
--- a/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
@@ -12,24 +12,28 @@ class ActionMacro(val c: MacroContext)
   import c.universe.{ Ident => _, Function => _, _ }
 
   def runAction(quoted: Tree): Tree =
-    q"""
-      val expanded = ${expand(extractAst(quoted))}
-      ${c.prefix}.executeAction(
-        expanded.string,
-        expanded.prepare
-      )
-    """
+    c.untypecheck {
+      q"""
+        val expanded = ${expand(extractAst(quoted))}
+        ${c.prefix}.executeAction(
+          expanded.string,
+          expanded.prepare
+        )
+      """
+    }
 
   def runActionReturning[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
-    q"""
-      val expanded = ${expand(extractAst(quoted))}
-      ${c.prefix}.executeActionReturning(
-        expanded.string,
-        expanded.prepare,
-        ${returningExtractor[T]},
-        $returningColumn
-      )
-    """
+    c.untypecheck {
+      q"""
+        val expanded = ${expand(extractAst(quoted))}
+        ${c.prefix}.executeActionReturning(
+          expanded.string,
+          expanded.prepare,
+          ${returningExtractor[T]},
+          $returningColumn
+        )
+      """
+    }
 
   def runBatchAction(quoted: Tree): Tree =
     expandBatchAction(quoted) {

--- a/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
@@ -11,7 +11,7 @@ class MetaDslMacro(val c: MacroContext) {
     c.untypecheck {
       q"""
         new ${c.prefix}.SchemaMeta[$t] {
-          override val entity =
+          val entity =
             ${c.prefix}.quote {
               ${c.prefix}.querySchema[$t]($entity, ..$columns)
             }
@@ -23,8 +23,8 @@ class MetaDslMacro(val c: MacroContext) {
     c.untypecheck {
       q"""
         new ${c.prefix}.QueryMeta[$t] {
-          override val expand = $expand
-          override val extract =
+          val expand = $expand
+          val extract =
             (r: ${c.prefix}.ResultRow) => $extract(implicitly[${c.prefix}.QueryMeta[$r]].extract(r))
         }
       """
@@ -40,8 +40,8 @@ class MetaDslMacro(val c: MacroContext) {
     val value = this.value("Decoder", t.tpe)
     q"""
       new ${c.prefix}.QueryMeta[$t] {
-        override val expand = ${expandQuery[T](value)}
-        override val extract = ${extract[T](value)}
+        val expand = ${expandQuery[T](value)}
+        val extract = ${extract[T](value)}
       }
     """
   }
@@ -57,7 +57,7 @@ class MetaDslMacro(val c: MacroContext) {
       case true =>
         q"""
           new ${c.prefix}.SchemaMeta[$t] {
-            override val entity =
+            val entity =
               ${c.prefix}.quote(${c.prefix}.querySchema[$t](${t.tpe.typeSymbol.name.decodedName.toString}))
           }
         """
@@ -119,7 +119,7 @@ class MetaDslMacro(val c: MacroContext) {
     c.untypecheck {
       q"""
         new ${c.prefix}.${TypeName(method.capitalize + "Meta")}[$t] {
-          override val expand =
+          val expand =
             ${c.prefix}.quote((q: ${c.prefix}.EntityQuery[$t], value: $t) => q.${TermName(method)}(..$assignments))
         }
       """

--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -23,20 +23,22 @@ trait Quotation extends Liftables with Unliftables with Parsing with ReifyLiftin
     val (reifiedAst, liftings) = reifyLiftings(ast)
 
     val quotation =
-      q"""
-        new ${c.prefix}.Quoted[$t] { 
-  
-          @${c.weakTypeOf[QuotedAst]}($reifiedAst)
-          def quoted = ast
-  
-          override def ast = $reifiedAst
-          override def toString = ast.toString
-  
-          def $id() = ()
-          
-          $liftings
-        }
-      """
+      c.untypecheck {
+        q"""
+          new ${c.prefix}.Quoted[$t] { 
+    
+            @${c.weakTypeOf[QuotedAst]}($reifiedAst)
+            def quoted = ast
+    
+            override def ast = $reifiedAst
+            override def toString = ast.toString
+    
+            def $id() = ()
+            
+            $liftings
+          }
+        """
+      }
 
     IsDynamic(ast) match {
       case true  => q"$quotation: ${c.prefix}.Quoted[$t]"

--- a/quill-core/src/test/scala/io/getquill/dsl/EncodingDslSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/dsl/EncodingDslSpec.scala
@@ -9,6 +9,27 @@ import scala.language.reflectiveCalls
 
 case class CustomValue(i: Int) extends AnyVal
 
+// Tests self lifting of `AnyVal`
+case class Address(id: AddressId)
+case class AddressId(value: Long) extends AnyVal {
+
+  def `inside quotation` = quote {
+    query[Address].filter(_.id == lift(this))
+  }
+
+  def `inside run - query` = run {
+    query[Address].filter(_.id == lift(this))
+  }
+
+  def `inside run - insert` = run {
+    query[Address].insert(_.id -> lift(this))
+  }
+
+  def `inside run - update` = run {
+    query[Address].update(_.id -> lift(this))
+  }
+}
+
 class EncodingDslSpec extends Spec {
 
   "provides factory methods for encoding" - {


### PR DESCRIPTION
Fixes #585 

### Problem

The compiler is having problems to typecheck self-references of `AnyVal`s expanded by macros.

### Solution

Untypecheck the trees and let the compiler typecheck everything again from scratch.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
