### PR TITLE
[WIP] io free monad

### DIFF
--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
@@ -17,11 +17,13 @@ import scala.util.Try
 import io.getquill.context.sql.SqlContext
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.NamingStrategy
+import io.getquill.monad.ScalaFutureIOMonad
 
 abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection](pool: PartitionedConnectionPool[C])
   extends SqlContext[D, N]
   with Decoders
-  with Encoders {
+  with Encoders
+  with ScalaFutureIOMonad {
 
   private val logger: Logger =
     Logger(LoggerFactory.getLogger(classOf[AsyncContext[_, _, _]]))
@@ -29,12 +31,13 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
   override type PrepareRow = List[Any]
   override type ResultRow = RowData
 
-  override type RunQueryResult[T] = Future[List[T]]
-  override type RunQuerySingleResult[T] = Future[T]
-  override type RunActionResult = Future[Long]
-  override type RunActionReturningResult[T] = Future[T]
-  override type RunBatchActionResult = Future[List[Long]]
-  override type RunBatchActionReturningResult[T] = Future[List[T]]
+  override type Result[T] = Future[T]
+  override type RunQueryResult[T] = List[T]
+  override type RunQuerySingleResult[T] = T
+  override type RunActionResult = Long
+  override type RunActionReturningResult[T] = T
+  override type RunBatchActionResult = List[Long]
+  override type RunBatchActionReturningResult[T] = List[T]
 
   override def close = {
     Await.result(pool.close, Duration.Inf)
@@ -59,6 +62,12 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
   def transaction[T](f: TransactionalExecutionContext => Future[T])(implicit ec: ExecutionContext) =
     pool.inTransaction { c =>
       f(TransactionalExecutionContext(ec, c))
+    }
+
+  override def unsafePerformIO[T](io: IO[T, _], transactional: Boolean = false)(implicit ec: ExecutionContext): Result[T] =
+    transactional match {
+      case false => super.unsafePerformIO(io)
+      case true  => transaction(super.unsafePerformIO(io)(_))
     }
 
   def executeQuery[T](sql: String, prepare: List[Any] => List[Any] = identity, extractor: RowData => T = identity[RowData] _)(implicit ec: ExecutionContext): Future[List[T]] = {

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
@@ -24,10 +24,11 @@ class CassandraStreamContext[N <: NamingStrategy](
   def this(config: Config) = this(CassandraContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 
-  override type RunQueryResult[T] = Observable[T]
-  override type RunQuerySingleResult[T] = Observable[T]
-  override type RunActionResult = Observable[Unit]
-  override type RunBatchActionResult = Observable[Unit]
+  override type Result[T] = Observable[T]
+  override type RunQueryResult[T] = T
+  override type RunQuerySingleResult[T] = T
+  override type RunActionResult = Unit
+  override type RunBatchActionResult = Unit
 
   protected def page(rs: ResultSet): Task[Iterable[Row]] = Task.defer {
     val available = rs.getAvailableWithoutFetching

--- a/quill-core/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorContext.scala
@@ -3,8 +3,8 @@ package io.getquill
 import io.getquill.context.Context
 import io.getquill.context.mirror.{ MirrorDecoders, MirrorEncoders, Row }
 import io.getquill.idiom.{ Idiom => BaseIdiom }
-
 import scala.util.{ Failure, Success, Try }
+import io.getquill.monad.SyncIOMonad
 
 class MirrorContextWithQueryProbing[Idiom <: BaseIdiom, Naming <: NamingStrategy]
   extends MirrorContext[Idiom, Naming] with QueryProbing
@@ -12,10 +12,13 @@ class MirrorContextWithQueryProbing[Idiom <: BaseIdiom, Naming <: NamingStrategy
 class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
   extends Context[Idiom, Naming]
   with MirrorEncoders
-  with MirrorDecoders {
+  with MirrorDecoders
+  with SyncIOMonad {
 
   override type PrepareRow = Row
   override type ResultRow = Row
+
+  override type Result[T] = T
   override type RunQueryResult[T] = QueryMirror[T]
   override type RunQuerySingleResult[T] = QueryMirror[T]
   override type RunActionResult = ActionMirror

--- a/quill-core/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Context.scala
@@ -11,6 +11,7 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
   extends Closeable
   with CoreDsl {
 
+  type Result[T]
   type RunQuerySingleResult[T]
   type RunQueryResult[T]
   type RunActionResult
@@ -23,12 +24,12 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
 
   def probe(statement: String): Try[_]
 
-  def run[T](quoted: Quoted[T]): RunQuerySingleResult[T] = macro QueryMacro.runQuerySingle[T]
-  def run[T](quoted: Quoted[Query[T]]): RunQueryResult[T] = macro QueryMacro.runQuery[T]
-  def run(quoted: Quoted[Action[_]]): RunActionResult = macro ActionMacro.runAction
-  def run[T](quoted: Quoted[ActionReturning[_, T]]): RunActionReturningResult[T] = macro ActionMacro.runActionReturning[T]
-  def run(quoted: Quoted[BatchAction[Action[_]]]): RunBatchActionResult = macro ActionMacro.runBatchAction
-  def run[T](quoted: Quoted[BatchAction[ActionReturning[_, T]]]): RunBatchActionReturningResult[T] = macro ActionMacro.runBatchActionReturning[T]
+  def run[T](quoted: Quoted[T]): Result[RunQuerySingleResult[T]] = macro QueryMacro.runQuerySingle[T]
+  def run[T](quoted: Quoted[Query[T]]): Result[RunQueryResult[T]] = macro QueryMacro.runQuery[T]
+  def run(quoted: Quoted[Action[_]]): Result[RunActionResult] = macro ActionMacro.runAction
+  def run[T](quoted: Quoted[ActionReturning[_, T]]): Result[RunActionReturningResult[T]] = macro ActionMacro.runActionReturning[T]
+  def run(quoted: Quoted[BatchAction[Action[_]]]): Result[RunBatchActionResult] = macro ActionMacro.runBatchAction
+  def run[T](quoted: Quoted[BatchAction[ActionReturning[_, T]]]): Result[RunBatchActionReturningResult[T]] = macro ActionMacro.runBatchActionReturning[T]
 
   protected def handleSingleResult[T](list: List[T]) =
     list match {

--- a/quill-core/src/main/scala/io/getquill/context/mirror/MirrorDecoders.scala
+++ b/quill-core/src/main/scala/io/getquill/context/mirror/MirrorDecoders.scala
@@ -3,13 +3,14 @@ package io.getquill.context.mirror
 import java.time.LocalDate
 import java.util.Date
 
-import io.getquill.MirrorContext
-
 import scala.reflect.ClassTag
+import io.getquill.context.Context
 
 trait MirrorDecoders {
-  this: MirrorContext[_, _] =>
+  this: Context[_, _] =>
 
+  override type PrepareRow = Row
+  override type ResultRow = Row
   override type Decoder[T] = MirrorDecoder[T]
 
   case class MirrorDecoder[T](decoder: BaseDecoder[T]) extends BaseDecoder[T] {

--- a/quill-core/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
+++ b/quill-core/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
@@ -2,12 +2,13 @@ package io.getquill.context.mirror
 
 import java.time.LocalDate
 import java.util.Date
-
-import io.getquill.MirrorContext
+import io.getquill.context.Context
 
 trait MirrorEncoders {
-  this: MirrorContext[_, _] =>
+  this: Context[_, _] =>
 
+  override type PrepareRow = Row
+  override type ResultRow = Row
   override type Encoder[T] = MirrorEncoder[T]
 
   case class MirrorEncoder[T](encoder: BaseEncoder[T]) extends BaseEncoder[T] {

--- a/quill-core/src/main/scala/io/getquill/monad/IOMonad.scala
+++ b/quill-core/src/main/scala/io/getquill/monad/IOMonad.scala
@@ -1,0 +1,126 @@
+package io.getquill.monad
+
+import scala.language.experimental.macros
+import scala.collection.generic.CanBuildFrom
+import scala.language.higherKinds
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import io.getquill.context.Context
+
+sealed trait Effect
+
+object Effect {
+  trait Read extends Effect
+  trait Write extends Effect
+  trait Transaction extends Effect
+}
+
+trait IOMonad {
+  this: Context[_, _] =>
+
+  type Effect = io.getquill.monad.Effect
+  val Effect = io.getquill.monad.Effect
+
+  def runIO[T](quoted: Quoted[T]): IO[RunQuerySingleResult[T], Effect.Read] = macro IOMonadMacro.runIO
+  def runIO[T](quoted: Quoted[Query[T]]): IO[RunQueryResult[T], Effect.Read] = macro IOMonadMacro.runIO
+  def runIO(quoted: Quoted[Action[_]]): IO[RunActionResult, Effect.Write] = macro IOMonadMacro.runIO
+  def runIO[T](quoted: Quoted[ActionReturning[_, T]]): IO[RunActionReturningResult[T], Effect.Write] = macro IOMonadMacro.runIO
+  def runIO(quoted: Quoted[BatchAction[Action[_]]]): IO[RunBatchActionResult, Effect.Write] = macro IOMonadMacro.runIO
+  def runIO[T](quoted: Quoted[BatchAction[ActionReturning[_, T]]]): IO[RunBatchActionReturningResult[T], Effect.Write] = macro IOMonadMacro.runIO
+
+  case class Run[T, E <: Effect](f: () => Result[T]) extends IO[T, E]
+  protected case class FromTry[T](t: Try[T]) extends IO[T, Effect]
+  protected case class Sequence[A, M[X] <: TraversableOnce[X], E <: Effect](in: M[IO[A, E]], cbfIOToResult: CanBuildFrom[M[IO[A, E]], Result[A], M[Result[A]]], cbfResultToValue: CanBuildFrom[M[Result[A]], A, M[A]]) extends IO[M[A], E]
+  protected case class TransformWith[T, S, E1 <: Effect, E2 <: Effect](io: IO[T, E1], f: Try[T] => IO[S, E2]) extends IO[S, E1 with E2]
+  protected case class Transactional[T, E <: Effect](io: IO[T, E]) extends IO[T, E with Effect.Transaction]
+
+  object IO {
+
+    def fromTry[T](result: Try[T]): IO[T, Effect] = FromTry(result)
+
+    def sequence[A, M[X] <: TraversableOnce[X], E <: Effect](in: M[IO[A, E]])(implicit cbfIOToResult: CanBuildFrom[M[IO[A, E]], Result[A], M[Result[A]]], cbfResultToValue: CanBuildFrom[M[Result[A]], A, M[A]]): IO[M[A], E] =
+      Sequence(in, cbfIOToResult, cbfResultToValue)
+
+    val unit: IO[Unit, Effect] = fromTry(Success(()))
+
+    def zip[T, E1 <: Effect, S, E2 <: Effect](a: IO[T, E1], b: IO[S, E2]): IO[(T, S), E1 with E2] =
+      sequence(List(a, b)).map {
+        case a :: b :: Nil => (a.asInstanceOf[T], b.asInstanceOf[S])
+        case other         => throw new IllegalStateException("Sequence returned less than two elements")
+      }
+
+    def failed[T](exception: Throwable): IO[T, Effect] = fromTry(Failure(exception))
+
+    def successful[T](result: T): IO[T, Effect] = fromTry(Success(result))
+
+    def apply[T](body: => T): IO[T, Effect] = fromTry(Try(body))
+
+    def foldLeft[T, R, E <: Effect](ios: collection.immutable.Iterable[IO[T, E]])(zero: R)(op: (R, T) => R): IO[R, E] =
+      sequence(ios).map(_.foldLeft(zero)(op))
+
+    def reduceLeft[T, R >: T, E <: Effect](ios: collection.immutable.Iterable[IO[T, E]])(op: (R, T) => R): IO[R, E] =
+      sequence(ios).map(_.reduceLeft(op))
+
+    def traverse[A, B, M[X] <: TraversableOnce[X], E <: Effect](in: M[A])(fn: A => IO[B, E])(implicit cbf: CanBuildFrom[M[A], B, M[B]]): IO[M[B], E] =
+      sequence(in.map(fn)).map(r => cbf().++=(r).result)
+  }
+
+  sealed trait IO[+T, -E <: Effect] {
+
+    def transactional: IO[T, E with Effect.Transaction] = Transactional(this)
+
+    def transformWith[S, E2 <: Effect](f: Try[T] => IO[S, E2]): IO[S, E with E2] =
+      TransformWith(this, f)
+
+    def transform[S](f: Try[T] => Try[S]): IO[S, E] =
+      transformWith { r =>
+        IO.fromTry(f(r))
+      }
+
+    def lowerFromTry[U](implicit ev: T => Try[U]) =
+      map(ev).flatMap {
+        case Success(v) => IO.successful(v)
+        case Failure(e) => IO.failed(e)
+      }
+
+    def liftToTry: IO[Try[T], E] =
+      transformWith(IO.successful)
+
+    def failed: IO[Throwable, E] =
+      transform {
+        case Failure(t) => Success(t)
+        case Success(v) => Failure(new NoSuchElementException("IO.failed not completed with a throwable."))
+      }
+
+    def map[S](f: T => S): IO[S, E] = transform(_.map(f))
+
+    def flatMap[S, E2 <: Effect](f: T => IO[S, E2]): IO[S, E with E2] =
+      transformWith {
+        case Success(s) => f(s)
+        case Failure(_) => this.asInstanceOf[IO[S, E with E2]]
+      }
+
+    def filter(p: T => Boolean): IO[T, E] =
+      map { r => if (p(r)) r else throw new NoSuchElementException("IO.filter predicate is not satisfied") }
+
+    final def withFilter(p: T => Boolean): IO[T, E] = filter(p)
+
+    def collect[S](pf: PartialFunction[T, S]): IO[S, E] =
+      map {
+        r => pf.applyOrElse(r, (t: T) => throw new NoSuchElementException("IO.collect partial function is not defined at: " + t))
+      }
+
+    def recover[U >: T](pf: PartialFunction[Throwable, U]): IO[U, E] =
+      transform { _ recover pf }
+
+    def recoverWith[U >: T, E2 <: Effect](pf: PartialFunction[Throwable, IO[U, E2]]): IO[U, E with E2] =
+      transformWith {
+        case Failure(t) => pf.applyOrElse(t, (_: Throwable) => this)
+        case Success(_) => this
+      }
+
+    def zip[S, E2 <: Effect](io: IO[S, E2]): IO[(T, S), E with E2] =
+      IO.zip(this, io)
+  }
+}

--- a/quill-core/src/main/scala/io/getquill/monad/IOMonadMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/monad/IOMonadMacro.scala
@@ -1,0 +1,11 @@
+package io.getquill.monad
+
+import io.getquill.util.Messages._
+import scala.reflect.macros.blackbox.{ Context => MacroContext }
+
+class IOMonadMacro(val c: MacroContext) {
+  import c.universe._
+
+  def runIO(quoted: Tree): Tree =
+    c.debug(q"${c.prefix}.Run(() => ${c.prefix}.run($quoted))")
+}

--- a/quill-core/src/main/scala/io/getquill/monad/ScalaFutureIOMonad.scala
+++ b/quill-core/src/main/scala/io/getquill/monad/ScalaFutureIOMonad.scala
@@ -1,0 +1,30 @@
+package io.getquill.monad
+
+import scala.util.Failure
+import scala.util.Success
+import io.getquill.context.Context
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+
+trait ScalaFutureIOMonad extends IOMonad {
+  this: Context[_, _] =>
+
+  type Result[T] = Future[T]
+
+  def unsafePerformIO[T](io: IO[T, _], transactional: Boolean = false)(implicit ec: ExecutionContext): Result[T] =
+    io match {
+      case FromTry(v) => Future.fromTry(v)
+      case Run(f)     => f()
+      case Sequence(in, cbfIOToResult, cbfResultToValue) =>
+        val builder = cbfIOToResult()
+        in.foreach(builder += unsafePerformIO(_))
+        Future.sequence(builder.result)(cbfResultToValue, ec)
+      case TransformWith(a, fA) =>
+        unsafePerformIO(a)
+          .map(Success(_))
+          .recover { case ex => Failure(ex) }
+          .flatMap(v => unsafePerformIO(fA(v)))
+      case Transactional(io) =>
+        unsafePerformIO(io, transactional = true)
+    }
+}

--- a/quill-core/src/main/scala/io/getquill/monad/SyncIOMonad.scala
+++ b/quill-core/src/main/scala/io/getquill/monad/SyncIOMonad.scala
@@ -1,0 +1,40 @@
+package io.getquill.monad
+
+import scala.language.higherKinds
+import io.getquill.context.Context
+import scala.annotation.tailrec
+import scala.util.Try
+
+trait SyncIOMonad extends IOMonad {
+  this: Context[_, _] =>
+
+  type Result[T] = T
+
+  def unsafePerformIO[T](io: IO[T, _], transactional: Boolean = false): Result[T] = {
+
+    @tailrec def loop[U](io: IO[U, _]): Result[U] = {
+
+      def flatten[Y, M[X] <: TraversableOnce[X]](seq: Sequence[Y, M, Effect]) =
+        seq.in.foldLeft(IO.successful(seq.cbfResultToValue())) {
+          (builder, item) =>
+            builder.flatMap(b => item.map(b += _))
+        }.map(_.result())
+
+      io match {
+        case FromTry(v)              => v.get
+        case Run(f)                  => f()
+        case seq @ Sequence(_, _, _) => loop(flatten(seq))
+        case TransformWith(a, fA) =>
+          a match {
+            case FromTry(v)              => loop(fA(v))
+            case Run(r)                  => loop(fA(Try(r())))
+            case seq @ Sequence(_, _, _) => loop(flatten(seq).transformWith(fA))
+            case TransformWith(b, fB)    => loop(b.transformWith(fB(_).transformWith(fA)))
+            case Transactional(io)       => loop(fA(Try(unsafePerformIO(io, transactional = true))))
+          }
+        case Transactional(io) => unsafePerformIO(io, transactional = true)
+      }
+    }
+    loop(io)
+  }
+}

--- a/quill-core/src/test/scala/io/getquill/monad/AsyncMirrorContext.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/AsyncMirrorContext.scala
@@ -1,0 +1,59 @@
+package io.getquill.monad
+
+import io.getquill.context.Context
+import io.getquill.context.mirror.Row
+import scala.concurrent.Future
+import io.getquill.context.mirror.MirrorEncoders
+import io.getquill.context.mirror.MirrorDecoders
+import io.getquill.MirrorIdiom
+import io.getquill.NamingStrategy
+import io.getquill.testContext
+
+class AsyncMirrorContext
+  extends Context[MirrorIdiom, NamingStrategy]
+  with MirrorEncoders
+  with MirrorDecoders
+  with ScalaFutureIOMonad {
+
+  override type PrepareRow = Row
+  override type ResultRow = Row
+
+  override type Result[T] = Future[T]
+  override type RunQueryResult[T] = testContext.QueryMirror[T]
+  override type RunQuerySingleResult[T] = testContext.QueryMirror[T]
+  override type RunActionResult = testContext.ActionMirror
+  override type RunActionReturningResult[T] = testContext.ActionReturningMirror[T]
+  override type RunBatchActionResult = testContext.BatchActionMirror
+  override type RunBatchActionReturningResult[T] = testContext.BatchActionReturningMirror[T]
+
+  override def close = ()
+
+  def probe(statement: String) = testContext.probe(statement)
+
+  def transaction[T](f: => T) = testContext.transaction(f)
+
+  def executeQuery[T](string: String, prepare: Row => Row = identity, extractor: Row => T = identity[Row] _) =
+    Future.successful(testContext.executeQuery(string, prepare, extractor))
+
+  def executeQuerySingle[T](string: String, prepare: Row => Row = identity, extractor: Row => T = identity[Row] _) =
+    Future.successful(testContext.executeQuerySingle(string, prepare, extractor))
+
+  def executeAction(string: String, prepare: Row => Row = identity) =
+    Future.successful(testContext.executeAction(string, prepare))
+
+  def executeActionReturning[O](string: String, prepare: Row => Row = identity, extractor: Row => O,
+                                returningColumn: String) =
+    Future.successful(testContext.executeActionReturning(string, prepare, extractor, returningColumn))
+
+  def executeBatchAction(groups: List[BatchGroup]) =
+    Future.successful(testContext.executeBatchAction(convertBatch(groups)))
+
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Row => T) =
+    Future.successful(testContext.executeBatchActionReturning(convertBatchReturning(groups), extractor))
+
+  private def convertBatch(g: List[BatchGroup]) =
+    g.map(b => testContext.BatchGroup(b.string, b.prepare))
+
+  private def convertBatchReturning(g: List[BatchGroupReturning]) =
+    g.map(b => testContext.BatchGroupReturning(b.string, b.column, b.prepare))
+}

--- a/quill-core/src/test/scala/io/getquill/monad/IOMonadSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/IOMonadSpec.scala
@@ -1,0 +1,428 @@
+package io.getquill.monad
+
+import io.getquill.Spec
+import scala.util.Success
+import scala.util.Try
+import scala.util.Failure
+import io.getquill.monad.Effect.Write
+import io.getquill.TestEntities
+import io.getquill.context.Context
+
+trait IOMonadSpec extends Spec {
+
+  val ctx: Context[_, _] with IOMonad with TestEntities
+  import ctx._
+
+  def eval[T](io: IO[T, _]): T
+
+  "IO companion object" - {
+
+    "fromTry" - {
+      "success" in {
+        val t = Success(1)
+        val io = IO.fromTry(t)
+        Try(eval(io)) mustEqual t
+      }
+      "failure" in {
+        val t = Failure(new Exception)
+        val io = IO.fromTry(t)
+        Try(eval(io)) mustEqual t
+      }
+    }
+
+    "sequence" - {
+      "empty" in {
+        val io = IO.sequence(Seq.empty[IO[Int, Write]])
+        eval(io) mustEqual Seq()
+      }
+      "non-empty" in {
+        val io = IO.sequence(Seq(IO.successful(1), IO.successful(2)))
+        eval(io) mustEqual Seq(1, 2)
+      }
+    }
+
+    "unit" in {
+      eval(IO.unit) mustEqual (())
+    }
+
+    "zip" - {
+      "success" in {
+        val io = IO.zip(IO.successful(1), IO.successful(2))
+        eval(io) mustEqual ((1, 2))
+      }
+      "failure" - {
+        "left" in {
+          val ex = new Exception
+          val io = IO.zip(IO.failed(ex), IO.successful(2))
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+        "right" in {
+          val ex = new Exception
+          val io = IO.zip(IO.successful(1), IO.failed(ex))
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+      }
+    }
+
+    "failed" in {
+      val ex = new Exception
+      val io = IO.failed(ex)
+      Try(eval(io)) mustEqual Failure(ex)
+    }
+
+    "successful" in {
+      val io = IO.successful(1)
+      eval(io) mustEqual 1
+    }
+
+    "apply" - {
+      "success" in {
+        val io = IO(1)
+        eval(io) mustEqual 1
+      }
+      "failure" in {
+        val ex = new Exception
+        val io = IO(throw ex)
+        Try(eval(io)) mustEqual Failure(ex)
+      }
+    }
+
+    "foldLeft" - {
+      "success" in {
+        val ios = List(IO(1), IO(2))
+        val io =
+          IO.foldLeft(ios)(0) {
+            case (a, b) => a + b
+          }
+        eval(io) mustEqual 3
+      }
+      "empty" in {
+        val io =
+          IO.foldLeft(List.empty[IO[Int, Effect]])(0) {
+            case (a, b) => a + b
+          }
+        eval(io) mustEqual 0
+      }
+      "failure" - {
+        "ios" in {
+          val ex = new Exception
+          val ios = List(IO(1), IO.failed[Int](ex))
+          val io =
+            IO.foldLeft(ios)(0) {
+              case (a, b) => a + b
+            }
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+        "op" in {
+          val ex = new Exception
+          val ios = List(IO(1), IO(2))
+          val io =
+            IO.foldLeft(ios)(0) {
+              case (a, b) => throw ex
+            }
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+      }
+    }
+
+    "reduceLeft" - {
+      "success" in {
+        val ios = List(IO(1), IO(2))
+        val io =
+          IO.reduceLeft(ios) {
+            case (a, b) => a + b
+          }
+        eval(io) mustEqual 3
+      }
+      "empty" in {
+        val io =
+          IO.reduceLeft(List.empty[IO[Int, Effect]]) {
+            case (a, b) => a + b
+          }
+        intercept[UnsupportedOperationException](eval(io))
+      }
+      "failure" - {
+        "ios" in {
+          val ex = new Exception
+          val ios = List(IO(1), IO.failed[Int](ex))
+          val io =
+            IO.reduceLeft(ios) {
+              case (a, b) => a + b
+            }
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+        "op" in {
+          val ex = new Exception
+          val ios = List(IO(1), IO(2))
+          val io =
+            IO.reduceLeft(ios) {
+              case (a, b) => throw ex
+            }
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+      }
+    }
+
+    "traverse" - {
+      "empty" in {
+        val ios = List.empty[IO[Int, Effect]]
+        val io = IO.traverse(ios)(IO.successful)
+        eval(io) mustEqual List()
+      }
+      "success" in {
+        val ints = List(1, 2)
+        val io = IO.traverse(ints)(IO.successful)
+        eval(io) mustEqual ints
+      }
+      "failure" in {
+        val ex = new Exception
+        val ints = List(1, 2)
+        val io = IO.traverse(ints)(_ => throw ex)
+        Try(eval(io)) mustEqual Failure(ex)
+      }
+    }
+  }
+
+  "IO instance" - {
+
+    "transformWith" - {
+      "base io" - {
+        "success" in {
+          val t = Success(1)
+          val io = IO.fromTry(t).transformWith(IO.fromTry)
+          Try(eval(io)) mustEqual t
+        }
+        "failure" in {
+          val t = Failure[Int](new Exception)
+          val io = IO.fromTry(t).transformWith(IO.fromTry)
+          Try(eval(io)) mustEqual t
+        }
+      }
+      "transformed io" - {
+        "success" in {
+          val t = Success(1)
+          val io = IO.successful(()).transformWith(_ => IO.fromTry(t))
+          Try(eval(io)) mustEqual t
+        }
+        "failure" in {
+          val t = Failure[Int](new Exception)
+          val io = IO.successful(()).transformWith(_ => IO.fromTry(t))
+          Try(eval(io)) mustEqual t
+        }
+      }
+      "transformation" - {
+        "success" in {
+          val io = IO.successful(1).transformWith(t => IO.fromTry(t.map(_ + 1)))
+          Try(eval(io)) mustEqual Success(2)
+        }
+        "failure" in {
+          val ex = new Exception
+          val io = IO.successful(()).transformWith(_ => throw ex)
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+      }
+    }
+
+    "transform" - {
+      "base io" - {
+        "success" in {
+          val t = Success(1)
+          val io = IO.fromTry(t).transform(identity)
+          Try(eval(io)) mustEqual t
+        }
+        "failure" in {
+          val t = Failure[Int](new Exception)
+          val io = IO.fromTry(t).transform(identity)
+          Try(eval(io)) mustEqual t
+        }
+      }
+      "transformed try" - {
+        "success" in {
+          val t = Success(1)
+          val io = IO.successful(()).transform(_ => t)
+          Try(eval(io)) mustEqual t
+        }
+        "failure" in {
+          val t = Failure[Int](new Exception)
+          val io = IO.successful(()).transform(_ => t)
+          Try(eval(io)) mustEqual t
+        }
+      }
+      "transformation" - {
+        "success" in {
+          val io = IO.successful(1).transform(_.map(_ + 1))
+          Try(eval(io)) mustEqual Success(2)
+        }
+        "failure" in {
+          val ex = new Exception
+          val io = IO.successful(()).transform(_ => throw ex)
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+      }
+    }
+
+    "lowerFromTry" - {
+      "success" in {
+        val t = Success(1)
+        val io = IO.successful(t).lowerFromTry
+        Try(eval(io)) mustEqual t
+      }
+      "failure" in {
+        val t = Failure(new Exception)
+        val io = IO.successful(t).lowerFromTry
+        Try(eval(io)) mustEqual t
+      }
+    }
+
+    "liftToTry" - {
+      "success" in {
+        val t = Success(1)
+        val io = IO.fromTry(t).liftToTry
+        eval(io) mustEqual t
+      }
+      "failure" in {
+        val t = Failure(new Exception)
+        val io = IO.fromTry(t).liftToTry
+        eval(io) mustEqual t
+      }
+    }
+
+    "failed" - {
+      "success" in {
+        val t = Success(1)
+        val io = IO.fromTry(t).failed
+        intercept[NoSuchElementException](eval(io))
+      }
+      "failure" in {
+        val ex = new Exception
+        val t = Failure(ex)
+        val io = IO.fromTry(t).failed
+        eval(io) mustEqual ex
+      }
+    }
+
+    "map" - {
+      "success" in {
+        val t = Success(1)
+        val io = IO.fromTry(t).map(_ + 1)
+        eval(io) mustEqual 2
+      }
+      "failure" in {
+        val t = Failure[Int](new Exception)
+        val io = IO.fromTry(t).map(_ + 1)
+        Try(eval(io)) mustEqual t
+      }
+    }
+
+    "flatMap" - {
+      "success" in {
+        val t = Success(1)
+        val io = IO.fromTry(t).flatMap(i => IO(i + 1))
+        eval(io) mustEqual 2
+      }
+      "failure" in {
+        val t = Failure[Int](new Exception)
+        val io = IO.fromTry(t).flatMap(i => IO(i + 1))
+        Try(eval(io)) mustEqual t
+      }
+    }
+
+    "filter" - {
+      "success" in {
+        val io = IO(1).filter(_ == 1)
+        eval(io) mustEqual 1
+      }
+      "failure" in {
+        val io = IO(1).filter(_ == 2)
+        intercept[NoSuchElementException](eval(io))
+      }
+    }
+
+    "withFilter" - {
+      "success" in {
+        val io = IO(1).filter(_ == 1)
+        eval(io) mustEqual 1
+      }
+      "failure" in {
+        val io = IO(1).filter(_ == 2)
+        intercept[NoSuchElementException](eval(io))
+      }
+    }
+
+    "collect" - {
+      "success" in {
+        val io = IO(1).collect { case 1 => 2 }
+        eval(io) mustEqual 2
+      }
+      "failure" in {
+        val io = IO(1).collect { case 2 => 3 }
+        intercept[NoSuchElementException](eval(io))
+      }
+    }
+
+    "recover" - {
+      "success" in {
+        val t = Success(1)
+        val io = IO.fromTry(t).recover { case _ => 2 }
+        eval(io) mustEqual 1
+      }
+      "failure" in {
+        val t = Failure[Int](new Exception)
+        val io = IO.fromTry(t).recover { case _ => 2 }
+        eval(io) mustEqual 2
+      }
+    }
+
+    "recoverWith" - {
+      "success" in {
+        val t = Success(1)
+        val io = IO.fromTry(t).recoverWith { case _ => IO(2) }
+        eval(io) mustEqual 1
+      }
+      "failure" in {
+        val t = Failure[Int](new Exception)
+        val io = IO.fromTry(t).recoverWith { case _ => IO(2) }
+        eval(io) mustEqual 2
+      }
+    }
+
+    "zip" - {
+      "success" in {
+        val io = IO(1).zip(IO(2))
+        eval(io) mustEqual ((1, 2))
+      }
+      "failure" - {
+        "left" in {
+          val ex = new Exception
+          val io = IO.failed(ex).zip(IO(2))
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+        "right" in {
+          val ex = new Exception
+          val io = IO(1).zip(IO.failed(ex))
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+      }
+    }
+
+    "zipWith" - {
+      "success" in {
+        val io = IO(1).zip(IO(2))
+        eval(io) mustEqual ((1, 2))
+      }
+      "failure" - {
+        "left" in {
+          val ex = new Exception
+          val io = IO.failed(ex).zip(IO(2))
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+        "right" in {
+          val ex = new Exception
+          val io = IO(1).zip(IO.failed(ex))
+          Try(eval(io)) mustEqual Failure(ex)
+        }
+      }
+    }
+  }
+
+}

--- a/quill-core/src/test/scala/io/getquill/monad/ScalaFutureMonadIOSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/ScalaFutureMonadIOSpec.scala
@@ -1,0 +1,25 @@
+package io.getquill.monad
+
+import io.getquill.TestEntities
+import scala.concurrent.ExecutionContext
+import scala.util.Failure
+import scala.util.Try
+
+class ScalaFutureMonadIOSpec extends IOMonadSpec {
+
+  override val ctx = new AsyncMirrorContext with TestEntities
+  import ctx._
+
+  override def eval[T](io: IO[T, _]) = {
+
+    // hack to avoid Await.result since scala.js doesn't support it
+    implicit val immediateEC = new ExecutionContext {
+      def execute(runnable: Runnable) = runnable.run()
+      def reportFailure(cause: Throwable) = ()
+    }
+
+    var res: Try[T] = Failure(new IllegalStateException())
+    unsafePerformIO(io.liftToTry).map(res = _)
+    res.get
+  }
+}

--- a/quill-core/src/test/scala/io/getquill/monad/SyncMonadIOSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/SyncMonadIOSpec.scala
@@ -1,0 +1,39 @@
+package io.getquill.monad
+
+class SyncMonadIOSpec extends IOMonadSpec {
+
+  override val ctx = io.getquill.testContext
+  import ctx._
+
+  override def eval[T](io: IO[T, _]) =
+    unsafePerformIO[T](io)
+
+  "runIO" - {
+    "RunQuerySingleResult" in {
+      val q = quote(qr1.map(_.i).max)
+      eval(ctx.runIO(q)).string mustEqual ctx.run(q).string
+    }
+    "RunQueryResult" in {
+      eval(ctx.runIO(qr1)).string mustEqual ctx.run(qr1).string
+    }
+    "RunActionResult" in {
+      val q = quote(qr1.delete)
+      eval(ctx.runIO(q)).string mustEqual ctx.run(q).string
+    }
+    "RunActionReturningResult" in {
+      val t = TestEntity("1", 2, 3L, Some(4))
+      val q = quote(qr1.insert(lift(t)).returning(_.i))
+      eval(ctx.runIO(q)).string mustEqual ctx.run(q).string
+    }
+    "RunBatchActionResult" in {
+      val l = List(TestEntity("1", 2, 3L, Some(4)))
+      val q = quote(liftQuery(l).foreach(t => qr1.insert(t)))
+      eval(ctx.runIO(q)).groups mustEqual ctx.run(q).groups
+    }
+    "RunBatchActionReturningResult" in {
+      val l = List(TestEntity("1", 2, 3L, Some(4)))
+      val q = quote(liftQuery(l).foreach(t => qr1.insert(t).returning(_.i)))
+      eval(ctx.runIO(q)).groups mustEqual ctx.run(q).groups
+    }
+  }
+}

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -10,7 +10,7 @@ import com.twitter.finagle.mysql.Client
 import com.twitter.finagle.mysql.LongValue
 import com.twitter.finagle.mysql.OK
 import com.twitter.finagle.mysql.Parameter
-import com.twitter.finagle.mysql.Result
+import com.twitter.finagle.mysql.{ Result => MysqlResult }
 import com.twitter.finagle.mysql.Row
 import com.twitter.finagle.mysql.Transactions
 import com.twitter.util.Await
@@ -25,6 +25,7 @@ import io.getquill.context.finagle.mysql.SingleValueRow
 import io.getquill.context.sql.SqlContext
 import io.getquill.util.LoadConfig
 import io.getquill.util.Messages.fail
+import io.getquill.monad.TwitterFutureIOMonad
 
 class FinagleMysqlContext[N <: NamingStrategy](
   client:                             Client with Transactions,
@@ -32,7 +33,8 @@ class FinagleMysqlContext[N <: NamingStrategy](
 )
   extends SqlContext[MySQLDialect, N]
   with FinagleMysqlDecoders
-  with FinagleMysqlEncoders {
+  with FinagleMysqlEncoders
+  with TwitterFutureIOMonad {
 
   def this(config: FinagleMysqlContextConfig) = this(config.client, config.dateTimezone)
   def this(config: Config) = this(FinagleMysqlContextConfig(config))
@@ -44,12 +46,13 @@ class FinagleMysqlContext[N <: NamingStrategy](
   override type PrepareRow = List[Parameter]
   override type ResultRow = Row
 
-  override type RunQueryResult[T] = Future[List[T]]
-  override type RunQuerySingleResult[T] = Future[T]
-  override type RunActionResult = Future[Long]
-  override type RunActionReturningResult[T] = Future[T]
-  override type RunBatchActionResult = Future[List[Long]]
-  override type RunBatchActionReturningResult[T] = Future[List[T]]
+  override type Result[T] = Future[T]
+  override type RunQueryResult[T] = List[T]
+  override type RunQuerySingleResult[T] = T
+  override type RunActionResult = Long
+  override type RunActionReturningResult[T] = T
+  override type RunBatchActionResult = List[Long]
+  override type RunBatchActionReturningResult[T] = List[T]
 
   Await.result(client.ping)
 
@@ -65,6 +68,12 @@ class FinagleMysqlContext[N <: NamingStrategy](
       transactional =>
         currentClient.update(transactional)
         f.ensure(currentClient.clear)
+    }
+
+  override def unsafePerformIO[T](io: IO[T, _], transactional: Boolean = false): Result[T] =
+    transactional match {
+      case false => super.unsafePerformIO(io)
+      case true  => transaction(super.unsafePerformIO(io))
     }
 
   def executeQuery[T](sql: String, prepare: List[Parameter] => List[Parameter] = identity, extractor: Row => T = identity[Row] _): Future[List[T]] = {
@@ -113,10 +122,10 @@ class FinagleMysqlContext[N <: NamingStrategy](
       }
     }.map(_.flatten.toList)
 
-  private def extractReturningValue[T](result: Result, extractor: Row => T) =
+  private def extractReturningValue[T](result: MysqlResult, extractor: Row => T) =
     extractor(SingleValueRow(LongValue(toOk(result).insertId)))
 
-  private def toOk(result: Result) =
+  private def toOk(result: MysqlResult) =
     result match {
       case ok: OK => ok
       case error  => fail(error.toString)

--- a/quill-finagle-mysql/src/main/scala/io/getquill/monad/TwitterFutureIOMonad.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/monad/TwitterFutureIOMonad.scala
@@ -1,0 +1,26 @@
+package io.getquill.monad
+
+import com.twitter.util.Future
+import io.getquill.context.Context
+import com.twitter.util.Try
+
+trait TwitterFutureIOMonad extends IOMonad {
+  this: Context[_, _] =>
+
+  type Result[T] = Future[T]
+
+  def unsafePerformIO[T](io: IO[T, _], transactional: Boolean = false): Result[T] =
+    io match {
+      case FromTry(t) => Future.const(Try.fromScala(t))
+      case Run(f)     => f()
+      case Sequence(in, _, cbf) =>
+        Future.collect(in.map(unsafePerformIO(_)).toSeq)
+          .map(r => cbf().++=(r).result)
+      case TransformWith(a, fA) =>
+        unsafePerformIO(a)
+          .liftToTry.map(_.asScala)
+          .flatMap(v => unsafePerformIO(fA(v)))
+      case Transactional(io) =>
+        unsafePerformIO(io, transactional = true)
+    }
+}

--- a/quill-finagle-mysql/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
@@ -1,0 +1,13 @@
+package io.getquill.monad
+
+import io.getquill.context.finagle.mysql.testContext
+import com.twitter.util.Await
+
+class TwitterFutureIOMonadSpec extends IOMonadSpec {
+
+  val ctx = testContext
+  import ctx._
+
+  def eval[T](io: IO[T, _]): T =
+    Await.result(unsafePerformIO(io))
+}

--- a/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
@@ -9,8 +9,13 @@ import io.getquill.context.sql.SqlContext
 import io.getquill.util.LoadConfig
 import org.slf4j.LoggerFactory
 import scala.util.Try
+import io.getquill.monad.TwitterFutureIOMonad
 
-class FinaglePostgresContext[N <: NamingStrategy](client: Client) extends SqlContext[FinaglePostgresDialect, N] with FinaglePostgresEncoders with FinaglePostgresDecoders {
+class FinaglePostgresContext[N <: NamingStrategy](client: Client)
+  extends SqlContext[FinaglePostgresDialect, N]
+  with FinaglePostgresEncoders
+  with FinaglePostgresDecoders
+  with TwitterFutureIOMonad {
 
   def this(config: FinaglePostgresContextConfig) = this(config.client)
   def this(config: Config) = this(FinaglePostgresContextConfig(config))
@@ -23,12 +28,14 @@ class FinaglePostgresContext[N <: NamingStrategy](client: Client) extends SqlCon
 
   override type PrepareRow = List[Param[_]]
   override type ResultRow = Row
-  override type RunQueryResult[T] = Future[List[T]]
-  override type RunQuerySingleResult[T] = Future[T]
-  override type RunActionResult = Future[Long]
-  override type RunActionReturningResult[T] = Future[T]
-  override type RunBatchActionResult = Future[List[Long]]
-  override type RunBatchActionReturningResult[T] = Future[List[T]]
+
+  override type Result[T] = Future[T]
+  override type RunQueryResult[T] = List[T]
+  override type RunQuerySingleResult[T] = T
+  override type RunActionResult = Long
+  override type RunActionReturningResult[T] = T
+  override type RunBatchActionResult = List[Long]
+  override type RunBatchActionReturningResult[T] = List[T]
 
   private val currentClient = new Local[Client]
 
@@ -39,10 +46,17 @@ class FinaglePostgresContext[N <: NamingStrategy](client: Client) extends SqlCon
 
   def probe(sql: String) = Try(Await.result(client.query(sql)))
 
-  def transaction[T](f: => Future[T]) = client.inTransaction { c =>
-    currentClient.update(c)
-    f.ensure(currentClient.clear)
-  }
+  def transaction[T](f: => Future[T]) =
+    client.inTransaction { c =>
+      currentClient.update(c)
+      f.ensure(currentClient.clear)
+    }
+
+  override def unsafePerformIO[T](io: IO[T, _], transactional: Boolean = false): Result[T] =
+    transactional match {
+      case false => super.unsafePerformIO(io)
+      case true  => transaction(super.unsafePerformIO(io))
+    }
 
   def executeQuery[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[List[T]] = {
     logger.info(sql)

--- a/quill-finagle-postgres/src/main/scala/io/getquill/monad/TwitterFutureIOMonad.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/monad/TwitterFutureIOMonad.scala
@@ -1,0 +1,33 @@
+package io.getquill.monad
+
+import com.twitter.util.Future
+import io.getquill.context.Context
+import com.twitter.util.Return
+import scala.util.Success
+import com.twitter.util.Throw
+import scala.util.Failure
+import com.twitter.util.Try
+
+trait TwitterFutureIOMonad extends IOMonad {
+  this: Context[_, _] =>
+
+  type Result[T] = Future[T]
+
+  def unsafePerformIO[T](io: IO[T, _], transactional: Boolean = false): Result[T] =
+    io match {
+      case FromTry(t) => Future.const(Try(t.get))
+      case Run(f)     => f()
+      case Sequence(in, _, cbf) =>
+        Future.collect(in.map(unsafePerformIO(_)).toSeq)
+          .map(r => cbf().++=(r).result)
+      case TransformWith(a, fA) =>
+        unsafePerformIO(a)
+          .liftToTry.map {
+            case Return(v) => Success(v)
+            case Throw(t)  => Failure(t)
+          }
+          .flatMap(v => unsafePerformIO(fA(v)))
+      case Transactional(io) =>
+        unsafePerformIO(io, transactional = true)
+    }
+}

--- a/quill-finagle-postgres/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
@@ -1,0 +1,13 @@
+package io.getquill.monad
+
+import io.getquill.context.finagle.postgres.testContext
+import com.twitter.util.Await
+
+class TwitterFutureIOMonadSpec extends IOMonadSpec {
+
+  val ctx = testContext
+  import ctx._
+
+  def eval[T](io: IO[T, _]): T =
+    Await.result(unsafePerformIO(io))
+}


### PR DESCRIPTION
Fixes #21 

### Problem

Quill performs side effects but doesn't provide an easy way to isolate them.

### Solution

Introduce the `IO` free monad that defers execution until `unsafePerformIO` is called.

### Notes

The execution of `IO` uses the same execution mechanism its context. For instance, it doesn't try to implement an async wrapper on top of jdbc; the return type of a synchronous context is synchronous.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
