### PR TITLE
Fixes 683 - Option.contains forces dynamic query

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -32,7 +32,7 @@ trait Unliftables {
     case q"$pack.OptionMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"    => OptionMap(a, b, c)
     case q"$pack.OptionForall.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionForall(a, b, c)
     case q"$pack.OptionExists.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionExists(a, b, c)
-    case q"$pack.OptionContains.apply(${ a: Ast }, ${ b: Ident })"            => OptionContains(a, b)
+    case q"$pack.OptionContains.apply(${ a: Ast }, ${ b: Ast })"              => OptionContains(a, b)
   }
 
   implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {


### PR DESCRIPTION
Fixes #683

### Problem

See #683 

### Solution

Silly mistake in `Unliftables.scala`

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
