### PR TITLE
Support nested embedded case classes and optionals

### DIFF
--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextMacroSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextMacroSpec.scala
@@ -54,4 +54,20 @@ class CassandraContextMacroSpec extends Spec {
       mirror.prepareRow mustEqual Row(2l, 1)
     }
   }
+
+  "multi-level embedded case class with optionals lifting" in {
+    case class TestEntity(level1: Level1)
+    case class Level1(level2: Level2, optionalLevel2: Option[Level2]) extends Embedded
+    case class Level2(level3: Level3, optionalLevel3: Option[Level3]) extends Embedded
+    case class Level3(value: Option[String], optionalLevel4: Option[Level4]) extends Embedded
+    case class Level4(id: Int) extends Embedded
+
+    val e = TestEntity(Level1(Level2(Level3(Some("test"), None), Some(Level3(None, Some(Level4(1))))), None))
+    val q = quote {
+      query[TestEntity].insert(lift(e))
+    }
+    val r = mirrorContext.run(q)
+    r.string mustEqual "INSERT INTO TestEntity (value,id,value,id,value,id,value,id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    r.prepareRow mustEqual Row(Some("test"), None, Some(None), Some(Some(1)), None, None, None, None)
+  }
 }

--- a/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
@@ -7,7 +7,7 @@ object FlattenOptionOperation extends StatelessTransformer {
   override def apply(ast: Ast) =
     ast match {
       case OptionMap(ast, alias, body) =>
-        BetaReduction(body, alias -> ast)
+        apply(BetaReduction(body, alias -> ast))
       case OptionForall(ast, alias, body) =>
         val isEmpty = BinaryOperation(ast, EqualityOperator.`==`, NullValue)
         val exists = BetaReduction(body, alias -> ast)

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -933,9 +933,9 @@ class QuotationSpec extends Spec {
         val q = quote {
           query[TestEntity].insert(lift(t))
         }
-        q.liftings.`t.embedded`.value mustEqual t.embedded
+        q.liftings.`t.embedded.id`.value mustEqual t.embedded.id
         val q2 = quote(q)
-        q2.liftings.`q.liftings.t.embedded.value.id`.value mustEqual t.embedded.id
+        q2.liftings.`q.t.embedded.id`.value mustEqual t.embedded.id
       }
       "merges properties into the case class lifting" - {
         val t = TestEntity("s", 1, 2L, Some(3))


### PR DESCRIPTION
Fixes #697

### Solution

Allow unlimited nesting of embedded case classes and optionals.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

