### PR TITLE
Support non-public accessors.

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/NotPublicWrapper.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/NotPublicWrapper.scala
@@ -1,0 +1,3 @@
+package io.getquill.dsl
+
+trait NotPublicWrapper

--- a/quill-core/src/main/scala/io/getquill/dsl/NotPublicWrapper.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/NotPublicWrapper.scala
@@ -1,3 +1,7 @@
 package io.getquill.dsl
 
 trait NotPublicWrapper
+
+object NotPublicWrapper {
+  val prefix = "_"
+}

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -5,7 +5,8 @@ import io.getquill.ast._
 import io.getquill.norm.BetaReduction
 import io.getquill.util.Messages.RichContext
 import io.getquill.util.Interleave
-import io.getquill.dsl.CoreDsl
+import io.getquill.dsl.{ CoreDsl, NotPublicWrapper }
+
 import scala.collection.immutable.StringOps
 import scala.reflect.macros.TypecheckException
 
@@ -51,6 +52,7 @@ trait Parsing {
     case `ifParser`(value)                  => value
     case `patMatchParser`(value)            => value
     case `blockParser`(block)               => block
+    case `notPublicWrapperParser`(value)    => value
   }
 
   val blockParser: Parser[Block] = Parser[Block] {
@@ -288,6 +290,10 @@ trait Parsing {
       OptionOperation(OptionExists, astParser(o), identParser(alias), astParser(body))
   }
 
+  val notPublicWrapperParser: Parser[Ast] = Parser[Ast] {
+    case q"new $w($x)" if w.symbol.typeSignature.baseClasses.contains(typeOf[NotPublicWrapper].typeSymbol) =>
+      astParser(x)
+  }
   val propertyParser: Parser[Ast] = Parser[Ast] {
     case q"$e.$property" => Property(astParser(e), property.decodedName.toString)
   }

--- a/quill-core/src/test/scala/io/getquill/context/QueryMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/QueryMacroSpec.scala
@@ -82,4 +82,12 @@ class QueryMacroSpec extends Spec {
       }
     }
   }
+  "runs query with case class with private val" in {
+    case class Entity(a: Int, private val b: Int)
+    val q = quote {
+      query[Entity]
+    }
+    testContext.run(q).string mustEqual
+      """querySchema("Entity").map(x => (x.a, x.b))"""
+  }
 }

--- a/quill-core/src/test/scala/io/getquill/dsl/MetaDslSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/dsl/MetaDslSpec.scala
@@ -1,8 +1,8 @@
 package io.getquill.dsl
 
 import io.getquill.Spec
-import io.getquill.testContext._
 import io.getquill.context.mirror.Row
