### PR TITLE
Add arrays support for SqlMirrorContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,13 +702,13 @@ SQL-specific encoding
 **Arrays**
 
 Quill provides SQL Arrays support. In Scala we represent them as any collection that implements `Seq`:
-```
+```scala
 import java.util.Date
 
-case class Person(id: Int, phones: List[String], cards: Vector[Int], dates: Seq[Date])
+case class Book(id: Int, notes: List[String], pages: Vector[Int], history: Seq[Date])
 
-ctx.run(query[Person])
-// SELECT x.id, x.phones, x.cards, x.dates FROM Person x
+ctx.run(query[Book])
+// SELECT x.id, x.notes, x.pages, x.history FROM Book x
 ```
 Note that not all drivers/databases provides such feature hence only `PostgresJdbcContext` and
 `PostgresAsyncContext` support SQL Arrays.
@@ -838,13 +838,13 @@ Cassandra-specific encoding
 **Collections**
 
 Quill provides List, Set and Map encoding:
-```
+```scala
 import java.util.Date
 
-case class Person(id: Int, phones: Set[String], cards: List[Int], dates: Map[Date, Boolean])
+case class Book(id: Int, notes: Set[String], pages: List[Int], history: Map[Date, Boolean])
 
-ctx.run(query[Person])
-// SELECT id, phones, cards, dates FROM Person
+ctx.run(query[Book])
+// SELECT id, notes, pages, history FROM Book
 ```
 
 Dynamic queries

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ArrayJdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ArrayJdbcEncodingSpec.scala
@@ -12,12 +12,13 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
   import ctx._
 
   val q = quote(query[ArraysTestEntity])
+  val corrected = e.copy(timestamps = e.timestamps.map(d => new Timestamp(d.getTime)))
 
   "Support all sql base types and `Seq` implementers" in {
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insert(lift(corrected)))
     val actual = ctx.run(q).head
-    actual mustEqual e
-    baseEntityDeepCheck(actual, e)
+    actual mustEqual corrected
+    baseEntityDeepCheck(actual, corrected)
   }
 
   "Support Seq encoding basing on MappedEncoding" in {
@@ -41,9 +42,9 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
         arrayDecoder[LocalDate, LocalDate, Col](identity)
     }
     import newCtx._
-    newCtx.run(query[ArraysTestEntity].insert(lift(e)))
+    newCtx.run(query[ArraysTestEntity].insert(lift(corrected)))
     intercept[IllegalStateException] {
-      newCtx.run(query[ArraysTestEntity]).head mustBe e
+      newCtx.run(query[ArraysTestEntity]).head mustBe corrected
     }
     newCtx.close()
   }
@@ -61,10 +62,10 @@ class ArrayJdbcEncodingSpec extends ArrayEncodingBaseSpec {
   }
 
   "Arrays in where clause" in {
-    ctx.run(q.insert(lift(e)))
+    ctx.run(q.insert(lift(corrected)))
     val actual1 = ctx.run(q.filter(_.texts == lift(List("test"))))
     val actual2 = ctx.run(q.filter(_.texts == lift(List("test2"))))
-    actual1 mustEqual List(e)
+    actual1 mustEqual List(corrected)
     actual2 mustEqual List()
   }
 

--- a/quill-sql/src/main/scala/io/getquill/SqlMirrorContext.scala
+++ b/quill-sql/src/main/scala/io/getquill/SqlMirrorContext.scala
@@ -2,6 +2,9 @@ package io.getquill
 
 import io.getquill.idiom.{ Idiom => BaseIdiom }
 import io.getquill.context.sql.SqlContext
+import io.getquill.context.sql.encoding.mirror.ArrayMirrorEncoding
 
 class SqlMirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
-  extends MirrorContext[Idiom, Naming] with SqlContext[Idiom, Naming]
+  extends MirrorContext[Idiom, Naming]
+  with SqlContext[Idiom, Naming]
+  with ArrayMirrorEncoding

