### PR TITLE
Build changed docker images after pulling.

### DIFF
--- a/build/pull_docker_images.sh
+++ b/build/pull_docker_images.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 docker-compose pull
+docker-compose build


### PR DESCRIPTION
### Problem

Docker images aren't being rebuilt if some of the docker setup is changed (https://github.com/docker/compose/issues/1487).

### Solution

Build images with `docker-compose build` after pulling them with `docker-compose pull`. Unchanged image layers should be reused from cache.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