+import io.getquill.testContext._
 
 class MetaDslSpec extends Spec {
 
@@ -73,8 +73,22 @@ class MetaDslSpec extends Spec {
       "> 22 fields" in {
         val meta = materializeQueryMeta[MoreThan22]
         meta.expand.toString mustEqual "(q) => q.map(x => (x.v0, x.v1, x.v2, x.v3, x.v4, x.v5, x.v6, x.v7, x.v8, x.v9, x.x0, x.x1, x.x2, x.x3, x.x4, x.x5, x.x6, x.x7, x.x8, x.x9, x.y0, x.y1, x.y2, x.y3, x.y4, x.y5, x.y6, x.y7, x.y8, x.y9))"
-        meta.extract(Row((0 until 30): _*)) mustEqual
+        meta.extract(Row(0 until 30: _*)) mustEqual
           MoreThan22(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29)
+      }
+    }
+    "private val" - {
+      "only" in {
+        case class Entity(private val a: Int)
+        val meta = materializeQueryMeta[Entity]
+        meta.expand.toString mustEqual "(q) => q.map(x => ())"
+        meta.extract(Row(1)) mustEqual Entity(1)
+      }
+      "mixed" in {
+        case class Entity(a: Int, private val b: Int)
+        val meta = materializeQueryMeta[Entity]
+        meta.expand.toString mustEqual "(q) => q.map(x => x.a)"
+        meta.extract(Row(1, 2)) mustEqual Entity(1, 2)
       }
     }
     "custom" in {
@@ -132,6 +146,17 @@ class MetaDslSpec extends Spec {
       "> 22 fields" in {
         val meta = materializeUpdateMeta[MoreThan22]
         meta.expand.toString mustEqual "(q, value) => q.update(v => v.v0 -> value.v0, v => v.v1 -> value.v1, v => v.v2 -> value.v2, v => v.v3 -> value.v3, v => v.v4 -> value.v4, v => v.v5 -> value.v5, v => v.v6 -> value.v6, v => v.v7 -> value.v7, v => v.v8 -> value.v8, v => v.v9 -> value.v9, v => v.x0 -> value.x0, v => v.x1 -> value.x1, v => v.x2 -> value.x2, v => v.x3 -> value.x3, v => v.x4 -> value.x4, v => v.x5 -> value.x5, v => v.x6 -> value.x6, v => v.x7 -> value.x7, v => v.x8 -> value.x8, v => v.x9 -> value.x9, v => v.y0 -> value.y0, v => v.y1 -> value.y1, v => v.y2 -> value.y2, v => v.y3 -> value.y3, v => v.y4 -> value.y4, v => v.y5 -> value.y5, v => v.y6 -> value.y6, v => v.y7 -> value.y7, v => v.y8 -> value.y8, v => v.y9 -> value.y9)"
+      }
+      "private val" - {
+        "only" in {
+          case class Entity(private val a: Int)
+          "materializeUpdateMeta[Entity]" mustNot compile
+        }
+        "mixed" in {
+          case class Entity(a: Int, private val b: Int)
+          val meta = materializeUpdateMeta[Entity]
+          meta.expand.toString mustEqual "(q, value) => q.update(v => v.a -> value.a)"
+        }
       }
     }
     "custom" - {
@@ -202,6 +227,17 @@ class MetaDslSpec extends Spec {
       "> 22 fields" in {
         val meta = materializeInsertMeta[MoreThan22]
         meta.expand.toString mustEqual "(q, value) => q.insert(v => v.v0 -> value.v0, v => v.v1 -> value.v1, v => v.v2 -> value.v2, v => v.v3 -> value.v3, v => v.v4 -> value.v4, v => v.v5 -> value.v5, v => v.v6 -> value.v6, v => v.v7 -> value.v7, v => v.v8 -> value.v8, v => v.v9 -> value.v9, v => v.x0 -> value.x0, v => v.x1 -> value.x1, v => v.x2 -> value.x2, v => v.x3 -> value.x3, v => v.x4 -> value.x4, v => v.x5 -> value.x5, v => v.x6 -> value.x6, v => v.x7 -> value.x7, v => v.x8 -> value.x8, v => v.x9 -> value.x9, v => v.y0 -> value.y0, v => v.y1 -> value.y1, v => v.y2 -> value.y2, v => v.y3 -> value.y3, v => v.y4 -> value.y4, v => v.y5 -> value.y5, v => v.y6 -> value.y6, v => v.y7 -> value.y7, v => v.y8 -> value.y8, v => v.y9 -> value.y9)"
+      }
+      "private val" - {
+        "only" in {
+          case class Entity(private val a: Int)
+          "materializeInsertMeta[Entity]" mustNot compile
+        }
+        "mixed" in {
+          case class Entity(a: Int, private val b: Int)
+          val meta = materializeInsertMeta[Entity]
+          meta.expand.toString mustEqual "(q, value) => q.insert(v => v.a -> value.a)"
+        }
       }
     }
     "custom" - {

--- a/quill-core/src/test/scala/io/getquill/dsl/MetaDslSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/dsl/MetaDslSpec.scala
@@ -77,18 +77,30 @@ class MetaDslSpec extends Spec {
           MoreThan22(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29)
       }
     }
-    "private val" - {
+    "not public" - {
       "only" in {
         case class Entity(private val a: Int)
         val meta = materializeQueryMeta[Entity]
-        meta.expand.toString mustEqual "(q) => q.map(x => ())"
+        meta.expand.toString mustEqual "(q) => q.map(x => x.a)"
         meta.extract(Row(1)) mustEqual Entity(1)
       }
       "mixed" in {
         case class Entity(a: Int, private val b: Int)
         val meta = materializeQueryMeta[Entity]
-        meta.expand.toString mustEqual "(q) => q.map(x => x.a)"
+        meta.expand.toString mustEqual "(q) => q.map(x => (x.a, x.b))"
         meta.extract(Row(1, 2)) mustEqual Entity(1, 2)
+      }
+      "embedded" in {
+        case class EmbeddedEntity(a: Int) extends Embedded
+        case class Entity(private val b: EmbeddedEntity)
+        val meta = materializeQueryMeta[Entity]
+        meta.expand.toString mustEqual "(q) => q.map(x => x.b.a)"
+      }
+      "option embedded" in {
+        case class EmbeddedEntity(a: Int) extends Embedded
+        case class Entity(private val b: Option[EmbeddedEntity])
+        val meta = materializeQueryMeta[Entity]
+        meta.expand.toString mustEqual "(q) => q.map(x => x.b.map((v) => v.a))"
       }
     }
     "custom" in {
@@ -147,15 +159,28 @@ class MetaDslSpec extends Spec {
         val meta = materializeUpdateMeta[MoreThan22]
         meta.expand.toString mustEqual "(q, value) => q.update(v => v.v0 -> value.v0, v => v.v1 -> value.v1, v => v.v2 -> value.v2, v => v.v3 -> value.v3, v => v.v4 -> value.v4, v => v.v5 -> value.v5, v => v.v6 -> value.v6, v => v.v7 -> value.v7, v => v.v8 -> value.v8, v => v.v9 -> value.v9, v => v.x0 -> value.x0, v => v.x1 -> value.x1, v => v.x2 -> value.x2, v => v.x3 -> value.x3, v => v.x4 -> value.x4, v => v.x5 -> value.x5, v => v.x6 -> value.x6, v => v.x7 -> value.x7, v => v.x8 -> value.x8, v => v.x9 -> value.x9, v => v.y0 -> value.y0, v => v.y1 -> value.y1, v => v.y2 -> value.y2, v => v.y3 -> value.y3, v => v.y4 -> value.y4, v => v.y5 -> value.y5, v => v.y6 -> value.y6, v => v.y7 -> value.y7, v => v.y8 -> value.y8, v => v.y9 -> value.y9)"
       }
-      "private val" - {
+      "not public" - {
         "only" in {
           case class Entity(private val a: Int)
-          "materializeUpdateMeta[Entity]" mustNot compile
+          val meta = materializeUpdateMeta[Entity]
+          meta.expand.toString mustEqual "(q, value) => q.update(v => v.a -> value.a)"
         }
         "mixed" in {
           case class Entity(a: Int, private val b: Int)
           val meta = materializeUpdateMeta[Entity]
-          meta.expand.toString mustEqual "(q, value) => q.update(v => v.a -> value.a)"
+          meta.expand.toString mustEqual "(q, value) => q.update(v => v.a -> value.a, v => v.b -> value.b)"
+        }
+        "embedded" in {
+          case class EmbeddedEntity(a: Int) extends Embedded
+          case class Entity(private val b: EmbeddedEntity)
+          val meta = materializeUpdateMeta[Entity]
+          meta.expand.toString mustEqual "(q, value) => q.update(v => v.b.a -> value.b.a)"
+        }
+        "option embedded" in {
+          case class EmbeddedEntity(a: Int) extends Embedded
+          case class Entity(private val b: Option[EmbeddedEntity])
+          val meta = materializeUpdateMeta[Entity]
+          meta.expand.toString mustEqual "(q, value) => q.update(v => v.b.map((v) => v.a) -> value.b.map((v) => v.a))"
         }
       }
     }
@@ -228,15 +253,28 @@ class MetaDslSpec extends Spec {
         val meta = materializeInsertMeta[MoreThan22]
         meta.expand.toString mustEqual "(q, value) => q.insert(v => v.v0 -> value.v0, v => v.v1 -> value.v1, v => v.v2 -> value.v2, v => v.v3 -> value.v3, v => v.v4 -> value.v4, v => v.v5 -> value.v5, v => v.v6 -> value.v6, v => v.v7 -> value.v7, v => v.v8 -> value.v8, v => v.v9 -> value.v9, v => v.x0 -> value.x0, v => v.x1 -> value.x1, v => v.x2 -> value.x2, v => v.x3 -> value.x3, v => v.x4 -> value.x4, v => v.x5 -> value.x5, v => v.x6 -> value.x6, v => v.x7 -> value.x7, v => v.x8 -> value.x8, v => v.x9 -> value.x9, v => v.y0 -> value.y0, v => v.y1 -> value.y1, v => v.y2 -> value.y2, v => v.y3 -> value.y3, v => v.y4 -> value.y4, v => v.y5 -> value.y5, v => v.y6 -> value.y6, v => v.y7 -> value.y7, v => v.y8 -> value.y8, v => v.y9 -> value.y9)"
       }
-      "private val" - {
+      "not public" - {
         "only" in {
           case class Entity(private val a: Int)
-          "materializeInsertMeta[Entity]" mustNot compile
+          val meta = materializeInsertMeta[Entity]
+          meta.expand.toString mustEqual "(q, value) => q.insert(v => v.a -> value.a)"
         }
         "mixed" in {
           case class Entity(a: Int, private val b: Int)
           val meta = materializeInsertMeta[Entity]
-          meta.expand.toString mustEqual "(q, value) => q.insert(v => v.a -> value.a)"
+          meta.expand.toString mustEqual "(q, value) => q.insert(v => v.a -> value.a, v => v.b -> value.b)"
+        }
+        "embedded" in {
+          case class EmbeddedEntity(a: Int) extends Embedded
+          case class Entity(private val b: EmbeddedEntity)
+          val meta = materializeInsertMeta[Entity]
+          meta.expand.toString mustEqual "(q, value) => q.insert(v => v.b.a -> value.b.a)"
+        }
+        "option embedded" in {
+          case class EmbeddedEntity(a: Int) extends Embedded
+          case class Entity(private val b: Option[EmbeddedEntity])
+          val meta = materializeInsertMeta[Entity]
+          meta.expand.toString mustEqual "(q, value) => q.insert(v => v.b.map((v) => v.a) -> value.b.map((v) => v.a))"
         }
       }
     }


### PR DESCRIPTION
Fixes #606 

### Problem

`QueryMeta` is not materializing because it tries to access case class private fields during query expansion.

### Solution

For every case class constructor parameter check corresponding field (getter) access level and exclude those fields from being used during query expansion.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

