### PR TITLE
Removed unnecessary double-quotes from application.properties examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,7 +1248,7 @@ lazy val ctx = new SqliteJdbcContext[SnakeCase]("ctx")
 application.properties
 ```
 ctx.driverClassName=org.sqlite.JDBC
-ctx.jdbcUrl="jdbc:sqlite:/path/to/db/file.db"
+ctx.jdbcUrl=jdbc:sqlite:/path/to/db/file.db
 ```
 
 **H2**
@@ -1269,7 +1269,7 @@ lazy val ctx = new H2JdbcContext[SnakeCase]("ctx")
 application.properties
 ```
 ctx.dataSourceClassName=org.h2.jdbcx.JdbcDataSource
-ctx.dataSource.url="jdbc:h2:mem:yourdbname"
+ctx.dataSource.url=jdbc:h2:mem:yourdbname
 ctx.dataSource.user=sa
 ```
 
@@ -1338,7 +1338,7 @@ ctx.poolMaxObjects=4
 ctx.poolMaxIdle=999999999
 ctx.poolValidationInterval=10000
 ctx.sslmode=disable # optional, one of [disable|prefer|require|verify-ca|verify-full]
-ctx.sslrootcert="./path/to/cert/file" # optional, required for sslmode=verify-ca or verify-full
+ctx.sslrootcert=./path/to/cert/file # optional, required for sslmode=verify-ca or verify-full
 ```
 
 **Postgres Async**
@@ -1367,7 +1367,7 @@ ctx.poolMaxObjects=4
 ctx.poolMaxIdle=999999999
 ctx.poolValidationInterval=10000
 ctx.sslmode=disable # optional, one of [disable|prefer|require|verify-ca|verify-full]
-ctx.sslrootcert="./path/to/cert/file" # optional, required for sslmode=verify-ca or verify-full
+ctx.sslrootcert=./path/to/cert/file # optional, required for sslmode=verify-ca or verify-full
 ```
 
 ##### quill-finagle-mysql


### PR DESCRIPTION
### Problem

According https://en.wikipedia.org/wiki/.properties:

> double-quotes are considered part of the string

See @phaistos [issue in Gitter](https://gitter.im/getquill/quill?at=587ba728300f220a66ee8159).

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers