### PR TITLE
Add support to Option.contains

### DIFF
--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -120,13 +120,10 @@ class MirrorIdiom extends Idiom {
   }
 
   implicit def optionOperationTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[OptionOperation] = Tokenizer[OptionOperation] {
-    case q: OptionOperation =>
-      val method = q.t match {
-        case OptionMap    => "map"
-        case OptionForall => "forall"
-        case OptionExists => "exists"
-      }
-      stmt"${q.ast.token}.${method.token}((${q.alias.token}) => ${q.body.token})"
+    case OptionMap(ast, alias, body)    => stmt"${ast.token}.map((${alias.token}) => ${body.token})"
+    case OptionForall(ast, alias, body) => stmt"${ast.token}.forall((${alias.token}) => ${body.token})"
+    case OptionExists(ast, alias, body) => stmt"${ast.token}.exists((${alias.token}) => ${body.token})"
+    case OptionContains(ast, body)      => stmt"${ast.token}.contains(${body.token})"
   }
 
   implicit val joinTypeTokenizer: Tokenizer[JoinType] = Tokenizer[JoinType] {

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -69,7 +69,11 @@ case class Ident(name: String) extends Ast
 
 case class Property(ast: Ast, name: String) extends Ast
 
-case class OptionOperation(t: OptionOperationType, ast: Ast, alias: Ident, body: Ast) extends Ast
+sealed trait OptionOperation extends Ast
+case class OptionMap(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
+case class OptionForall(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
+case class OptionExists(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
+case class OptionContains(ast: Ast, body: Ast) extends OptionOperation
 
 case class If(condition: Ast, `then`: Ast, `else`: Ast) extends Ast
 

--- a/quill-core/src/main/scala/io/getquill/ast/OptionOperationType.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/OptionOperationType.scala
@@ -1,7 +1,0 @@
-package io.getquill.ast
-
-sealed trait OptionOperationType
-
-case object OptionMap extends OptionOperationType
-case object OptionForall extends OptionOperationType
-case object OptionExists extends OptionOperationType

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -4,23 +4,31 @@ trait StatelessTransformer {
 
   def apply(e: Ast): Ast =
     e match {
-      case e: Query                    => apply(e)
-      case e: Operation                => apply(e)
-      case e: Action                   => apply(e)
-      case e: Value                    => apply(e)
-      case e: Assignment               => apply(e)
-      case Function(params, body)      => Function(params, apply(body))
-      case e: Ident                    => e
-      case Property(a, name)           => Property(apply(a), name)
-      case Infix(a, b)                 => Infix(a, b.map(apply))
-      case OptionOperation(t, a, b, c) => OptionOperation(t, apply(a), b, apply(c))
-      case If(a, b, c)                 => If(apply(a), apply(b), apply(c))
-      case e: Dynamic                  => e
-      case e: Lift                     => e
-      case e: QuotedReference          => e
-      case Block(statements)           => Block(statements.map(apply))
-      case Val(name, body)             => Val(name, apply(body))
-      case o: Ordering                 => o
+      case e: Query               => apply(e)
+      case e: Operation           => apply(e)
+      case e: Action              => apply(e)
+      case e: Value               => apply(e)
+      case e: Assignment          => apply(e)
+      case Function(params, body) => Function(params, apply(body))
+      case e: Ident               => e
+      case Property(a, name)      => Property(apply(a), name)
+      case Infix(a, b)            => Infix(a, b.map(apply))
+      case e: OptionOperation     => apply(e)
+      case If(a, b, c)            => If(apply(a), apply(b), apply(c))
+      case e: Dynamic             => e
+      case e: Lift                => e
+      case e: QuotedReference     => e
+      case Block(statements)      => Block(statements.map(apply))
+      case Val(name, body)        => Val(name, apply(body))
+      case o: Ordering            => o
+    }
+
+  def apply(o: OptionOperation): OptionOperation =
+    o match {
+      case OptionMap(a, b, c)    => OptionMap(apply(a), b, apply(c))
+      case OptionForall(a, b, c) => OptionForall(apply(a), b, apply(c))
+      case OptionExists(a, b, c) => OptionExists(apply(a), b, apply(c))
+      case OptionContains(a, b)  => OptionContains(apply(a), apply(b))
     }
 
   def apply(e: Query): Query =

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -25,9 +25,6 @@ case class BetaReduction(map: collection.Map[Ast, Ast])
       case Function(params, body) =>
         Function(params, BetaReduction(map -- params)(body))
 
-      case OptionOperation(t, a, b, c) =>
-        OptionOperation(t, apply(a), b, BetaReduction(map - b)(c))
-
       case Block(statements) =>
         val vals = statements.collect { case x: Val => x.name -> x.body }
         BetaReduction(map ++ vals)(statements.last)
@@ -39,6 +36,18 @@ case class BetaReduction(map: collection.Map[Ast, Ast])
         val t = BetaReduction(map - alias)
         Returning(apply(action), alias, t(prop))
 
+      case other =>
+        super.apply(other)
+    }
+
+  override def apply(o: OptionOperation) =
+    o match {
+      case OptionMap(a, b, c) =>
+        OptionMap(apply(a), b, BetaReduction(map - b)(c))
+      case OptionForall(a, b, c) =>
+        OptionForall(apply(a), b, BetaReduction(map - b)(c))
+      case OptionExists(a, b, c) =>
+        OptionExists(apply(a), b, BetaReduction(map - b)(c))
       case other =>
         super.apply(other)
     }

--- a/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
@@ -1,15 +1,19 @@
 package io.getquill.norm
 
-import io.getquill.ast.Ast
-import io.getquill.ast.OptionOperation
-import io.getquill.ast.StatelessTransformer
+import io.getquill.ast._
 
 object FlattenOptionOperation extends StatelessTransformer {
 
   override def apply(ast: Ast) =
     ast match {
-      case OptionOperation(t, ast, alias, body) =>
+      case OptionMap(ast, alias, body) =>
         BetaReduction(body, alias -> ast)
+      case OptionForall(ast, alias, body) =>
+        BetaReduction(body, alias -> ast)
+      case OptionExists(ast, alias, body) =>
+        BetaReduction(body, alias -> ast)
+      case OptionContains(ast, body) =>
+        BinaryOperation(ast, EqualityOperator.`==`, body)
       case other =>
         super.apply(ast)
     }

--- a/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
@@ -14,9 +14,19 @@ case class FreeVariables(state: State)
       case f @ Function(params, body) =>
         val (_, t) = FreeVariables(State(state.seen ++ params, state.free))(body)
         (f, FreeVariables(State(state.seen, state.free ++ t.state.free)))
-      case OptionOperation(t, a, b, c) =>
-        (ast, free(a, b, c))
       case q @ Foreach(a, b, c) =>
+        (q, free(a, b, c))
+      case other =>
+        super.apply(other)
+    }
+
+  override def apply(o: OptionOperation): (OptionOperation, StatefulTransformer[State]) =
+    o match {
+      case q @ OptionMap(a, b, c) =>
+        (q, free(a, b, c))
+      case q @ OptionForall(a, b, c) =>
+        (q, free(a, b, c))
+      case q @ OptionExists(a, b, c) =>
         (q, free(a, b, c))
       case other =>
         super.apply(other)

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -19,6 +19,7 @@ trait Liftables {
     case ast: Ordering => orderingLiftable(ast)
     case ast: Lift => liftLiftable(ast)
     case ast: Assignment => assignmentLiftable(ast)
+    case ast: OptionOperation => optionOperationLiftable(ast)
     case Val(name, body) => q"$pack.Val($name, $body)"
     case Block(statements) => q"$pack.Block($statements)"
     case Property(a, b) => q"$pack.Property($a, $b)"
@@ -27,17 +28,17 @@ trait Liftables {
     case BinaryOperation(a, b, c) => q"$pack.BinaryOperation($a, $b, $c)"
     case UnaryOperation(a, b) => q"$pack.UnaryOperation($a, $b)"
     case Infix(a, b) => q"$pack.Infix($a, $b)"
-    case OptionOperation(a, b, c, d) => q"$pack.OptionOperation($a, $b, $c, $d)"
     case If(a, b, c) => q"$pack.If($a, $b, $c)"
     case Dynamic(tree: Tree) if (tree.tpe <:< c.weakTypeOf[CoreDsl#Quoted[Any]]) => q"$tree.ast"
     case Dynamic(tree: Tree) => q"$pack.Constant($tree)"
     case QuotedReference(tree: Tree, ast) => q"$ast"
   }
 
-  implicit val optionOperationTypeLiftable: Liftable[OptionOperationType] = Liftable[OptionOperationType] {
-    case OptionMap    => q"$pack.OptionMap"
-    case OptionForall => q"$pack.OptionForall"
-    case OptionExists => q"$pack.OptionExists"
+  implicit val optionOperationLiftable: Liftable[OptionOperation] = Liftable[OptionOperation] {
+    case OptionMap(a, b, c)    => q"$pack.OptionMap($a,$b,$c)"
+    case OptionForall(a, b, c) => q"$pack.OptionForall($a,$b,$c)"
+    case OptionExists(a, b, c) => q"$pack.OptionExists($a,$b,$c)"
+    case OptionContains(a, b)  => q"$pack.OptionContains($a,$b)"
   }
 
   implicit val binaryOperatorLiftable: Liftable[BinaryOperator] = Liftable[BinaryOperator] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -281,11 +281,13 @@ trait Parsing {
 
   val optionOperationParser: Parser[OptionOperation] = Parser[OptionOperation] {
     case q"$o.map[$t]({($alias) => $body})" if (is[Option[Any]](o)) =>
-      OptionOperation(OptionMap, astParser(o), identParser(alias), astParser(body))
+      OptionMap(astParser(o), identParser(alias), astParser(body))
     case q"$o.forall({($alias) => $body})" if (is[Option[Any]](o)) =>
-      OptionOperation(OptionForall, astParser(o), identParser(alias), astParser(body))
+      OptionForall(astParser(o), identParser(alias), astParser(body))
     case q"$o.exists({($alias) => $body})" if (is[Option[Any]](o)) =>
-      OptionOperation(OptionExists, astParser(o), identParser(alias), astParser(body))
+      OptionExists(astParser(o), identParser(alias), astParser(body))
+    case q"$o.contains[$t]($body)" if (is[Option[Any]](o)) =>
+      OptionContains(astParser(o), astParser(body))
   }
 
   val propertyParser: Parser[Ast] = Parser[Ast] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -16,6 +16,7 @@ trait Unliftables {
     case valueUnliftable(ast) => ast
     case identUnliftable(ast) => ast
     case orderingUnliftable(ast) => ast
+    case optionOperationUnliftable(ast) => ast
     case q"$pack.Property.apply(${ a: Ast }, ${ b: String })" => Property(a, b)
     case q"$pack.Function.apply(${ a: List[Ident] }, ${ b: Ast })" => Function(a, b)
     case q"$pack.FunctionApply.apply(${ a: Ast }, ${ b: List[Ast] })" => FunctionApply(a, b)
@@ -23,15 +24,15 @@ trait Unliftables {
     case q"$pack.UnaryOperation.apply(${ a: UnaryOperator }, ${ b: Ast })" => UnaryOperation(a, b)
     case q"$pack.Aggregation.apply(${ a: AggregationOperator }, ${ b: Ast })" => Aggregation(a, b)
     case q"$pack.Infix.apply(${ a: List[String] }, ${ b: List[Ast] })" => Infix(a, b)
-    case q"$pack.OptionOperation.apply(${ a: OptionOperationType }, ${ b: Ast }, ${ c: Ident }, ${ d: Ast })" => OptionOperation(a, b, c, d)
     case q"$pack.If.apply(${ a: Ast }, ${ b: Ast }, ${ c: Ast })" => If(a, b, c)
     case q"$tree.ast" => Dynamic(tree)
   }
 
-  implicit val optionOperationTypeUnliftable: Unliftable[OptionOperationType] = Unliftable[OptionOperationType] {
-    case q"$pack.OptionMap"    => OptionMap
-    case q"$pack.OptionForall" => OptionForall
-    case q"$pack.OptionExists" => OptionExists
+  implicit val optionOperationUnliftable: Unliftable[OptionOperation] = Unliftable[OptionOperation] {
+    case q"$pack.OptionMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"    => OptionMap(a, b, c)
+    case q"$pack.OptionForall.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionForall(a, b, c)
+    case q"$pack.OptionExists.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionExists(a, b, c)
+    case q"$pack.OptionContains.apply(${ a: Ast }, ${ b: Ident })"            => OptionContains(a, b)
   }
 
   implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -247,12 +247,38 @@ class StatefulTransformerSpec extends Spec {
       }
     }
 
-    "option operation" in {
-      val ast: Ast = OptionOperation(OptionMap, Ident("a"), Ident("b"), Ident("c"))
-      Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {
-        case (at, att) =>
-          at mustEqual OptionOperation(OptionMap, Ident("a'"), Ident("b"), Ident("c'"))
-          att.state mustEqual List(Ident("a"), Ident("c"))
+    "option operation" - {
+      "map" in {
+        val ast: Ast = OptionMap(Ident("a"), Ident("b"), Ident("c"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionMap(Ident("a'"), Ident("b"), Ident("c'"))
+            att.state mustEqual List(Ident("a"), Ident("c"))
+        }
+      }
+      "forall" in {
+        val ast: Ast = OptionForall(Ident("a"), Ident("b"), Ident("c"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionForall(Ident("a'"), Ident("b"), Ident("c'"))
+            att.state mustEqual List(Ident("a"), Ident("c"))
+        }
+      }
+      "exists" in {
+        val ast: Ast = OptionExists(Ident("a"), Ident("b"), Ident("c"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionExists(Ident("a'"), Ident("b"), Ident("c'"))
+            att.state mustEqual List(Ident("a"), Ident("c"))
+        }
+      }
+      "contains" in {
+        val ast: Ast = OptionContains(Ident("a"), Ident("c"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("c") -> Ident("c'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionContains(Ident("a'"), Ident("c'"))
+            att.state mustEqual List(Ident("a"), Ident("c"))
+        }
       }
     }
 

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -153,10 +153,27 @@ class StatelessTransformerSpec extends Spec {
         Infix(List("test"), List(Ident("a'"), Ident("b'")))
     }
 
-    "option operation" in {
-      val ast: Ast = OptionOperation(OptionForall, Ident("a"), Ident("b"), Ident("c"))
-      Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
-        OptionOperation(OptionForall, Ident("a'"), Ident("b"), Ident("c'"))
+    "option operation" - {
+      "map" in {
+        val ast: Ast = OptionMap(Ident("a"), Ident("b"), Ident("c"))
+        Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+          OptionMap(Ident("a'"), Ident("b"), Ident("c'"))
+      }
+      "forall" in {
+        val ast: Ast = OptionForall(Ident("a"), Ident("b"), Ident("c"))
+        Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+          OptionForall(Ident("a'"), Ident("b"), Ident("c'"))
+      }
+      "exists" in {
+        val ast: Ast = OptionExists(Ident("a"), Ident("b"), Ident("c"))
+        Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+          OptionExists(Ident("a'"), Ident("b"), Ident("c'"))
+      }
+      "contains" in {
+        val ast: Ast = OptionContains(Ident("a"), Ident("c"))
+        Subject(Ident("a") -> Ident("a'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+          OptionContains(Ident("a'"), Ident("c'"))
+      }
     }
 
     "if" in {

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -82,9 +82,19 @@ class BetaReductionSpec extends Spec {
         val ast: Ast = Join(LeftJoin, Ident("a"), Ident("b"), Ident("c"), Ident("d"), Tuple(List(Ident("c"), Ident("d"))))
         BetaReduction(ast, Ident("c") -> Ident("c'"), Ident("d") -> Ident("d'")) mustEqual ast
       }
-      "option operation" in {
-        val ast: Ast = OptionOperation(OptionMap, Ident("a"), Ident("b"), Ident("b"))
-        BetaReduction(ast, Ident("b") -> Ident("b'")) mustEqual ast
+      "option operation" - {
+        "map" in {
+          val ast: Ast = OptionMap(Ident("a"), Ident("b"), Ident("b"))
+          BetaReduction(ast, Ident("b") -> Ident("b'")) mustEqual ast
+        }
+        "forall" in {
+          val ast: Ast = OptionForall(Ident("a"), Ident("b"), Ident("b"))
+          BetaReduction(ast, Ident("b") -> Ident("b'")) mustEqual ast
+        }
+        "exists" in {
+          val ast: Ast = OptionExists(Ident("a"), Ident("b"), Ident("b"))
+          BetaReduction(ast, Ident("b") -> Ident("b'")) mustEqual ast
+        }
       }
     }
   }

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -7,11 +7,36 @@ import io.getquill.ast.NumericOperator
 
 class FlattenOptionOperationSpec extends Spec {
 
-  "transforms option operations into simple properties" in {
-    val q = quote {
-      (o: Option[Int]) => o.map(i => i + 1)
+  "transforms option operations into simple properties" - {
+    "map" in {
+      val q = quote {
+        (o: Option[Int]) => o.map(i => i + 1)
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        BinaryOperation(Ident("o"), NumericOperator.`+`, Constant(1))
     }
-    FlattenOptionOperation(q.ast.body: Ast) mustEqual
-      BinaryOperation(Ident("o"), NumericOperator.`+`, Constant(1))
+    "forall" in {
+      val q = quote {
+        (o: Option[Int]) => o.forall(i => i != 1)
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        BinaryOperation(Ident("o"), EqualityOperator.`!=`, Constant(1))
+    }
+
+    "exists" in {
+      val q = quote {
+        (o: Option[Int]) => o.exists(i => i > 1)
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        BinaryOperation(Ident("o"), NumericOperator.`>`, Constant(1))
+    }
+
+    "contains" in {
+      val q = quote {
+        (o: Option[Int]) => o.contains(1)
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        BinaryOperation(Ident("o"), EqualityOperator.`==`, Constant(1))
+    }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/quotation/FreeVariablesSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/FreeVariablesSpec.scala
@@ -88,6 +88,37 @@ class FreeVariablesSpec extends Spec {
       }
       FreeVariables(q.ast) mustEqual Set(Ident("i"))
     }
+    "option operators" - {
+      "map" in {
+        val i = 1
+        val q = quote {
+          qr1.map(_.o.map(_ == i))
+        }
+        FreeVariables(q.ast) mustEqual Set(Ident("i"))
+      }
+      "forall" in {
+        val i = 1
+        val q = quote {
+          qr1.filter(_.o.forall(_ == i))
+        }
+        FreeVariables(q.ast) mustEqual Set(Ident("i"))
+
+      }
+      "exists" in {
+        val i = 1
+        val q = quote {
+          qr1.filter(_.o.exists(_ == i))
+        }
+        FreeVariables(q.ast) mustEqual Set(Ident("i"))
+      }
+      "contains" in {
+        val i = 1
+        val q = quote {
+          qr1.filter(_.o.contains(i))
+        }
+        FreeVariables(q.ast) mustEqual Set(Ident("i"))
+      }
+    }
   }
 
   "takes in consideration variables defined in the quotation" - {
@@ -121,11 +152,36 @@ class FreeVariablesSpec extends Spec {
       }
       FreeVariables(q.ast) mustBe empty
     }
-    "option operator" in {
-      val q = quote {
-        qr1.filter(t => t.s == "s1")
+    "option operators" - {
+      "map" in {
+        val i = 1
+        val q = quote {
+          qr1.map(t => t.o.map(_ == t.i))
+        }
+        FreeVariables(q.ast) mustBe empty
       }
-      FreeVariables(q.ast) mustBe empty
+      "forall" in {
+        val i = 1
+        val q = quote {
+          qr1.filter(t => t.o.forall(_ == t.i))
+        }
+        FreeVariables(q.ast) mustBe empty
+
+      }
+      "exists" in {
+        val i = 1
+        val q = quote {
+          qr1.filter(t => t.o.exists(_ == t.i))
+        }
+        FreeVariables(q.ast) mustBe empty
+      }
+      "contains" in {
+        val i = 1
+        val q = quote {
+          qr1.filter(t => t.o.contains(t.i))
+        }
+        FreeVariables(q.ast) mustBe empty
+      }
     }
     "assignment" in {
       val q = quote {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -670,19 +670,25 @@ class QuotationSpec extends Spec {
         val q = quote {
           (o: Option[Int]) => o.map(v => v)
         }
-        quote(unquote(q)).ast.body mustEqual OptionOperation(OptionMap, Ident("o"), Ident("v"), Ident("v"))
+        quote(unquote(q)).ast.body mustEqual OptionMap(Ident("o"), Ident("v"), Ident("v"))
       }
       "forall" in {
         val q = quote {
           (o: Option[Boolean]) => o.forall(v => v)
         }
-        quote(unquote(q)).ast.body mustEqual OptionOperation(OptionForall, Ident("o"), Ident("v"), Ident("v"))
+        quote(unquote(q)).ast.body mustEqual OptionForall(Ident("o"), Ident("v"), Ident("v"))
       }
       "exists" in {
         val q = quote {
           (o: Option[Boolean]) => o.exists(v => v)
         }
-        quote(unquote(q)).ast.body mustEqual OptionOperation(OptionExists, Ident("o"), Ident("v"), Ident("v"))
+        quote(unquote(q)).ast.body mustEqual OptionExists(Ident("o"), Ident("v"), Ident("v"))
+      }
+      "contains" in {
+        val q = quote {
+          (o: Option[Boolean], v: Int) => o.contains(v)
+        }
+        quote(unquote(q)).ast.body mustEqual OptionContains(Ident("o"), Ident("v"))
       }
     }
     "boxed numbers" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -588,6 +588,13 @@ class SqlIdiomSpec extends Spec {
             testContext.run(q).string mustEqual
               "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.i IN (SELECT p.i FROM TestEntity2 p)"
           }
+          "option" in {
+            val q = quote {
+              qr1.filter(t => t.o.contains(1))
+            }
+            testContext.run(q).string mustEqual
+              "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o = 1"
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #630, inspired by #631

### Problem
Add support to `Option.contains`


### Solution

Refactoring `OptionOperation` to a regular ADT and adding the `OptionContains` node. 
### Notes
The trait `Parsing` is not being used to do transformation, I think this change crosses this boundary. At the same time, I don't know if it is worth changing the AST and doing a stateless tranformation just to get the same result. WDYT? 

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
