### PR TITLE
[WIP] Upserts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -252,6 +252,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     "-Xfatal-warnings",
     "-deprecation",
     "-encoding", "UTF-8",
+    "-Xmax-classfile-name", "140",
     "-feature",
     "-unchecked",
     "-Yno-adapted-args",

--- a/quill-core/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorContext.scala
@@ -56,6 +56,9 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
                                 returningColumn: String) =
     ActionReturningMirror[O](string, prepare(Row())._2, extractor, returningColumn)
 
+  def executeActionConflict[O](string: String, prepare: Row => Row = identity, extractor: Row => O, returningColumn: String) =
+    ActionReturningMirror[O](string, prepare(Row()), extractor, returningColumn)
+
   def executeBatchAction(groups: List[BatchGroup]) =
     BatchActionMirror {
       groups.map {

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -167,6 +167,8 @@ class MirrorIdiom extends Idiom {
   implicit def actionTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Action] = Tokenizer[Action] {
     case Update(query, assignments)    => stmt"${query.token}.update(${assignments.token})"
     case Insert(query, assignments)    => stmt"${query.token}.insert(${assignments.token})"
+    case Upsert(query, assignments)    => stmt"${query.token}.upsert(${assignments.token})"
+    case Conflict(query, alias, body) => stmt"${query.token}.conflict((${alias.token}) => ${body.token})"
     case Delete(query)                 => stmt"${query.token}.delete"
     case Returning(query, alias, body) => stmt"${query.token}.returning((${alias.token}) => ${body.token})"
     case Foreach(query, alias, body)   => stmt"${query.token}.foreach((${alias.token}) => ${body.token})"

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -165,14 +165,15 @@ class MirrorIdiom extends Idiom {
   }
 
   implicit def actionTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Action] = Tokenizer[Action] {
-    case Update(query, assignments)    => stmt"${query.token}.update(${assignments.token})"
-    case Insert(query, assignments)    => stmt"${query.token}.insert(${assignments.token})"
-    case Upsert(query, assignments)    => stmt"${query.token}.upsert(${assignments.token})"
-    case Conflict(query, alias, body) => stmt"${query.token}.conflict((${alias.token}) => ${body.token})"
+    case Update(query, assignments)         => stmt"${query.token}.update(${assignments.token})"
+    case Insert(query, assignments)         => stmt"${query.token}.insert(${assignments.token})"
+    case Upsert(query, assignments)         => stmt"${query.token}.upsert(${assignments.token})"
+    case Conflict(query, alias, body)       => stmt"${query.token}.conflict((${alias.token}) => ${body.token})"
     case ConflictUpdate(query, assignments) => stmt"${query.token}.conflictUpdate(${assignments.token})"
-    case Delete(query)                 => stmt"${query.token}.delete"
-    case Returning(query, alias, body) => stmt"${query.token}.returning((${alias.token}) => ${body.token})"
-    case Foreach(query, alias, body)   => stmt"${query.token}.foreach((${alias.token}) => ${body.token})"
+    case Nothing(query)                     => stmt"${query.token}.doNothing()"
+    case Delete(query)                      => stmt"${query.token}.delete"
+    case Returning(query, alias, body)      => stmt"${query.token}.returning((${alias.token}) => ${body.token})"
+    case Foreach(query, alias, body)        => stmt"${query.token}.foreach((${alias.token}) => ${body.token})"
   }
 
   implicit def assignmentTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Assignment] = Tokenizer[Assignment] {

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -169,6 +169,7 @@ class MirrorIdiom extends Idiom {
     case Insert(query, assignments)    => stmt"${query.token}.insert(${assignments.token})"
     case Upsert(query, assignments)    => stmt"${query.token}.upsert(${assignments.token})"
     case Conflict(query, alias, body) => stmt"${query.token}.conflict((${alias.token}) => ${body.token})"
+    case ConflictUpdate(query, assignments) => stmt"${query.token}.conflictUpdate(${assignments.token})"
     case Delete(query)                 => stmt"${query.token}.delete"
     case Returning(query, alias, body) => stmt"${query.token}.returning((${alias.token}) => ${body.token})"
     case Foreach(query, alias, body)   => stmt"${query.token}.foreach((${alias.token}) => ${body.token})"

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -112,7 +112,7 @@ case class Insert(query: Ast, assignments: List[Assignment]) extends Action
 case class Upsert(query: Ast, assignments: List[Assignment]) extends Action
 case class Delete(query: Ast) extends Action
 case class Conflict(query: Ast, alias: Ident, property: Ast) extends Action
-
+case class Nothing(query: Ast) extends Action
 case class ConflictUpdate(query: Ast, assignments: List[Assignment]) extends Action
 case class Returning(action: Ast, alias: Ident, property: Ast) extends Action
 

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -109,8 +109,9 @@ sealed trait Action extends Ast
 
 case class Update(query: Ast, assignments: List[Assignment]) extends Action
 case class Insert(query: Ast, assignments: List[Assignment]) extends Action
+case class Upsert(query: Ast, assignments: List[Assignment]) extends Action
 case class Delete(query: Ast) extends Action
-
+case class Conflict(query: Ast, alias: Ident, property: Ast) extends Action
 case class Returning(action: Ast, alias: Ident, property: Ast) extends Action
 
 case class Foreach(query: Ast, alias: Ident, body: Ast) extends Action

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -112,6 +112,8 @@ case class Insert(query: Ast, assignments: List[Assignment]) extends Action
 case class Upsert(query: Ast, assignments: List[Assignment]) extends Action
 case class Delete(query: Ast) extends Action
 case class Conflict(query: Ast, alias: Ident, property: Ast) extends Action
+
+case class ConflictUpdate(query: Ast, assignments: List[Assignment]) extends Action
 case class Returning(action: Ast, alias: Ident, property: Ast) extends Action
 
 case class Foreach(query: Ast, alias: Ident, body: Ast) extends Action

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -172,6 +172,14 @@ trait StatefulTransformer[T] {
         val (at, att) = apply(a)
         val (bt, btt) = att.apply(b)(_.apply)
         (Update(at, bt), btt)
+      case Upsert(a, b) =>
+        val (at, att) = apply(a)
+        val (bt, btt) = att.apply(b)(_.apply)
+        (Upsert(at, bt), btt)
+      case Conflict(a, b, c) =>
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
+        (Conflict(at, b, ct), ctt)
       case Delete(a) =>
         val (at, att) = apply(a)
         (Delete(at), att)

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -184,6 +184,9 @@ trait StatefulTransformer[T] {
         val (at, att) = apply(a)
         val (bt, btt) = att.apply(b)(_.apply)
         (ConflictUpdate(at, bt), btt)
+      case Nothing(a) =>
+        val (at, att) = apply(a)
+        (Nothing(at), att)
       case Delete(a) =>
         val (at, att) = apply(a)
         (Delete(at), att)

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -180,6 +180,10 @@ trait StatefulTransformer[T] {
         val (at, att) = apply(a)
         val (ct, ctt) = att.apply(c)
         (Conflict(at, b, ct), ctt)
+      case ConflictUpdate(a, b) =>
+        val (at, att) = apply(a)
+        val (bt, btt) = att.apply(b)(_.apply)
+        (ConflictUpdate(at, bt), btt)
       case Delete(a) =>
         val (at, att) = apply(a)
         (Delete(at), att)

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -75,6 +75,8 @@ trait StatelessTransformer {
     e match {
       case Update(query, assignments)        => Update(apply(query), assignments.map(apply))
       case Insert(query, assignments)        => Insert(apply(query), assignments.map(apply))
+      case Upsert(query, assignments)        => Upsert(apply(query), assignments.map(apply))
+      case Conflict(query, alias, property) => Conflict(apply(query), alias, apply(property))
       case Delete(query)                     => Delete(apply(query))
       case Returning(query, alias, property) => Returning(apply(query), alias, apply(property))
       case Foreach(query, alias, body)       => Foreach(apply(query), alias, apply(body))

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -77,6 +77,7 @@ trait StatelessTransformer {
       case Insert(query, assignments)        => Insert(apply(query), assignments.map(apply))
       case Upsert(query, assignments)        => Upsert(apply(query), assignments.map(apply))
       case Conflict(query, alias, property) => Conflict(apply(query), alias, apply(property))
+      case ConflictUpdate(query, assignments) => ConflictUpdate(apply(query), assignments.map(apply))
       case Delete(query)                     => Delete(apply(query))
       case Returning(query, alias, property) => Returning(apply(query), alias, apply(property))
       case Foreach(query, alias, body)       => Foreach(apply(query), alias, apply(body))

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -73,14 +73,15 @@ trait StatelessTransformer {
 
   def apply(e: Action): Action =
     e match {
-      case Update(query, assignments)        => Update(apply(query), assignments.map(apply))
-      case Insert(query, assignments)        => Insert(apply(query), assignments.map(apply))
-      case Upsert(query, assignments)        => Upsert(apply(query), assignments.map(apply))
-      case Conflict(query, alias, property) => Conflict(apply(query), alias, apply(property))
+      case Update(query, assignments)         => Update(apply(query), assignments.map(apply))
+      case Insert(query, assignments)         => Insert(apply(query), assignments.map(apply))
+      case Upsert(query, assignments)         => Upsert(apply(query), assignments.map(apply))
+      case Conflict(query, alias, property)   => Conflict(apply(query), alias, apply(property))
       case ConflictUpdate(query, assignments) => ConflictUpdate(apply(query), assignments.map(apply))
-      case Delete(query)                     => Delete(apply(query))
-      case Returning(query, alias, property) => Returning(apply(query), alias, apply(property))
-      case Foreach(query, alias, body)       => Foreach(apply(query), alias, apply(body))
+      case Nothing(query)                     => Nothing(apply(query))
+      case Delete(query)                      => Delete(apply(query))
+      case Returning(query, alias, property)  => Returning(apply(query), alias, apply(property))
+      case Foreach(query, alias, body)        => Foreach(apply(query), alias, apply(body))
     }
 
 }

--- a/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
@@ -36,6 +36,7 @@ class ActionMacro(val c: MacroContext)
         )
       """
     }
+
   def runActionReturning[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
     c.untypecheck {
       q"""

--- a/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
@@ -24,6 +24,18 @@ class ActionMacro(val c: MacroContext)
       """
     }
 
+  def runActionConflict[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
+    c.untypecheck{
+      q"""
+        val expanded = ${expand(extractAst(quoted))}
+        ${c.prefix}.executeActionConflict(
+          expanded.string,
+          expanded.prepare,
+          ${conflictExtractor[T]},
+          $conflictColumn
+        )
+      """
+    }
   def runActionReturning[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
     c.untypecheck {
       q"""
@@ -106,6 +118,19 @@ class ActionMacro(val c: MacroContext)
       }
     """
 
+  private def conflictColumn =
+    q"""
+      expanded.ast match {
+        case io.getquill.ast.Conflict(_, _, io.getquill.ast.Property(_, property)) =>
+        property
+        case ast =>
+          io.getquill.util.Messages.fail(s"Can't find conflict column. Ast: '$$ast'")
+      }
+    """
+
   private def returningExtractor[T](implicit t: WeakTypeTag[T]) =
+    q"(row: ${c.prefix}.ResultRow) => implicitly[Decoder[$t]].apply(0, row)"
+
+  private def conflictExtractor[T](implicit t: WeakTypeTag[T]) =
     q"(row: ${c.prefix}.ResultRow) => implicitly[Decoder[$t]].apply(0, row)"
 }

--- a/quill-core/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Context.scala
@@ -30,6 +30,7 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
   def run[T](quoted: Quoted[Query[T]]): RunQueryResult[T] = macro QueryMacro.runQuery[T]
   def run(quoted: Quoted[Action[_]]): RunActionResult = macro ActionMacro.runAction
   def run[T](quoted: Quoted[ActionReturning[_, T]]): RunActionReturningResult[T] = macro ActionMacro.runActionReturning[T]
+  def run[T](quoted: Quoted[ConflictAction[_, T]]): RunActionReturningResult[T] = macro ActionMacro.runActionConflict[T]
   def run(quoted: Quoted[BatchAction[Action[_]]]): RunBatchActionResult = macro ActionMacro.runBatchAction
   def run[T](quoted: Quoted[BatchAction[ActionReturning[_, T]]]): RunBatchActionReturningResult[T] = macro ActionMacro.runBatchActionReturning[T]
 

--- a/quill-core/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Context.scala
@@ -30,7 +30,7 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
   def run[T](quoted: Quoted[Query[T]]): RunQueryResult[T] = macro QueryMacro.runQuery[T]
   def run(quoted: Quoted[Action[_]]): RunActionResult = macro ActionMacro.runAction
   def run[T](quoted: Quoted[ActionReturning[_, T]]): RunActionReturningResult[T] = macro ActionMacro.runActionReturning[T]
-  def run[T](quoted: Quoted[ConflictAction[_, T]]): RunActionReturningResult[T] = macro ActionMacro.runActionConflict[T]
+  def run[T](quoted: Quoted[ActionConflict[_, T]]): RunActionReturningResult[T] = macro ActionMacro.runActionConflict[T]
   def run(quoted: Quoted[BatchAction[Action[_]]]): RunBatchActionResult = macro ActionMacro.runBatchAction
   def run[T](quoted: Quoted[BatchAction[ActionReturning[_, T]]]): RunBatchActionReturningResult[T] = macro ActionMacro.runBatchActionReturning[T]
 

--- a/quill-core/src/main/scala/io/getquill/dsl/MetaDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/MetaDsl.scala
@@ -9,6 +9,7 @@ trait MetaDslLowPriorityImplicits {
   implicit def materializeUpdateMeta[T]: UpdateMeta[T] = macro MetaDslMacro.materializeUpdateMeta[T]
   implicit def materializeInsertMeta[T]: InsertMeta[T] = macro MetaDslMacro.materializeInsertMeta[T]
   implicit def materializeSchemaMeta[T]: SchemaMeta[T] = macro MetaDslMacro.materializeSchemaMeta[T]
+  implicit def materializeUpsertMeta[T]: UpsertMeta[T] = macro MetaDslMacro.materializeUpsertMeta[T]
 }
 
 trait MetaDsl extends MetaDslLowPriorityImplicits {
@@ -20,6 +21,7 @@ trait MetaDsl extends MetaDslLowPriorityImplicits {
   def queryMeta[T, R](expand: Quoted[Query[T] => Query[R]])(extract: R => T): QueryMeta[T] = macro MetaDslMacro.queryMeta[T, R]
   def updateMeta[T](exclude: (T => Any)*): UpdateMeta[T] = macro MetaDslMacro.updateMeta[T]
   def insertMeta[T](exclude: (T => Any)*): InsertMeta[T] = macro MetaDslMacro.insertMeta[T]
+  def upsertMeta[T](exclude: (T => Any)*): UpsertMeta[T] = macro MetaDslMacro.upsertMeta[T]
 
   trait SchemaMeta[T] {
     def entity: Quoted[EntityQuery[T]]
@@ -36,5 +38,9 @@ trait MetaDsl extends MetaDslLowPriorityImplicits {
 
   trait InsertMeta[T] {
     def expand: Quoted[(EntityQuery[T], T) => Insert[T]]
+  }
+
+  trait UpsertMeta[T] {
+    val expand: Quoted[(EntityQuery[T], T) => Upsert[T]]
   }
 }

--- a/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
@@ -38,6 +38,9 @@ class MetaDslMacro(val c: MacroContext) {
   def updateMeta[T](exclude: Tree*)(implicit t: WeakTypeTag[T]): Tree =
     actionMeta[T](value("Encoder", t.tpe, exclude: _*), "update")
 
+  def upsertMeta[T](exclude: Tree*)(implicit t: WeakTypeTag[T]): Tree =
+    actionMeta[T](value("Encoder", t.tpe, exclude: _*), "upsert")
+
   def materializeQueryMeta[T](implicit t: WeakTypeTag[T]): Tree = {
     val value = this.value("Decoder", t.tpe)
     q"""
@@ -54,6 +57,9 @@ class MetaDslMacro(val c: MacroContext) {
 
   def materializeInsertMeta[T](implicit t: WeakTypeTag[T]): Tree =
     actionMeta[T](value("Encoder", t.tpe), "insert")
+
+  def materializeUpsertMeta[T](implicit t: WeakTypeTag[T]): Tree =
+    actionMeta[T](value("Encoder", t.tpe), "upsert")
 
   def materializeSchemaMeta[T](implicit t: WeakTypeTag[T]): Tree =
     if (t.tpe.typeSymbol.isClass && t.tpe.typeSymbol.asClass.isCaseClass) {

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -92,23 +92,21 @@ private[dsl] trait QueryDsl {
   }
 
   sealed trait ActionReturning[E, Output] extends Action[E]
-  sealed trait ConflictAction[E, Output] extends Action[E]
+
+  sealed trait ActionConflict[E, Output] extends Action[E] {
+    @compileTimeOnly(NonQuotedException.message)
+    def conflictUpdate(value: E): Action[E] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
+    def conflictUpdate(f: (E => (Any, Any)), f2: (E => (Any, Any))*): Action[E] = NonQuotedException()
+  }
 
   sealed trait Update[E] extends Action[E]
   sealed trait Delete[E] extends Action[E]
 
   sealed trait Upsert[E] extends Action[E]{
     @compileTimeOnly(NonQuotedException.message)
-    def update(value: E): Action[E] = NonQuotedException()
-
-    @compileTimeOnly(NonQuotedException.message)
-    def update(f: (E => (Any, Any)), f2: (E => (Any, Any))*): Action[E] = NonQuotedException()
-
-    @compileTimeOnly(NonQuotedException.message)
-    def conflict[R](f: E => R): ConflictAction[E, R] = NonQuotedException()
-
-    @compileTimeOnly(NonQuotedException.message)
-    def returning[R](f: E => R): ActionReturning[E, R] = NonQuotedException()
+    def conflict[R](f: E => R): ActionConflict[E, R] = NonQuotedException()
   }
 
   sealed trait BatchAction[+A <: Action[_]]

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -78,6 +78,9 @@ private[dsl] trait QueryDsl {
     def update(value: T): Update[T] = macro QueryDslMacro.expandUpdate[T]
     def update(f: (T => (Any, Any)), f2: (T => (Any, Any))*): Update[T]
 
+    def upsert(value: T): Upsert[T] = macro QueryDslMacro.expandUpsert[T]
+    def upsert(f: (T => (Any, Any)), f2: (T => (Any, Any))*): Upsert[T]
+
     def delete: Delete[T]
   }
 
@@ -89,8 +92,24 @@ private[dsl] trait QueryDsl {
   }
 
   sealed trait ActionReturning[E, Output] extends Action[E]
+  sealed trait ConflictAction[E, Output] extends Action[E]
+
   sealed trait Update[E] extends Action[E]
   sealed trait Delete[E] extends Action[E]
+
+  sealed trait Upsert[E] extends Action[E]{
+    @compileTimeOnly(NonQuotedException.message)
+    def update(value: E): Action[E] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
+    def update(f: (E => (Any, Any)), f2: (E => (Any, Any))*): Action[E] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
+    def conflict[R](f: E => R): ConflictAction[E, R] = NonQuotedException()
+
+    @compileTimeOnly(NonQuotedException.message)
+    def returning[R](f: E => R): ActionReturning[E, R] = NonQuotedException()
+  }
 
   sealed trait BatchAction[+A <: Action[_]]
 }

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -95,18 +95,19 @@ private[dsl] trait QueryDsl {
 
   sealed trait ActionConflict[E, Output] extends Action[E] {
     @compileTimeOnly(NonQuotedException.message)
-    def conflictUpdate(value: E): Action[E] = NonQuotedException()
+    def conflictUpdate(f: (E => (Any, Any)), f2: (E => (Any, Any))*): Action[E] = NonQuotedException()
 
     @compileTimeOnly(NonQuotedException.message)
-    def conflictUpdate(f: (E => (Any, Any)), f2: (E => (Any, Any))*): Action[E] = NonQuotedException()
+    def doNothing(): Action[E] = NonQuotedException()
   }
 
   sealed trait Update[E] extends Action[E]
   sealed trait Delete[E] extends Action[E]
 
-  sealed trait Upsert[E] extends Action[E]{
+  sealed trait Upsert[E] extends Action[E] {
     @compileTimeOnly(NonQuotedException.message)
     def conflict[R](f: E => R): ActionConflict[E, R] = NonQuotedException()
+    def conflict[R](): ActionConflict[E, R] = NonQuotedException()
   }
 
   sealed trait BatchAction[+A <: Action[_]]

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDslMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDslMacro.scala
@@ -16,6 +16,9 @@ class QueryDslMacro(val c: MacroContext) {
   def expandUpdate[T](value: Tree)(implicit t: WeakTypeTag[T]): Tree =
     expandAction(value, "Update")
 
+  def expandUpsert[T](value: Tree)(implicit t: WeakTypeTag[T]): Tree =
+    expandAction(value, "Upsert")
+
   private def expandAction[T](value: Tree, prefix: String)(implicit t: WeakTypeTag[T]) =
     q"${meta(prefix)}.expand(${c.prefix}, $value)"
 

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -36,6 +36,10 @@ case class BetaReduction(map: collection.Map[Ast, Ast])
         val t = BetaReduction(map - alias)
         Returning(apply(action), alias, t(prop))
 
+      case Conflict(action, alias, prop) =>
+        val t = BetaReduction(map - alias)
+        Conflict(apply(action), alias, t(prop))
+
       case other =>
         super.apply(other)
     }

--- a/quill-core/src/main/scala/io/getquill/norm/Normalize.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/Normalize.scala
@@ -11,8 +11,8 @@ object Normalize extends StatelessTransformer {
   override def apply(q: Action): Action =
     q match {
       case Returning(_, _, _) => NormalizeReturning(super.apply(q))
-      case Conflict(_, _, _) => NormalizeConflict(super.apply(q))
-      case _ => NormalizeReturning(super.apply(q))
+      case Conflict(_, _, _)  => NormalizeConflict(super.apply(q))
+      case _                  => NormalizeReturning(super.apply(q))
     }
 
   override def apply(q: Query): Query =

--- a/quill-core/src/main/scala/io/getquill/norm/Normalize.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/Normalize.scala
@@ -1,10 +1,7 @@
 package io.getquill.norm
 
-import io.getquill.ast.Ast
-import io.getquill.ast.Query
-import io.getquill.ast.StatelessTransformer
+import io.getquill.ast._
 import io.getquill.norm.capture.AvoidCapture
-import io.getquill.ast.Action
 
 object Normalize extends StatelessTransformer {
 
@@ -12,7 +9,11 @@ object Normalize extends StatelessTransformer {
     super.apply(BetaReduction(q))
 
   override def apply(q: Action): Action =
-    NormalizeReturning(super.apply(q))
+    q match {
+      case Returning(_, _, _) => NormalizeReturning(super.apply(q))
+      case Conflict(_, _, _) => NormalizeConflict(super.apply(q))
+      case _ => NormalizeReturning(super.apply(q))
+    }
 
   override def apply(q: Query): Query =
     norm(AvoidCapture(q))

--- a/quill-core/src/main/scala/io/getquill/norm/NormalizeConflict.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/NormalizeConflict.scala
@@ -1,0 +1,24 @@
+package io.getquill.norm
+
+import io.getquill.ast._
+
+object NormalizeConflict {
+
+  def apply(e: Action): Action = {
+    e match {
+      case Conflict(Upsert(query, assignments), alias, body) =>
+        Conflict(Upsert(query, filterReturnedColumn(assignments, body)), alias, body)
+      case e => e
+    }
+  }
+  private def filterReturnedColumn(assignments: List[Assignment], column: Ast): List[Assignment] =
+    assignments.map(filterReturnedColumn(_, column)).flatten
+
+  private def filterReturnedColumn(assignment: Assignment, column: Ast): Option[Assignment] =
+    (assignment, column) match {
+      case (Assignment(_, Property(_, p1), _), Property(_, p2)) if (p1 == p2) =>
+        None
+      case (assignment, column) =>
+        Some(assignment)
+    }
+}

--- a/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -29,6 +29,13 @@ object RenameProperties extends StatelessTransformer {
             val bodyr = BetaReduction(body, replace: _*)
             (Returning(action, alias, bodyr), schema)
         }
+      case Conflict(action: Action, alias, body) =>
+        applySchema(action) match {
+          case (action, schema) =>
+            val replace = replacements(alias, schema)
+            val bodyr = BetaReduction(body, replace: _*)
+            (Conflict(action, alias, bodyr), schema)
+        }
       case q => (q, Tuple(List.empty))
     }
 

--- a/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
@@ -45,6 +45,8 @@ case class FreeVariables(state: State)
     action match {
       case q @ Returning(a, b, c) =>
         (q, free(a, b, c))
+      case q @ Conflict(a, b, c) =>
+        (q, free(a, b, c))
       case other =>
         super.apply(other)
     }

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -122,6 +122,7 @@ trait Liftables {
     case Insert(a, b)       => q"$pack.Insert($a, $b)"
     case Upsert(a, b)       => q"$pack.Upsert($a, $b)"
     case Conflict(a, b, c)    => q"$pack.Conflict($a, $b, $c)"
+    case ConflictUpdate(a, b) => q"$pack.ConflictUpdate($a, $b)"
     case Delete(a)          => q"$pack.Delete($a)"
     case Returning(a, b, c) => q"$pack.Returning($a, $b, $c)"
     case Foreach(a, b, c)   => q"$pack.Foreach($a, $b, $c)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -120,6 +120,8 @@ trait Liftables {
   implicit val actionLiftable: Liftable[Action] = Liftable[Action] {
     case Update(a, b)       => q"$pack.Update($a, $b)"
     case Insert(a, b)       => q"$pack.Insert($a, $b)"
+    case Upsert(a, b)       => q"$pack.Upsert($a, $b)"
+    case Conflict(a, b, c)    => q"$pack.Conflict($a, $b, $c)"
     case Delete(a)          => q"$pack.Delete($a)"
     case Returning(a, b, c) => q"$pack.Returning($a, $b, $c)"
     case Foreach(a, b, c)   => q"$pack.Foreach($a, $b, $c)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -118,14 +118,15 @@ trait Liftables {
   }
 
   implicit val actionLiftable: Liftable[Action] = Liftable[Action] {
-    case Update(a, b)       => q"$pack.Update($a, $b)"
-    case Insert(a, b)       => q"$pack.Insert($a, $b)"
-    case Upsert(a, b)       => q"$pack.Upsert($a, $b)"
+    case Update(a, b)         => q"$pack.Update($a, $b)"
+    case Insert(a, b)         => q"$pack.Insert($a, $b)"
+    case Upsert(a, b)         => q"$pack.Upsert($a, $b)"
     case Conflict(a, b, c)    => q"$pack.Conflict($a, $b, $c)"
     case ConflictUpdate(a, b) => q"$pack.ConflictUpdate($a, $b)"
-    case Delete(a)          => q"$pack.Delete($a)"
-    case Returning(a, b, c) => q"$pack.Returning($a, $b, $c)"
-    case Foreach(a, b, c)   => q"$pack.Foreach($a, $b, $c)"
+    case Nothing(a)           => q"$pack.Nothing($a)"
+    case Delete(a)            => q"$pack.Delete($a)"
+    case Returning(a, b, c)   => q"$pack.Returning($a, $b, $c)"
+    case Foreach(a, b, c)     => q"$pack.Foreach($a, $b, $c)"
   }
 
   implicit val assignmentLiftable: Liftable[Assignment] = Liftable[Assignment] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -418,6 +418,9 @@ trait Parsing {
     case q"$query.$method(..$assignments)" if (method.decodedName.toString == "upsert") =>
       Upsert(astParser(query), assignments.map(assignmentParser(_)))
 
+    case q"$action.$method(..$assignments)" if (method.decodedName.toString == "conflictUpdate") =>
+      ConflictUpdate(astParser(action), assignments.map(assignmentParser(_)))
+
     case q"$query.delete" =>
       Delete(astParser(query))
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -421,6 +421,9 @@ trait Parsing {
     case q"$action.$method(..$assignments)" if (method.decodedName.toString == "conflictUpdate") =>
       ConflictUpdate(astParser(action), assignments.map(assignmentParser(_)))
 
+    case q"$query.doNothing()" =>
+      Nothing(astParser(query))
+
     case q"$query.delete" =>
       Delete(astParser(query))
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -408,14 +408,25 @@ trait Parsing {
   }
 
   val actionParser: Parser[Ast] = Parser[Ast] {
+
     case q"$query.$method(..$assignments)" if (method.decodedName.toString == "update") =>
       Update(astParser(query), assignments.map(assignmentParser(_)))
+
     case q"$query.insert(..$assignments)" =>
       Insert(astParser(query), assignments.map(assignmentParser(_)))
+
+    case q"$query.$method(..$assignments)" if (method.decodedName.toString == "upsert") =>
+      Upsert(astParser(query), assignments.map(assignmentParser(_)))
+
     case q"$query.delete" =>
       Delete(astParser(query))
+
+    case q"$action.conflict[$r](($alias) => $body)" =>
+      Conflict(astParser(action), identParser(alias), astParser(body))
+
     case q"$action.returning[$r](($alias) => $body)" =>
       Returning(astParser(action), identParser(alias), astParser(body))
+    
     case q"$query.foreach[$t1, $t2](($alias) => $body)($f)" if (is[CoreDsl#Query[Any]](query)) =>
       Foreach(astParser(query), identParser(alias), astParser(body))
   }

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -123,14 +123,12 @@ trait Unliftables {
   }
 
   implicit val actionUnliftable: Unliftable[Action] = Unliftable[Action] {
-    case q"$pack.Update.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Update(a, b)
-    case q"$pack.Insert.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Insert(a, b)
-    case q"$pack.Upsert.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Upsert(a, b)
-    case q"$pack.Conflict.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"  => Conflict(a, b, c)
-    case q"$pack.ConflictUpdate.apply(${ a: Ast }, ${ b: List[Assignment]})" => ConflictUpdate(a, b)
-    case q"$pack.Delete.apply(${ a: Ast })"                                => Delete(a)
+    case q"$pack.Update.apply(${ a: Ast }, ${ b: List[Assignment] })" => Update(a, b)
+    case q"$pack.Insert.apply(${ a: Ast }, ${ b: List[Assignment] })" => Insert(a, b)
+    case q"$pack.Conflict.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast }, ${ d: List[Assignment] })" => Conflict(a, b, c, d)
+    case q"$pack.Delete.apply(${ a: Ast })" => Delete(a)
     case q"$pack.Returning.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Returning(a, b, c)
-    case q"$pack.Foreach.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"   => Foreach(a, b, c)
+    case q"$pack.Foreach.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Foreach(a, b, c)
   }
 
   implicit val assignmentUnliftable: Unliftable[Assignment] = Unliftable[Assignment] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -125,6 +125,8 @@ trait Unliftables {
   implicit val actionUnliftable: Unliftable[Action] = Unliftable[Action] {
     case q"$pack.Update.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Update(a, b)
     case q"$pack.Insert.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Insert(a, b)
+    case q"$pack.Upsert.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Upsert(a, b)
+    case q"$pack.Conflict.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"  => Conflict(a, b, c)
     case q"$pack.Delete.apply(${ a: Ast })"                                => Delete(a)
     case q"$pack.Returning.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Returning(a, b, c)
     case q"$pack.Foreach.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"   => Foreach(a, b, c)

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -127,6 +127,7 @@ trait Unliftables {
     case q"$pack.Insert.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Insert(a, b)
     case q"$pack.Upsert.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Upsert(a, b)
     case q"$pack.Conflict.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"  => Conflict(a, b, c)
+    case q"$pack.ConflictUpdate.apply(${ a: Ast }, ${ b: List[Assignment]})" => ConflictUpdate(a, b)
     case q"$pack.Delete.apply(${ a: Ast })"                                => Delete(a)
     case q"$pack.Returning.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Returning(a, b, c)
     case q"$pack.Foreach.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"   => Foreach(a, b, c)

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -123,12 +123,14 @@ trait Unliftables {
   }
 
   implicit val actionUnliftable: Unliftable[Action] = Unliftable[Action] {
-    case q"$pack.Update.apply(${ a: Ast }, ${ b: List[Assignment] })" => Update(a, b)
-    case q"$pack.Insert.apply(${ a: Ast }, ${ b: List[Assignment] })" => Insert(a, b)
-    case q"$pack.Conflict.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast }, ${ d: List[Assignment] })" => Conflict(a, b, c, d)
-    case q"$pack.Delete.apply(${ a: Ast })" => Delete(a)
+    case q"$pack.Update.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Update(a, b)
+    case q"$pack.Insert.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Insert(a, b)
+    case q"$pack.Upsert.apply(${ a: Ast }, ${ b: List[Assignment] })"      => Upsert(a, b)
+    case q"$pack.Conflict.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"  => Conflict(a, b, c)
+    case q"$pack.Delete.apply(${ a: Ast })"                                => Nothing(a)
+    case q"$pack.Delete.apply(${ a: Ast })"                                => Delete(a)
     case q"$pack.Returning.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Returning(a, b, c)
-    case q"$pack.Foreach.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => Foreach(a, b, c)
+    case q"$pack.Foreach.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"   => Foreach(a, b, c)
   }
 
   implicit val assignmentUnliftable: Unliftable[Assignment] = Unliftable[Assignment] {

--- a/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
@@ -1,13 +1,10 @@
 package io.getquill
 
-import io.getquill.idiom.StatementInterpolator._
 import java.util.concurrent.atomic.AtomicInteger
-import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.ast.UnaryOperation
-import io.getquill.ast.Operation
-import io.getquill.ast.Property
-import io.getquill.ast.StringOperator
-import io.getquill.context.sql.idiom.QuestionMarkBindVariables
+
+import io.getquill.ast._
+import io.getquill.context.sql.idiom.{QuestionMarkBindVariables, SqlIdiom}
+import io.getquill.idiom.StatementInterpolator._
 
 trait PostgresDialect
   extends SqlIdiom
@@ -24,6 +21,15 @@ trait PostgresDialect
 
   override def prepareForProbing(string: String) =
     s"PREPARE p${preparedStatementId.incrementAndGet.toString.token} AS $string"
+
+  /*
+  override implicit def actionTokenizer(implicit strategy: NamingStrategy): Tokenizer[Action] = {
+    Tokenizer[Action] {
+      case Upsert(table: Entity, assignments) => super.actionTokenizer.token(Upsert(table, assignments))
+      case action => super.actionTokenizer.token(action)
+    }
+  }
+  */
 }
 
 object PostgresDialect extends PostgresDialect

--- a/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
@@ -3,7 +3,7 @@ package io.getquill
 import java.util.concurrent.atomic.AtomicInteger
 
 import io.getquill.ast._
-import io.getquill.context.sql.idiom.{QuestionMarkBindVariables, SqlIdiom}
+import io.getquill.context.sql.idiom.{ QuestionMarkBindVariables, SqlIdiom }
 import io.getquill.idiom.StatementInterpolator._
 
 trait PostgresDialect
@@ -22,26 +22,30 @@ trait PostgresDialect
   override def prepareForProbing(string: String) =
     s"PREPARE p${preparedStatementId.incrementAndGet.toString.token} AS $string"
 
-
-  /*
-  This doesn't work correctly...
-  INSERT INTO TestEntity (v.s,v.l,v.o) VALUES (?, ?, ?) ON CONFLICT(x1.i) DO UPDATE SET x2.i = ?, x3.l = ?, x4.s = ?
-
   override implicit def actionTokenizer(implicit strategy: NamingStrategy): Tokenizer[Action] = {
+
+    implicit def propertyTokenizer: Tokenizer[Property] = Tokenizer[Property] {
+      case Property(Property(_, name), "isEmpty")   => stmt"${strategy.column(name).token} IS NULL"
+      case Property(Property(_, name), "isDefined") => stmt"${strategy.column(name).token} IS NOT NULL"
+      case Property(Property(_, name), "nonEmpty")  => stmt"${strategy.column(name).token} IS NOT NULL"
+      case Property(_, name)                        => strategy.column(name).token
+    }
+
     Tokenizer[Action] {
       case Upsert(table: Entity, assignments) =>
         val columns = assignments.map(_.property.token)
         val values = assignments.map(_.value)
-        stmt"INSERT INTO ${table.token} (${columns.mkStmt(",")}) VALUES (${values.map(scopedTokenizer(_)).mkStmt(", ")})"
+        stmt"INSERT INTO ${table.token} (${columns.mkStmt()}) VALUES (${values.map(scopedTokenizer(_)).mkStmt()})"
 
-      case Conflict(action, prop, value) => stmt"${action.token} ON CONFLICT(${value.token})"
+      case Conflict(action, _, value)          => stmt"${action.token} ON CONFLICT(${value.token})"
 
       case ConflictUpdate(action, assignments) => stmt"${action.token} DO UPDATE SET ${assignments.mkStmt()}"
 
-      case action => super.actionTokenizer.token(action)
+      case Nothing(query)                      => stmt"${query.token} DO NOTHING"
+
+      case action                              => super.actionTokenizer.token(action)
     }
   }
-  */
 }
 
 object PostgresDialect extends PostgresDialect

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -288,7 +288,14 @@ trait SqlIdiom extends Idiom {
         val values = assignments.map(_.value)
         stmt"INSERT INTO ${table.token} (${columns.mkStmt(",")}) VALUES (${values.map(scopedTokenizer(_)).mkStmt(", ")})"
 
-      //case Upsert(table: Entity, assignments) => fail(s"Your dialect does not support upserts. :-(")
+      case Upsert(_, _) =>
+        fail(s"Your dialect does not support upserts. :-(")
+
+      case Conflict(_, _, _) =>
+        fail(s"Your dialect does not support upserts. :-(")
+
+      case Nothing(_) =>
+        fail(s"Your dialect does not support upserts. :-(")
 
       case Update(table: Entity, assignments) =>
         stmt"UPDATE ${table.token} SET ${assignments.token}"
@@ -302,22 +309,8 @@ trait SqlIdiom extends Idiom {
       case Delete(table: Entity) =>
         stmt"DELETE FROM ${table.token}"
 
-      //case Conflict(action, prop, value) => fail(s"Your dialect does not support upserts. :-(")
-
       case Returning(action, prop, value) =>
         action.token
-
-      //case ConflictUpdate(action, assignments) => fail(s"Your dialect does not support upserts. :-(")
-      /*
-      When implemented here, the query is correct, why?
-      INSERT INTO TestEntity (s,l,o) VALUES (?, ?, ?) ON CONFLICT(i) DO UPDATE SET i = ?, l = ?, s = ?
-      */
-      case Upsert(table: Entity, assignments) =>
-        val columns = assignments.map(_.property.token)
-        val values = assignments.map(_.value)
-        stmt"INSERT INTO ${table.token} (${columns.mkStmt(",")}) VALUES (${values.map(scopedTokenizer(_)).mkStmt(", ")})"
-      case Conflict(action, prop, value) => stmt"${action.token} ON CONFLICT(${value.token})"
-      case ConflictUpdate(action, assignments) => stmt"${action.token} DO UPDATE SET ${assignments.mkStmt()}"
 
       case other =>
         fail(s"Action ast can't be translated to sql: '$other' ${other.getClass}")

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -288,6 +288,8 @@ trait SqlIdiom extends Idiom {
         val values = assignments.map(_.value)
         stmt"INSERT INTO ${table.token} (${columns.mkStmt(",")}) VALUES (${values.map(scopedTokenizer(_)).mkStmt(", ")})"
 
+      case Upsert(table: Entity, assignments) => actionTokenizer.token(Insert(table, assignments))
+
       case Update(table: Entity, assignments) =>
         stmt"UPDATE ${table.token} SET ${assignments.token}"
 
@@ -299,6 +301,9 @@ trait SqlIdiom extends Idiom {
 
       case Delete(table: Entity) =>
         stmt"DELETE FROM ${table.token}"
+
+      case Conflict(action, prop, value) =>
+        stmt"${action.token} ON CONFLICT(${value.token}) UPDATE ${prop.name.token}"
 
       case Returning(action, prop, value) =>
         action.token

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
@@ -24,5 +24,16 @@ class PostgresDialectSpec extends Spec {
       }
       context.run(q).string mustEqual "SELECT t.s::integer FROM TestEntity t"
     }
+    "upsert" in {
+      val e = TestEntity("", 1, 1L, Some(1))
+      val q = quote {
+        qr1.upsert(lift(e)).conflict(_.i)
+      }
+      val i = quote {
+        qr1.insert(lift(TestEntity("", 1, 1L, Some(1))))
+      }
+      println(context.run(i).string)
+      println(context.run(q).string)
+    }
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
@@ -27,12 +27,9 @@ class PostgresDialectSpec extends Spec {
     "upsert" in {
       val e = TestEntity("", 1, 1L, Some(1))
       val q = quote {
-        qr1.upsert(lift(e)).conflict(_.i)
+        query[TestEntity].upsert(lift(e)).conflict(_.i).conflictUpdate(_.i -> lift(2), _.l -> lift(1L), _.s -> lift("Test String"))
       }
-      val i = quote {
-        qr1.insert(lift(TestEntity("", 1, 1L, Some(1))))
-      }
-      println(context.run(i).string)
+
       println(context.run(q).string)
     }
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
@@ -24,13 +24,39 @@ class PostgresDialectSpec extends Spec {
       }
       context.run(q).string mustEqual "SELECT t.s::integer FROM TestEntity t"
     }
+
     "upsert" in {
       val e = TestEntity("", 1, 1L, Some(1))
       val q = quote {
-        query[TestEntity].upsert(lift(e)).conflict(_.i).conflictUpdate(_.i -> lift(2), _.l -> lift(1L), _.s -> lift("Test String"))
+        query[TestEntity]
+          .upsert(e)
+          .conflict(_.i)
+          .conflictUpdate(_.i -> lift(2), _.l -> lift(1L), _.s -> lift("Test String"))
+      }
+
+      val q2 = quote {
+        query[TestEntity]
+          .upsert(lift(e))
+          .conflict(_.i)
+          .doNothing()
+      }
+
+      val q3 = quote {
+        query[TestEntity]
+          .upsert(_.s -> "Hi", _.l -> 10L)
+          .conflict(_.i)
+          .conflictUpdate(_.s -> "Hihi")
       }
 
       println(context.run(q).string)
+      println(context.run(q2).string)
+      println(context.run(q3).string)
+
+      /*
+      INSERT INTO TestEntity (s, l, o) VALUES (s, l, o) ON CONFLICT(i) DO UPDATE SET i = ?, l = ?, s = ?
+      INSERT INTO TestEntity (s, l, o) VALUES (?, ?, ?) ON CONFLICT(i) DO NOTHING
+      INSERT INTO TestEntity (s, l) VALUES ('Hi', 10) ON CONFLICT(i) DO UPDATE SET s = 'Yoyo'
+      */
     }
   }
 }


### PR DESCRIPTION
This is in reference to #16 
### Problem

This ideally should bring atomic upsert support to PostgreSQL 9.5+ and MySQL via the following queries

PgSQL

``` sql
INSERT INTO TestEntity (s,l,o) VALUES (?, ?, ?) ON CONFLICT(i) DO UPDATE SET i = ?, l = ?, s = ?
```

MySQL

``` sql
INSERT INTO TestEntity (s,l,o) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE i = ?, l = ?, s = ?;
```
### Solution

I have added to the DSL an interface that I think encompasses most of the upsert syntax here. You can see in the example queries there are 3 important parts, the insert, the conflict key and then what to do about it.

Thus I have modeled the DSL to look like this

``` scala
quote {
  query[TestEntity]
    .upsert(lift(e))
    .conflict(_.i)
    .conflictUpdate(_.i -> lift(2), _.l -> lift(1L), _.s -> lift("Test String"))
}
```

There are some problems with it right now as I've written it, but I think this is mostly consistent with how it should be, but you guys are in charge so don't let me tell you how to model your DSL :-)

The checklist in #16 was rather out of date with the current library it seemed, so I had to improvise a bit in some places. I'm not sure if the normalization is necessary at all to be honest. There is also some other bugs I've run across I'd like some insight on how to sort out.
### Notes

Additional notes.
### Checklist
- [X] Base DSL Finished
- [X] Able to generate a standard PostgreSQL upsert
- [x] Fix inability to lift a case class in to conflictUpdate()
- [ ] Fix the ability to implement the dialect specific SQL in it's proper dialect subtrait
- [ ] Actually implement the proper dialect specific SQL
  - [x] PostgreSQL
  - [ ] MySQL
- [x] Add inability to use upserts without specifying conflicts or conflict updates
- [x] Add ability to do nothing when an upsert conflicts, such as `INSERT INTO TestEntity (s,l,o) VALUES (?, ?, ?) ON CONFLICT(i) DO NOTHING`
- [ ] Placeholder for things I've probably forgot.

@getquill/maintainers
