### PR TITLE
Make Quill compatible with Scala 2.12.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -241,14 +241,19 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     "-encoding", "UTF-8",
     "-feature",
     "-unchecked",
-    "-Xlint",
     "-Yno-adapted-args",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard",
-    "-Xfuture",
-    "-Ywarn-unused-import"
+    "-Xfuture"
   ),
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 11)) => Seq("-Xlint", "-Ywarn-unused-import")
+      case Some((2, 12)) => Seq("-Xlint:-unused,_", "-Ywarn-unused:imports")
+      case _ => Seq()
+    }
+  },
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   scoverage.ScoverageKeys.coverageMinimum := 96,
@@ -318,10 +323,4 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
         <url>http://github.com/fwbrasil/</url>
       </developer>
     </developers>)
-) ++ update2_12
-
-lazy val update2_12 = Seq(
-  scalacOptions -= (
-    if (scalaVersion.value.startsWith("2.12.")) "-Xfatal-warnings" else ""
-  )
 )

--- a/build/build.sh
+++ b/build/build.sh
@@ -22,16 +22,16 @@ then
 		git checkout master || git checkout -b master
 		git reset --hard origin/master
 		git push --delete origin website
-		sbt tut 'release with-defaults'
+		sbt tut 'release cross with-defaults'
 	elif [[ $TRAVIS_BRANCH == "master" ]]
 	then
-		sbt clean coverage test tut coverageReport coverageAggregate checkUnformattedFiles
+		sbt clean ++2.12.2 test ++2.11.11 coverage test tut coverageReport coverageAggregate checkUnformattedFiles
 		sbt coverageOff publish
 	else
-		sbt clean coverage test tut coverageReport coverageAggregate checkUnformattedFiles
+		sbt clean ++2.12.2 test ++2.11.11 coverage test tut coverageReport coverageAggregate checkUnformattedFiles
 		echo "version in ThisBuild := \"$TRAVIS_BRANCH-SNAPSHOT\"" > version.sbt
 		sbt coverageOff publish
 	fi
 else
-	sbt clean coverage test tut coverageReport coverageAggregate checkUnformattedFiles
+	sbt clean ++2.12.2 test ++2.11.11 coverage test tut coverageReport coverageAggregate checkUnformattedFiles
 fi

--- a/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncEncodingSpec.scala
+++ b/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncEncodingSpec.scala
@@ -5,7 +5,7 @@ import java.time.{ LocalDate, LocalDateTime }
 import io.getquill.context.sql.EncodingSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import java.util.Date
 
