### PR TITLE
force travis retry if databases take too long to load

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -4,60 +4,47 @@ DB_FILE=quill_test.db
 
 rm $DB_FILE
 
-echo "Waiting for Sqlite"
-until sqlite3 $DB_FILE "SELECT 1" &> /dev/null
-do
-  printf "."
-  sleep 1
-done
-echo -e "\nSqlite ready"
+function waitFor() {
+  echo "Waiting for $1"
+  i=20
+  until eval $2 &> /dev/null
+  do
+    printf ".$i"
+    if [[ "$i" -eq 0 ]]; then
+      printf "timeout!"
+      exit 1
+    fi
+    i=$((i-1))
+    sleep 1s
+  done
+  echo -e "\n$1 ready"
+}
 
 sqlite3 $DB_FILE < quill-jdbc/src/test/resources/sql/sqlite-schema.sql
 
-echo "Waiting for Mysql"
-until mysql -u root -proot -h mysql -e "SELECT 1" &> /dev/null
-do
-  printf "."
-  sleep 1
-done
-echo -e "\nMysql ready"
 
-mysql -u root -proot -h mysql -e "ALTER USER 'root'@'%' IDENTIFIED BY ''"
-mysql -u root -h mysql quill_test < quill-sql/src/test/sql/mysql-schema.sql
-mysql -u root -h mysql -e "CREATE USER 'finagle'@'%' IDENTIFIED BY 'finagle';"
-mysql -u root -h mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'finagle'@'%';"
-mysql -u root -h mysql -e "FLUSH PRIVILEGES;"
+waitFor 'Mysql' 'mysql -u root -proot -h mysql -e "SELECT 1"'
 
-echo "Waiting for Postgres"
-until psql -h postgres -U postgres -c "SELECT 1" &> /dev/null
-do
-  printf "."
-  sleep 1
-done
-echo -e "\nPostgres ready"
+mysql -u root -proot -h mysql quill_test < quill-sql/src/test/sql/mysql-schema.sql
+mysql -u root -proot -h mysql -e "CREATE USER 'finagle'@'%' IDENTIFIED BY 'finagle';"
+mysql -u root -proot -h mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'finagle'@'%';"
+mysql -u root -proot -h mysql -e "FLUSH PRIVILEGES;"
+
+
+waitFor 'Postgres' 'psql -h postgres -U postgres -c "SELECT 1"'
 
 psql -h postgres -U postgres -c "CREATE DATABASE quill_test"
 psql -h postgres -U postgres -d quill_test -a -f quill-sql/src/test/sql/postgres-schema.sql
 
-echo "Waiting for Cassandra"
-until nc -z cassandra 9042
-do
-  printf "."
-  sleep 1
-done
-echo -e "\nCassandra ready"
+
+waitFor 'Cassandra' 'nc -z cassandra 9042'
 
 echo "CREATE KEYSPACE quill_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};" > /tmp/create-keyspace.cql
 cqlsh cassandra -f /tmp/create-keyspace.cql
 cqlsh cassandra -k quill_test -f quill-cassandra/src/test/cql/cassandra-schema.cql
 
-echo "Waiting for Sql Server"
-until sqlcmd -S sqlserver -U SA -P 'QuillRocks!' -Q "SELECT 1" &> /dev/null
-do
-  printf "."
-  sleep 1
-done
-echo -e "\nSql Server ready"
+
+waitFor 'SqlServer' 'sqlcmd -S sqlserver -U SA -P 'QuillRocks!' -Q "SELECT 1"'
 
 sqlcmd -S sqlserver -U SA -P "QuillRocks!" -Q "CREATE DATABASE quill_test"
 sqlcmd -S sqlserver -U SA -P "QuillRocks!" -d quill_test -i quill-sql/src/test/sql/sqlserver-schema.sql

--- a/quill-async-mysql/src/test/resources/application.conf
+++ b/quill-async-mysql/src/test/resources/application.conf
@@ -1,6 +1,7 @@
 testMysqlDB.host=${?MYSQL_HOST}
 testMysqlDB.port=${?MYSQL_PORT}
 testMysqlDB.user=root
+testMysqlDB.password=root
 testMysqlDB.database=quill_test
 testMysqlDB.poolMaxQueueSize=10
 testMysqlDB.poolMaxObjects=10

--- a/quill-jdbc/src/test/resources/application.conf
+++ b/quill-jdbc/src/test/resources/application.conf
@@ -1,6 +1,7 @@
 testMysqlDB.dataSourceClassName=com.mysql.jdbc.jdbc2.optional.MysqlDataSource
 testMysqlDB.dataSource.url="jdbc:mysql://"${?MYSQL_HOST}":"${?MYSQL_PORT}"/quill_test"
 testMysqlDB.dataSource.user=root
+testMysqlDB.dataSource.password=root
 testMysqlDB.dataSource.cachePrepStmts=true
 testMysqlDB.dataSource.prepStmtCacheSize=250
 testMysqlDB.dataSource.prepStmtCacheSqlLimit=2048


### PR DESCRIPTION
### Problem

The build is still failing because sometimes sqlserver takes too long to load, but it also fails for mysql eventually.

### Solution
Timeout the setup script if the databases take too long to load, triggering a travis retry

### Notes

- Docker is not keeping its promise of reproducible builds here :(
- @mxl @mentegy thanks for your efforts trying to fix the build. Let's see if this workaround works.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
