### PR TITLE
Delete quill_test.db file before setup.

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
 
+DB_FILE=quill_test.db
+
+rm $DB_FILE
+
 echo "Waiting for Sqlite"
-until sqlite3 quill_test.db "SELECT 1" &> /dev/null
+until sqlite3 $DB_FILE "SELECT 1" &> /dev/null
 do
   printf "."
   sleep 1
 done
 echo -e "\nSqlite ready"
 
-sqlite3 quill_test.db < quill-jdbc/src/test/resources/sql/sqlite-schema.sql
+sqlite3 $DB_FILE < quill-jdbc/src/test/resources/sql/sqlite-schema.sql
 
 echo "Waiting for Mysql"
 until mysql -u root -proot -h mysql -e "SELECT 1" &> /dev/null


### PR DESCRIPTION
### Problem

After changing *quill-jdbc/src/test/resources/sql/sqlite-schema.sql* and running `docker-compose stop && docker-compose rm && docker-compose run --rm setup` tests are starting to fail because *quill_test.db* is not recreated during `docker-compose run --rm setup` and *sqlite-schema.sql* only creates tables if they do not exists.

### Solution

Delete *quill_test.db* before setup.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
