### PR TITLE
Ignore SqlServer tests

### DIFF
--- a/build/Dockerfile-setup
+++ b/build/Dockerfile-setup
@@ -13,20 +13,20 @@ RUN apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --no-insta
     apt-transport-https \
     locales
 
-RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/stretch.list && \
-    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
-    apt-get update && ACCEPT_EULA=Y apt-get install -y \
-    msodbcsql=13.1.4.0-1 \
-    mssql-tools \
-    unixodbc-dev
+#RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list.d/stretch.list && \
+#    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+#    curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
+#    apt-get update && ACCEPT_EULA=Y apt-get install -y \
+#    msodbcsql=13.1.4.0-1 \
+#    mssql-tools \
+#    unixodbc-dev
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV PATH $PATH:/opt/mssql-tools/bin
+#ENV PATH $PATH:/opt/mssql-tools/bin
 
 RUN  cd /opt ; \
      curl http://archive.apache.org/dist/cassandra/3.7/apache-cassandra-3.7-bin.tar.gz | tar zx

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -51,13 +51,13 @@ echo "CREATE KEYSPACE quill_test WITH replication = {'class': 'SimpleStrategy', 
 cqlsh cassandra -f /tmp/create-keyspace.cql
 cqlsh cassandra -k quill_test -f quill-cassandra/src/test/cql/cassandra-schema.cql
 
-echo "Waiting for Sql Server"
-until sqlcmd -S sqlserver -U SA -P 'QuillRocks!' -Q "SELECT 1" &> /dev/null
-do
-  printf "."
-  sleep 1
-done
-echo -e "\nSql Server ready"
+#echo "Waiting for Sql Server"
+#until sqlcmd -S sqlserver -U SA -P 'QuillRocks!' -Q "SELECT 1" &> /dev/null
+#do
+#  printf "."
+#  sleep 1
+#done
+#echo -e "\nSql Server ready"
 
-sqlcmd -S sqlserver -U SA -P "QuillRocks!" -Q "CREATE DATABASE quill_test"
-sqlcmd -S sqlserver -U SA -P "QuillRocks!" -d quill_test -i quill-sql/src/test/sql/sqlserver-schema.sql
+#sqlcmd -S sqlserver -U SA -P "QuillRocks!" -Q "CREATE DATABASE quill_test"
+#sqlcmd -S sqlserver -U SA -P "QuillRocks!" -d quill_test -i quill-sql/src/test/sql/sqlserver-schema.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,13 @@ services:
       - "17001:7001"
       - "17000:7000"
 
-  sqlserver:
-    image: microsoft/mssql-server-linux
-    ports:
-      - "1433:1433"
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=QuillRocks!
+#  sqlserver:
+#    image: microsoft/mssql-server-linux
+#    ports:
+#      - "1433:1433"
+#    environment:
+#      - ACCEPT_EULA=Y
+#      - SA_PASSWORD=QuillRocks!
 
   setup:
     build:
@@ -45,7 +45,7 @@ services:
       - postgres:postgres
       - mysql:mysql
       - cassandra:cassandra
-      - sqlserver:sqlserver
+#     - sqlserver:sqlserver
     volumes:
       - ./:/app
     command:
@@ -65,7 +65,7 @@ services:
       - postgres:postgres
       - mysql:mysql
       - cassandra:cassandra
-      - sqlserver:sqlserver
+#     - sqlserver:sqlserver
     volumes:
       - ./:/app
       - ~/.ivy2:/root/.ivy2

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/DepartmentsJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/DepartmentsJdbcSpec.scala
@@ -1,7 +1,9 @@
 package io.getquill.context.jdbc.sqlserver
 
 import io.getquill.context.sql.DepartmentsSpec
+import org.scalatest.DoNotDiscover
 
+@DoNotDiscover
 class DepartmentsJdbcSpec extends DepartmentsSpec {
 
   val context = testContext

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcContextSpec.scala
@@ -1,7 +1,9 @@
 package io.getquill.context.jdbc.sqlserver
 
 import io.getquill._
+import org.scalatest.DoNotDiscover
 
+@DoNotDiscover
 class JdbcContextSpec extends Spec {
 
   val context = testContext

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcEncodingSpec.scala
@@ -1,7 +1,9 @@
 package io.getquill.context.jdbc.sqlserver
 
 import io.getquill.context.sql.EncodingSpec
+import org.scalatest.DoNotDiscover
 
+@DoNotDiscover
 class JdbcEncodingSpec extends EncodingSpec {
 
   val context = testContext

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/PeopleJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/PeopleJdbcSpec.scala
@@ -1,7 +1,9 @@
 package io.getquill.context.jdbc.sqlserver
 
 import io.getquill.context.sql.PeopleSpec
+import org.scalatest.DoNotDiscover
 
+@DoNotDiscover
 class PeopleJdbcSpec extends PeopleSpec {
 
   val context = testContext

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/ProductJdbcSpec.scala
@@ -1,7 +1,9 @@
 package io.getquill.context.jdbc.sqlserver
 
 import io.getquill.context.sql.ProductSpec
+import org.scalatest.DoNotDiscover
 
+@DoNotDiscover
 class ProductJdbcSpec extends ProductSpec {
 
   val context = testContext


### PR DESCRIPTION
### Problem

SqlServer docker image is unstable #795, #798, #800.

### Solution

Ignore SqlServer test for now until we have stable & working build.

### Notes

We should manually run these tests when releasing new version.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
