### PR TITLE
avoid merging filter condition into a groupBy.map

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/AttachToEntity.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/AttachToEntity.scala
@@ -13,17 +13,16 @@ object AttachToEntity {
       case Filter(a: Entity, b, c) => Filter(f(a, b), b, c)
       case SortBy(a: Entity, b, c, d) => SortBy(f(a, b), b, c, d)
 
+      case Map(_: GroupBy, _, _) | _: Union | _: UnionAll | _: Join | _: FlatJoin => f(q, alias.getOrElse(Ident("x")))
+
       case Map(a: Query, b, c) => Map(apply(f, Some(b))(a), b, c)
       case FlatMap(a: Query, b, c) => FlatMap(apply(f, Some(b))(a), b, c)
       case Filter(a: Query, b, c) => Filter(apply(f, Some(b))(a), b, c)
       case SortBy(a: Query, b, c, d) => SortBy(apply(f, Some(b))(a), b, c, d)
       case Take(a: Query, b) => Take(apply(f, alias)(a), b)
       case Drop(a: Query, b) => Drop(apply(f, alias)(a), b)
-      case GroupBy(a: Query, b, c) => GroupBy(apply(f, Some(b))(a), b, c)
       case Aggregation(op, a: Query) => Aggregation(op, apply(f, alias)(a))
       case Distinct(a: Query) => Distinct(apply(f, alias)(a))
-
-      case _: Union | _: UnionAll | _: Join | _: FlatJoin => f(q, alias.getOrElse(Ident("x")))
 
       case e: Entity => f(e, alias.getOrElse(Ident("x")))
 

--- a/quill-core/src/test/scala/io/getquill/norm/AttachToEntitySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/AttachToEntitySpec.scala
@@ -78,15 +78,6 @@ class AttachToEntitySpec extends Spec {
         }
         attachToEntity(q.ast) mustEqual n.ast
       }
-      "groupBy" in {
-        val q = quote {
-          qr1.groupBy(b => b.s)
-        }
-        val n = quote {
-          qr1.sortBy(b => 1).groupBy(b => b.s)
-        }
-        attachToEntity(q.ast) mustEqual n.ast
-      }
       "distinct" in {
         val q = quote {
           qr1.sortBy(b => b.s).drop(1).distinct
@@ -124,6 +115,15 @@ class AttachToEntitySpec extends Spec {
       }
       val n = quote {
         qr1.leftJoin(qr2).on((a, b) => true).sortBy(x => 1)
+      }
+      attachToEntity(q.ast) mustEqual n.ast
+    }
+    "groupBy.map" in {
+      val q = quote {
+        qr1.groupBy(a => a.i).map(a => 1)
+      }
+      val n = quote {
+        qr1.groupBy(a => a.i).map(a => 1).sortBy(x => 1)
       }
       attachToEntity(q.ast) mustEqual n.ast
     }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -183,6 +183,16 @@ class SqlIdiomSpec extends Spec {
           testContext.run(q).string mustEqual
             "SELECT t._1, t._2 FROM (SELECT t.i _1, MIN(t.l) _2 FROM TestEntity t GROUP BY t.i) t LIMIT 10"
         }
+        "filter.flatMap(groupBy)" in {
+          val q = quote {
+            for {
+              a <- qr1 if a.i == 1
+              b <- qr2.groupBy(t => t.i).map { case _ => 1 }
+            } yield b
+          }
+          testContext.run(q).string mustEqual
+            "SELECT t.* FROM TestEntity a, (SELECT 1 FROM TestEntity2 t GROUP BY t.i) t WHERE a.i = 1"
+        }
       }
       "aggregated" - {
         "min" in {


### PR DESCRIPTION
Fixes #583

### Problem

`AdHocReduction` moves filter clauses to a position before `groupBy.map`, which is not possible to SQL.

### Solution

Only add the filter after `groupBy.map`.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

