### PR TITLE
Introduce SqlServer in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,8 @@ export MYSQL_HOST=<docker host address>
 export MYSQL_PORT=13306
 export POSTGRES_HOST=<docker host address>
 export POSTGRES_PORT=15432
+export SQL_SERVER_HOST=<docker host address>
+export SQL_SERVER_PORT=11433
 ```
 
 If you run docker locally then usually docker host address is `localhost` or `127.0.0.1`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
 #  sqlserver:
 #    image: microsoft/mssql-server-linux
 #    ports:
-#      - "1433:1433"
+#      - "11433:1433"
 #    environment:
 #      - ACCEPT_EULA=Y
 #      - SA_PASSWORD=QuillRocks!
@@ -82,5 +82,7 @@ services:
       - POSTGRES_PORT=5432
       - MYSQL_HOST=mysql
       - MYSQL_PORT=3306
+      - SQL_SERVER_HOST=sqlserver
+      - SQL_SERVER_PORT=1433
       - CASSANDRA_HOST=cassandra
       - CASSANDRA_PORT=9042

--- a/quill-jdbc/src/test/resources/application.conf
+++ b/quill-jdbc/src/test/resources/application.conf
@@ -23,5 +23,5 @@ testSqlServerDB.dataSourceClassName=com.microsoft.sqlserver.jdbc.SQLServerDataSo
 testSqlServerDB.dataSource.user=sa
 testSqlServerDB.dataSource.password="QuillRocks!"
 testSqlServerDB.dataSource.databaseName=quill_test
-testSqlServerDB.dataSource.portNumber=1433
-testSqlServerDB.dataSource.serverName=sqlserver
+testSqlServerDB.dataSource.portNumber=${?SQL_SERVER_PORT}
+testSqlServerDB.dataSource.serverName=${?SQL_SERVER_HOST}


### PR DESCRIPTION
Enriches #791

### Problem

Missing sql server details in CONTRIBUTING.md.
Cannot build jdbc module in local sbt

### Solution

Make sql server host/port to be env variables.

- [x] Unit test all changes
- [x] Update `CONTRIBUTING.md`

@getquill/maintainers 