### PR TITLE
Added a link to the Templates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1513,6 +1513,7 @@ Templates
 In order to quickly start with Quill, we have setup some template projects:
 
 * [Play Framework with Quill JDBC](https://github.com/getquill/play-quill-jdbc)
+* [Play Framework with Quill async-postgres](https://github.com/jeffmath/play-quill-async-postgres-example)
 
 Slick comparison
 ----------------


### PR DESCRIPTION
The link is to the play-quill-async-postgres-example project, which I created.  I am hoping it will save other Quill newbies the headache I had to go through over the past few days to obtain a current, working example of Quill's async PostgreSQL support.

@getquill/maintainers
