### PR TITLE
Updated sbt to 0.13.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,24 +155,25 @@ lazy val `tut-settings` = Seq(
   tutScalacOptions := Seq(),
   tutSourceDirectory := baseDirectory.value / "target" / "tut",
   tutNameFilter := `tut-sources`.map(_.replaceAll("""\.""", """\.""")).mkString("(", "|", ")").r,
-  sourceGenerators in Compile <+= Def.task {
-    `tut-sources`.foreach { name =>
-      val source = baseDirectory.value / name
-      val file = baseDirectory.value / "target" / "tut" / name
-      val str = IO.read(source).replace("```scala", "```tut")
-      IO.write(file, str)
-    }
-    Seq()
-  }
+  sourceGenerators in Compile +=
+    Def.task {
+      `tut-sources`.foreach { name =>
+        val source = baseDirectory.value / name
+        val file = baseDirectory.value / "target" / "tut" / name
+        val str = IO.read(source).replace("```scala", "```tut")
+        IO.write(file, str)
+      }
+      Seq()
+    }.taskValue
 )
 
 lazy val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
-  previousArtifact := {
+  mimaPreviousArtifacts := {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, scalaMajor)) if scalaMajor <= 11 =>
-        Some(organization.value % s"${name.value}_${scalaBinaryVersion.value}" % "0.5.0")
+        Set(organization.value % s"${name.value}_${scalaBinaryVersion.value}" % "0.5.0")
       case _ =>
-        None
+        Set()
     }
   }
 )
@@ -228,7 +229,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     "ch.qos.logback"  % "logback-classic" % "1.1.7"     % "test",
     "com.google.code.findbugs" % "jsr305" % "3.0.1"     % "provided" // just to avoid warnings during compilation
   ),
-  EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource,
+  EclipseKeys.createSrc := EclipseCreateSrc.Default,
   unmanagedClasspath in Test ++= Seq(
     baseDirectory.value / "src" / "test" / "resources"
   ),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13


### PR DESCRIPTION
Updated sbt version to 0.13.13 and fixed deprecations:

> /app/build.sbt:158: warning: `<+=` operator is deprecated. Use `lhs += { x.value }`.
>   sourceGenerators in Compile <+= Def.task {
>                               ^
> /app/build.sbt:170: warning: value previousArtifact in class BaseMimaKeys is deprecated: Please use mimaPreviousArtifacts which allows setting more than one previous artifact.
>   previousArtifact := {
>   ^
> /app/build.sbt:231: warning: value Resource in object EclipseCreateSrc is deprecated: Always enabled
>   EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource,

See https://github.com/sbt/sbt/releases/tag/v0.13.13

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
