### PR TITLE
Add abstract encoders/decoders to CassandraContext and uuid mirror encoder/decoder

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContext.scala
@@ -1,8 +1,36 @@
 package io.getquill.context.cassandra
 
-import io.getquill.context.Context
+import java.util.{ Date, UUID }
+
 import io.getquill.NamingStrategy
+import io.getquill.context.Context
 
 trait CassandraContext[N <: NamingStrategy]
   extends Context[CqlIdiom, N]
-  with Ops
+  with Ops {
+
+  implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]]
+  implicit def optionEncoder[T](implicit d: Encoder[T]): Encoder[Option[T]]
+
+  implicit val stringDecoder: Decoder[String]
+  implicit val bigDecimalDecoder: Decoder[BigDecimal]
+  implicit val booleanDecoder: Decoder[Boolean]
+  implicit val intDecoder: Decoder[Int]
+  implicit val longDecoder: Decoder[Long]
+  implicit val floatDecoder: Decoder[Float]
+  implicit val doubleDecoder: Decoder[Double]
+  implicit val byteArrayDecoder: Decoder[Array[Byte]]
+  implicit val uuidDecoder: Decoder[UUID]
+  implicit val dateDecoder: Decoder[Date]
+
+  implicit val stringEncoder: Encoder[String]
+  implicit val bigDecimalEncoder: Encoder[BigDecimal]
+  implicit val booleanEncoder: Encoder[Boolean]
+  implicit val intEncoder: Encoder[Int]
+  implicit val longEncoder: Encoder[Long]
+  implicit val floatEncoder: Encoder[Float]
+  implicit val doubleEncoder: Encoder[Double]
+  implicit val byteArrayEncoder: Encoder[Array[Byte]]
+  implicit val uuidEncoder: Encoder[UUID]
+  implicit val dateEncoder: Encoder[Date]
+}

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
@@ -1,5 +1,7 @@
 package io.getquill.context.cassandra.encoding
 
+import java.util.{ Date, UUID }
+
 import io.getquill.context.cassandra.CassandraSessionContext
 import io.getquill.util.Messages.fail
 
@@ -36,21 +38,21 @@ trait Decoders {
   implicit def mappedDecoder[I, O](implicit mapped: MappedEncoding[I, O], decoder: Decoder[I]): Decoder[O] =
     CassandraDecoder(mappedBaseDecoder(mapped, decoder.decoder))
 
-  implicit val stringDecoder = decoder(_.getString)
+  implicit val stringDecoder: Decoder[String] = decoder(_.getString)
   implicit val bigDecimalDecoder: Decoder[BigDecimal] =
     decoder((index, row) => row.getDecimal(index))
-  implicit val booleanDecoder = decoder(_.getBool)
-  implicit val intDecoder = decoder(_.getInt)
-  implicit val longDecoder = decoder(_.getLong)
-  implicit val floatDecoder = decoder(_.getFloat)
-  implicit val doubleDecoder = decoder(_.getDouble)
-  implicit val byteArrayDecoder =
+  implicit val booleanDecoder: Decoder[Boolean] = decoder(_.getBool)
+  implicit val intDecoder: Decoder[Int] = decoder(_.getInt)
+  implicit val longDecoder: Decoder[Long] = decoder(_.getLong)
+  implicit val floatDecoder: Decoder[Float] = decoder(_.getFloat)
+  implicit val doubleDecoder: Decoder[Double] = decoder(_.getDouble)
+  implicit val byteArrayDecoder: Decoder[Array[Byte]] =
     decoder((index, row) => {
       val bb = row.getBytes(index)
       val b = new Array[Byte](bb.remaining())
       bb.get(b)
       b
     })
-  implicit val uuidDecoder = decoder(_.getUUID)
-  implicit val dateDecoder = decoder(_.getTimestamp)
+  implicit val uuidDecoder: Decoder[UUID] = decoder(_.getUUID)
+  implicit val dateDecoder: Decoder[Date] = decoder(_.getTimestamp)
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
@@ -1,6 +1,7 @@
 package io.getquill.context.cassandra.encoding
 
 import java.nio.ByteBuffer
+import java.util.{ Date, UUID }
 
 import io.getquill.context.cassandra.CassandraSessionContext
 
@@ -33,16 +34,16 @@ trait Encoders {
   implicit def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], encoder: Encoder[O]): Encoder[I] =
     CassandraEncoder(mappedBaseEncoder(mapped, encoder.encoder))
 
