### PR TITLE
Enable cross building for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -223,6 +223,7 @@ def updateWebsiteTag =
 lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
   organization := "io.getquill",
   scalaVersion := "2.11.11",
+  crossScalaVersions := Seq("2.11.11","2.12.2"),
   libraryDependencies ++= Seq(
     "org.scalamacros" %% "resetallattrs"  % "1.0.0",
     "org.scalatest"   %%% "scalatest"     % "3.0.1"     % Test,
@@ -317,4 +318,10 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
         <url>http://github.com/fwbrasil/</url>
       </developer>
     </developers>)
+) ++ update2_12
+
+lazy val update2_12 = Seq(
+  scalacOptions -= (
+    if (scalaVersion.value.startsWith("2.12.")) "-Xfatal-warnings" else ""
+  )
 )


### PR DESCRIPTION
Is this all that's left for #231 ?

### Problem

Scala 2.12 introduced new warnings that were not in 2.11, which breaks the build because of `-Xfatal-warnings`.

### Solution

Only treat Scala 2.11 warning as fatal for now.

### Notes

Someone should eventually decide whether to change the API or disable/sidestep the new warnings for unused params.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
