### PR TITLE
Fix encoders and decoders for java.util.UUID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,7 +942,7 @@ If the database type is not supported by Quill, it is possible to provide "raw" 
 
 ```scala
 trait UUIDEncodingExample {
-  val jdbcContext: JdbcContext[PostgresDialect, Literal] // your context should go here
+  val jdbcContext: PostgresJdbcContext[Literal] // your context should go here
 
   import jdbcContext._
 
@@ -1106,7 +1106,7 @@ SQL Contexts
 Example:
 
 ```scala
-lazy val ctx = new JdbcContext[MySQLDialect, SnakeCase]("ctx")
+lazy val ctx = new MysqlJdbcContext[SnakeCase]("ctx")
 ```
 
 #### Dialect
@@ -1155,7 +1155,7 @@ Additionally, the contexts provide multiple constructors. For instance, with `Jd
 ```scala
 def createDataSource: javax.sql.DataSource with java.io.Closeable = ???
 
-lazy val ctx = new JdbcContext[MySQLDialect, SnakeCase](createDataSource)
+lazy val ctx = new MysqlJdbcContext[SnakeCase](createDataSource)
 ```
 
 ##### quill-jdbc
@@ -1189,7 +1189,7 @@ libraryDependencies ++= Seq(
 
 context definition
 ```scala
-lazy val ctx = new JdbcContext[MySQLDialect, SnakeCase]("ctx")
+lazy val ctx = new MysqlJdbcContext[SnakeCase]("ctx")
 ```
 
 application.properties
@@ -1216,7 +1216,7 @@ libraryDependencies ++= Seq(
 
 context definition
 ```scala
-lazy val ctx = new JdbcContext[PostgresDialect, SnakeCase]("ctx")
+lazy val ctx = new PostgresJdbcContext[SnakeCase]("ctx")
 ```
 
 application.properties
@@ -1242,7 +1242,7 @@ libraryDependencies ++= Seq(
 
 context definition
 ```scala
-lazy val ctx = new JdbcContext[SqliteDialect, SnakeCase]("ctx")
+lazy val ctx = new SqliteJdbcContext[SnakeCase]("ctx")
 ```
 
 application.properties
@@ -1263,7 +1263,7 @@ libraryDependencies ++= Seq(
 
 context definition
 ```scala
-lazy val ctx = new JdbcContext[H2Dialect, SnakeCase]("ctx")
+lazy val ctx = new H2JdbcContext[SnakeCase]("ctx")
 ```
 
 application.properties

--- a/quill-async-mysql/src/main/scala/io/getquill/MysqlAsyncContext.scala
+++ b/quill-async-mysql/src/main/scala/io/getquill/MysqlAsyncContext.scala
@@ -5,12 +5,12 @@ import com.github.mauricio.async.db.mysql.MySQLConnection
 import com.github.mauricio.async.db.mysql.MySQLQueryResult
 import com.github.mauricio.async.db.pool.PartitionedConnectionPool
 import com.typesafe.config.Config
-import io.getquill.context.async.AsyncContext
+import io.getquill.context.async.{ AsyncContext, UUIDStringEncoding }
 import io.getquill.util.LoadConfig
 import com.github.mauricio.async.db.general.ArrayRowData
 
 class MysqlAsyncContext[N <: NamingStrategy](pool: PartitionedConnectionPool[MySQLConnection])
-  extends AsyncContext[MySQLDialect, N, MySQLConnection](pool) {
+  extends AsyncContext[MySQLDialect, N, MySQLConnection](pool) with UUIDStringEncoding {
 
   def this(config: MysqlAsyncContextConfig) = this(config.pool)
   def this(config: Config) = this(MysqlAsyncContextConfig(config))

--- a/quill-async-postgres/src/main/scala/io/getquill/PostgresAsyncContext.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/PostgresAsyncContext.scala
@@ -4,11 +4,11 @@ import com.github.mauricio.async.db.{ RowData, QueryResult => DBQueryResult }
 import com.github.mauricio.async.db.pool.PartitionedConnectionPool
 import com.github.mauricio.async.db.postgresql.PostgreSQLConnection
 import com.typesafe.config.Config
-import io.getquill.context.async.AsyncContext
+import io.getquill.context.async.{ AsyncContext, UUIDObjectEncoding }
 import io.getquill.util.LoadConfig
 
 class PostgresAsyncContext[N <: NamingStrategy](pool: PartitionedConnectionPool[PostgreSQLConnection])
-  extends AsyncContext[PostgresDialect, N, PostgreSQLConnection](pool) {
+  extends AsyncContext[PostgresDialect, N, PostgreSQLConnection](pool) with UUIDObjectEncoding {
 
   def this(config: PostgresAsyncContextConfig) = this(config.pool)
   def this(config: Config) = this(PostgresAsyncContextConfig(config))

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
@@ -79,7 +79,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
 
   "returning UUID" in {
     val success = for {
-      uuid <- Await.result(testContext.run(insertBarCode.apply(lift(barCodeEntry))), Duration.Inf)
+      uuid <- Await.result(testContext.run(insertBarCode(lift(barCodeEntry))), Duration.Inf)
       barCode <- Await.result(testContext.run(findBarCodeByUuid(uuid)), Duration.Inf).headOption
     } yield {
       verifyBarcode(barCode)

--- a/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
@@ -1,9 +1,8 @@
 package io.getquill.context.async
 
 import java.time.{ LocalDate, LocalDateTime, ZoneId }
-import java.util.{ Date, UUID }
+import java.util.Date
 
-import com.github.mauricio.async.db.RowData
 import io.getquill.util.Messages.fail
 import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
 
@@ -27,7 +26,7 @@ trait Decoders {
     sqlType: DecoderSqlType
   ): Decoder[T] =
     AsyncDecoder[T](sqlType)(new BaseDecoder[T] {
-      def apply(index: Int, row: RowData) = {
+      def apply(index: Index, row: ResultRow) = {
         row(index) match {
           case value: T                      => value
           case value if f.isDefinedAt(value) => f(value)
@@ -46,7 +45,7 @@ trait Decoders {
     })
 
   trait NumericDecoder[T] extends BaseDecoder[T] {
-    def apply(index: Int, row: RowData) =
+    def apply(index: Index, row: ResultRow) =
       row(index) match {
         case v: Byte       => decode(v)
         case v: Short      => decode(v)
@@ -64,7 +63,7 @@ trait Decoders {
 
   implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] =
     AsyncDecoder(d.sqlType)(new BaseDecoder[Option[T]] {
-      def apply(index: Int, row: RowData) = {
+      def apply(index: Index, row: ResultRow) = {
         row(index) match {
           case null  => None
           case value => Some(d(index, row))
@@ -161,12 +160,5 @@ trait Decoders {
           ZoneId.systemDefault()
         )
     }, SqlTypes.TIMESTAMP)
-
-  implicit val uuidDecoder: Decoder[UUID] =
-    AsyncDecoder(SqlTypes.UUID)(new BaseDecoder[UUID] {
-      def apply(index: Int, row: RowData): UUID = row(index) match {
-        case value: UUID => value
-      }
-    })
 
 }

--- a/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.async
 
 import java.time.{ LocalDate, LocalDateTime, ZoneId }
-import java.util.{ Date, UUID }
+import java.util.Date
 
 import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
 
@@ -59,7 +59,6 @@ trait Encoders {
     encoder[Date]({ (value: Date) =>
       new JodaLocalDateTime(value)
     }, SqlTypes.TIMESTAMP)
-  implicit val uuidEncoder: Encoder[UUID] = encoder[UUID](SqlTypes.UUID)
   implicit val localDateEncoder: Encoder[LocalDate] =
     encoder[LocalDate]({ (value: LocalDate) =>
       new JodaLocalDate(

--- a/quill-async/src/main/scala/io/getquill/context/async/UUIDObjectEncoding.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/UUIDObjectEncoding.scala
@@ -1,0 +1,16 @@
+package io.getquill.context.async
+
+import java.util.UUID
+
+trait UUIDObjectEncoding {
+  this: AsyncContext[_, _, _] =>
+
+  implicit val uuidEncoder: Encoder[UUID] = encoder[UUID](SqlTypes.UUID)
+
+  implicit val uuidDecoder: Decoder[UUID] =
+    AsyncDecoder(SqlTypes.UUID)(
+      (index: Index, row: ResultRow) => row(index) match {
+        case value: UUID => value
+      }
+    )
+}

--- a/quill-async/src/main/scala/io/getquill/context/async/UUIDStringEncoding.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/UUIDStringEncoding.scala
@@ -1,0 +1,16 @@
+package io.getquill.context.async
+
+import java.util.UUID
+
+trait UUIDStringEncoding {
+  this: AsyncContext[_, _, _] =>
+
+  implicit val uuidEncoder: Encoder[UUID] = encoder[UUID]((v: UUID) => v.toString, SqlTypes.UUID)
+
+  implicit val uuidDecoder: Decoder[UUID] =
+    AsyncDecoder(SqlTypes.UUID)(
+      (index: Index, row: ResultRow) => row(index) match {
+        case value: String => UUID.fromString(value)
+      }
+    )
+}

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.finagle.mysql
 
 import java.time.{ LocalDate, LocalDateTime }
-import java.util.Date
+import java.util.{ Date, UUID }
 
 import com.twitter.finagle.mysql._
 import io.getquill.FinagleMysqlContext
@@ -35,7 +35,7 @@ trait FinagleMysqlDecoders {
     FinangleMysqlDecoder((index, row) => {
       row.values(index) match {
         case NullValue => None
-        case other     => Some(d.decoder(index, row))
+        case _         => Some(d.decoder(index, row))
       }
     })
 
@@ -102,4 +102,6 @@ trait FinagleMysqlDecoders {
   implicit val localDateTimeDecoder: Decoder[LocalDateTime] = decoder[LocalDateTime] {
     case `timestampValue`(v) => v.toLocalDateTime
   }
+
+  implicit val uuidDecoder: Decoder[UUID] = mappedDecoder(MappedEncoding(UUID.fromString), stringDecoder)
 }

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
@@ -2,7 +2,7 @@ package io.getquill.context.finagle.mysql
 
 import java.sql.Timestamp
 import java.time.{ LocalDate, LocalDateTime }
-import java.util.Date
+import java.util.{ Date, UUID }
 
 import com.twitter.finagle.mysql.CanBeParameter._
 import com.twitter.finagle.mysql.Parameter.wrap
@@ -58,4 +58,5 @@ trait FinagleMysqlEncoders {
   implicit val localDateTimeEncoder: Encoder[LocalDateTime] = encoder[LocalDateTime] {
     (d: LocalDateTime) => new TimestampValue(dateTimezone, dateTimezone).apply(Timestamp.valueOf(d)): Parameter
   }
+  implicit val uuidEncoder: Encoder[UUID] = mappedEncoder(MappedEncoding(_.toString), stringEncoder)
 }

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncodingSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncodingSpec.scala
@@ -73,7 +73,7 @@ class FinaglePostgresEncodingSpec extends EncodingSpec {
 
   "returning UUID" in {
     val success = for {
-      uuid <- Await.result(testContext.run(insertBarCode.apply(lift(barCodeEntry))))
+      uuid <- Await.result(testContext.run(insertBarCode(lift(barCodeEntry))))
       barCode <- Await.result(testContext.run(findBarCodeByUuid(uuid))).headOption
     } yield {
       verifyBarcode(barCode)

--- a/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/H2JdbcContext.scala
@@ -1,0 +1,17 @@
+package io.getquill
+
+import java.io.Closeable
+import javax.sql.DataSource
+
+import com.typesafe.config.Config
+import io.getquill.context.jdbc.{ JdbcContext, UUIDStringEncoding }
+import io.getquill.util.LoadConfig
+
+class H2JdbcContext[N <: NamingStrategy](dataSource: DataSource with Closeable)
+  extends JdbcContext[H2Dialect, N](dataSource) with UUIDStringEncoding {
+
+  def this(config: JdbcContextConfig) = this(config.dataSource)
+  def this(config: Config) = this(JdbcContextConfig(config))
+  def this(configPrefix: String) = this(LoadConfig(configPrefix))
+
+}

--- a/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/MysqlJdbcContext.scala
@@ -1,0 +1,17 @@
+package io.getquill
+
+import java.io.Closeable
+import javax.sql.DataSource
+
+import com.typesafe.config.Config
+import io.getquill.context.jdbc.{ JdbcContext, UUIDStringEncoding }
+import io.getquill.util.LoadConfig
+
+class MysqlJdbcContext[N <: NamingStrategy](dataSource: DataSource with Closeable)
+  extends JdbcContext[MySQLDialect, N](dataSource) with UUIDStringEncoding {
+
+  def this(config: JdbcContextConfig) = this(config.dataSource)
+  def this(config: Config) = this(JdbcContextConfig(config))
+  def this(configPrefix: String) = this(LoadConfig(configPrefix))
+
+}

--- a/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/PostgresJdbcContext.scala
@@ -1,0 +1,17 @@
+package io.getquill
+
+import java.io.Closeable
+import javax.sql.DataSource
+
+import com.typesafe.config.Config
+import io.getquill.context.jdbc.{ JdbcContext, UUIDObjectEncoding }
+import io.getquill.util.LoadConfig
+
+class PostgresJdbcContext[N <: NamingStrategy](dataSource: DataSource with Closeable)
+  extends JdbcContext[PostgresDialect, N](dataSource) with UUIDObjectEncoding {
+
+  def this(config: JdbcContextConfig) = this(config.dataSource)
+  def this(config: Config) = this(JdbcContextConfig(config))
+  def this(configPrefix: String) = this(LoadConfig(configPrefix))
+
+}

--- a/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/SqliteJdbcContext.scala
@@ -1,0 +1,17 @@
+package io.getquill
+
+import java.io.Closeable
+import javax.sql.DataSource
+
+import com.typesafe.config.Config
+import io.getquill.context.jdbc.{ JdbcContext, UUIDStringEncoding }
+import io.getquill.util.LoadConfig
+
+class SqliteJdbcContext[N <: NamingStrategy](dataSource: DataSource with Closeable)
+  extends JdbcContext[SqliteDialect, N](dataSource) with UUIDStringEncoding {
+
+  def this(config: JdbcContextConfig) = this(config.dataSource)
+  def this(config: Config) = this(JdbcContextConfig(config))
+  def this(configPrefix: String) = this(LoadConfig(configPrefix))
+
+}

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
@@ -5,11 +5,9 @@ import java.time.{ LocalDate, LocalDateTime }
 import java.util
 import java.util.Calendar
 
-import io.getquill.JdbcContext
-
 import scala.math.BigDecimal.javaBigDecimal2bigDecimal
 
-trait JdbcDecoders {
+trait Decoders {
   this: JdbcContext[_, _] =>
 
   type Decoder[T] = JdbcDecoder[T]
@@ -32,10 +30,15 @@ trait JdbcDecoders {
     JdbcDecoder(
       d.sqlType,
       (index, row) => {
-        val res = d.decoder(index, row)
-        row.wasNull match {
-          case true  => None
-          case false => Some(res)
+        try {
+          val res = d.decoder(index, row)
+          if (row.wasNull()) {
+            None
+          } else {
+            Some(res)
+          }
+        } catch {
+          case _: NullPointerException if row.wasNull() => None
         }
       }
     )

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -5,11 +5,9 @@ import java.time.{ LocalDate, LocalDateTime }
 import java.util.{ Calendar, TimeZone }
 import java.{ sql, util }
 
-import io.getquill.JdbcContext
-
 import scala.reflect.ClassTag
 
-trait JdbcEncoders {
+trait Encoders {
   this: JdbcContext[_, _] =>
 
   type Encoder[T] = JdbcEncoder[T]

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDObjectEncoding.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDObjectEncoding.scala
@@ -1,0 +1,10 @@
+package io.getquill.context.jdbc
+
+import java.sql.Types
+import java.util.UUID
+
+trait UUIDObjectEncoding {
+  this: JdbcContext[_, _] =>
+  implicit val uuidEncoder: Encoder[UUID] = encoder(Types.OTHER, (index, value, row) => row.setObject(index, value, Types.OTHER))
+  implicit val uuidDecoder: Decoder[UUID] = decoder(Types.OTHER, (index, row) => UUID.fromString(row.getObject(index).toString))
+}

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDStringEncoding.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDStringEncoding.scala
@@ -1,0 +1,10 @@
+package io.getquill.context.jdbc
+
+import java.sql.Types
+import java.util.UUID
+
+trait UUIDStringEncoding {
+  this: JdbcContext[_, _] =>
+  implicit val uuidEncoder: Encoder[UUID] = encoder(Types.VARCHAR, (index, value, row) => row.setString(index, value.toString))
+  implicit val uuidDecoder: Decoder[UUID] = decoder(Types.VARCHAR, (index, row) => UUID.fromString(row.getString(index)))
+}

--- a/quill-jdbc/src/test/resources/sql/h2-schema.sql
+++ b/quill-jdbc/src/test/resources/sql/h2-schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     v11 TIMESTAMP,
     v12 VARCHAR(255),
     v13 DATE,
-    v14 TIMESTAMP,
+    v14 UUID,
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     o11 TIMESTAMP,
     o12 VARCHAR(255),
     o13 DATE,
-    o14 TIMESTAMP
+    o14 UUID
 );
 
 CREATE TABLE IF NOT EXISTS TestEntity(

--- a/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
+++ b/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     v11 BIGINT,
     v12 VARCHAR(255),
     v13 BIGINT,
-    v14 BIGINT,
+    v14 VARCHAR(36),
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     o11 BIGINT,
     o12 VARCHAR(255),
     o13 BIGINT,
-    o14 BIGINT
+    o14 VARCHAR(36)
 );
 
 CREATE TABLE IF NOT EXISTS TestEntity(

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/TestContext.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/TestContext.scala
@@ -1,7 +1,0 @@
-package io.getquill.context.jdbc.h2
-
-import io.getquill.{ H2Dialect, JdbcContext, Literal, TestEntities }
-import io.getquill.context.sql.TestEncoders
-import io.getquill.context.sql.TestDecoders
-
-object testContext extends JdbcContext[H2Dialect, Literal]("testH2DB") with TestEntities with TestEncoders with TestDecoders

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/package.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/package.scala
@@ -1,0 +1,10 @@
+package io.getquill.context.jdbc
+
+import io.getquill._
+import io.getquill.context.sql.{ TestDecoders, TestEncoders }
+
+package object h2 {
+
+  object testContext extends H2JdbcContext[Literal]("testH2DB") with TestEntities with TestEncoders with TestDecoders
+
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/QueryResultTypeJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/QueryResultTypeJdbcSpec.scala
@@ -1,12 +1,14 @@
-package io.getquill.context.jdbc
+package io.getquill.context.jdbc.mysql
+
+import java.util.concurrent.ConcurrentLinkedQueue
 
 import io.getquill.context.sql._
-import java.util.concurrent.ConcurrentLinkedQueue
+
 import scala.collection.JavaConverters._
 
 class QueryResultTypeJdbcSpec extends QueryResultTypeSpec {
 
-  override val context = mysql.testContext
+  override val context = testContext
   import context._
 
   def await[T](r: T) = r

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/TestContext.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/TestContext.scala
@@ -1,7 +1,0 @@
-package io.getquill.context.jdbc.mysql
-
-import io.getquill.context.sql.TestEncoders
-import io.getquill.context.sql.TestDecoders
-import io.getquill.{ JdbcContext, Literal, MySQLDialect, TestEntities }
-
-object testContext extends JdbcContext[MySQLDialect, Literal]("testMysqlDB") with TestEntities with TestEncoders with TestDecoders

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/package.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/package.scala
@@ -1,0 +1,10 @@
+package io.getquill.context.jdbc
+
+import io.getquill._
+import io.getquill.context.sql.{ TestDecoders, TestEncoders }
+
+package object mysql {
+
+  object testContext extends MysqlJdbcContext[Literal]("testMysqlDB") with TestEntities with TestEncoders with TestDecoders
+
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcEncodingSpec.scala
@@ -1,8 +1,5 @@
 package io.getquill.context.jdbc.postgres
 
-import java.sql.Types
-import java.util.UUID
-
 import io.getquill.context.sql.EncodingSpec
 
 class JdbcEncodingSpec extends EncodingSpec {
@@ -27,13 +24,7 @@ class JdbcEncodingSpec extends EncodingSpec {
   }
 
   "returning custom type" in {
-    implicit val uuidDecoder: Decoder[UUID] =
-      decoder(Types.OTHER, (index, row) => UUID.fromString(row.getObject(index).toString))
-
-    implicit val uuidEncoder: Encoder[UUID] =
-      encoder(Types.OTHER, (index, value, row) => row.setObject(index, value, Types.OTHER))
-
-    val uuid = testContext.run(insertBarCode.apply(lift(barCodeEntry))).get
+    val uuid = testContext.run(insertBarCode(lift(barCodeEntry))).get
     val (barCode :: Nil) = testContext.run(findBarCodeByUuid(uuid))
 
     verifyBarcode(barCode)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/TestContext.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/TestContext.scala
@@ -1,7 +1,0 @@
-package io.getquill.context.jdbc.postgres
-
-import io.getquill.{ JdbcContext, Literal, PostgresDialect, TestEntities }
-import io.getquill.context.sql.TestEncoders
-import io.getquill.context.sql.TestDecoders
-
-object testContext extends JdbcContext[PostgresDialect, Literal]("testPostgresDB") with TestEntities with TestEncoders with TestDecoders

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/package.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/package.scala
@@ -1,0 +1,10 @@
+package io.getquill.context.jdbc
+
+import io.getquill._
+import io.getquill.context.sql.{ TestDecoders, TestEncoders }
+
+package object postgres {
+
+  object testContext extends PostgresJdbcContext[Literal]("testPostgresDB") with TestEntities with TestEncoders with TestDecoders
+
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/TestContext.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/TestContext.scala
@@ -1,7 +1,0 @@
-package io.getquill.context.jdbc.sqlite
-
-import io.getquill.{ JdbcContext, Literal, SqliteDialect, TestEntities }
-import io.getquill.context.sql.TestEncoders
-import io.getquill.context.sql.TestDecoders
-
-object testContext extends JdbcContext[SqliteDialect, Literal]("testSqliteDB") with TestEntities with TestEncoders with TestDecoders

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/package.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/package.scala
@@ -1,0 +1,10 @@
+package io.getquill.context.jdbc
+
+import io.getquill.context.sql.{ TestDecoders, TestEncoders }
+import io.getquill.{ Literal, SqliteJdbcContext, TestEntities }
+
+package object sqlite {
+
+  object testContext extends SqliteJdbcContext[Literal]("testSqliteDB") with TestEntities with TestEncoders with TestDecoders
+
+}

--- a/quill-sql/src/main/scala/io/getquill/context/sql/SqlContext.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/SqlContext.scala
@@ -3,7 +3,7 @@ package io.getquill.context.sql
 import java.time.LocalDate
 
 import io.getquill.idiom.{ Idiom => BaseIdiom }
-import java.util.Date
+import java.util.{ Date, UUID }
 
 import io.getquill.context.Context
 import io.getquill.context.sql.dsl.SqlDsl
@@ -28,6 +28,7 @@ trait SqlContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
   implicit val byteArrayDecoder: Decoder[Array[Byte]]
   implicit val dateDecoder: Decoder[Date]
   implicit val localDateDecoder: Decoder[LocalDate]
+  implicit val uuidDecoder: Decoder[UUID]
 
   implicit val stringEncoder: Encoder[String]
   implicit val bigDecimalEncoder: Encoder[BigDecimal]
@@ -41,4 +42,5 @@ trait SqlContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
   implicit val byteArrayEncoder: Encoder[Array[Byte]]
   implicit val dateEncoder: Encoder[Date]
   implicit val localDateEncoder: Encoder[LocalDate]
+  implicit val uuidEncoder: Encoder[UUID]
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
@@ -27,6 +27,7 @@ trait EncodingSpec extends Spec {
     v11: Date,
     v12: EncodingTestType,
     v13: LocalDate,
+    v14: UUID,
     o1:  Option[String],
     o2:  Option[BigDecimal],
     o3:  Option[Boolean],
@@ -39,7 +40,8 @@ trait EncodingSpec extends Spec {
     o10: Option[Array[Byte]],
     o11: Option[Date],
     o12: Option[EncodingTestType],
-    o13: Option[LocalDate]
+    o13: Option[LocalDate],
+    o14: Option[UUID]
   )
 
   val delete = quote {
@@ -66,6 +68,7 @@ trait EncodingSpec extends Spec {
         new Date(31200000),
         EncodingTestType("s"),
         LocalDate.of(2013, 11, 23),
+        UUID.randomUUID(),
         Some("s"),
         Some(BigDecimal(1.1)),
         Some(true),
@@ -78,7 +81,8 @@ trait EncodingSpec extends Spec {
         Some(Array(1.toByte, 2.toByte)),
         Some(new Date(31200000)),
         Some(EncodingTestType("s")),
-        Some(LocalDate.of(2013, 11, 23))
+        Some(LocalDate.of(2013, 11, 23)),
+        Some(UUID.randomUUID())
       ),
       EncodingTestEntity(
         "",
@@ -94,6 +98,8 @@ trait EncodingSpec extends Spec {
         new Date(0),
         EncodingTestType(""),
         LocalDate.ofEpochDay(0),
+        UUID.randomUUID(),
+        None,
         None,
         None,
         None,
@@ -110,73 +116,48 @@ trait EncodingSpec extends Spec {
       )
     )
 
-  def verify(result: List[EncodingTestEntity]) =
-    result match {
-      case List(e1, e2) =>
+  def verify(result: List[EncodingTestEntity]) = {
+    result.size mustEqual insertValues.size
+    result.zip(insertValues).foreach {
+      case (e1, e2) =>
+        e1.v1 mustEqual e2.v1
+        e1.v2 mustEqual e2.v2
+        e1.v3 mustEqual e2.v3
+        e1.v4 mustEqual e2.v4
+        e1.v5 mustEqual e2.v5
+        e1.v6 mustEqual e2.v6
+        e1.v7 mustEqual e2.v7
+        e1.v8 mustEqual e2.v8
+        e1.v9 mustEqual e2.v9
+        e1.v10 mustEqual e2.v10
+        e1.v11 mustEqual e2.v11
+        e1.v12 mustEqual e2.v12
+        e1.v13 mustEqual e2.v13
+        e1.v14 mustEqual e2.v14
 
-        e1.v1 mustEqual "s"
-        e1.v2 mustEqual BigDecimal(1.1)
-        e1.v3 mustEqual true
-        e1.v4 mustEqual 11.toByte
-        e1.v5 mustEqual 23.toShort
-        e1.v6 mustEqual 33
-        e1.v7 mustEqual 431L
-        e1.v8 mustEqual 34.4f
-        e1.v9 mustEqual 42d
-        e1.v10.toList mustEqual List(1.toByte, 2.toByte)
-        e1.v11 mustEqual new Date(31200000)
-        e1.v12 mustEqual EncodingTestType("s")
-        e1.v13 mustEqual LocalDate.of(2013, 11, 23)
-
-        e1.o1 mustEqual Some("s")
-        e1.o2 mustEqual Some(BigDecimal(1.1))
-        e1.o3 mustEqual Some(true)
-        e1.o4 mustEqual Some(11.toByte)
-        e1.o5 mustEqual Some(23.toShort)
-        e1.o6 mustEqual Some(33)
-        e1.o7 mustEqual Some(431L)
-        e1.o8 mustEqual Some(34.4f)
-        e1.o9 mustEqual Some(42d)
-        e1.o10.map(_.toList) mustEqual Some(List(1.toByte, 2.toByte))
-        e1.o11 mustEqual Some(new Date(31200000))
-        e1.o12 mustEqual Some(EncodingTestType("s"))
-        e1.o13 mustEqual Some(LocalDate.of(2013, 11, 23))
-
-        e2.v1 mustEqual ""
-        e2.v2 mustEqual BigDecimal(0)
-        e2.v3 mustEqual false
-        e2.v4 mustEqual 0.toByte
-        e2.v5 mustEqual 0.toShort
-        e2.v6 mustEqual 0
-        e2.v7 mustEqual 0L
-        e2.v8 mustEqual 0f
-        e2.v9 mustEqual 0d
-        e2.v10.toList mustEqual Nil
-        e2.v11 mustEqual new Date(0)
-        e2.v12 mustEqual EncodingTestType("")
-        e2.v13 mustEqual LocalDate.ofEpochDay(0)
-
-        e2.o1 mustEqual None
-        e2.o2 mustEqual None
-        e2.o3 mustEqual None
-        e2.o4 mustEqual None
-        e2.o5 mustEqual None
-        e2.o6 mustEqual None
-        e2.o7 mustEqual None
-        e2.o8 mustEqual None
-        e2.o9 mustEqual None
-        e2.o10 mustEqual None
-        e2.o11 mustEqual None
-        e2.o12 mustEqual None
-        e2.o13 mustEqual None
+        e1.o1 mustEqual e2.o1
+        e1.o2 mustEqual e2.o2
+        e1.o3 mustEqual e2.o3
+        e1.o4 mustEqual e2.o4
+        e1.o5 mustEqual e2.o5
+        e1.o6 mustEqual e2.o6
+        e1.o7 mustEqual e2.o7
+        e1.o8 mustEqual e2.o8
+        e1.o9 mustEqual e2.o9
+        e1.o10.getOrElse(Array()) mustEqual e2.o10.getOrElse(Array())
+        e1.o11 mustEqual e2.o11
+        e1.o12 mustEqual e2.o12
+        e1.o13 mustEqual e2.o13
+        e1.o14 mustEqual e2.o14
     }
+  }
 
   case class BarCode(description: String, uuid: Option[UUID] = None)
 
-  def insertBarCode(implicit e: Encoder[UUID]) = quote((b: BarCode) => query[BarCode].insert(b).returning(_.uuid))
+  val insertBarCode = quote((b: BarCode) => query[BarCode].insert(b).returning(_.uuid))
   val barCodeEntry = BarCode("returning UUID")
 
-  def findBarCodeByUuid(uuid: UUID)(implicit enc: Encoder[UUID]) = quote(query[BarCode].filter(_.uuid == lift(Option(uuid))))
+  def findBarCodeByUuid(uuid: UUID) = quote(query[BarCode].filter(_.uuid == lift(Option(uuid))))
 
   def verifyBarcode(barCode: BarCode) = barCode.description mustEqual "returning UUID"
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlContextSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlContextSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.sql
 
 import java.time.LocalDate
-import java.util.Date
+import java.util.{ Date, UUID }
 
 import io.getquill._
 import io.getquill.context.mirror.Row
@@ -84,6 +84,7 @@ class SqlContextSpec extends Spec {
       implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder[Array[Byte]]
       implicit val dateEncoder: Encoder[Date] = encoder[Date]
       implicit val localDateEncoder: Encoder[LocalDate] = encoder[LocalDate]
+      implicit val uuidEncoder: Encoder[UUID] = encoder[UUID]
 
       implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] = decoder[Option[T]]
 
@@ -99,6 +100,7 @@ class SqlContextSpec extends Spec {
       implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoder[Array[Byte]]
       implicit val localDateDecoder: Decoder[LocalDate] = decoder[LocalDate]
       implicit val dateDecoder: Decoder[Date] = decoder[Date]
+      implicit val uuidDecoder: Decoder[UUID] = decoder[UUID]
 
       implicit def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], e: Encoder[O]): Encoder[I] =
         encoder[I]

--- a/quill-sql/src/test/scala/io/getquill/context/sql/mirror/MirrorContextEncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/mirror/MirrorContextEncodingSpec.scala
@@ -11,8 +11,8 @@ class MirrorContextEncodingSpec extends EncodingSpec {
 
   "encodes and decodes types" in {
     val rows = insertValues.map(v =>
-      Row(v.v1, v.v2, v.v3, v.v4, v.v5, v.v6, v.v7, v.v8, v.v9, v.v10, v.v11, v.v12.value, v.v13,
-        v.o1, v.o2, v.o3, v.o4, v.o5, v.o6, v.o7, v.o8, v.o9, v.o10, v.o11, v.o12.map(_.value), v.o13))
+      Row(v.v1, v.v2, v.v3, v.v4, v.v5, v.v6, v.v7, v.v8, v.v9, v.v10, v.v11, v.v12.value, v.v13, v.v14,
+        v.o1, v.o2, v.o3, v.o4, v.o5, v.o6, v.o7, v.o8, v.o9, v.o10, v.o11, v.o12.map(_.value), v.o13, v.o14))
     context.run(liftQuery(insertValues).foreach(p => insert(p))).groups.flatMap(_._2) mustEqual rows
 
     val mirror = context.run(query[EncodingTestEntity])

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE EncodingTestEntity(
     v11 DATETIME,
     v12 VARCHAR(255),
     v13 DATE,
-    v14 DATETIME,
+    v14 VARCHAR(255),
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -51,7 +51,7 @@ CREATE TABLE EncodingTestEntity(
     o11 DATETIME,
     o12 VARCHAR(255),
     o13 DATE,
-    o14 DATETIME
+    o14 VARCHAR(255)
 );
 
 Create TABLE DateEncodingTestEntity(

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE EncodingTestEntity(
     v11 TIMESTAMP,
     v12 VARCHAR(255),
     v13 DATE,
-    v14 TIMESTAMP,
+    v14 UUID,
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -51,7 +51,7 @@ CREATE TABLE EncodingTestEntity(
     o11 TIMESTAMP,
     o12 VARCHAR(255),
     o13 DATE,
-    o14 TIMESTAMP
+    o14 UUID
 );
 
 CREATE TABLE EncodingUUIDTestEntity(


### PR DESCRIPTION
Fixes #594 
Temporary workaround for #535 (only for JDBC)

### Problem

- No UUID encoder and decoder in `SqlContext`.
- MySQL does not support UUID data type. Async and jdbc MySQL drivers does not support `java.util.UUID` conversion to some other type like `String`.
- It's not possible to override things in `JdbcContext` for specific `SqlIdiom`.
- ~~`quill-jdbc` depends on driver libraries for all dialects which is not necessary when using one specific dialect~~.

### Solution
- Implement missing UUID encoders and decoders.
- ~~Split `quill-jdbc` to separate projects for each dialect~~.
- Make `JdbcContext` abstract and remove default `uuidEncoder` and `uuidDecoder`.
- Make separate `JdbcContext` for each dialect with mixed-in trait with custom `uuidEncoder` and `uuidDecoder`.
- [Catch](https://github.com/getquill/quill/pull/665/files#diff-86fe88e01533d968b403802d40a4e2acR41) NPE in JDBC Option decoder as a temporary workaround for #535.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers