### PR TITLE
Setup sqlserver database at image startup

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -50,14 +50,3 @@ echo -e "\nCassandra ready"
 echo "CREATE KEYSPACE quill_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};" > /tmp/create-keyspace.cql
 cqlsh cassandra -f /tmp/create-keyspace.cql
 cqlsh cassandra -k quill_test -f quill-cassandra/src/test/cql/cassandra-schema.cql
-
-echo "Waiting for Sql Server"
-until sqlcmd -S sqlserver -U SA -P 'QuillRocks!' -Q "SELECT 1" &> /dev/null
-do
-  printf "."
-  sleep 1
-done
-echo -e "\nSql Server ready"
-
-sqlcmd -S sqlserver -U SA -P "QuillRocks!" -Q "CREATE DATABASE quill_test"
-sqlcmd -S sqlserver -U SA -P "QuillRocks!" -d quill_test -i quill-sql/src/test/sql/sqlserver-schema.sql

--- a/build/sqlserver_entrypoint.sh
+++ b/build/sqlserver_entrypoint.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+/app/build/sqlserver_setup.sh & /opt/mssql/bin/sqlservr

--- a/build/sqlserver_setup.sh
+++ b/build/sqlserver_setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+echo "Waiting for Sql Server"
+until /opt/mssql-tools/bin/sqlcmd -S sqlserver -U SA -P 'QuillRocks!' -Q "SELECT 1" &> /dev/null
+do
+  printf "."
+  sleep 1
+done
+echo -e "\nSql Server ready"
+
+/opt/mssql-tools/bin/sqlcmd -S sqlserver -U SA -P "QuillRocks!" -Q "DROP DATABASE IF EXISTS quill_test"
+/opt/mssql-tools/bin/sqlcmd -S sqlserver -U SA -P "QuillRocks!" -Q "CREATE DATABASE quill_test"
+/opt/mssql-tools/bin/sqlcmd -S sqlserver -U SA -P "QuillRocks!" -d quill_test -i /app/quill-sql/src/test/sql/sqlserver-schema.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,9 @@ services:
     ports:
       - "19042:9042"
       - "19160:9160"
-      - "17199:7199"
-      - "17001:7001"
-      - "17000:7000"
+    environment:
+      - HEAP_NEWSIZE=128M
+      - MAX_HEAP_SIZE=512M
 
   sqlserver:
     image: microsoft/mssql-server-linux

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,13 @@ services:
     image: microsoft/mssql-server-linux
     ports:
       - "1433:1433"
+    volumes:
+      - ./:/app
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=QuillRocks!
+    command:
+      - /app/build/sqlserver_entrypoint.sh
 
   setup:
     build:


### PR DESCRIPTION
Fixed travis matrix build

### Problem
One of the build job hangs with setting up sqlserver db.

### Solution
Move sqlserver db setup into image startup

@getquill/maintainers
