### PR TITLE
Introduce `SetContainsToken`

### DIFF
--- a/quill-core/src/main/scala/io/getquill/context/ContextMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextMacro.scala
@@ -10,13 +10,7 @@ import io.getquill.util.Messages._
 import io.getquill.quotation.IsDynamic
 import io.getquill.ast.Lift
 import io.getquill.NamingStrategy
-import io.getquill.idiom.Idiom
-import io.getquill.idiom.Statement
-import io.getquill.idiom.Token
-import io.getquill.idiom.StringToken
-import io.getquill.idiom.ScalarLiftToken
-import io.getquill.idiom.ReifyStatement
-import io.getquill.idiom.LoadNaming
+import io.getquill.idiom._
 import scala.util.Success
 import scala.util.Failure
 
@@ -45,9 +39,10 @@ trait ContextMacro extends Quotation {
     }
 
   private implicit val tokenLiftable: Liftable[Token] = Liftable[Token] {
-    case StringToken(string)   => q"io.getquill.idiom.StringToken($string)"
-    case ScalarLiftToken(lift) => q"io.getquill.idiom.ScalarLiftToken(${lift: Lift})"
-    case Statement(tokens)     => q"io.getquill.idiom.Statement(scala.List(..$tokens))"
+    case StringToken(string)        => q"io.getquill.idiom.StringToken($string)"
+    case ScalarLiftToken(lift)      => q"io.getquill.idiom.ScalarLiftToken(${lift: Lift})"
+    case Statement(tokens)          => q"io.getquill.idiom.Statement(scala.List(..$tokens))"
+    case SetContainsToken(a, op, b) => q"io.getquill.idiom.SetContainsToken($a, $op, $b)"
   }
 
   private def translateStatic(ast: Ast): Tree = {
@@ -58,7 +53,7 @@ trait ContextMacro extends Quotation {
         val (string, _) =
           ReifyStatement(
             idiom.liftingPlaceholder,
-            idiom.emptyQuery,
+            idiom.emptySetContainsToken,
             statement,
             forProbing = true
           )

--- a/quill-core/src/main/scala/io/getquill/context/Expand.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Expand.scala
@@ -17,7 +17,7 @@ case class Expand[C <: Context[_, _]](
   val (string, liftings) =
     ReifyStatement(
       idiom.liftingPlaceholder,
-      idiom.emptyQuery,
+      idiom.emptySetContainsToken,
       statement,
       forProbing = false
     )

--- a/quill-core/src/main/scala/io/getquill/idiom/Idiom.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/Idiom.scala
@@ -5,9 +5,9 @@ import io.getquill.NamingStrategy
 
 trait Idiom {
 
-  def liftingPlaceholder(index: Int): String
+  def emptySetContainsToken(field: Token): Token = StringToken("FALSE")
 
-  def emptyQuery: String
+  def liftingPlaceholder(index: Int): String
 
   def translate(ast: Ast)(implicit naming: NamingStrategy): (Ast, Statement)
 

--- a/quill-core/src/main/scala/io/getquill/idiom/ReifyStatement.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/ReifyStatement.scala
@@ -2,39 +2,41 @@ package io.getquill.idiom
 
 import io.getquill.ast._
 import io.getquill.util.Interleave
+import io.getquill.idiom.StatementInterpolator._
 
 object ReifyStatement {
 
   def apply(
-    liftingPlaceholder: Int => String,
-    emptyQuery:         String,
-    statement:          Statement,
-    forProbing:         Boolean
+    liftingPlaceholder:    Int => String,
+    emptySetContainsToken: Token => Token,
+    statement:             Statement,
+    forProbing:            Boolean
   ): (String, List[ScalarLift]) = {
     def apply(acc: (String, List[ScalarLift]), token: Token): (String, List[ScalarLift]) =
       (acc, token) match {
-        case ((s1, liftings), StringToken(s2))       => (s"$s1$s2", liftings)
-        case ((s1, liftings), Statement(tokens))     => tokens.foldLeft((s1, liftings))(apply)
-        case ((s1, liftings), ScalarLiftToken(lift)) => (s"$s1${liftingPlaceholder(liftings.size)}", liftings :+ lift)
+        case ((s1, liftings), StringToken(s2))            => (s"$s1$s2", liftings)
+        case ((s1, liftings), Statement(tokens))          => tokens.foldLeft((s1, liftings))(apply)
+        case ((s1, liftings), ScalarLiftToken(lift))      => (s"$s1${liftingPlaceholder(liftings.size)}", liftings :+ lift)
+        case ((s1, liftings), SetContainsToken(a, op, b)) => apply(s1 -> liftings, stmt"$a $op ($b)")
       }
     val expanded =
       forProbing match {
         case true  => statement
-        case false => expandLiftings(statement, emptyQuery)
+        case false => expandLiftings(statement, emptySetContainsToken)
       }
     apply(("", List.empty), expanded)
   }
 
-  private def expandLiftings(statement: Statement, emptyQuery: String) = {
+  private def expandLiftings(statement: Statement, emptySetContainsToken: Token => Token) = {
     Statement {
       statement.tokens.foldLeft(List.empty[Token]) {
-        case (tokens, ScalarLiftToken(lift: ScalarQueryLift)) =>
+        case (tokens, SetContainsToken(a, op, ScalarLiftToken(lift: ScalarQueryLift))) =>
           lift.value.asInstanceOf[Traversable[Any]].toList match {
-            case Nil => tokens :+ StringToken(emptyQuery)
+            case Nil => tokens :+ emptySetContainsToken(a)
             case values =>
               val liftings = values.map(v => ScalarLiftToken(ScalarValueLift(lift.name, v, lift.encoder)))
               val separators = List.fill(liftings.size - 1)(StringToken(", "))
-              tokens ++ Interleave(liftings, separators)
+              (tokens :+ stmt"$a $op (") ++ Interleave(liftings, separators) :+ StringToken(")")
           }
         case (tokens, token) =>
           tokens :+ token

--- a/quill-core/src/main/scala/io/getquill/idiom/Statement.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/Statement.scala
@@ -15,3 +15,7 @@ case class ScalarLiftToken(lift: ScalarLift) extends Token {
 case class Statement(tokens: List[Token]) extends Token {
   override def toString = tokens.mkString
 }
+
+case class SetContainsToken(a: Token, op: Token, b: Token) extends Token {
+  override def toString = s"${a.toString} ${op.toString} (${b.toString})"
+}

--- a/quill-sql/src/main/scala/io/getquill/MySQLDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/MySQLDialect.scala
@@ -21,8 +21,6 @@ trait MySQLDialect
   with OffsetWithoutLimitWorkaround
   with QuestionMarkBindVariables {
 
-  override def emptyQuery = "SELECT 0 FROM DUAL WHERE FALSE"
-
   override def prepareForProbing(string: String) = {
     val quoted = string.replace("'", "\\'")
     s"PREPARE p${quoted.hashCode.abs.toString.token} FROM '$quoted'"

--- a/quill-sql/src/main/scala/io/getquill/SQLServerDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/SQLServerDialect.scala
@@ -1,11 +1,12 @@
 package io.getquill
 
+import io.getquill.idiom.{ Token, StringToken }
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.idiom.QuestionMarkBindVariables
 
 trait SQLServerDialect extends SqlIdiom with QuestionMarkBindVariables {
 
-  override def emptyQuery = "SELECT TOP 0 NULL"
+  override def emptySetContainsToken(field: Token) = StringToken("1 <> 1")
 
   override def prepareForProbing(string: String) = string
 }

--- a/quill-sql/src/main/scala/io/getquill/SqliteDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/SqliteDialect.scala
@@ -1,11 +1,14 @@
 package io.getquill
 
+import io.getquill.idiom.{ Token, StringToken }
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.idiom.QuestionMarkBindVariables
 
 trait SqliteDialect
   extends SqlIdiom
   with QuestionMarkBindVariables {
+
+  override def emptySetContainsToken(field: Token) = StringToken("0")
 
   override def prepareForProbing(string: String) = s"sqlite3_prepare_v2($string)"
 }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -20,6 +20,7 @@ import io.getquill.context.sql.UnionOperation
 import io.getquill.NamingStrategy
 import io.getquill.util.Messages.fail
 import io.getquill.idiom.Idiom
+import io.getquill.idiom.SetContainsToken
 import io.getquill.idiom.Statement
 import io.getquill.context.sql.norm.SqlNormalize
 import io.getquill.util.Interleave
@@ -29,8 +30,6 @@ import io.getquill.context.sql.FlatJoinContext
 trait SqlIdiom extends Idiom {
 
   override def prepareForProbing(string: String): String
-
-  override def emptyQuery = "SELECT 0 LIMIT 0"
 
   override def translate(ast: Ast)(implicit naming: NamingStrategy) = {
     val normalizedAst = SqlNormalize(ast)
@@ -159,7 +158,7 @@ trait SqlIdiom extends Idiom {
     case BinaryOperation(NullValue, EqualityOperator.`==`, b) => stmt"${scopedTokenizer(b)} IS NULL"
     case BinaryOperation(a, EqualityOperator.`!=`, NullValue) => stmt"${scopedTokenizer(a)} IS NOT NULL"
     case BinaryOperation(NullValue, EqualityOperator.`!=`, b) => stmt"${scopedTokenizer(b)} IS NOT NULL"
-    case BinaryOperation(a, op @ SetOperator.`contains`, b)   => stmt"${scopedTokenizer(b)} ${op.token} (${a.token})"
+    case BinaryOperation(a, op @ SetOperator.`contains`, b)   => SetContainsToken(scopedTokenizer(b), op.token, a.token)
     case BinaryOperation(a, op, b)                            => stmt"${scopedTokenizer(a)} ${op.token} ${scopedTokenizer(b)}"
     case e: FunctionApply                                     => fail(s"Can't translate the ast to sql: '$e'")
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -602,6 +602,20 @@ class SqlIdiomSpec extends Spec {
             testContext.run(q).string mustEqual
               "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.o = 1"
           }
+          "set" - {
+            "non-empty" in {
+              val q = quote {
+                qr1.filter(t => liftQuery(Set(1, 2, 3)).contains(t.i))
+              }
+              testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE t.i IN (?, ?, ?)"
+            }
+            "empty" in {
+              val q = quote {
+                qr1.filter(t => liftQuery(Set.empty[Int]).contains(t.i))
+              }
+              testContext.run(q).string mustEqual "SELECT t.s, t.i, t.l, t.o FROM TestEntity t WHERE FALSE"
+            }
+          }
 
         }
       }


### PR DESCRIPTION
Fixes #680  
Fixes #601 

### Problem

Empty `liftQuery().contains` will generate invalid sql

### Solution

Get rid of `emptyQuery` introduce `SetContainsToken` and eliminate the `IN ()` as `FALSE`


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
