### PR TITLE
elimiate nest sql query like `SELECT x.* FROM (xxx) x`

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/SqlQuery.scala
@@ -53,6 +53,7 @@ object SqlQuery {
       case UnionAll(a, b)               => SetOperationSqlQuery(apply(a), UnionAllOperation, apply(b))
       case UnaryOperation(op, q: Query) => UnaryOperationSqlQuery(op, apply(q))
       case _: Operation | _: Value      => FlattenSqlQuery(select = List(SelectValue(query)))
+      case Map(q, a, b) if a == b       => apply(q)
       case q: Query                     => flatten(q, "x")
       case other                        => fail(s"Query not properly normalized. Please open a bug report. Ast: '$other'")
     }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -48,12 +48,12 @@ class SqlQuerySpec extends Spec {
           qr1.map(t => t.i).contains(1)
         }
         testContext.run(q).string mustEqual
-          "SELECT t.* FROM (SELECT 1 IN (SELECT t.i FROM TestEntity t)) t"
+          "SELECT 1 IN (SELECT t.i FROM TestEntity t)"
       }
       "simple value" in {
         val q = quote(1)
         testContext.run(q).string mustEqual
-          "SELECT x.* FROM (SELECT 1) x"
+          "SELECT 1"
       }
     }
 
@@ -159,7 +159,7 @@ class SqlQuerySpec extends Spec {
           qr1.groupBy(t => t.i).map(t => t._1)
         }
         testContext.run(q).string mustEqual
-          "SELECT t.* FROM (SELECT t.i FROM TestEntity t GROUP BY t.i) t"
+          "SELECT t.i FROM TestEntity t GROUP BY t.i"
       }
       "nested" in {
         val q = quote {
@@ -338,14 +338,14 @@ class SqlQuerySpec extends Spec {
           qr1.nonEmpty
         }
         testContext.run(q).string mustEqual
-          "SELECT x.* FROM (SELECT EXISTS (SELECT x.* FROM TestEntity x)) x"
+          "SELECT EXISTS (SELECT x.* FROM TestEntity x)"
       }
       "isEmpty" in {
         val q = quote {
           qr1.isEmpty
         }
         testContext.run(q).string mustEqual
-          "SELECT x.* FROM (SELECT NOT EXISTS (SELECT x.* FROM TestEntity x)) x"
+          "SELECT NOT EXISTS (SELECT x.* FROM TestEntity x)"
       }
     }
     "aggregated and mapped query" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -255,11 +255,11 @@ class SqlIdiomSpec extends Spec {
       "unary operation" - {
         "nonEmpty" in {
           testContext.run(qr1.nonEmpty).string mustEqual
-            "SELECT x.* FROM (SELECT EXISTS (SELECT x.* FROM TestEntity x)) x"
+            "SELECT EXISTS (SELECT x.* FROM TestEntity x)"
         }
         "isEmpty" in {
           testContext.run(qr1.isEmpty).string mustEqual
-            "SELECT x.* FROM (SELECT NOT EXISTS (SELECT x.* FROM TestEntity x)) x"
+            "SELECT NOT EXISTS (SELECT x.* FROM TestEntity x)"
         }
       }
       "limited" - {
@@ -381,7 +381,7 @@ class SqlIdiomSpec extends Spec {
           qr1.map(t => t.i).size == 1L
         }
         testContext.run(q).string mustEqual
-          "SELECT x.* FROM (SELECT (SELECT COUNT(t.i) FROM TestEntity t) = 1) x"
+          "SELECT (SELECT COUNT(t.i) FROM TestEntity t) = 1"
       }
     }
     "operations" - {


### PR DESCRIPTION
### Problem

Quill now generate sqls like `SELECT x.* FROM (xxx) x`

### Solution

Eliminate the nested query



### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

