### PR TITLE
avoid alias conflict for multiple nested explicit joins

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
@@ -34,8 +34,8 @@ private case class AvoidAliasConflict(state: collection.Set[Ident])
       case Join(t, a, b, iA, iB, o) =>
         val (ar, art) = apply(a)
         val (br, brt) = art.apply(b)
-        val freshA = freshIdent(iA)
-        val freshB = freshIdent(iB)
+        val freshA = freshIdent(iA, brt.state)
+        val freshB = freshIdent(iB, brt.state)
         val or = BetaReduction(o, iA -> freshA, iB -> freshB)
         val (orr, orrt) = AvoidAliasConflict(brt.state + freshA + freshB)(or)
         (Join(t, ar, br, freshA, freshB, orr), orrt)
@@ -57,7 +57,7 @@ private case class AvoidAliasConflict(state: collection.Set[Ident])
     (f(fresh, prr), t)
   }
 
-  private def freshIdent(x: Ident): Ident =
+  private def freshIdent(x: Ident, state: collection.Set[Ident] = state): Ident =
     if (!state.contains(x))
       x
     else

--- a/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
@@ -116,6 +116,19 @@ class AvoidAliasConflictSpec extends Spec {
         }
         AvoidAliasConflict(q.ast) mustEqual n.ast
       }
+      "multiple" in {
+        val q = quote {
+          qr1.leftJoin(qr2).on((a, b) => a.i == b.i)
+            .leftJoin(qr1).on((a, b) => a._2.forall(v => v.i == b.i))
+            .map(t => 1)
+        }
+        val n = quote {
+          qr1.leftJoin(qr2).on((a, b) => a.i == b.i)
+            .leftJoin(qr1).on((a1, b1) => a1._2.forall(v => v.i == b1.i))
+            .map(t => 1)
+        }
+        AvoidAliasConflict(q.ast) mustEqual n.ast
+      }
     }
   }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/PrepareSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/PrepareSpec.scala
@@ -15,7 +15,7 @@ class PrepareSpec extends Spec {
       }
     }
     testContext.run(q).string mustEqual
-      "SELECT t._1, t1._2 FROM TestEntity a LEFT JOIN (SELECT t.i _1 FROM TestEntity2 t) t ON a.i > t._1, TestEntity a1 LEFT JOIN (SELECT t1.l _2 FROM TestEntity2 t1) t1 ON a1.l < t1._2"
+      "SELECT t._1, t11._2 FROM TestEntity a LEFT JOIN (SELECT t.i _1 FROM TestEntity2 t) t ON a.i > t._1, TestEntity a1 LEFT JOIN (SELECT t11.l _2 FROM TestEntity2 t11) t11 ON a1.l < t11._2"
   }
 
   "mirror sql joins" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -347,7 +347,7 @@ class SqlIdiomSpec extends Spec {
             qr1.leftJoin(qr2).on((a, b) => a.s == b.s).leftJoin(qr2).on((a, b) => a._1.s == b.s).map(_._1._1)
           }
           testContext.run(q).string mustEqual
-            "SELECT a.s, a.i, a.l, a.o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.s = b.s LEFT JOIN TestEntity2 b ON a.s = b.s"
+            "SELECT a.s, a.i, a.l, a.o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.s = b.s LEFT JOIN TestEntity2 b1 ON a.s = b1.s"
         }
         "with flatMap" - {
           "left" ignore {


### PR DESCRIPTION
Fixes #537 

### Problem

Quill doesn't avoid alias conflict when there are multiple nested explicit joins that use the same identifier.

### Solution

Fix `AvoidAliasConflict` to take into consideration the alias already assigned to its subqueries.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

