### PR TITLE
Materialize encoding for generic value class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,7 +937,7 @@ trait UUIDEncodingExample {
 `AnyVal`
 --------
 
-Quill automatically encodes `AnyVal`s:
+Quill automatically encodes `AnyVal`s (value classes):
 
 ```scala
 case class UserId(value: Int) extends AnyVal

--- a/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/ProductMysqlAsyncSpec.scala
+++ b/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/ProductMysqlAsyncSpec.scala
@@ -60,7 +60,7 @@ class ProductMysqlAsyncSpec extends ProductSpec {
       returnedProduct.id mustEqual inserted
     }
 
-    "Single insert with wrapped value" in {
+    "Single insert with value class" in {
       case class Product(id: Id, description: String, sku: Long)
       val prd = Product(Id(0L), "test2", 2L)
       val q1 = quote {

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ProductPostgresAsyncSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ProductPostgresAsyncSpec.scala
@@ -68,7 +68,7 @@ class ProductPostgresAsyncSpec extends ProductSpec {
       returnedProduct.id mustEqual inserted
     }
 
-    "Single insert with wrapped value" in {
+    "Single insert with value class" in {
       case class Product(id: Id, description: String, sku: Long)
       val prd = Product(Id(0L), "test2", 2L)
       val q1 = quote {

--- a/quill-core/src/main/scala/io/getquill/dsl/EncodingDslMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/EncodingDslMacro.scala
@@ -67,6 +67,6 @@ class EncodingDslMacro(val c: MacroContext) {
 
   private def primaryConstructor(t: Type) =
     t.members.collect {
-      case m: MethodSymbol if (m.isPrimaryConstructor) => m
+      case m: MethodSymbol if m.isPrimaryConstructor => m.typeSignature.asSeenFrom(t, t.typeSymbol)
     }.headOption
 }

--- a/quill-core/src/test/scala/io/getquill/context/ContextMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/ContextMacroSpec.scala
@@ -112,10 +112,19 @@ class ContextMacroSpec extends Spec {
         r.prepareRow mustEqual Row("a")
       }
 
-      "wrapped" in {
-        case class Entity(x: WrappedEncodable)
+      "value class" in {
+        case class Entity(x: ValueClass)
         val q = quote {
-          query[Entity].filter(t => t.x == lift(WrappedEncodable(1)))
+          query[Entity].filter(t => t.x == lift(ValueClass(1)))
+        }
+        val r = testContext.run(q)
+        r.string mustEqual """querySchema("Entity").filter(t => t.x == ?).map(t => t.x)"""
+        r.prepareRow mustEqual Row(1)
+      }
+      "generic value class" in {
+        case class Entity(x: GenericValueClass[Int])
+        val q = quote {
+          query[Entity].filter(t => t.x == lift(GenericValueClass(1)))
         }
         val r = testContext.run(q)
         r.string mustEqual """querySchema("Entity").filter(t => t.x == ?).map(t => t.x)"""

--- a/quill-core/src/test/scala/io/getquill/context/EncodeBindVariablesSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/EncodeBindVariablesSpec.scala
@@ -1,8 +1,7 @@
 package io.getquill.context
 
-import io.getquill.Spec
 import io.getquill.context.mirror.Row
-import io.getquill.testContext
+import io.getquill.{ Spec, testContext }
 import io.getquill.testContext._
 
 class EncodeBindVariablesSpec extends Spec {
@@ -42,25 +41,12 @@ class EncodeBindVariablesSpec extends Spec {
     testContext.run(q).prepareRow mustEqual Row(1D)
   }
 
-  "encodes bind variables for wrapped types" - {
-
-    "encodes `WrappedValue` extended value class" in {
-      case class Entity(x: WrappedEncodable)
-      val q = quote {
-        query[Entity].filter(t => t.x == lift(WrappedEncodable(1)))
-      }
-      val r = testContext.run(q)
-      r.string mustEqual """querySchema("Entity").filter(t => t.x == ?).map(t => t.x)"""
-      r.prepareRow mustEqual Row(1)
+  "fails for not value class without encoder" in {
+    case class NotValueClass(value: Int)
+    case class Entity(x: NotValueClass)
+    val q = quote {
+      (x: NotValueClass) => query[Entity].filter(_.x == x)
     }
-
-    "fails for unwrapped class" in {
-      case class WrappedNotEncodable(value: Int)
-      case class Entity(x: WrappedNotEncodable)
-      val q = quote {
-        (x: WrappedNotEncodable) => query[Entity].filter(_.x == x)
-      }
-      "testContext.run(q)(WrappedNotEncodable(1))" mustNot compile
-    }
+    "testContext.run(q)(NotValueClass(1))" mustNot compile
   }
 }

--- a/quill-core/src/test/scala/io/getquill/dsl/EncodingDslSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/dsl/EncodingDslSpec.scala
@@ -9,6 +9,8 @@ import scala.language.reflectiveCalls
 
 case class CustomValue(i: Int) extends AnyVal
 
+case class CustomGenericValue[T](v: T) extends AnyVal
+
 // Tests self lifting of `AnyVal`
 case class Address(id: AddressId)
 
@@ -94,6 +96,17 @@ class EncodingDslSpec extends Spec {
     "decoder" in {
       val dec = implicitly[Decoder[CustomValue]]
       dec(0, Row(1)) mustEqual CustomValue(1)
+    }
+  }
+
+  "materializes encoding for generic AnyVal" - {
+    "encoder" in {
+      val enc = implicitly[Encoder[CustomGenericValue[Int]]]
+      enc(0, CustomGenericValue(1), Row()) mustEqual Row(1)
+    }
+    "decoder" in {
+      val dec = implicitly[Decoder[CustomGenericValue[Int]]]
+      dec(0, Row(1)) mustEqual CustomGenericValue(1)
     }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -8,7 +8,7 @@ import scala.math.BigDecimal.long2bigDecimal
 import io.getquill.Spec
 import io.getquill.ast.{ Query => _, _ }
 import io.getquill.testContext._
-import io.getquill.context.WrappedEncodable
+import io.getquill.context.ValueClass
 
 case class CustomAnyValue(i: Int) extends AnyVal
 
@@ -955,14 +955,14 @@ class QuotationSpec extends Spec {
       }
     }
 
-    "supports WrappedValue" in {
-      def q(v: WrappedEncodable) = quote {
+    "supports value class" in {
+      def q(v: ValueClass) = quote {
         lift(v)
       }
-      q(WrappedEncodable(1)).liftings.`v`.value mustEqual WrappedEncodable(1)
+      q(ValueClass(1)).liftings.`v`.value mustEqual ValueClass(1)
     }
 
-    "supports custom anyval" in {
+    "supports custom AnyVal" in {
       def q(v: CustomAnyValue) = quote {
         lift(v)
       }

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/ProductFinagleMysqlSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/ProductFinagleMysqlSpec.scala
@@ -65,7 +65,7 @@ class ProductFinagleMysqlSpec extends ProductSpec {
       returnedProduct.id mustEqual inserted
     }
 
-    "Single insert with wrapped value" in {
+    "Single insert with value class" in {
       case class Product(id: Id, description: String, sku: Long)
       val prd = Product(Id(0L), "test2", 2L)
       val q1 = quote {

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/ProductFinaglePostgresSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/ProductFinaglePostgresSpec.scala
@@ -65,7 +65,7 @@ class ProductFinaglePostgresSpec extends ProductSpec {
       returnedProduct.id mustEqual inserted
     }
 
-    "Single insert with wrapped value" in {
+    "Single insert with value class" in {
       case class Product(id: Id, description: String, sku: Long)
       val prd = Product(Id(0L), "test2", 2L)
       val q1 = quote {


### PR DESCRIPTION
Fixes #655 

### Problem

Generic value class encoder materialization does not respect it's real type parameter.

### Solution

Get value class constructor signature with `m.typeSignature.asSeenFrom(t, t.typeSymbol)`.

### Notes

Replaced "wrapped value" with "value class" terminology.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers