### PR TITLE
Fix building sql-server in travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,11 @@ branches:
   except:
     - release
     - website
-before_install:
-  - ./build/update_docker.sh
-  - ./build/update_docker-compose.sh
 before_script:
-  - ./build/pull_docker_images.sh
   - travis_retry docker-compose run setup
 script:
   - docker-compose run sbt bash -c "./build/build.sh"
 after_success:
-  - ./build/push_docker_images.sh
   - pip install --user codecov && codecov
 before_cache:
   - ./build/cleanup_cache.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,8 @@ export MYSQL_HOST=<docker host address>
 export MYSQL_PORT=13306
 export POSTGRES_HOST=<docker host address>
 export POSTGRES_PORT=15432
+export POSTGRES_HOST=<docker host address>
+export POSTGRES_PORT=11433
 ```
 
 If you run docker locally then usually docker host address is `localhost` or `127.0.0.1`.

--- a/build/Dockerfile-setup
+++ b/build/Dockerfile-setup
@@ -18,8 +18,7 @@ RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list
     curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
     apt-get update && ACCEPT_EULA=Y apt-get install -y \
     msodbcsql=13.1.4.0-1 \
-    mssql-tools \
-    unixodbc-dev
+    mssql-tools
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -52,12 +52,12 @@ cqlsh cassandra -f /tmp/create-keyspace.cql
 cqlsh cassandra -k quill_test -f quill-cassandra/src/test/cql/cassandra-schema.cql
 
 echo "Waiting for Sql Server"
-until sqlcmd -S sqlserver -U SA -P 'QuillRocks!' -Q "SELECT 1" &> /dev/null
+until sqlcmd -S sqlserver,1433 -U SA -P 'QuillRocks!' -Q "SELECT 1" &> /dev/null
 do
   printf "."
   sleep 1
 done
 echo -e "\nSql Server ready"
 
-sqlcmd -S sqlserver -U SA -P "QuillRocks!" -Q "CREATE DATABASE quill_test"
-sqlcmd -S sqlserver -U SA -P "QuillRocks!" -d quill_test -i quill-sql/src/test/sql/sqlserver-schema.sql
+sqlcmd -S sqlserver,1433 -U SA -P "QuillRocks!" -Q "CREATE DATABASE quill_test"
+sqlcmd -S sqlserver,1433 -U SA -P "QuillRocks!" -d quill_test -i quill-sql/src/test/sql/sqlserver-schema.sql

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -51,6 +51,8 @@ echo "CREATE KEYSPACE quill_test WITH replication = {'class': 'SimpleStrategy', 
 cqlsh cassandra -f /tmp/create-keyspace.cql
 cqlsh cassandra -k quill_test -f quill-cassandra/src/test/cql/cassandra-schema.cql
 
+nc -zv sqlserver 1433
+
 echo "Waiting for Sql Server"
 until sqlcmd -S sqlserver,1433 -U SA -P 'QuillRocks!' -Q "SELECT 1" &> /dev/null
 do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '2'
 
 services:
   postgres:
@@ -36,8 +36,6 @@ services:
 
   setup:
     build:
-      cache_from:
-        - quillscala/setup:latest
       context: .
       dockerfile: ./build/Dockerfile-setup
     image: quillscala/setup
@@ -53,8 +51,6 @@ services:
 
   sbt:
     build:
-      cache_from:
-        - quillscala/sbt:latest
       context: .
       dockerfile: ./build/Dockerfile-sbt
     image: quillscala/sbt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   sqlserver:
     image: microsoft/mssql-server-linux
     ports:
-      - "1433:1433"
+      - "11433:1433"
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=QuillRocks!
@@ -82,5 +82,7 @@ services:
       - POSTGRES_PORT=5432
       - MYSQL_HOST=mysql
       - MYSQL_PORT=3306
+      - SQL_SERVER_HOST=sqlserver
+      - SQL_SERVER_PORT=1433
       - CASSANDRA_HOST=cassandra
       - CASSANDRA_PORT=9042

--- a/quill-jdbc/src/test/resources/application.conf
+++ b/quill-jdbc/src/test/resources/application.conf
@@ -23,5 +23,5 @@ testSqlServerDB.dataSourceClassName=com.microsoft.sqlserver.jdbc.SQLServerDataSo
 testSqlServerDB.dataSource.user=sa
 testSqlServerDB.dataSource.password="QuillRocks!"
 testSqlServerDB.dataSource.databaseName=quill_test
-testSqlServerDB.dataSource.portNumber=1433
-testSqlServerDB.dataSource.serverName=sqlserver
+testSqlServerDB.dataSource.portNumber=${?SQL_SERVER_PORT}
+testSqlServerDB.dataSource.serverName=${?SQL_SERVER_HOST}


### PR DESCRIPTION
Fixes travis matrix build with introduced sql server
### Problem
Randomly 2.11 or 2.12 build hangs on preparing sql-server 

@getquill/maintainers
