### PR TITLE
hides debug/info/warn messages behind a flag

### DIFF
--- a/quill-core/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core/src/main/scala/io/getquill/util/Messages.scala
@@ -4,6 +4,11 @@ import scala.reflect.macros.blackbox.{ Context => MacroContext }
 
 object Messages {
 
+  private val debugEnabled = {
+    !sys.env.get("quill.macro.log").filterNot(_.isEmpty).map(_.toLowerCase).contains("false") &&
+      !Option(System.getProperty("quill.macro.log")).filterNot(_.isEmpty).map(_.toLowerCase).contains("false")
+  }
+
   def fail(msg: String) =
     throw new IllegalStateException(msg)
 
@@ -19,7 +24,7 @@ object Messages {
       c.warning(c.enclosingPosition, msg)
 
     def info(msg: String): Unit =
-      c.info(c.enclosingPosition, msg, force = true)
+      if (debugEnabled) c.info(c.enclosingPosition, msg, force = true)
 
     def debug[T](v: T): T = {
       info(v.toString)


### PR DESCRIPTION
Fixes #632

### Problem

When you people reach more and more compiled queries the log gets overhauled whenever doing a `sbt clean compile` run. This hides the debug/info/warn output behind a flag, so that whenever somebody wants to enable it, they need to run via `sbt -Dquill.macro.log=true`. (Does not disable, fail and error, maybe I will exclude warn as well?)

More info in Ticket.

P.S.: not sure if this is testable :-(

@getquill/maintainers

