### PR TITLE
workaround compiler bug involving reflective calls

### DIFF
--- a/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
@@ -5,6 +5,7 @@ import io.getquill.ast._
 import io.getquill.quotation.ReifyLiftings
 import io.getquill.util.Messages._
 import io.getquill.norm.BetaReduction
+import io.getquill.util.EnableReflectiveCalls
 
 class ActionMacro(val c: MacroContext)
   extends ContextMacro
@@ -14,6 +15,7 @@ class ActionMacro(val c: MacroContext)
   def runAction(quoted: Tree): Tree =
     c.untypecheck {
       q"""
+        ..${EnableReflectiveCalls(c)}
         val expanded = ${expand(extractAst(quoted))}
         ${c.prefix}.executeAction(
           expanded.string,
@@ -25,6 +27,7 @@ class ActionMacro(val c: MacroContext)
   def runActionReturning[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
     c.untypecheck {
       q"""
+        ..${EnableReflectiveCalls(c)}
         val expanded = ${expand(extractAst(quoted))}
         ${c.prefix}.executeActionReturning(
           expanded.string,
@@ -39,6 +42,7 @@ class ActionMacro(val c: MacroContext)
     expandBatchAction(quoted) {
       case (batch, param, expanded) =>
         q"""
+          ..${EnableReflectiveCalls(c)}
           ${c.prefix}.executeBatchAction(
             $batch.map { $param => 
               val expanded = $expanded
@@ -55,6 +59,7 @@ class ActionMacro(val c: MacroContext)
     expandBatchAction(quoted) {
       case (batch, param, expanded) =>
         q"""
+          ..${EnableReflectiveCalls(c)}
           ${c.prefix}.executeBatchActionReturning(
             $batch.map { $param => 
               val expanded = $expanded

--- a/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
@@ -3,6 +3,7 @@ package io.getquill.context
 import io.getquill.ast._
 import scala.reflect.macros.whitebox.{ Context => MacroContext }
 import io.getquill.util.OptionalTypecheck
+import io.getquill.util.EnableReflectiveCalls
 
 class QueryMacro(val c: MacroContext) extends ContextMacro {
   import c.universe.{ Ident => _, _ }
@@ -23,6 +24,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
     val ast = Map(extractAst(quoted), Ident("x"), Ident("x"))
     c.untypecheck {
       q"""
+        ..${EnableReflectiveCalls(c)}
         val expanded = ${expand(ast)}
         ${c.prefix}.${TermName(method)}(
           expanded.string,
@@ -39,6 +41,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
     val ast = extractAst(c.typecheck(q"${c.prefix}.quote($meta.expand($quoted))"))
     c.untypecheck {
       q"""
+        ..${EnableReflectiveCalls(c)}
         val expanded = ${expand(ast)}
         ${c.prefix}.${TermName(method)}(
           expanded.string,

--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -7,6 +7,7 @@ import scala.reflect.macros.whitebox.Context
 import io.getquill.ast._
 import io.getquill.util.Messages.RichContext
 import io.getquill.norm.BetaReduction
+import io.getquill.util.EnableReflectiveCalls
 
 case class QuotedAst(ast: Ast) extends StaticAnnotation
 
@@ -25,13 +26,16 @@ trait Quotation extends Liftables with Unliftables with Parsing with ReifyLiftin
     val quotation =
       c.untypecheck {
         q"""
-          new ${c.prefix}.Quoted[$t] { 
+          new ${c.prefix}.Quoted[$t] {
+ 
+            ..${EnableReflectiveCalls(c)}
     
             @${c.weakTypeOf[QuotedAst]}($reifiedAst)
             def quoted = ast
     
             override def ast = $reifiedAst
             override def toString = ast.toString
+
     
             def $id() = ()
             

--- a/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
@@ -57,10 +57,7 @@ trait ReifyLiftings {
             Transform(refAst) {
               case lift: Lift =>
                 val nested =
-                  q"""
-                    import scala.language.reflectiveCalls
-                    $ref.$liftings.${encode(lift.name)}
-                  """
+                  q"$ref.$liftings.${encode(lift.name)}"
                 lift match {
                   case ScalarValueLift(name, value, encoder) =>
                     ScalarValueLift(s"$ref.$name", q"$nested.value", q"$nested.encoder")

--- a/quill-core/src/main/scala/io/getquill/util/EnableReflectiveCalls.scala
+++ b/quill-core/src/main/scala/io/getquill/util/EnableReflectiveCalls.scala
@@ -1,0 +1,13 @@
+package io.getquill.util
+
+import scala.reflect.macros.blackbox.Context
+
+object EnableReflectiveCalls {
+
+  def apply(c: Context) = {
+    import c.universe._
+    q"import scala.language.reflectiveCalls" ::
+      q"Nil.asInstanceOf[{ def size }].size" ::
+      Nil
+  }
+}

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -1078,4 +1078,12 @@ class QuotationSpec extends Spec {
 
     quote(unquote(q)).ast mustEqual q2.ast
   }
+
+  // nested quotation with lifting compiles as a type member
+  def quote1(i: Int) = quote {
+    qr1.filter(_.i == lift(i))
+  }
+  def quote2 = quote {
+    quote1(1)
+  }
 }


### PR DESCRIPTION
Fixes #542 

### Problem

The compiler tries to infer the type of the `reflectiveCalls` but fails with an NPE when the import is inside the nested structural value.

### Solution

Move the import to the upper level and use a mechanism to avoid unused import warnings.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