-  implicit val stringEncoder = encoder(_.setString)
+  implicit val stringEncoder: Encoder[String] = encoder(_.setString)
   implicit val bigDecimalEncoder: Encoder[BigDecimal] =
     encoder((index, value, row) => row.setDecimal(index, value.bigDecimal))
-  implicit val booleanEncoder = encoder(_.setBool)
-  implicit val intEncoder = encoder(_.setInt)
-  implicit val longEncoder = encoder(_.setLong)
-  implicit val floatEncoder = encoder(_.setFloat)
-  implicit val doubleEncoder = encoder(_.setDouble)
+  implicit val booleanEncoder: Encoder[Boolean] = encoder(_.setBool)
+  implicit val intEncoder: Encoder[Int] = encoder(_.setInt)
+  implicit val longEncoder: Encoder[Long] = encoder(_.setLong)
+  implicit val floatEncoder: Encoder[Float] = encoder(_.setFloat)
+  implicit val doubleEncoder: Encoder[Double] = encoder(_.setDouble)
   implicit val byteArrayEncoder: Encoder[Array[Byte]] =
     encoder((index, value, row) => row.setBytes(index, ByteBuffer.wrap(value)))
-  implicit val uuidEncoder = encoder(_.setUUID)
-  implicit val dateEncoder = encoder(_.setTimestamp)
+  implicit val uuidEncoder: Encoder[UUID] = encoder(_.setUUID)
+  implicit val dateEncoder: Encoder[Date] = encoder(_.setTimestamp)
 }

--- a/quill-core/src/main/scala/io/getquill/context/mirror/MirrorDecoders.scala
+++ b/quill-core/src/main/scala/io/getquill/context/mirror/MirrorDecoders.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.mirror
 
 import java.time.LocalDate
-import java.util.Date
+import java.util.{ Date, UUID }
 
 import io.getquill.MirrorContext
 
@@ -41,4 +41,5 @@ trait MirrorDecoders {
   implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoder[Array[Byte]]
   implicit val dateDecoder: Decoder[Date] = decoder[Date]
   implicit val localDateDecoder: Decoder[LocalDate] = decoder[LocalDate]
+  implicit val uuidDecoder: Decoder[UUID] = decoder[UUID]
 }

--- a/quill-core/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
+++ b/quill-core/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.mirror
 
 import java.time.LocalDate
-import java.util.Date
+import java.util.{ Date, UUID }
 
 import io.getquill.MirrorContext
 
@@ -40,4 +40,5 @@ trait MirrorEncoders {
   implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder[Array[Byte]]
   implicit val dateEncoder: Encoder[Date] = encoder[Date]
   implicit val localDateEncoder: Encoder[LocalDate] = encoder[LocalDate]
+  implicit val uuidEncoder: Encoder[UUID] = encoder[UUID]
 }


### PR DESCRIPTION
Fixes #634

### Problem

Currently we cannot use CassandraContext scope to create useful queries because of lack of decoders/encoders. This PR brings the possibility to do so. More info in issue #634

### Solution

Add abstract encoders/decoders in CassandraContext trait

### Notes

`io.getquill.context.cassandra.encoding.Decoders / Encders` now have explicit types due to compilation errors. Added uuid mirror encoder/decoder to have compatibility with cassandra one.

### Checklist

- [+] Unit test all changes
- [+] Update `README.md` if applicable
- [+] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [+] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers