### PR TITLE
DB should be db for case sensitivity

### DIFF
--- a/CASSANDRA.md
+++ b/CASSANDRA.md
@@ -163,7 +163,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object Quill extends App {
 
-  val db = new CassandraAsyncContext[SnakeCase]("DB")
+  val db = new CassandraAsyncContext[SnakeCase]("db")
 
   import db._
 
@@ -317,7 +317,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object Quill extends App {
 
-  val db = new CassandraAsyncContext[SnakeCase]("DB")
+  val db = new CassandraAsyncContext[SnakeCase]("db")
 
   import db._
 
@@ -542,7 +542,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object Quill extends App {
 
-  val db = new CassandraAsyncContext[SnakeCase]("DB")
+  val db = new CassandraAsyncContext[SnakeCase]("db")
 
   import db._
 


### PR DESCRIPTION
exception is being thrown for not finding key `session` in application .conf. Caused by referencing the top key as DB instead of db

Fixes #issue_number

### Problem

Explain here the context, and why you're making that change.
What is the problem you're trying to solve?

### Solution

Describe the modifications you've done.

### Notes

Additional notes.

### Checklist

- [ ] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
