### PR TITLE
Make cassandra image to consume less resources

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,9 @@ services:
     ports:
       - "19042:9042"
       - "19160:9160"
-      - "17199:7199"
-      - "17001:7001"
-      - "17000:7000"
+    environment:
+      - MAX_HEAP_SIZE=512m
+      - HEAP_NEWSIZE=256m
 
 #  sqlserver:
 #    image: microsoft/mssql-server-linux


### PR DESCRIPTION
### Problem

Cassandra docker image consume a lot of resources ~ 4GB RAM

### Solution

Decrease number of nodes and heap size 


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
