### PR TITLE
Fix error while import `List` types other than `scala.collection.immutable.List`

### DIFF
--- a/quill-core/src/main/scala/io/getquill/context/ContextMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextMacro.scala
@@ -47,7 +47,7 @@ trait ContextMacro extends Quotation {
   private implicit val tokenLiftable: Liftable[Token] = Liftable[Token] {
     case StringToken(string)   => q"io.getquill.idiom.StringToken($string)"
     case ScalarLiftToken(lift) => q"io.getquill.idiom.ScalarLiftToken(${lift: Lift})"
-    case Statement(tokens)     => q"io.getquill.idiom.Statement(List(..$tokens))"
+    case Statement(tokens)     => q"io.getquill.idiom.Statement(scala.List(..$tokens))"
   }
 
   private def translateStatic(ast: Ast): Tree = {


### PR DESCRIPTION
If we have `List`  other than `scala.collection.immutable.List` imported inside the scope, compile will fail