### PR TITLE
Apply NamingStrategy to returning column

### DIFF
--- a/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
@@ -100,7 +100,7 @@ class ActionMacro(val c: MacroContext)
     q"""
       expanded.ast match {
         case io.getquill.ast.Returning(_, _, io.getquill.ast.Property(_, property)) => 
-          property
+          expanded.naming.column(property)
         case ast => 
           io.getquill.util.Messages.fail(s"Can't find returning column. Ast: '$$ast'")
       }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
@@ -1,12 +1,12 @@
 package io.getquill.context.sql
 
-import io.getquill.Spec
+import io.getquill._
 import io.getquill.context.mirror.Row
-import io.getquill.context.sql.testContext._
 
 class SqlActionMacroSpec extends Spec {
 
   "runs actions" - {
+    import io.getquill.context.sql.testContext._
     "without bindings" - {
       "update" in {
         val q = quote {
@@ -66,5 +66,16 @@ class SqlActionMacroSpec extends Spec {
       mirror.string mustEqual "INSERT INTO TestEntity (s,i) VALUES ('s', 0)"
       mirror.returningColumn mustEqual "l"
     }
+  }
+  "apply naming strategy to returning action" in {
+    case class TestEntity4(intId: Int, someText: String)
+    val ctx = new SqlMirrorContext[MirrorSqlDialect, SnakeCase]
+    import ctx._
+    val q = quote {
+      query[TestEntity4].insert(lift(TestEntity4(1, "s"))).returning(_.intId)
+    }
+    val mirror = ctx.run(q)
+    mirror.string mustEqual "INSERT INTO test_entity4 (some_text) VALUES (?)"
+    mirror.returningColumn mustEqual "int_id"
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
@@ -6,7 +6,7 @@ import io.getquill.context.mirror.Row
 class SqlActionMacroSpec extends Spec {
 
   "runs actions" - {
-    import io.getquill.context.sql.testContext._
+    import testContext._
     "without bindings" - {
       "update" in {
         val q = quote {
@@ -67,15 +67,14 @@ class SqlActionMacroSpec extends Spec {
       mirror.returningColumn mustEqual "l"
     }
   }
-  "apply naming strategy to returning action" in {
-    case class TestEntity4(intId: Int, someText: String)
-    val ctx = new SqlMirrorContext[MirrorSqlDialect, SnakeCase]
+  "apply naming strategy to returning action" in testContext.withNaming[SnakeCase] { ctx =>
     import ctx._
+    case class TestEntity4(intId: Int, textCol: String)
     val q = quote {
       query[TestEntity4].insert(lift(TestEntity4(1, "s"))).returning(_.intId)
     }
     val mirror = ctx.run(q)
-    mirror.string mustEqual "INSERT INTO test_entity4 (some_text) VALUES (?)"
+    mirror.string mustEqual "INSERT INTO test_entity4 (text_col) VALUES (?)"
     mirror.returningColumn mustEqual "int_id"
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
@@ -1,13 +1,13 @@
 package io.getquill.context.sql
 
-import io.getquill.TestEntities
-import io.getquill.Literal
-import io.getquill.MirrorSqlDialect
-import io.getquill.SqlMirrorContext
+import io.getquill._
 
-object testContext extends TestContextTemplate
+object testContext extends TestContextTemplate[Literal] {
 
-class TestContextTemplate
+  def withNaming[Naming <: NamingStrategy] = new TestContextTemplate[Naming]
+}
+
+class TestContextTemplate[Naming <: NamingStrategy]
   extends SqlMirrorContext[MirrorSqlDialect, Literal]
   with TestEntities
   with TestEncoders

--- a/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
@@ -4,11 +4,15 @@ import io.getquill._
 
 object testContext extends TestContextTemplate[Literal] {
 
-  def withNaming[Naming <: NamingStrategy] = new TestContextTemplate[Naming]
+  def withNaming[N <: NamingStrategy](f: TestContextTemplate[N] => Any): Unit = {
+    val ctx = new TestContextTemplate[N]
+    f(ctx)
+    ctx.close
+  }
 }
 
-class TestContextTemplate[Naming <: NamingStrategy]
-  extends SqlMirrorContext[MirrorSqlDialect, Literal]
+class TestContextTemplate[N <: NamingStrategy]
+  extends SqlMirrorContext[MirrorSqlDialect, N]
   with TestEntities
   with TestEncoders
   with TestDecoders


### PR DESCRIPTION
Fixes #721

### Problem

Naming Strategy does not work for returning column

### Solution

Apply NamingStrategy to returning column 

### Notes
### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
