### PR TITLE
Prevents breaking-change on FinagleMysqlContext's constructor which takes TimeZone in 2nd parameter on v1.1.0.

### DIFF
--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -28,18 +28,26 @@ import io.getquill.util.LoadConfig
 import io.getquill.util.Messages.fail
 
 class FinagleMysqlContext[N <: NamingStrategy](
-  client:                                  Client with Transactions,
-  private[getquill] val injectionTimeZone: TimeZone                 = TimeZone.getDefault
-)(
-  private[getquill] val extractionTimeZone: TimeZone = injectionTimeZone
+  client:                                   Client with Transactions,
+  private[getquill] val injectionTimeZone:  TimeZone,
+  private[getquill] val extractionTimeZone: TimeZone
 )
   extends SqlContext[MySQLDialect, N]
   with FinagleMysqlDecoders
   with FinagleMysqlEncoders {
 
-  def this(config: FinagleMysqlContextConfig) = this(config.client, config.injectionTimeZone)(config.extractionTimeZone)
+  def this(config: FinagleMysqlContextConfig) = this(config.client, config.injectionTimeZone, config.extractionTimeZone)
   def this(config: Config) = this(FinagleMysqlContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
+
+  def this(client: Client with Transactions, timeZone: TimeZone) = this(client, timeZone, timeZone)
+  def this(config: FinagleMysqlContextConfig, timeZone: TimeZone) = this(config.client, timeZone)
+  def this(config: Config, timeZone: TimeZone) = this(FinagleMysqlContextConfig(config), timeZone)
+  def this(configPrefix: String, timeZone: TimeZone) = this(LoadConfig(configPrefix), timeZone)
+
+  def this(config: FinagleMysqlContextConfig, injectionTimeZone: TimeZone, extractionTimeZone: TimeZone) = this(config.client, injectionTimeZone, extractionTimeZone)
+  def this(config: Config, injectionTimeZone: TimeZone, extractionTimeZone: TimeZone) = this(FinagleMysqlContextConfig(config), injectionTimeZone, extractionTimeZone)
+  def this(configPrefix: String, injectionTimeZone: TimeZone, extractionTimeZone: TimeZone) = this(LoadConfig(configPrefix), injectionTimeZone, extractionTimeZone)
 
   protected val logger: Logger =
     Logger(LoggerFactory.getLogger(classOf[FinagleMysqlContext[_]]))

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -28,15 +28,16 @@ import io.getquill.util.LoadConfig
 import io.getquill.util.Messages.fail
 
 class FinagleMysqlContext[N <: NamingStrategy](
-  client:                                   Client with Transactions,
-  private[getquill] val injectionTimeZone:  TimeZone                 = TimeZone.getDefault,
-  private[getquill] val extractionTimeZone: TimeZone                 = TimeZone.getDefault
+  client:                                  Client with Transactions,
+  private[getquill] val injectionTimeZone: TimeZone                 = TimeZone.getDefault
+)(
+  private[getquill] val extractionTimeZone: TimeZone = injectionTimeZone
 )
   extends SqlContext[MySQLDialect, N]
   with FinagleMysqlDecoders
   with FinagleMysqlEncoders {
 
-  def this(config: FinagleMysqlContextConfig) = this(config.client, config.injectionTimeZone, config.extractionTimeZone)
+  def this(config: FinagleMysqlContextConfig) = this(config.client, config.injectionTimeZone)(config.extractionTimeZone)
   def this(config: Config) = this(FinagleMysqlContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
@@ -135,7 +135,7 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
 
     "different timezone" in {
       val config = FinagleMysqlContextConfig(LoadConfig("testDB"))
-      val testTimezoneContext = new FinagleMysqlContext[Literal](config.client, TimeZone.getTimeZone("KST"))(TimeZone.getTimeZone("UTC"))
+      val testTimezoneContext = new FinagleMysqlContext[Literal](config.client, TimeZone.getTimeZone("KST"), TimeZone.getTimeZone("UTC"))
       import testTimezoneContext._
 
       val r = for {

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
@@ -135,7 +135,7 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
 
     "different timezone" in {
       val config = FinagleMysqlContextConfig(LoadConfig("testDB"))
-      val testTimezoneContext = new FinagleMysqlContext[Literal](config.client, TimeZone.getTimeZone("KST"), TimeZone.getTimeZone("UTC"))
+      val testTimezoneContext = new FinagleMysqlContext[Literal](config.client, TimeZone.getTimeZone("KST"))(TimeZone.getTimeZone("UTC"))
       import testTimezoneContext._
 
       val r = for {


### PR DESCRIPTION
### Problem

We are using https://github.com/laysakura/quill/blob/v1.1.0/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala#L29-L32 with passing JST timezone like below:

```sacala
abstract class JSTFinagleMysqlContext[N <: NamingStrategy](config: Config)
  extends FinagleMysqlContext[N](
    FinagleMysqlContextConfig(config).client,
    TimeZone.getTimeZone(ZoneId.of("Asia/Tokyo")) // for explicitly using JST, not relying on system timezone settings
  )
```

But https://github.com/getquill/quill/pull/722 has broken backword-compatibility in that `extractionTimeZone` (new 3rd parameter) will be set to `TimeZone.getDefault` (passed as default value).

### Solution

This commit:
- Keeps the ability to split inject/extraction timezone as https://github.com/getquill/quill/pull/722 .
- Keeps extraction timezone the same as inject timezone if a caller of FinagleMysqlContext's constructor passes only 2nd parameter.

### Notes

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
