### PR TITLE
Fix different timezone issue and add max prepare statement configuration.

### DIFF
--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContextConfig.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContextConfig.scala
@@ -9,7 +9,8 @@ import com.twitter.util.TimeConversions._
 
 case class FinagleMysqlContextConfig(config: Config) {
 
-  def dateTimezone = TimeZone.getDefault
+  def injectionTimeZone = Try(TimeZone.getTimeZone(config.getString("timezone.injection"))).getOrElse(TimeZone.getDefault)
+  def extractionTimeZone = Try(TimeZone.getTimeZone(config.getString("timezone.extraction"))).getOrElse(TimeZone.getDefault)
   def user = config.getString("user")
   def password = Try(config.getString("password")).getOrElse(null)
   def database = config.getString("database")
@@ -19,11 +20,13 @@ case class FinagleMysqlContextConfig(config: Config) {
   def idleTime = Try(config.getInt("pool.idleTime")).getOrElse(5)
   def bufferSize = Try(config.getInt("pool.bufferSize")).getOrElse(0)
   def maxWaiters = Try(config.getInt("pool.maxWaiters")).getOrElse(Int.MaxValue)
+  def maxPrepareStatements = Try(config.getInt("maxPrepareStatements")).getOrElse(20)
 
   def client =
     Mysql.client
       .withCredentials(user, password)
       .withDatabase(database)
+      .withMaxConcurrentPrepareStatements(maxPrepareStatements)
       .configured(DefaultPool.Param(
         low = lowWatermark, high = highWatermark,
         idleTime = idleTime.seconds,

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
@@ -19,12 +19,6 @@ trait FinagleMysqlDecoders {
       decoder(index, row)
   }
 
-  protected val timestampValue =
-    new TimestampValue(
-      dateTimezone,
-      dateTimezone
-    )
-
   def decoder[T: ClassTag](f: PartialFunction[Value, T]): Decoder[T] =
     FinangleMysqlDecoder((index, row) => {
       val value = row.values(index)
@@ -92,6 +86,7 @@ trait FinagleMysqlDecoders {
   implicit val dateDecoder: Decoder[Date] =
     decoder[Date] {
       case `timestampValue`(v) => new Date(v.getTime)
+      case DateValue(d)        => new Date(d.getTime)
     }
 
   implicit val localDateDecoder: Decoder[LocalDate] = decoder[LocalDate] {

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
@@ -51,12 +51,14 @@ trait FinagleMysqlEncoders {
   implicit val floatEncoder: Encoder[Float] = encoder[Float]
   implicit val doubleEncoder: Encoder[Double] = encoder[Double]
   implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder[Array[Byte]]
-  implicit val dateEncoder: Encoder[Date] = encoder[Date]
+  implicit val dateEncoder: Encoder[Date] = encoder[Date] {
+    (value: Date) => timestampValue(new Timestamp(value.getTime)): Parameter
+  }
   implicit val localDateEncoder: Encoder[LocalDate] = encoder[LocalDate] {
     (d: LocalDate) => DateValue(java.sql.Date.valueOf(d)): Parameter
   }
   implicit val localDateTimeEncoder: Encoder[LocalDateTime] = encoder[LocalDateTime] {
-    (d: LocalDateTime) => new TimestampValue(dateTimezone, dateTimezone).apply(Timestamp.valueOf(d)): Parameter
+    (d: LocalDateTime) => timestampValue(Timestamp.valueOf(d)): Parameter
   }
   implicit val uuidEncoder: Encoder[UUID] = mappedEncoder(MappedEncoding(_.toString), stringEncoder)
 }


### PR DESCRIPTION
### Problem
1. Wrong encoding issue occured by differences between DB and `finagle-mysql` client timezone.
2. Mysql Date type can't be decoded to `java.util.Date` in `finagle-mysql`.
3. Max prepared statement config is needed.

``` java
Value 'RawValue(10,63,true,[B@69c21295)' can't be decoded to 'class java.util.Date'
java.lang.IllegalStateException: Value 'RawValue(10,63,true,[B@69c21295)' can't be decoded to 'class java.util.Date'
```
### Solution
- Apply encoder using timestampValue

> Current
> 
> ``` scala
> implicit val dateEncoder: Encoder[Date] = encoder[Date]
> ```
> 
> Fixed
> 
> ``` scala
> implicit val dateEncoder: Encoder[Date] = encoder[Date] { (value: Date) =>
>  timestampValue(new java.sql.Timestamp(value.getTime)): Parameter
> }
> ```
- Add `DateValue` in dateDecoder

> ``` scala
> implicit val dateDecoder: Decoder[Date] =
>   decoder[Date] {
>     case DateValue(v)        => v  // Add for Mysql Date
>     case `timestampValue`(v) => new Date(v.getTime)
>   }
> ```

- Max prepare statement configuration
[finagle's max prepare statement default value is 20](https://github.com/twitter/finagle/blob/develop/finagle-mysql/src/main/scala/com/twitter/finagle/Mysql.scala#L93
)

> ```scala
>   def maxPrepareStatements = Try(config.getInt("maxPrepareStatements")).getOrElse(20)
>
>   def client =
>    Mysql.client
>      .withCredentials(user, password)
>      .withDatabase(database)
>      .withMaxConcurrentPrepareStatements(maxPrepareStatements)  // Add MaxConcurrentPrepareStatements
>      .configured(DefaultPool.Param(
>        low = lowWatermark, high = highWatermark,
>        idleTime = idleTime.seconds,
>        bufferSize = bufferSize,
>        maxWaiters = maxWaiters
>      ))
>      .newRichClient(dest)
> ```

### Notes

- Previous PR #418 is reverted, because unit test fail. :sob:

### Checklist
- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
