### PR TITLE
Made the SQL types for AsyncEncoder/AsyncDecoder generic

### DIFF
--- a/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
@@ -14,7 +14,9 @@ trait Decoders {
 
   type Decoder[T] = AsyncDecoder[T]
 
-  case class AsyncDecoder[T](sqlType: SqlTypes.SqlTypes)(implicit decoder: BaseDecoder[T])
+  type DecoderSqlType = SqlTypes.SqlTypes
+
+  case class AsyncDecoder[T](sqlType: DecoderSqlType)(implicit decoder: BaseDecoder[T])
     extends BaseDecoder[T] {
     override def apply(index: Index, row: ResultRow) =
       decoder(index, row)
@@ -22,7 +24,7 @@ trait Decoders {
 
   def decoder[T: ClassTag](
     f:       PartialFunction[Any, T] = PartialFunction.empty,
-    sqlType: SqlTypes.SqlTypes
+    sqlType: DecoderSqlType
   ): Decoder[T] =
     AsyncDecoder[T](sqlType)(new BaseDecoder[T] {
       def apply(index: Int, row: RowData) = {

--- a/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
@@ -10,16 +10,18 @@ trait Encoders {
 
   type Encoder[T] = AsyncEncoder[T]
 
-  case class AsyncEncoder[T](sqlType: SqlTypes.SqlTypes)(implicit encoder: BaseEncoder[T])
+  type EncoderSqlType = SqlTypes.SqlTypes
+
+  case class AsyncEncoder[T](sqlType: DecoderSqlType)(implicit encoder: BaseEncoder[T])
     extends BaseEncoder[T] {
     override def apply(index: Index, value: T, row: PrepareRow) =
       encoder.apply(index, value, row)
   }
 
-  def encoder[T](sqlType: SqlTypes.SqlTypes): Encoder[T] =
+  def encoder[T](sqlType: DecoderSqlType): Encoder[T] =
     encoder(identity[T], sqlType)
 
-  def encoder[T](f: T => Any, sqlType: SqlTypes.SqlTypes): Encoder[T] =
+  def encoder[T](f: T => Any, sqlType: DecoderSqlType): Encoder[T] =
     AsyncEncoder[T](sqlType)(new BaseEncoder[T] {
       def apply(index: Index, value: T, row: PrepareRow) =
         row :+ f(value)


### PR DESCRIPTION
### Problem

For custom driver solutions that are based off postgres-async, I need to be able to override the SQL type to add extra options to the enum (for example, `JSON`/`JSONB`)

### Solution

Created a type alias for `SqlTypes.SqlType` which can be overridden when you extend the trait

### Checklist

- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers