### PR TITLE
[WIP] Support Option.contains

### DIFF
--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -122,9 +122,10 @@ class MirrorIdiom extends Idiom {
   implicit def optionOperationTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[OptionOperation] = Tokenizer[OptionOperation] {
     case q: OptionOperation =>
       val method = q.t match {
-        case OptionMap    => "map"
-        case OptionForall => "forall"
-        case OptionExists => "exists"
+        case OptionMap      => "map"
+        case OptionContains => "contains"
+        case OptionForall   => "forall"
+        case OptionExists   => "exists"
       }
       stmt"${q.ast.token}.${method.token}((${q.alias.token}) => ${q.body.token})"
   }

--- a/quill-core/src/main/scala/io/getquill/ast/OptionOperationType.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/OptionOperationType.scala
@@ -3,5 +3,6 @@ package io.getquill.ast
 sealed trait OptionOperationType
 
 case object OptionMap extends OptionOperationType
+case object OptionContains extends OptionOperationType
 case object OptionForall extends OptionOperationType
 case object OptionExists extends OptionOperationType

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -35,9 +35,10 @@ trait Liftables {
   }
 
   implicit val optionOperationTypeLiftable: Liftable[OptionOperationType] = Liftable[OptionOperationType] {
-    case OptionMap    => q"$pack.OptionMap"
-    case OptionForall => q"$pack.OptionForall"
-    case OptionExists => q"$pack.OptionExists"
+    case OptionMap      => q"$pack.OptionMap"
+    case OptionContains => q"$pack.OptionContains"
+    case OptionForall   => q"$pack.OptionForall"
+    case OptionExists   => q"$pack.OptionExists"
   }
 
   implicit val binaryOperatorLiftable: Liftable[BinaryOperator] = Liftable[BinaryOperator] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -282,6 +282,8 @@ trait Parsing {
   val optionOperationParser: Parser[OptionOperation] = Parser[OptionOperation] {
     case q"$o.map[$t]({($alias) => $body})" if (is[Option[Any]](o)) =>
       OptionOperation(OptionMap, astParser(o), identParser(alias), astParser(body))
+    case q"$o.contains[$t]($body)" if (is[Option[Any]](o)) =>
+      OptionOperation(OptionContains, astParser(o), identParser(q"???"), astParser(body))
     case q"$o.forall({($alias) => $body})" if (is[Option[Any]](o)) =>
       OptionOperation(OptionForall, astParser(o), identParser(alias), astParser(body))
     case q"$o.exists({($alias) => $body})" if (is[Option[Any]](o)) =>

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -29,9 +29,10 @@ trait Unliftables {
   }
 
   implicit val optionOperationTypeUnliftable: Unliftable[OptionOperationType] = Unliftable[OptionOperationType] {
-    case q"$pack.OptionMap"    => OptionMap
-    case q"$pack.OptionForall" => OptionForall
-    case q"$pack.OptionExists" => OptionExists
+    case q"$pack.OptionMap"      => OptionMap
+    case q"$pack.OptionContains" => OptionContains
+    case q"$pack.OptionForall"   => OptionForall
+    case q"$pack.OptionExists"   => OptionExists
   }
 
   implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -153,7 +153,13 @@ class StatelessTransformerSpec extends Spec {
         Infix(List("test"), List(Ident("a'"), Ident("b'")))
     }
 
-    "option operation" in {
+    "option contains" in {
+      val ast: Ast = OptionOperation(OptionContains, Ident("a"), Ident("b"), Ident("c"))
+      Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+        OptionOperation(OptionContains, Ident("a'"), Ident("b"), Ident("c'"))
+    }
+
+    "option forall" in {
       val ast: Ast = OptionOperation(OptionForall, Ident("a"), Ident("b"), Ident("c"))
       Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
         OptionOperation(OptionForall, Ident("a'"), Ident("b"), Ident("c'"))

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -672,6 +672,12 @@ class QuotationSpec extends Spec {
         }
         quote(unquote(q)).ast.body mustEqual OptionOperation(OptionMap, Ident("o"), Ident("v"), Ident("v"))
       }
+      "contains" in {
+        val q = quote {
+          (o: Option[Int]) => o.contains(1)
+        }
+        quote(unquote(q)).ast.body mustEqual OptionOperation(OptionContains, Ident("o"), Ident("qmarkqmarkqmark"), Constant(1))
+      }
       "forall" in {
         val q = quote {
           (o: Option[Boolean]) => o.forall(v => v)


### PR DESCRIPTION
Partially addresses #630

### Problem

Currently, `Option.contains` produces a compilation error: `Tree 'p.emailSettingId.contains[Int](c.id)' can't be parsed to 'Ast'`

### Solution

This PR adds support for `Option.contains`, using the same mechanism as for `forall`, `exists` and `map`.

### Notes

I don't know what to put into `OptionOperation.alias`, because contains accepts a body and not a lambda. I currently just put `q"???"` into the alias, just to make it compile. I'm opening this PR to get feedback on possible workaround.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers