### PR TITLE
Stop using java.sql.Timestamp's deprecated methods to correctly reflect timezone specified in FinagleMysqlContext constructors.

### DIFF
--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
@@ -95,7 +95,7 @@ trait FinagleMysqlDecoders {
   }
 
   implicit val localDateTimeDecoder: Decoder[LocalDateTime] = decoder[LocalDateTime] {
-    case `timestampValue`(v) => v.toLocalDateTime
+    case `timestampValue`(v) => v.toInstant.atZone(extractionTimeZone.toZoneId).toLocalDateTime
   }
 
   implicit val uuidDecoder: Decoder[UUID] = mappedDecoder(MappedEncoding(UUID.fromString), stringDecoder)

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
@@ -58,7 +58,7 @@ trait FinagleMysqlEncoders {
     (d: LocalDate) => DateValue(java.sql.Date.valueOf(d)): Parameter
   }
   implicit val localDateTimeEncoder: Encoder[LocalDateTime] = encoder[LocalDateTime] {
-    (d: LocalDateTime) => timestampValue(Timestamp.valueOf(d)): Parameter
+    (d: LocalDateTime) => timestampValue(new Timestamp(d.atZone(injectionTimeZone.toZoneId).toInstant.toEpochMilli)): Parameter
   }
   implicit val uuidEncoder: Encoder[UUID] = mappedEncoder(MappedEncoding(_.toString), stringEncoder)
 }

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -60,6 +60,11 @@ Create TABLE DateEncodingTestEntity(
     v3 timestamp
 );
 
+Create TABLE LocalDateTimeEncodingTestEntity(
+    v1 datetime,
+    v2 timestamp
+);
+
 Create TABLE BooleanEncodingTestEntity(
     v1 BOOLEAN,
     v2 BIT(1),


### PR DESCRIPTION
### Problem

- localDateTimeEncoder uses `java.sql.Timestamp.valueOf()`, which is deprecated and calls `TimeZone.getDefaultRef()` internally.
- localDateTimeDecoder uses `java.sql.Timestamp.toLocalDateTime()`, which is deprecated and does not use any timezone information to create LocalDateTime instance.

### Solution

- localDateTimeEncoder: uses `new Timestamp(long)` instead in order not to rely on `TimeZone.getDefaultRef()`.
- localDateTimeDecoder: uses `Instant.atZone()` in order to give timezone to create LocalDateTime instance.

### Notes

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
