### PR TITLE
Changed logger info in context to debug

### DIFF
--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
@@ -62,7 +62,7 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
     }
 
   def executeQuery[T](sql: String, prepare: List[Any] => List[Any] = identity, extractor: RowData => T = identity[RowData] _)(implicit ec: ExecutionContext): Future[List[T]] = {
-    logger.info(sql)
+    logger.debug(sql)
     withConnection(_.sendPreparedStatement(sql, prepare(List()))).map {
       _.rows match {
         case Some(rows) => rows.map(extractor).toList
@@ -75,13 +75,13 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
     executeQuery(sql, prepare, extractor).map(handleSingleResult)
 
   def executeAction[T](sql: String, prepare: List[Any] => List[Any] = identity)(implicit ec: ExecutionContext): Future[Long] = {
-    logger.info(sql)
+    logger.debug(sql)
     withConnection(_.sendPreparedStatement(sql, prepare(List()))).map(_.rowsAffected)
   }
 
   def executeActionReturning[T](sql: String, prepare: List[Any] => List[Any] = identity, extractor: RowData => T, returningColumn: String)(implicit ec: ExecutionContext): Future[T] = {
     val expanded = expandAction(sql, returningColumn)
-    logger.info(expanded)
+    logger.debug(expanded)
     withConnection(_.sendPreparedStatement(expanded, prepare(List())))
       .map(extractActionResult(returningColumn, extractor))
   }

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -68,7 +68,7 @@ class FinagleMysqlContext[N <: NamingStrategy](
     }
 
   def executeQuery[T](sql: String, prepare: List[Parameter] => List[Parameter] = identity, extractor: Row => T = identity[Row] _): Future[List[T]] = {
-    logger.info(sql)
+    logger.debug(sql)
     withClient(_.prepare(sql).select(prepare(List()): _*)(extractor)).map(_.toList)
   }
 
@@ -76,13 +76,13 @@ class FinagleMysqlContext[N <: NamingStrategy](
     executeQuery(sql, prepare, extractor).map(handleSingleResult)
 
   def executeAction[T](sql: String, prepare: List[Parameter] => List[Parameter] = identity): Future[Long] = {
-    logger.info(sql)
+    logger.debug(sql)
     withClient(_.prepare(sql)(prepare(List()): _*))
       .map(r => toOk(r).affectedRows)
   }
 
   def executeActionReturning[T](sql: String, prepare: List[Parameter] => List[Parameter] = identity, extractor: Row => T, returningColumn: String): Future[T] = {
-    logger.info(sql)
+    logger.debug(sql)
     withClient(_.prepare(sql)(prepare(List()): _*))
       .map(extractReturningValue(_, extractor))
   }

--- a/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
@@ -45,7 +45,7 @@ class FinaglePostgresContext[N <: NamingStrategy](client: Client) extends SqlCon
   }
 
   def executeQuery[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[List[T]] = {
-    logger.info(sql)
+    logger.debug(sql)
     withClient(_.prepareAndQuery(sql, prepare(Nil): _*)(extractor).map(_.toList))
   }
 
@@ -53,7 +53,7 @@ class FinaglePostgresContext[N <: NamingStrategy](client: Client) extends SqlCon
     executeQuery(sql, prepare, extractor).map(handleSingleResult)
 
   def executeAction[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T = identity[Row] _): Future[Long] = {
-    logger.info(sql)
+    logger.debug(sql)
     withClient(_.prepareAndExecute(sql, prepare(Nil): _*)).map(_.toLong)
   }
 
@@ -70,7 +70,7 @@ class FinaglePostgresContext[N <: NamingStrategy](client: Client) extends SqlCon
   }.map(_.flatten.toList)
 
   def executeActionReturning[T](sql: String, prepare: PrepareRow => PrepareRow = identity, extractor: Row => T, returningColumn: String): Future[T] = {
-    logger.info(sql)
+    logger.debug(sql)
     withClient(_.prepareAndQuery(expandAction(sql, returningColumn), prepare(List()): _*)(extractor)).map(v => handleSingleResult(v.toList))
   }
 

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
@@ -72,7 +72,7 @@ abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](dataSo
 
   def executeQuery[T](sql: String, prepare: PreparedStatement => PreparedStatement = identity, extractor: ResultSet => T = identity[ResultSet] _): List[T] =
     withConnection { conn =>
-      logger.info(sql)
+      logger.debug(sql)
       val ps = prepare(conn.prepareStatement(sql))
       val rs = ps.executeQuery()
       extractResult(rs, extractor)
@@ -83,13 +83,13 @@ abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](dataSo
 
   def executeAction[T](sql: String, prepare: PreparedStatement => PreparedStatement = identity): Long =
     withConnection { conn =>
-      logger.info(sql)
+      logger.debug(sql)
       prepare(conn.prepareStatement(sql)).executeUpdate().toLong
     }
 
   def executeActionReturning[O](sql: String, prepare: PreparedStatement => PreparedStatement = identity, extractor: ResultSet => O, returningColumn: String): O =
     withConnection { conn =>
-      logger.info(sql)
+      logger.debug(sql)
       val ps = prepare(conn.prepareStatement(sql, Array(returningColumn)))
       ps.executeUpdate()
       handleSingleResult(extractResult(ps.getGeneratedKeys, extractor))
@@ -99,7 +99,7 @@ abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](dataSo
     withConnection { conn =>
       groups.flatMap {
         case BatchGroup(sql, prepare) =>
-          logger.info(sql)
+          logger.debug(sql)
           val ps = conn.prepareStatement(sql)
           prepare.foreach { f =>
             f(ps)
@@ -113,7 +113,7 @@ abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](dataSo
     withConnection { conn =>
       groups.flatMap {
         case BatchGroupReturning(sql, column, prepare) =>
-          logger.info(sql)
+          logger.debug(sql)
           val ps = conn.prepareStatement(sql, Array(column))
           prepare.foreach { f =>
             f(ps)


### PR DESCRIPTION
### Problem

SQL using context is logged at info level.
Normally, SQL issued in a library assembles SQL should use debug.

### Solution

Changed logger info in context to debug

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
