### PR TITLE
Log bound parameters at query execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1570,6 +1570,14 @@ To disable logging of queries during compilation use `quill.macro.log` option:
 ```
 sbt -Dquill.macro.log=false
 ```
+## Runtime
+
+Quill uses SLF4J for logging. Each context logs queries which are currently executed.
+It also logs the list of parameters which are bound into prepared statement if any.
+To disable that use `quill.binds.log` option:
+```
+java -Dquill.binds.log=false -jar myapp.jar
+```
 
 # Additional resources
 

--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
@@ -4,27 +4,22 @@ import com.github.mauricio.async.db.Connection
 import com.github.mauricio.async.db.{ QueryResult => DBQueryResult }
 import com.github.mauricio.async.db.RowData
 import com.github.mauricio.async.db.pool.PartitionedConnectionPool
-import com.typesafe.scalalogging.Logger
-
-import org.slf4j.LoggerFactory
-
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.Try
-
 import io.getquill.context.sql.SqlContext
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.NamingStrategy
+import io.getquill.util.ContextLogger
 
 abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection](pool: PartitionedConnectionPool[C])
   extends SqlContext[D, N]
   with Decoders
   with Encoders {
 
-  private val logger: Logger =
-    Logger(LoggerFactory.getLogger(classOf[AsyncContext[_, _, _]]))
+  private val logger = ContextLogger(classOf[AsyncContext[_, _, _]])
 
   override type PrepareRow = List[Any]
   override type ResultRow = RowData
@@ -61,28 +56,31 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
       f(TransactionalExecutionContext(ec, c))
     }
 