@@ -143,7 +143,7 @@ class MysqlAsyncEncodingSpec extends EncodingSpec {
 
   "encodes custom type inside singleton object" in {
     object Singleton {
-      def apply()(implicit c: TestContext, ec: ExecutionContext) = {
+      def apply()(implicit c: TestContext) = {
         import c._
         for {
           _ <- c.run(query[EncodingTestEntity].delete)

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
@@ -5,7 +5,7 @@ import java.time.{ LocalDate, LocalDateTime }
 import io.getquill.context.sql.EncodingSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import java.util.Date
 import java.util.UUID
@@ -111,7 +111,7 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
 
   "encodes custom type inside singleton object" in {
     object Singleton {
-      def apply()(implicit c: TestContext, ec: ExecutionContext) = {
+      def apply()(implicit c: TestContext) = {
         import c._
         for {
           _ <- c.run(query[EncodingTestEntity].delete)

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/cluster/ClusterBuilder.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/cluster/ClusterBuilder.scala
@@ -5,7 +5,6 @@ import scala.util.Try
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigValueType
 import java.lang.reflect.Method
-import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 import com.datastax.driver.core.Cluster
 
@@ -15,7 +14,7 @@ object ClusterBuilder {
     set(Cluster.builder, cfg)
 
   private def set[T](instance: T, cfg: Config): T = {
-    for (key <- cfg.entrySet.map(_.getKey.split('.').head)) {
+    for (key <- cfg.entrySet.asScala.map(_.getKey.split('.').head)) {
 
       def tryMethod(m: Method) =
         m.getParameterTypes.toList match {

--- a/quill-core/src/main/scala/io/getquill/dsl/MetaDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/MetaDsl.scala
@@ -22,19 +22,19 @@ trait MetaDsl extends MetaDslLowPriorityImplicits {
   def insertMeta[T](exclude: (T => Any)*): InsertMeta[T] = macro MetaDslMacro.insertMeta[T]
 
   trait SchemaMeta[T] {
-    val entity: Quoted[EntityQuery[T]]
+    def entity: Quoted[EntityQuery[T]]
   }
 
   trait QueryMeta[T] {
-    val expand: Quoted[Query[T] => Query[_]]
-    val extract: ResultRow => T
+    def expand: Quoted[Query[T] => Query[_]]
+    def extract: ResultRow => T
   }
 
   trait UpdateMeta[T] {
-    val expand: Quoted[(EntityQuery[T], T) => Update[T]]
+    def expand: Quoted[(EntityQuery[T], T) => Update[T]]
   }
 
   trait InsertMeta[T] {
-    val expand: Quoted[(EntityQuery[T], T) => Insert[T]]
+    def expand: Quoted[(EntityQuery[T], T) => Insert[T]]
   }
 }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -4,11 +4,11 @@ import scala.math.BigDecimal.double2bigDecimal
 import scala.math.BigDecimal.int2bigDecimal
 import scala.math.BigDecimal.javaBigDecimal2bigDecimal
 import scala.math.BigDecimal.long2bigDecimal
-
 import io.getquill.Spec
 import io.getquill.ast.{ Query => _, _ }
 import io.getquill.testContext._
 import io.getquill.context.ValueClass
+import io.getquill.util.Messages
 
 case class CustomAnyValue(i: Int) extends AnyVal
 case class EmbeddedValue(s: String, i: Int) extends Embedded
@@ -726,6 +726,7 @@ class QuotationSpec extends Spec {
           quote(unquote(q)).ast match {
             case Function(params, Tuple(values)) =>
               values mustEqual params
+            case _ => Messages.fail("Should not happen")
           }
         }
         "java to scala" in {
@@ -739,6 +740,7 @@ class QuotationSpec extends Spec {
           quote(unquote(q)).ast match {
             case Function(params, Tuple(values)) =>
               values mustEqual params
+            case _ => Messages.fail("Should not happen")
           }
         }
       }
@@ -847,8 +849,8 @@ class QuotationSpec extends Spec {
         l.encoder mustEqual intEncoder
       }
       "property" in {
-        case class Test(a: String)
-        val t = Test("a")
+        case class TestEntity(a: String)
+        val t = TestEntity("a")
         val q = quote(lift(t.a))
 
         val l = q.liftings.`t.a`
@@ -856,8 +858,9 @@ class QuotationSpec extends Spec {
         l.encoder mustEqual stringEncoder
       }
       "abritrary" in {
-        val q = quote(lift(String.valueOf(1)))
-        q.liftings.`java.this.lang.String.valueOf(1)`.value mustEqual String.valueOf(1)
+        class A { def x = 1 }
+        val q = quote(lift(new A().x))
+        q.liftings.`new A().x`.value mustEqual new A().x
       }
       "duplicate" in {
         val i = 1


### PR DESCRIPTION
Fixes #231

### Problem
Build fails against 2.12

### Solution
Make Quill compatible with 2.12.2, more in todo list

- [x] adjust travis build
- [x] adjust new flags for scalac 2.12.2
- [x] fix failing tests (deprecations, not exhaustive match etc.)
- [x] workaround for bug intoduced with 2.12.2 with macros untypechek (manual creating of private[this] param with different name to accessor)
- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
