### PR TITLE
Fix query compilation of nested of single select query

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/ApplyMap.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/ApplyMap.scala
@@ -17,6 +17,7 @@ object ApplyMap {
       case Take(Map(a: GroupBy, b, c), d)         => None
       case Drop(Map(a: GroupBy, b, c), d)         => None
       case Map(a: GroupBy, b, c) if (b == c)      => None
+      case Map(a: Nested, b, c) if (b == c)       => None
 
       //  map(i => (i.i, i.l)).distinct.map(x => (x._1, x._2)) =>
       //    map(i => (i.i, i.l)).distinct

--- a/quill-core/src/test/scala/io/getquill/norm/ApplyMapSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ApplyMapSpec.scala
@@ -56,6 +56,13 @@ class ApplyMapSpec extends Spec {
     }
   }
 
+  "avoids applying the identity map with nested query" in {
+    val q = quote {
+      qr1.map(x => x.i).nested.map(x => x)
+    }
+    ApplyMap.unapply(q.ast) mustEqual None
+  }
+
   "applies intermediate map" - {
     "flatMap" in {
       val q = quote {

--- a/quill-sql/src/main/scala/io/getquill/context/sql/SqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/SqlQuery.scala
@@ -49,14 +49,15 @@ object SqlQuery {
 
   def apply(query: Ast): SqlQuery =
     query match {
-      case Union(a, b)                  => SetOperationSqlQuery(apply(a), UnionOperation, apply(b))
-      case UnionAll(a, b)               => SetOperationSqlQuery(apply(a), UnionAllOperation, apply(b))
-      case UnaryOperation(op, q: Query) => UnaryOperationSqlQuery(op, apply(q))
-      case _: Operation | _: Value      => FlattenSqlQuery(select = List(SelectValue(query)))
-      case Map(q, a, b) if a == b       => apply(q)
-      case q: Query                     => flatten(q, "x")
-      case infix: Infix                 => flatten(infix, "x")
-      case other                        => fail(s"Query not properly normalized. Please open a bug report. Ast: '$other'")
+      case Union(a, b)                          => SetOperationSqlQuery(apply(a), UnionOperation, apply(b))
+      case UnionAll(a, b)                       => SetOperationSqlQuery(apply(a), UnionAllOperation, apply(b))
+      case UnaryOperation(op, q: Query)         => UnaryOperationSqlQuery(op, apply(q))
+      case _: Operation | _: Value              => FlattenSqlQuery(select = List(SelectValue(query)))
+      case map @ Map(_: Nested, a, b) if a == b => flatten(map, a.name)
+      case Map(q, a, b) if a == b               => apply(q)
+      case q: Query                             => flatten(q, "x")
+      case infix: Infix                         => flatten(infix, "x")
+      case other                                => fail(s"Query not properly normalized. Please open a bug report. Ast: '$other'")
     }
 
   private def flatten(query: Ast, alias: String): FlattenSqlQuery = {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -385,6 +385,21 @@ class SqlQuerySpec extends Spec {
         testContext.run(q).string mustEqual
           "SELECT x.s, x.i, x.l, x.o FROM (SELECT x.s, x.i, x.l, x.o FROM TestEntity x) x"
       }
+      "pointless nesting of single yielding element" in {
+        val q = quote {
+          qr1.map(x => x.i).nested
+        }
+        testContext.run(q).string mustEqual "SELECT x.* FROM (SELECT x.i FROM TestEntity x) x"
+      }
+      "pointless nesting in for-comp of single yielding element" in {
+        val q = quote {
+          (for {
+            a <- qr1
+            b <- qr2
+          } yield a.i).nested
+        }
+        testContext.run(q).string mustEqual "SELECT x.* FROM (SELECT a.i FROM TestEntity a, TestEntity2 b) x"
+      }
       "mapped" in {
         val q = quote {
           qr1.nested.map(t => t.i)


### PR DESCRIPTION
Fixes #782

### Problem

`nested` of single select query leads into StackOverFlowError

### Solution

Queries in #782 should compile

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
