### PR TITLE
Document support for Infix Raw Queries with Tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,18 @@ ctx.run(q)
 // SELECT MY_FUNCTION(p.age) FROM Person p
 ```
 
+You can also use infix to port raw SQL queries to Quill and map it to regular scala tuples.
+ 
+```scala
+val rawQuery = quote {
+  (id: Int) => infix"""SELECT id AS "_1", name AS "_2" FROM my_entity WHERE id = $id""".as[Query[(Int, String)]]
+}
+ctx.run(rawQuery(1))
+//SELECT id AS "_1", name AS "_2" FROM my_entity WHERE id = 1
+```
+
+
+
 Custom encoding
 ---------------
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -57,6 +57,16 @@ class SqlQuerySpec extends Spec {
       }
     }
 
+    "raw queries with infix" - {
+      "using tuples" in {
+        val q = quote {
+          infix"""SELECT t.s AS "_1", t.i AS "_2" FROM TestEntity t""".as[Query[(String, Int)]]
+        }
+        testContext.run(q).string mustEqual
+          """SELECT x._1, x._2 FROM (SELECT t.s AS "_1", t.i AS "_2" FROM TestEntity t) x"""
+      }
+    }
+
     "nested infix query" - {
       "as source" in {
         val q = quote {


### PR DESCRIPTION
I have been using this feature, so I decided to document it so it becomes more oficial. 

Basically, you can combine `infix` and tuples to migrate legacy SQL queries. 

### Problem

N/A

### Solution

N/A

### Notes

Additional notes.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