-  def executeQuery[T](sql: String, prepare: List[Any] => List[Any] = identity, extractor: RowData => T = identity[RowData] _)(implicit ec: ExecutionContext): Future[List[T]] = {
-    logger.debug(sql)
-    withConnection(_.sendPreparedStatement(sql, prepare(List()))).map {
+  def executeQuery[T](sql: String, prepare: List[Any] => (List[Any], List[Any]) = row => (Nil, row), extractor: RowData => T = identity[RowData] _)(implicit ec: ExecutionContext): Future[List[T]] = {
+    val (params, values) = prepare(Nil)
+    logger.logQuery(sql, params)
+    withConnection(_.sendPreparedStatement(sql, values)).map {
       _.rows match {
         case Some(rows) => rows.map(extractor).toList
-        case None       => List()
+        case None       => Nil
       }
     }
   }
 
-  def executeQuerySingle[T](sql: String, prepare: List[Any] => List[Any] = identity, extractor: RowData => T = identity[RowData] _)(implicit ec: ExecutionContext): Future[T] =
+  def executeQuerySingle[T](sql: String, prepare: List[Any] => (List[Any], List[Any]) = row => (Nil, row), extractor: RowData => T = identity[RowData] _)(implicit ec: ExecutionContext): Future[T] =
     executeQuery(sql, prepare, extractor).map(handleSingleResult)
 
-  def executeAction[T](sql: String, prepare: List[Any] => List[Any] = identity)(implicit ec: ExecutionContext): Future[Long] = {
-    logger.debug(sql)
-    withConnection(_.sendPreparedStatement(sql, prepare(List()))).map(_.rowsAffected)
+  def executeAction[T](sql: String, prepare: List[Any] => (List[Any], List[Any]) = row => (Nil, row))(implicit ec: ExecutionContext): Future[Long] = {
+    val (params, values) = prepare(Nil)
+    logger.logQuery(sql, params)
+    withConnection(_.sendPreparedStatement(sql, values)).map(_.rowsAffected)
   }
 
-  def executeActionReturning[T](sql: String, prepare: List[Any] => List[Any] = identity, extractor: RowData => T, returningColumn: String)(implicit ec: ExecutionContext): Future[T] = {
+  def executeActionReturning[T](sql: String, prepare: List[Any] => (List[Any], List[Any]) = row => (Nil, row), extractor: RowData => T, returningColumn: String)(implicit ec: ExecutionContext): Future[T] = {
     val expanded = expandAction(sql, returningColumn)
-    logger.debug(expanded)
-    withConnection(_.sendPreparedStatement(expanded, prepare(List())))
+    val (params, values) = prepare(Nil)
+    logger.logQuery(sql, params)
+    withConnection(_.sendPreparedStatement(expanded, values))
       .map(extractActionResult(returningColumn, extractor))
   }
 

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -5,7 +5,7 @@ import scala.concurrent.Future
 import com.datastax.driver.core.BoundStatement
 import com.datastax.driver.core.Row
 import io.getquill.context.cassandra.util.FutureConversions.toScalaFuture
-import io.getquill.util.LoadConfig
+import io.getquill.util.{ ContextLogger, LoadConfig }
 import com.typesafe.config.Config
 import scala.collection.JavaConverters._
 import io.getquill.context.cassandra.CassandraSessionContext
@@ -22,26 +22,34 @@ class CassandraAsyncContext[N <: NamingStrategy](
   def this(config: Config) = this(CassandraContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 
+  private val logger = ContextLogger(classOf[CassandraAsyncContext[_]])
+
   override type RunQueryResult[T] = Future[List[T]]
   override type RunQuerySingleResult[T] = Future[T]
   override type RunActionResult = Future[Unit]
   override type RunBatchActionResult = Future[Unit]
 
-  def executeQuery[T](cql: String, prepare: BoundStatement => BoundStatement = identity, extractor: Row => T = identity[Row] _)(implicit ec: ExecutionContext): Future[List[T]] =
-    session.executeAsync(prepare(super.prepare(cql)))
+  def executeQuery[T](cql: String, prepare: BoundStatement => (List[Any], BoundStatement) = row => (Nil, row), extractor: Row => T = identity[Row] _)(implicit ec: ExecutionContext): Future[List[T]] = {
+    val (params, bs) = prepare(super.prepare(cql))
+    logger.logQuery(cql, params)
+    session.executeAsync(bs)
       .map(_.all.asScala.toList.map(extractor))
+  }
 
-  def executeQuerySingle[T](cql: String, prepare: BoundStatement => BoundStatement = identity, extractor: Row => T = identity[Row] _)(implicit ec: ExecutionContext): Future[T] =
+  def executeQuerySingle[T](cql: String, prepare: BoundStatement => (List[Any], BoundStatement) = row => (Nil, row), extractor: Row => T = identity[Row] _)(implicit ec: ExecutionContext): Future[T] =
     executeQuery(cql, prepare, extractor).map(handleSingleResult)
 
-  def executeAction[T](cql: String, prepare: BoundStatement => BoundStatement = identity)(implicit ec: ExecutionContext): Future[Unit] =
-    session.executeAsync(prepare(super.prepare(cql))).map(_ => ())
+  def executeAction[T](cql: String, prepare: BoundStatement => (List[Any], BoundStatement) = row => (Nil, row))(implicit ec: ExecutionContext): Future[Unit] = {
+    val (params, bs) = prepare(super.prepare(cql))
+    logger.logQuery(cql, params)
+    session.executeAsync(bs).map(_ => ())
+  }
 
   def executeBatchAction(groups: List[BatchGroup])(implicit ec: ExecutionContext): Future[Unit] =
     Future.sequence {
-      groups.map {
+      groups.flatMap {
         case BatchGroup(cql, prepare) =>
           prepare.map(executeAction(cql, _))
-      }.flatten
+      }
     }.map(_ => ())
 }

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
@@ -3,7 +3,7 @@ package io.getquill
 import com.datastax.driver.core.BoundStatement
 import com.datastax.driver.core.Row
 import com.typesafe.config.Config
-import io.getquill.util.LoadConfig
+import io.getquill.util.{ ContextLogger, LoadConfig }
 import io.getquill.context.cassandra.CassandraSessionContext
 import scala.collection.JavaConverters._
 import com.datastax.driver.core.Cluster
@@ -19,20 +19,27 @@ class CassandraSyncContext[N <: NamingStrategy](
   def this(config: Config) = this(CassandraContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 
+  private val logger = ContextLogger(classOf[CassandraSyncContext[_]])
+
   override type RunQueryResult[T] = List[T]
   override type RunQuerySingleResult[T] = T
   override type RunActionResult = Unit
   override type RunBatchActionResult = Unit
 
-  def executeQuery[T](cql: String, prepare: BoundStatement => BoundStatement = identity, extractor: Row => T = identity[Row] _): List[T] =
-    session.execute(prepare(super.prepare(cql)))
+  def executeQuery[T](cql: String, prepare: BoundStatement => (List[Any], BoundStatement) = row => (Nil, row), extractor: Row => T = identity[Row] _): List[T] = {
+    val (params, bs) = prepare(super.prepare(cql))
+    logger.logQuery(cql, params)
+    session.execute(bs)
       .all.asScala.toList.map(extractor)
+  }
 
-  def executeQuerySingle[T](cql: String, prepare: BoundStatement => BoundStatement = identity, extractor: Row => T = identity[Row] _): T =
+  def executeQuerySingle[T](cql: String, prepare: BoundStatement => (List[Any], BoundStatement) = row => (Nil, row), extractor: Row => T = identity[Row] _): T =
     handleSingleResult(executeQuery(cql, prepare, extractor))
 
-  def executeAction[T](cql: String, prepare: BoundStatement => BoundStatement = identity): Unit = {
-    session.execute(prepare(super.prepare(cql)))
+  def executeAction[T](cql: String, prepare: BoundStatement => (List[Any], BoundStatement) = row => (Nil, row)): Unit = {
+    val (params, bs) = prepare(super.prepare(cql))
+    logger.logQuery(cql, params)
+    session.execute(bs)
     ()
   }
 

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
@@ -1,10 +1,8 @@
 package io.getquill.context.cassandra
 
 import scala.util.Try
-import org.slf4j.LoggerFactory
 import com.datastax.driver.core.BoundStatement
 import com.datastax.driver.core.Row
-import com.typesafe.scalalogging.Logger
 import io.getquill.NamingStrategy
 import io.getquill.context.cassandra.encoding.{ CassandraTypes, Decoders, Encoders }
 import io.getquill.util.Messages.fail
@@ -26,9 +24,6 @@ abstract class CassandraSessionContext[N <: NamingStrategy](
   override type RunActionReturningResult[T] = Unit
   override type RunBatchActionReturningResult[T] = Unit
 
-  protected val logger: Logger =
-    Logger(LoggerFactory.getLogger(classOf[CassandraSessionContext[_]]))
-
   private val preparedStatementCache =
     new PrepareStatementCache(preparedStatementCacheSize)
 
@@ -48,7 +43,7 @@ abstract class CassandraSessionContext[N <: NamingStrategy](
       ()
     }
 
-  def executeActionReturning[O](sql: String, prepare: BoundStatement => BoundStatement = identity, extractor: Row => O, returningColumn: String): Unit =
+  def executeActionReturning[O](sql: String, prepare: BoundStatement => (List[Any], BoundStatement) = row => (Nil, row), extractor: Row => O, returningColumn: String): Unit =
     fail("Cassandra doesn't support `returning`.")
 
   def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Row => T): Unit =

--- a/quill-core/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorContext.scala
@@ -43,24 +43,24 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
 
   case class QueryMirror[T](string: String, prepareRow: Row, extractor: Row => T)
 
-  def executeQuery[T](string: String, prepare: Row => Row = identity, extractor: Row => T = identity[Row] _) =
-    QueryMirror(string, prepare(Row()), extractor)
+  def executeQuery[T](string: String, prepare: Row => (List[Any], Row) = row => (Nil, row), extractor: Row => T = identity[Row] _) =
+    QueryMirror(string, prepare(Row())._2, extractor)
 
-  def executeQuerySingle[T](string: String, prepare: Row => Row = identity, extractor: Row => T = identity[Row] _) =
-    QueryMirror(string, prepare(Row()), extractor)
+  def executeQuerySingle[T](string: String, prepare: Row => (List[Any], Row) = row => (Nil, row), extractor: Row => T = identity[Row] _) =
+    QueryMirror(string, prepare(Row())._2, extractor)
 
-  def executeAction(string: String, prepare: Row => Row = identity) =
-    ActionMirror(string, prepare(Row()))
+  def executeAction(string: String, prepare: Row => (List[Any], Row) = row => (Nil, row)) =
+    ActionMirror(string, prepare(Row())._2)
 
-  def executeActionReturning[O](string: String, prepare: Row => Row = identity, extractor: Row => O,
+  def executeActionReturning[O](string: String, prepare: Row => (List[Any], Row) = row => (Nil, row), extractor: Row => O,
                                 returningColumn: String) =
-    ActionReturningMirror[O](string, prepare(Row()), extractor, returningColumn)
+    ActionReturningMirror[O](string, prepare(Row())._2, extractor, returningColumn)
 
   def executeBatchAction(groups: List[BatchGroup]) =
     BatchActionMirror {
       groups.map {
         case BatchGroup(string, prepare) =>
-          (string, prepare.map(_(Row())))
+          (string, prepare.map(_(Row())._2))
       }
     }
 
@@ -68,7 +68,7 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
     BatchActionReturningMirror[T](
       groups.map {
         case BatchGroupReturning(string, column, prepare) =>
-          (string, column, prepare.map(_(Row())))
+          (string, column, prepare.map(_(Row())._2))
       }, extractor
     )
 }

--- a/quill-core/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Context.scala
@@ -18,8 +18,8 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
   type RunBatchActionResult
   type RunBatchActionReturningResult[T]
 
-  case class BatchGroup(string: String, prepare: List[PrepareRow => PrepareRow])
-  case class BatchGroupReturning(string: String, column: String, prepare: List[PrepareRow => PrepareRow])
+  case class BatchGroup(string: String, prepare: List[PrepareRow => (List[Any], PrepareRow)])
+  case class BatchGroupReturning(string: String, column: String, prepare: List[PrepareRow => (List[Any], PrepareRow)])
 
   def probe(statement: String): Try[_]
 
@@ -35,5 +35,4 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
       case value :: Nil => value
       case other        => throw new IllegalStateException(s"Expected a single result but got $other")
     }
-
 }

--- a/quill-core/src/main/scala/io/getquill/context/Expand.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Expand.scala
@@ -23,11 +23,13 @@ case class Expand[C <: Context[_, _]](
     )
 
   val prepare =
-    (row: context.PrepareRow) =>
-      (liftings.foldLeft((0, row)) {
-        case ((idx, row), lift) =>
+    (row: context.PrepareRow) => {
+      val (_, values, prepare) = liftings.foldLeft((0, List.empty[Any], row)) {
+        case ((idx, values, row), lift) =>
           val encoder = lift.encoder.asInstanceOf[context.Encoder[Any]]
           val newRow = encoder(idx, lift.value, row)
-          (idx + 1, newRow)
-      })._2
+          (idx + 1, lift.value :: values, newRow)
+      }
+      (values, prepare)
+    }
 }

--- a/quill-core/src/main/scala/io/getquill/util/ContextLogger.scala
+++ b/quill-core/src/main/scala/io/getquill/util/ContextLogger.scala
@@ -1,0 +1,37 @@
+package io.getquill.util
+
+import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
+
+class ContextLogger(name: String) {
+  val underlying = Logger(LoggerFactory.getLogger(name))
+
+  private val bindsDisabled = sys.props.get("quill.binds.log").contains("false")
+  private val nullToken = "null"
+
+  def logQuery(query: String, params: Seq[Any]): Unit = {
+    if (bindsDisabled || params.isEmpty) underlying.debug(query)
+    else {
+      underlying.debug("{} - binds: {}", query, prepareParams(params))
+    }
+  }
+
+  def logBatchItem(query: String, params: Seq[Any]): Unit = {
+    if (!bindsDisabled) {
+      underlying.debug("{} - batch item: {}", query, prepareParams(params))
+    }
+  }
+
+  private def prepareParams(params: Seq[Any]): String = params.map(prepareParam).mkString("[", ", ", "]")
+  private def prepareParam(param: Any): String = param match {
+    case None | null => nullToken
+    case Some(x)     => prepareParam(x)
+    case str: String => s"'$str'"
+    case _           => param.toString
+  }
+}
+
+object ContextLogger {
+  def apply(ctxClass: Class[_]): ContextLogger = new ContextLogger(ctxClass.getName)
+}
+

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBSessionContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBSessionContext.scala
@@ -3,12 +3,10 @@ package io.getquill.context.orientdb
 import com.orientechnologies.orient.core.db.OPartitionedDatabasePool
 import com.orientechnologies.orient.core.record.impl.ODocument
 import com.orientechnologies.orient.core.sql.query.OSQLQuery
-import com.typesafe.scalalogging.Logger
 import io.getquill.NamingStrategy
 import io.getquill.context.mirror.Row
 import io.getquill.context.orientdb.encoding.{ Decoders, Encoders }
 import io.getquill.util.Messages.fail
-import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
@@ -26,9 +24,6 @@ abstract class OrientDBSessionContext[N <: NamingStrategy](
 
   override type RunActionReturningResult[T] = Unit
   override type RunBatchActionReturningResult[T] = Unit
-
-  protected val logger: Logger =
-    Logger(LoggerFactory.getLogger(classOf[OrientDBSessionContext[_]]))
 
   protected val session = new OPartitionedDatabasePool(dbUrl, username, password)
   protected val oDatabase = session.acquire()


### PR DESCRIPTION
Fixes #799 

### Problem

#783 brings logging of bound parameters however it is done only for jdbc and finagle-mysql contexts, also there's some issues as described in #799.

### Solution

Enhance logging. 

### Notes

 - `io.getquill.context.Expand.prepare` is modified, was `PrepareRow => PrepareRow`, now `PrepareRow => (List[Any], PrepareRow)` so we can pull list of bound params.
- List of bound parameters are appended to log message. To disable logging of prepared statement binds set `quill.binds.log` option to false..

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable - TODO Add Logging section
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
