### PR TITLE
upgrade finagle-mysql from 6.41.0 to 6.43.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val `quill-finagle-mysql` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "com.twitter" %% "finagle-mysql" % "6.41.0"
+        "com.twitter" %% "finagle-mysql" % "6.43.0"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")


### PR DESCRIPTION
- finagle-mysql from 6.41.0 -> 6.43.0 support

https://finagle.github.io/blog/2017/03/14/release-notes-6-43/

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
