### PR TITLE
fix property renaming normalization order

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlNormalize.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlNormalize.scala
@@ -12,8 +12,8 @@ object CqlNormalize {
 
   private[this] val normalize =
     (identity[Ast] _)
-      .andThen(RenameProperties.apply _)
-      .andThen(Normalize.apply _)
-      .andThen(ExpandMappedInfix.apply _)
       .andThen(FlattenOptionOperation.apply _)
+      .andThen(Normalize.apply _)
+      .andThen(RenameProperties.apply _)
+      .andThen(ExpandMappedInfix.apply _)
 }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
@@ -10,8 +10,8 @@ object SqlNormalize {
   private val normalize =
     (identity[Ast] _)
       .andThen(FlattenOptionOperation.apply _)
-      .andThen(RenameProperties.apply _)
       .andThen(Normalize.apply _)
+      .andThen(RenameProperties.apply _)
       .andThen(ExpandJoin.apply _)
       .andThen(Normalize.apply _)
       .andThen(MergeSecondaryJoin.apply _)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -62,13 +62,24 @@ class RenamePropertiesSpec extends Spec {
         testContext.run(q).string mustEqual
           "SELECT u.s, u.i, u.l, u.o FROM test_entity t, TestEntity2 u WHERE u.s = t.field_s"
       }
-      "transitive" in pendingUntilFixed {
+      "transitive" in {
         val q = quote {
           e.flatMap(t => qr2.map(u => t)).map(t => t.s)
         }
         testContext.run(q.dynamic).string mustEqual
           "SELECT t.field_s FROM test_entity t, TestEntity2 u"
-        ()
+      }
+      "with filter" in {
+        val q = quote {
+          for {
+            a <- e
+            b <- qr2 if (a.s == b.s)
+          } yield {
+            (a, b)
+          }
+        }
+        testContext.run(q).string mustEqual
+          "SELECT a.field_s, a.field_i, a.l, a.o, b.s, b.i, b.l, b.o FROM test_entity a, TestEntity2 b WHERE a.field_s = b.s"
       }
     }
     "map" - {


### PR DESCRIPTION
Fixes #557

### Problem

The property renaming runs too early in the normalization pipeline. It should be applied after the standard normalization, that applies intermediate mappings.

### Solution

Fix the normalization order.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
