### PR TITLE
Fixes #694 - forall() has the same behavior as exists() in quotations

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
@@ -9,7 +9,9 @@ object FlattenOptionOperation extends StatelessTransformer {
       case OptionMap(ast, alias, body) =>
         BetaReduction(body, alias -> ast)
       case OptionForall(ast, alias, body) =>
-        BetaReduction(body, alias -> ast)
+        val isEmpty = BinaryOperation(ast, EqualityOperator.`==`, NullValue)
+        val exists = BetaReduction(body, alias -> ast)
+        BinaryOperation(isEmpty, BooleanOperator.`||`, exists)
       case OptionExists(ast, alias, body) =>
         BetaReduction(body, alias -> ast)
       case OptionContains(ast, body) =>

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -20,7 +20,11 @@ class FlattenOptionOperationSpec extends Spec {
         (o: Option[Int]) => o.forall(i => i != 1)
       }
       FlattenOptionOperation(q.ast.body: Ast) mustEqual
-        BinaryOperation(Ident("o"), EqualityOperator.`!=`, Constant(1))
+        BinaryOperation(
+          BinaryOperation(Ident("o"), EqualityOperator.`==`, NullValue),
+          BooleanOperator.`||`,
+          BinaryOperation(Ident("o"), EqualityOperator.`!=`, Constant(1))
+        )
     }
 
     "exists" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -580,6 +580,13 @@ class SqlIdiomSpec extends Spec {
           testContext.run(q).string mustEqual
             "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE (t.i % t.l) = 0"
         }
+        "forall" in {
+          val q = quote {
+            qr1.filter(t => t.i != 1 && t.o.forall(op => op == 1))
+          }
+          testContext.run(q).string mustEqual
+            "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE (t.i <> 1) AND ((t.o IS NULL) OR (t.o = 1))"
+        }
         "contains" - {
           "query" in {
             val q = quote {
@@ -595,6 +602,7 @@ class SqlIdiomSpec extends Spec {
             testContext.run(q).string mustEqual
               "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o = 1"
           }
+
         }
       }
     }


### PR DESCRIPTION
Fixes #694

### Problem

The `forall` has the same `exists` 

### Solution

In `FlattenOptionOperation.scala`, transform the ast to include the `IS NULL OR`.

### Notes

Additional notes.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