--- a/quill-sql/src/main/scala/io/getquill/context/sql/encoding/mirror/ArrayMirrorEncoding.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/encoding/mirror/ArrayMirrorEncoding.scala
@@ -1,0 +1,36 @@
+package io.getquill.context.sql.encoding.mirror
+
+import java.time.LocalDate
+import java.util.Date
+
+import io.getquill.SqlMirrorContext
+import io.getquill.context.sql.encoding.ArrayEncoding
+
+trait ArrayMirrorEncoding extends ArrayEncoding {
+  this: SqlMirrorContext[_, _] =>
+
+  implicit def arrayStringEncoder[Col <: Seq[String]]: Encoder[Col] = encoder[Col]
+  implicit def arrayBigDecimalEncoder[Col <: Seq[BigDecimal]]: Encoder[Col] = encoder[Col]
+  implicit def arrayBooleanEncoder[Col <: Seq[Boolean]]: Encoder[Col] = encoder[Col]
+  implicit def arrayByteEncoder[Col <: Seq[Byte]]: Encoder[Col] = encoder[Col]
+  implicit def arrayShortEncoder[Col <: Seq[Short]]: Encoder[Col] = encoder[Col]
+  implicit def arrayIntEncoder[Col <: Seq[Int]]: Encoder[Col] = encoder[Col]
+  implicit def arrayLongEncoder[Col <: Seq[Long]]: Encoder[Col] = encoder[Col]
+  implicit def arrayFloatEncoder[Col <: Seq[Float]]: Encoder[Col] = encoder[Col]
+  implicit def arrayDoubleEncoder[Col <: Seq[Double]]: Encoder[Col] = encoder[Col]
+  implicit def arrayDateEncoder[Col <: Seq[Date]]: Encoder[Col] = encoder[Col]
+  implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] = encoder[Col]
+
+  implicit def arrayStringDecoder[Col <: Seq[String]](implicit bf: CBF[String, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayBigDecimalDecoder[Col <: Seq[BigDecimal]](implicit bf: CBF[BigDecimal, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayBooleanDecoder[Col <: Seq[Boolean]](implicit bf: CBF[Boolean, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayByteDecoder[Col <: Seq[Byte]](implicit bf: CBF[Byte, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayShortDecoder[Col <: Seq[Short]](implicit bf: CBF[Short, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayIntDecoder[Col <: Seq[Int]](implicit bf: CBF[Int, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayLongDecoder[Col <: Seq[Long]](implicit bf: CBF[Long, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayFloatDecoder[Col <: Seq[Float]](implicit bf: CBF[Float, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayDoubleDecoder[Col <: Seq[Double]](implicit bf: CBF[Double, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayDateDecoder[Col <: Seq[Date]](implicit bf: CBF[Date, Col]): Decoder[Col] = decoderUnsafe[Col]
+  implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: CBF[LocalDate, Col]): Decoder[Col] = decoderUnsafe[Col]
+}
+

--- a/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
@@ -1,10 +1,6 @@
 package io.getquill.context.sql
 
-import java.time.LocalDate
-import java.util.Date
-
 import io.getquill.{ MirrorSqlDialect, NamingStrategy, SqlMirrorContext, TestEntities, Literal }
-import io.getquill.context.sql.encoding.ArrayEncoding
 
 class TestContextTemplate[Naming <: NamingStrategy]
   extends SqlMirrorContext[MirrorSqlDialect, Naming]
@@ -20,28 +16,3 @@ class TestContextTemplate[Naming <: NamingStrategy]
 }
 
 object testContext extends TestContextTemplate[Literal]
-
-object testContextWithArrays extends TestContextTemplate[Literal] with ArrayEncoding {
-  implicit def arrayStringEncoder[Col <: Seq[String]]: Encoder[Col] = encoder[Col]
-  implicit def arrayBigDecimalEncoder[Col <: Seq[BigDecimal]]: Encoder[Col] = encoder[Col]
-  implicit def arrayBooleanEncoder[Col <: Seq[Boolean]]: Encoder[Col] = encoder[Col]
-  implicit def arrayByteEncoder[Col <: Seq[Byte]]: Encoder[Col] = encoder[Col]
-  implicit def arrayShortEncoder[Col <: Seq[Short]]: Encoder[Col] = encoder[Col]
-  implicit def arrayIntEncoder[Col <: Seq[Index]]: Encoder[Col] = encoder[Col]
-  implicit def arrayLongEncoder[Col <: Seq[Long]]: Encoder[Col] = encoder[Col]
-  implicit def arrayFloatEncoder[Col <: Seq[Float]]: Encoder[Col] = encoder[Col]
-  implicit def arrayDoubleEncoder[Col <: Seq[Double]]: Encoder[Col] = encoder[Col]
-  implicit def arrayDateEncoder[Col <: Seq[Date]]: Encoder[Col] = encoder[Col]
-  implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] = encoder[Col]
-  implicit def arrayStringDecoder[Col <: Seq[String]](implicit bf: testContextWithArrays.CBF[String, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayBigDecimalDecoder[Col <: Seq[BigDecimal]](implicit bf: testContextWithArrays.CBF[BigDecimal, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayBooleanDecoder[Col <: Seq[Boolean]](implicit bf: testContextWithArrays.CBF[Boolean, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayByteDecoder[Col <: Seq[Byte]](implicit bf: testContextWithArrays.CBF[Byte, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayShortDecoder[Col <: Seq[Short]](implicit bf: testContextWithArrays.CBF[Short, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayIntDecoder[Col <: Seq[Index]](implicit bf: testContextWithArrays.CBF[Index, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayLongDecoder[Col <: Seq[Long]](implicit bf: testContextWithArrays.CBF[Long, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayFloatDecoder[Col <: Seq[Float]](implicit bf: testContextWithArrays.CBF[Float, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayDoubleDecoder[Col <: Seq[Double]](implicit bf: testContextWithArrays.CBF[Double, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayDateDecoder[Col <: Seq[Date]](implicit bf: testContextWithArrays.CBF[Date, Col]): Decoder[Col] = decoderUnsafe[Col]
-  implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: testContextWithArrays.CBF[LocalDate, Col]): Decoder[Col] = decoderUnsafe[Col]
-}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingBaseSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingBaseSpec.scala
@@ -1,6 +1,5 @@
 package io.getquill.context.sql.encoding
 
-import java.sql.Timestamp
 import java.time.LocalDate
 import java.util.Date
 
@@ -28,7 +27,7 @@ trait ArrayEncodingBaseSpec extends Spec with BeforeAndAfterEach {
 
   val e = ArraysTestEntity(List("test"), Seq(BigDecimal(2.33)), Vector(true, true), ListBuffer(1),
     IndexedSeq(3), Seq(2), Seq(1, 2, 3), Seq(1f, 2f), Seq(4d, 3d),
-    Seq(new Timestamp(System.currentTimeMillis())), Seq(LocalDate.now()))
+    Seq(new Date(System.currentTimeMillis())), Seq(LocalDate.now()))
 
   // casting types can be dangerous so we need to ensure that everything is ok
   def baseEntityDeepCheck(e1: ArraysTestEntity, e2: ArraysTestEntity): Assertion = {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.sql.encoding
 
 import io.getquill.Spec
-import io.getquill.context.sql.{ testContextWithArrays => ctx }
+import io.getquill.context.sql.{ testContext => ctx }
 
 class ArrayEncodingSpec extends Spec {
   import ctx._

--- a/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ArrayMirrorEncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ArrayMirrorEncodingSpec.scala
@@ -1,0 +1,63 @@
+package io.getquill.context.sql.mirror
+
+import java.time.LocalDate
+import java.util.Date
+
+import io.getquill.context.sql.encoding.ArrayEncodingBaseSpec
+import io.getquill.context.sql.testContext
+
+class ArrayMirrorEncodingSpec extends ArrayEncodingBaseSpec {
+  val ctx = testContext
+
+  import ctx._
+
+  val q = quote(query[ArraysTestEntity])
+
+  "Support all sql base types and `Seq` implementers" in {
+    val insertStr = ctx.run(q.insert(lift(e))).string
+    val selectStr = ctx.run(q).string
+
+    insertStr mustEqual "INSERT INTO ArraysTestEntity (texts,decimals,bools,bytes,shorts,ints,longs,floats," +
+      "doubles,timestamps,dates) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+
+    selectStr mustEqual "SELECT x.texts, x.decimals, x.bools, x.bytes, x.shorts, x.ints, x.longs, x.floats, " +
+      "x.doubles, x.timestamps, x.dates FROM ArraysTestEntity x"
+  }
+
+  "Support Seq encoding basing on MappedEncoding" in {
+    val wrapQ = quote(querySchema[WrapEntity]("ArraysTestEntity"))
+
+    val insertStr = ctx.run(wrapQ.insert(lift(wrapE))).string
+    val selectStr = ctx.run(wrapQ).string
+    insertStr mustEqual "INSERT INTO ArraysTestEntity (texts) VALUES (?)"
+    selectStr mustEqual "SELECT x.texts FROM ArraysTestEntity x"
+  }
+
+  "Provide implicit encoders for raw types" in {
+    implicitly[Encoder[List[String]]]
+    implicitly[Encoder[List[BigDecimal]]]
+    implicitly[Encoder[List[Boolean]]]
+    implicitly[Encoder[List[Byte]]]
+    implicitly[Encoder[List[Short]]]
+    implicitly[Encoder[List[Index]]]
+    implicitly[Encoder[List[Long]]]
+    implicitly[Encoder[List[Float]]]
+    implicitly[Encoder[List[Double]]]
+    implicitly[Encoder[List[Date]]]
+    implicitly[Encoder[List[LocalDate]]]
+  }
+
+  "Provide implicit decoders for raw types" in {
+    implicitly[Decoder[List[String]]]
+    implicitly[Decoder[List[BigDecimal]]]
+    implicitly[Decoder[List[Boolean]]]
+    implicitly[Decoder[List[Byte]]]
+    implicitly[Decoder[List[Short]]]
+    implicitly[Decoder[List[Index]]]
+    implicitly[Decoder[List[Long]]]
+    implicitly[Decoder[List[Float]]]
+    implicitly[Decoder[List[Double]]]
+    implicitly[Decoder[List[Date]]]
+    implicitly[Decoder[List[LocalDate]]]
+  }
+}


### PR DESCRIPTION
Fixes #763 

### Problem
SqlMirrorContext has no encoding for arrays. 
tut cannot compile arrays example in readme

### Solution

Add arrays support for SqlMirrorContext

### Notes

Should arrays encoding be already present in SqlMirrorContext or just provide trait which can be mixed by user if needed?

### Checklist

- [x] satisfy coverage
- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
