### PR TITLE
update scala from 2.11.10 to 2.11.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -222,7 +222,7 @@ def updateWebsiteTag =
 
 lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
   organization := "io.getquill",
-  scalaVersion := "2.11.10",
+  scalaVersion := "2.11.11",
   libraryDependencies ++= Seq(
     "org.scalamacros" %% "resetallattrs"  % "1.0.0",
     "org.scalatest"   %%% "scalatest"     % "3.0.1"     % Test,


### PR DESCRIPTION
### Problem

https://github.com/scala/scala/releases/tag/v2.11.10
scala 2.11.10 has regression.

and scala 2.11.11 was released. https://github.com/scala/scala/releases/tag/v2.11.11

### Solution

update it.

### Notes

ref: https://github.com/getquill/quill/pull/741

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
