### PR TITLE
Prevent generating invalid nested queries with take/drop after for comprehension

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/OrderTerms.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/OrderTerms.scala
@@ -1,11 +1,6 @@
 package io.getquill.norm
 
-import io.getquill.ast.Filter
-import io.getquill.ast.GroupBy
-import io.getquill.ast.Map
-import io.getquill.ast.Query
-import io.getquill.ast.SortBy
-import io.getquill.ast.Take
+import io.getquill.ast._
 
 object OrderTerms {
 
@@ -19,10 +14,15 @@ object OrderTerms {
       case Filter(SortBy(a, b, c, d), e, f) =>
         Some(SortBy(Filter(a, e, f), b, c, d))
 
-      // a.map(b => c).take(d) =>
-      //    a.take(d).map(b => c)
-      case Take(Map(a, b, c), d) =>
-        Some(Map(Take(a, d), b, c))
+      // a.flatMap(b => c).take(n).map(d => e) =>
+      //   a.flatMap(b => c).map(d => e).take(n)
+      case Map(Take(fm: FlatMap, n), ma, mb) =>
+        Some(Take(Map(fm, ma, mb), n))
+
+      // a.flatMap(b => c).drop(n).map(d => e) =>
+      //   a.flatMap(b => c).map(d => e).drop(n)
+      case Map(Drop(fm: FlatMap, n), ma, mb) =>
+        Some(Drop(Map(fm, ma, mb), n))
 
       case other => None
     }

--- a/quill-core/src/test/scala/io/getquill/norm/OrderTermsSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/OrderTermsSpec.scala
@@ -3,6 +3,7 @@ package io.getquill.norm
 import io.getquill.Spec
 import io.getquill.testContext.implicitOrd
 import io.getquill.testContext.qr1
+import io.getquill.testContext.qr2
 import io.getquill.testContext.quote
 import io.getquill.testContext.unquote
 
@@ -27,13 +28,22 @@ class OrderTermsSpec extends Spec {
     }
   }
 
-  "take" - {
-    "a.map(b => c).take(d)" in {
+  "a.flatMap(b => c).?.map(d => e)" - {
+    "take" in {
       val q = quote {
-        qr1.map(b => b.s).take(10)
+        qr1.flatMap(b => qr2).take(3).map(d => d.s)
       }
       val n = quote {
-        qr1.take(10).map(b => b.s)
+        qr1.flatMap(b => qr2).map(d => d.s).take(3)
+      }
+      OrderTerms.unapply(q.ast) mustEqual Some(n.ast)
+    }
+    "drop" in {
+      val q = quote {
+        qr1.flatMap(b => qr2).drop(3).map(d => d.s)
+      }
+      val n = quote {
+        qr1.flatMap(b => qr2).map(d => d.s).drop(3)
       }
       OrderTerms.unapply(q.ast) mustEqual Some(n.ast)
     }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -332,6 +332,21 @@ class SqlQuerySpec extends Spec {
         testContext.run(q).string mustEqual
           "SELECT x.s, x.i, x.l, x.o FROM (SELECT x.s, x.i, x.l, x.o FROM TestEntity x LIMIT 1) x OFFSET 2"
       }
+      "for comprehension" - {
+        val q = quote(for {
+          q1 <- qr1
+          q2 <- qr2 if q1.i == q2.i
+        } yield (q1.i, q2.i, q1.s, q2.s))
+
+        "take" in {
+          testContext.run(q.take(3)).string mustEqual
+            "SELECT q1.i, q2.i, q1.s, q2.s FROM TestEntity q1, TestEntity2 q2 WHERE q1.i = q2.i LIMIT 3"
+        }
+        "drop" in {
+          testContext.run(q.drop(3)).string mustEqual
+            "SELECT q1.i, q2.i, q1.s, q2.s FROM TestEntity q1, TestEntity2 q2 WHERE q1.i = q2.i OFFSET 3"
+        }
+      }
     }
     "set operation query" - {
       "union" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -11,11 +11,11 @@ class ExpandNestedQueriesSpec extends Spec {
       (for {
         a <- qr1
         b <- qr2
-      } yield b).take(10)
+      } yield b).nested
     }
 
     testContext.run(q).string mustEqual
-      "SELECT b.s, b.i, b.l, b.o FROM (SELECT x.s, x.i, x.l, x.o FROM TestEntity a, TestEntity2 x) b LIMIT 10"
+      "SELECT x.s, x.i, x.l, x.o FROM (SELECT x.s, x.i, x.l, x.o FROM TestEntity a, TestEntity2 x) x"
   }
 
   "partial select" in {
@@ -24,10 +24,10 @@ class ExpandNestedQueriesSpec extends Spec {
       (for {
         a <- qr1
         b <- qr2
-      } yield b.i).take(10)
+      } yield (b.i, a.i)).nested
     }
     testContext.run(q).string mustEqual
-      "SELECT x.* FROM (SELECT b.i FROM TestEntity a, TestEntity2 b) x LIMIT 10"
+      "SELECT x._1, x._2 FROM (SELECT b.i _1, a.i _2 FROM TestEntity a, TestEntity2 b) x"
   }
 
   "tokenize property" in {


### PR DESCRIPTION
Fixes #718

### Problem

Normalization make take/drop after for comp queries nested and can lead into ambiguous column reference.

### Solution

Prevent unnecessary nested queries.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
