### PR TITLE
Add example for comparison operators infix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,17 @@ ctx.run(rawQuery(1))
 //SELECT id AS "_1", name AS "_2" FROM my_entity WHERE id = 1
 ```
 
+You can implement comparison operators by defining implicit conversion and using infix.
 
+```scala
+import java.util.Date
+
+implicit class DateQuotes(left: Date) {
+  def >(right: Date) = quote(infix"$left > $right".as[Boolean])
+
+  def <(right: Date) = quote(infix"$left < $right".as[Boolean])
+}
+```
 
 Custom encoding
 ---------------


### PR DESCRIPTION
Example for #677 

### Problem

People are asking from time to time about comparison operators for `java.util.Date` or `org.jode.time.LocalDateTime`, etc.

### Solution

I think it's useful to have an example in README.md.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers