### PR TITLE
Apply querySchema to optional nested case class properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,20 +252,20 @@ Note that default naming behavior uses the name of the nested case class propert
 
 ```scala
 case class Contact(phone: String, address: String) extends Embedded
-case class Person(id: Int, name: String, homeContact: Contact, workContact: Contact)
+case class Person(id: Int, name: String, homeContact: Contact, workContact: Option[Contact])
 
 val q = quote {
   querySchema[Person](
     "Person",
-    _.homeContact.phone   -> "homePhone",
-    _.homeContact.address -> "homeAdress",
-    _.workContact.phone   -> "workPhone",
-    _.workContact.address -> "workAdress"
+    _.homeContact.phone          -> "homePhone",
+    _.homeContact.address        -> "homeAddress",
+    _.workContact.map(_.phone)   -> "workPhone",
+    _.workContact.map(_.address) -> "workAddress"
   )
 }
 
 ctx.run(q)
-// SELECT x.id, x.name, x.homePhone, x.homeAdress, x.workPhone, x.workAdress FROM Person x
+// SELECT x.id, x.name, x.homePhone, x.homeAddress, x.workPhone, x.workAddress FROM Person x
 ```
 
 Queries

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -227,6 +227,8 @@ trait Parsing {
         tree match {
           case q"$a.$b" =>
             path(a) :+ b.decodedName.toString
+          case q"$a.$b.map[$_]((..$_) => $_.$c)" =>
+            path(a) ++ List(b.decodedName.toString, c.decodedName.toString)
           case _ =>
             Nil
         }

--- a/quill-core/src/test/scala/io/getquill/dsl/MetaDslSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/dsl/MetaDslSpec.scala
@@ -12,6 +12,8 @@ class MetaDslSpec extends Spec {
     y0: Int, y1: Int, y2: Int, y3: Int, y4: Int, y5: Int, y6: Int, y7: Int, y8: Int, y9: Int
   )
 
+  case class EmbValue(i: Int) extends Embedded
+
   "schema meta" - {
     "materialized" in {
       val meta = materializeSchemaMeta[TestEntity]
@@ -20,6 +22,16 @@ class MetaDslSpec extends Spec {
     "custom" in {
       val meta = schemaMeta[TestEntity]("test_entity", _.i -> "ii")
       meta.entity.toString mustEqual """querySchema("test_entity", _.i -> "ii")"""
+    }
+    "custom with embedded" in {
+      case class Entity(emb: EmbValue)
+      val meta = schemaMeta[Entity]("test_entity", _.emb.i -> "ii")
+      meta.entity.toString mustEqual """querySchema("test_entity", _.emb.i -> "ii")"""
+    }
+    "custom with optional embedded" in {
+      case class Entity(emb: Option[EmbValue])
+      val meta = schemaMeta[Entity]("test_entity", _.emb.map(_.i) -> "ii")
+      meta.entity.toString mustEqual """querySchema("test_entity", _.emb.i -> "ii")"""
     }
   }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -11,6 +11,7 @@ import io.getquill.testContext._
 import io.getquill.context.ValueClass
 
 case class CustomAnyValue(i: Int) extends AnyVal
+case class EmbeddedValue(s: String, i: Int) extends Embedded
 
 class QuotationSpec extends Spec {
 
@@ -32,6 +33,20 @@ class QuotationSpec extends Spec {
             querySchema[TestEntity]("SomeAlias", _.s -> "theS", _.i -> "theI")
           }
           quote(unquote(q)).ast mustEqual Entity("SomeAlias", List(PropertyAlias(List("s"), "theS"), PropertyAlias(List("i"), "theI")))
+        }
+        "with embedded property alias" in {
+          case class TestEnt(ev: EmbeddedValue)
+          val q = quote {
+            querySchema[TestEnt]("SomeAlias", _.ev.s -> "theS", _.ev.i -> "theI")
+          }
+          quote(unquote(q)).ast mustEqual Entity("SomeAlias", List(PropertyAlias(List("ev", "s"), "theS"), PropertyAlias(List("ev", "i"), "theI")))
+        }
+        "with embedded option property alias" in {
+          case class TestEnt(ev: Option[EmbeddedValue])
+          val q = quote {
+            querySchema[TestEnt]("SomeAlias", _.ev.map(_.s) -> "theS", _.ev.map(_.i) -> "theI")
+          }
+          quote(unquote(q)).ast mustEqual Entity("SomeAlias", List(PropertyAlias(List("ev", "s"), "theS"), PropertyAlias(List("ev", "i"), "theI")))
         }
         "explicit `Predef.ArrowAssoc`" in {
           val q = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -229,6 +229,23 @@ class RenamePropertiesSpec extends Spec {
           "SELECT x.bC FROM A x"
       }
     }
+    "query for Option embeddeds" - {
+      "without schema" in {
+        case class B(c1: Int, c2: Int) extends Embedded
+        case class A(b: Option[B])
+        testContext.run(query[A]).string mustEqual
+          "SELECT x.c1, x.c2 FROM A x"
+      }
+      "with schema" in {
+        case class B(c1: Int, c2: Int) extends Embedded
+        case class A(b: Option[B])
+        val q = quote {
+          querySchema[A]("A", _.b.map(_.c1) -> "bC1", _.b.map(_.c2) -> "bC2")
+        }
+        testContext.run(q).string mustEqual
+          "SELECT x.bC1, x.bC2 FROM A x"
+      }
+    }
     "update" - {
       "without schema" in {
         case class B(c: Int) extends Embedded


### PR DESCRIPTION
Fixes #727

### Problem

- `propertyAliasParser` was not able to parse `..map(_.x) -> "y"` tree

### Solution

- make `propertyAliasParser` to parse  tree with `map`
- tests for `schemaMeta` and `querySchema`

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
