### PR TITLE
make currentConnection protected

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/JdbcContext.scala
@@ -43,7 +43,7 @@ class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](dataSource: Dat
   override type RunBatchActionResult = List[Long]
   override type RunBatchActionReturningResult[T] = List[T]
 
-  private val currentConnection = new DynamicVariable[Option[Connection]](None)
+  protected val currentConnection = new DynamicVariable[Option[Connection]](None)
 
   protected def withConnection[T](f: Connection => T) =
     currentConnection.value.map(f).getOrElse {


### PR DESCRIPTION
### Problem

Actually at the moment it's really hard to convert our JDBC code to quill due to the fact that we can't override/change the `currentConnection`.

At the moment we just want to create a Adapter that takes a `implicit connection` and does the same thing like `transaction` except getting a `Connection` via `withConnection`.

### Solution
Sets `currentConnection` to `protected`.

Current way: override transaction **and** withConnection and using our own currentConnection.

### Notes

none

### Checklist

- [ ] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

use case: creating a transaction adapter between other jdbc libraries and quill