### PR TITLE
[WIP] Initial commit for Scala 2.12 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -223,6 +223,7 @@ def updateWebsiteTag =
 lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
   organization := "io.getquill",
   scalaVersion := "2.11.11",
+  crossScalaVersions := Seq("2.11.11", "2.12.2"),
   libraryDependencies ++= Seq(
     "org.scalamacros" %% "resetallattrs"  % "1.0.0",
     "org.scalatest"   %%% "scalatest"     % "3.0.1"     % Test,


### PR DESCRIPTION
This is a pull request which adds Scala 2.12 support to Quill. Currently there are quite a few libraries which aren't publish for Scala 2.12 yet, they are documented/tracked here.

https://gist.github.com/mdedetrich/a49083b83ea6a517ceaf5401200a6630

I think it would be a good idea to track which libraries need to be published for 2.12 in this pull request

@getquill/maintainers

