### PR TITLE
Add support of 'contains' operation on Cassandra collections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val `quill-finagle-mysql` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "com.twitter" %% "finagle-mysql" % "7.1.0"
+        "com.twitter" %% "finagle-mysql" % "7.0.0"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -27,23 +27,21 @@ class CassandraAsyncContext[N <: NamingStrategy](
   override type RunActionResult = Future[Unit]
   override type RunBatchActionResult = Future[Unit]
 
-  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[List[T]] =
-    Future {
-      val (params, bs) = prepare(super.prepare(cql))
-      logger.logQuery(cql, params)
-      session.executeAsync(bs)
-        .map(_.all.asScala.toList.map(extractor))
-    }.flatMap(identity _)
+  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[List[T]] = {
+    val (params, bs) = prepare(super.prepare(cql))
+    logger.logQuery(cql, params)
+    session.executeAsync(bs)
+      .map(_.all.asScala.toList.map(extractor))
+  }
 
   def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[T] =
     executeQuery(cql, prepare, extractor).map(handleSingleResult)
 
-  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Unit] =
-    Future {
-      val (params, bs) = prepare(super.prepare(cql))
-      logger.logQuery(cql, params)
-      session.executeAsync(bs).map(_ => ())
-    }.flatMap(identity _)
+  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Unit] = {
+    val (params, bs) = prepare(super.prepare(cql))
+    logger.logQuery(cql, params)
+    session.executeAsync(bs).map(_ => ())
+  }
 
   def executeBatchAction(groups: List[BatchGroup])(implicit ec: ExecutionContext): Future[Unit] =
     Future.sequence {

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.cassandra
 
-import io.getquill.ast._
+import io.getquill.ast.{ TraversableOperation, _ }
 import io.getquill.NamingStrategy
 import io.getquill.util.Messages.fail
 import io.getquill.idiom.Idiom
@@ -29,16 +29,17 @@ trait CqlIdiom extends Idiom {
     Tokenizer[Ast] {
       case Aggregation(AggregationOperator.`size`, Constant(1)) =>
         "COUNT(1)".token
-      case a: Query      => a.token
-      case a: Operation  => a.token
-      case a: Action     => a.token
-      case a: Ident      => a.token
-      case a: Property   => a.token
-      case a: Value      => a.token
-      case a: Function   => a.body.token
-      case a: Infix      => a.token
-      case a: Lift       => a.token
-      case a: Assignment => a.token
+      case a: Query                => a.token
+      case a: Operation            => a.token
+      case a: Action               => a.token
+      case a: Ident                => a.token
+      case a: Property             => a.token
+      case a: Value                => a.token
+      case a: Function             => a.body.token
+      case a: Infix                => a.token
+      case a: Lift                 => a.token
+      case a: Assignment           => a.token
+      case a: TraversableOperation => a.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
         _: Val | _: Ordering | _: QuotedReference | _: If
@@ -181,4 +182,11 @@ trait CqlIdiom extends Idiom {
   implicit def entityTokenizer(implicit strategy: NamingStrategy): Tokenizer[Entity] = Tokenizer[Entity] {
     case Entity(name, properties) => strategy.table(name).token
   }
+
+  implicit def traversableTokenizer(implicit strategy: NamingStrategy): Tokenizer[TraversableOperation] =
+    Tokenizer[TraversableOperation] {
+      case MapContains(ast, body)  => stmt"${ast.token} CONTAINS KEY ${body.token}"
+      case SetContains(ast, body)  => stmt"${ast.token} CONTAINS ${body.token}"
+      case ListContains(ast, body) => stmt"${ast.token} CONTAINS ${body.token}"
+    }
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/Ops.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/Ops.scala
@@ -30,4 +30,8 @@ trait Ops {
     def ifCond(cond: T => Boolean) =
       quote(infix"$q IF $cond".as[Action[T]])
   }
+
+  implicit class MapOps[K, V](map: Map[K, V]) {
+    def containsValue(value: V) = quote(infix"$map CONTAINS $value".as[Boolean])
+  }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
@@ -2,7 +2,6 @@ package io.getquill.context.cassandra
 
 import io.getquill._
 import scala.concurrent.ExecutionContext.Implicits.{ global => ec }
-import scala.util.Try
 
 class CassandraContextSpec extends Spec {
 
@@ -24,15 +23,5 @@ class CassandraContextSpec extends Spec {
       }
       testSyncDB.run(update) mustEqual (())
     }
-  }
-
-  "async - returns failed future if prepare fails" in {
-    import testAsyncDB._
-    case class InvalidTestEntity(id: Int, s: String, i: Int, l: Long, o: Int)
-    val update = quote {
-      query[InvalidTestEntity].filter(_.id == lift(1)).update(_.i -> lift(1))
-    }
-    val fut = testAsyncDB.run(update)
-    Try(await(fut)).isFailure mustEqual true
   }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraTestEntities.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraTestEntities.scala
@@ -1,0 +1,16 @@
+package io.getquill.context.cassandra
+
+import io.getquill.TestEntities
+
+trait CassandraTestEntities extends TestEntities {
+  this: CassandraContext[_] =>
+
+  case class MapFrozen(id: Map[Int, Boolean])
+  val mapFroz = quote(query[MapFrozen])
+
+  case class SetFrozen(id: Set[Int])
+  val setFroz = quote(query[SetFrozen])
+
+  case class ListFrozen(id: List[Int])
+  val listFroz = quote(query[ListFrozen])
+}

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
@@ -337,4 +337,19 @@ class CqlIdiomSpec extends Spec {
       }
     }
   }
+
+  "collections operations" - {
+    "map.contains" in {
+      mirrorContext.run(mapFroz.filter(x => x.id.contains(1))).string mustEqual
+        "SELECT id FROM MapFrozen WHERE id CONTAINS KEY 1"
+    }
+    "set.contains" in {
+      mirrorContext.run(setFroz.filter(x => x.id.contains(2))).string mustEqual
+        "SELECT id FROM SetFrozen WHERE id CONTAINS 2"
+    }
+    "list.contains" in {
+      mirrorContext.run(listFroz.filter(x => x.id.contains(3))).string mustEqual
+        "SELECT id FROM ListFrozen WHERE id CONTAINS 3"
+    }
+  }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ListsEncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ListsEncodingSpec.scala
@@ -68,16 +68,18 @@ class ListsEncodingSpec extends CollectionsSpec {
       .head.blobs.map(_.toList) mustBe e.blobs.map(_.toList)
   }
 
-  "List in where clause" in {
-    case class ListFrozen(id: List[Int])
+  "List in where clause / contains" in {
     val e = ListFrozen(List(1, 2))
-    val q = quote(query[ListFrozen])
-    ctx.run(q.insert(lift(e)))
-    ctx.run(q.filter(_.id == lift(List(1, 2)))) mustBe List(e)
-    ctx.run(q.filter(_.id == lift(List(1)))) mustBe Nil
+    ctx.run(listFroz.insert(lift(e)))
+    ctx.run(listFroz.filter(_.id == lift(List(1, 2)))) mustBe List(e)
+    ctx.run(listFroz.filter(_.id == lift(List(1)))) mustBe Nil
+
+    ctx.run(listFroz.filter(_.id.contains(2)).allowFiltering) mustBe List(e)
+    ctx.run(listFroz.filter(_.id.contains(3)).allowFiltering) mustBe Nil
   }
 
   override protected def beforeEach(): Unit = {
     ctx.run(q.delete)
+    ctx.run(listFroz.delete)
   }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/MapsEncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/MapsEncodingSpec.scala
@@ -58,16 +58,26 @@ class MapsEncodingSpec extends CollectionsSpec {
     ctx.run(q.filter(_.id == 1)).head mustBe e
   }
 
-  "Map in where clause" in {
-    case class MapFrozen(id: Map[Int, Boolean])
+  "Map in where clause / contains" in {
     val e = MapFrozen(Map(1 -> true))
-    val q = quote(query[MapFrozen])
-    ctx.run(q.insert(lift(e)))
-    ctx.run(q.filter(_.id == lift(Map(1 -> true)))) mustBe List(e)
-    ctx.run(q.filter(_.id == lift(Map(1 -> false)))) mustBe List()
+    ctx.run(mapFroz.insert(lift(e)))
+    ctx.run(mapFroz.filter(_.id == lift(Map(1 -> true)))) mustBe List(e)
+    ctx.run(mapFroz.filter(_.id == lift(Map(1 -> false)))) mustBe Nil
+
+    ctx.run(mapFroz.filter(_.id.contains(1)).allowFiltering) mustBe List(e)
+    ctx.run(mapFroz.filter(_.id.contains(2)).allowFiltering) mustBe Nil
+  }
+
+  "Map.containsValue" in {
+    val e = MapFrozen(Map(1 -> true))
+    ctx.run(mapFroz.insert(lift(e)))
+
+    ctx.run(mapFroz.filter(_.id.containsValue(true)).allowFiltering) mustBe List(e)
+    ctx.run(mapFroz.filter(_.id.containsValue(false)).allowFiltering) mustBe Nil
   }
 
   override protected def beforeEach(): Unit = {
     ctx.run(q.delete)
+    ctx.run(mapFroz.delete)
   }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/SetsEncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/SetsEncodingSpec.scala
@@ -69,15 +69,14 @@ class SetsEncodingSpec extends CollectionsSpec {
   }
 
   "Set in where clause" in {
-    case class SetFrozen(id: Set[Int])
     val e = SetFrozen(Set(1, 2))
-    val q = quote(query[SetFrozen])
-    ctx.run(q.insert(lift(e)))
-    ctx.run(q.filter(_.id == lift(Set(1, 2)))) mustBe List(e)
-    ctx.run(q.filter(_.id == lift(Set(1)))) mustBe List()
+    ctx.run(setFroz.insert(lift(e)))
+    ctx.run(setFroz.filter(_.id == lift(Set(1, 2)))) mustBe List(e)
+    ctx.run(setFroz.filter(_.id == lift(Set(1)))) mustBe List()
   }
 
   override protected def beforeEach(): Unit = {
     ctx.run(q.delete)
+    ctx.run(setFroz.delete)
   }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ops/CassandraOpsSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ops/CassandraOpsSpec.scala
@@ -130,4 +130,11 @@ class CassandraOpsSpec extends Spec {
         "TRUNCATE TestEntity IF EXISTS"
     }
   }
+
+  "collection" - {
+    "map.containsValue" in {
+      mirrorContext.run(mapFroz.filter(x => x.id.containsValue(true))).string mustEqual
+        "SELECT id FROM MapFrozen WHERE id CONTAINS true"
+    }
+  }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/package.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/package.scala
@@ -10,13 +10,13 @@ import io.getquill.CassandraStreamContext
 
 package object cassandra {
 
-  lazy val mirrorContext = new CassandraMirrorContext with TestEntities
+  lazy val mirrorContext = new CassandraMirrorContext with CassandraTestEntities
 
-  lazy val testSyncDB = new CassandraSyncContext[Literal]("testSyncDB") with TestEntities
+  lazy val testSyncDB = new CassandraSyncContext[Literal]("testSyncDB") with CassandraTestEntities
 
-  lazy val testAsyncDB = new CassandraAsyncContext[Literal]("testAsyncDB") with TestEntities
+  lazy val testAsyncDB = new CassandraAsyncContext[Literal]("testAsyncDB") with CassandraTestEntities
 
-  lazy val testStreamDB = new CassandraStreamContext[Literal]("testStreamDB") with TestEntities
+  lazy val testStreamDB = new CassandraStreamContext[Literal]("testStreamDB") with CassandraTestEntities
 
   def await[T](f: Future[T]): T = Await.result(f, Duration.Inf)
 }

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -22,23 +22,24 @@ class MirrorIdiom extends Idiom {
   }
 
   implicit def astTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Ast] = Tokenizer[Ast] {
-    case ast: Query           => ast.token
-    case ast: Function        => ast.token
-    case ast: Value           => ast.token
-    case ast: Operation       => ast.token
-    case ast: Action          => ast.token
-    case ast: Ident           => ast.token
-    case ast: Property        => ast.token
-    case ast: Infix           => ast.token
-    case ast: OptionOperation => ast.token
-    case ast: Dynamic         => ast.token
-    case ast: If              => ast.token
-    case ast: Block           => ast.token
-    case ast: Val             => ast.token
-    case ast: Ordering        => ast.token
-    case ast: QuotedReference => ast.ast.token
-    case ast: Lift            => ast.token
-    case ast: Assignment      => ast.token
+    case ast: Query                => ast.token
+    case ast: Function             => ast.token
+    case ast: Value                => ast.token
+    case ast: Operation            => ast.token
+    case ast: Action               => ast.token
+    case ast: Ident                => ast.token
+    case ast: Property             => ast.token
+    case ast: Infix                => ast.token
+    case ast: OptionOperation      => ast.token
+    case ast: TraversableOperation => ast.token
+    case ast: Dynamic              => ast.token
+    case ast: If                   => ast.token
+    case ast: Block                => ast.token
+    case ast: Val                  => ast.token
+    case ast: Ordering             => ast.token
+    case ast: QuotedReference      => ast.ast.token
+    case ast: Lift                 => ast.token
+    case ast: Assignment           => ast.token
   }
 
   implicit def ifTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[If] = Tokenizer[If] {
@@ -123,6 +124,12 @@ class MirrorIdiom extends Idiom {
     case OptionForall(ast, alias, body) => stmt"${ast.token}.forall((${alias.token}) => ${body.token})"
     case OptionExists(ast, alias, body) => stmt"${ast.token}.exists((${alias.token}) => ${body.token})"
     case OptionContains(ast, body)      => stmt"${ast.token}.contains(${body.token})"
+  }
+
+  implicit def traversableOperationTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[TraversableOperation] = Tokenizer[TraversableOperation] {
+    case MapContains(ast, body)  => stmt"${ast.token}.contains(${body.token})"
+    case SetContains(ast, body)  => stmt"${ast.token}.contains(${body.token})"
+    case ListContains(ast, body) => stmt"${ast.token}.contains(${body.token})"
   }
 
   implicit val joinTypeTokenizer: Tokenizer[JoinType] = Tokenizer[JoinType] {

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -75,6 +75,11 @@ case class OptionForall(ast: Ast, alias: Ident, body: Ast) extends OptionOperati
 case class OptionExists(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
 case class OptionContains(ast: Ast, body: Ast) extends OptionOperation
 
+sealed trait TraversableOperation extends Ast
+case class MapContains(ast: Ast, body: Ast) extends TraversableOperation
+case class SetContains(ast: Ast, body: Ast) extends TraversableOperation
+case class ListContains(ast: Ast, body: Ast) extends TraversableOperation
+
 case class If(condition: Ast, `then`: Ast, `else`: Ast) extends Ast
 
 case class Assignment(alias: Ident, property: Ast, value: Ast) extends Ast

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -6,13 +6,14 @@ trait StatefulTransformer[T] {
 
   def apply(e: Ast): (Ast, StatefulTransformer[T]) =
     e match {
-      case e: Query           => apply(e)
-      case e: Operation       => apply(e)
-      case e: Action          => apply(e)
-      case e: Value           => apply(e)
-      case e: Assignment      => apply(e)
-      case e: Ident           => (e, this)
-      case e: OptionOperation => apply(e)
+      case e: Query                => apply(e)
+      case e: Operation            => apply(e)
+      case e: Action               => apply(e)
+      case e: Value                => apply(e)
+      case e: Assignment           => apply(e)
+      case e: Ident                => (e, this)
+      case e: OptionOperation      => apply(e)
+      case e: TraversableOperation => apply(e)
 
       case Function(a, b) =>
         val (bt, btt) = apply(b)
@@ -69,6 +70,22 @@ trait StatefulTransformer[T] {
         val (at, att) = apply(a)
         val (ct, ctt) = att.apply(c)
         (OptionContains(at, ct), ctt)
+    }
+
+  def apply(e: TraversableOperation): (TraversableOperation, StatefulTransformer[T]) =
+    e match {
+      case MapContains(a, c) =>
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
+        (MapContains(at, ct), ctt)
+      case SetContains(a, c) =>
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
+        (SetContains(at, ct), ctt)
+      case ListContains(a, c) =>
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
+        (ListContains(at, ct), ctt)
     }
 
   def apply(e: Query): (Query, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -4,23 +4,24 @@ trait StatelessTransformer {
 
   def apply(e: Ast): Ast =
     e match {
-      case e: Query               => apply(e)
-      case e: Operation           => apply(e)
-      case e: Action              => apply(e)
-      case e: Value               => apply(e)
-      case e: Assignment          => apply(e)
-      case Function(params, body) => Function(params, apply(body))
-      case e: Ident               => e
-      case Property(a, name)      => Property(apply(a), name)
-      case Infix(a, b)            => Infix(a, b.map(apply))
-      case e: OptionOperation     => apply(e)
-      case If(a, b, c)            => If(apply(a), apply(b), apply(c))
-      case e: Dynamic             => e
-      case e: Lift                => e
-      case e: QuotedReference     => e
-      case Block(statements)      => Block(statements.map(apply))
-      case Val(name, body)        => Val(name, apply(body))
-      case o: Ordering            => o
+      case e: Query                => apply(e)
+      case e: Operation            => apply(e)
+      case e: Action               => apply(e)
+      case e: Value                => apply(e)
+      case e: Assignment           => apply(e)
+      case Function(params, body)  => Function(params, apply(body))
+      case e: Ident                => e
+      case Property(a, name)       => Property(apply(a), name)
+      case Infix(a, b)             => Infix(a, b.map(apply))
+      case e: OptionOperation      => apply(e)
+      case e: TraversableOperation => apply(e)
+      case If(a, b, c)             => If(apply(a), apply(b), apply(c))
+      case e: Dynamic              => e
+      case e: Lift                 => e
+      case e: QuotedReference      => e
+      case Block(statements)       => Block(statements.map(apply))
+      case Val(name, body)         => Val(name, apply(body))
+      case o: Ordering             => o
     }
 
   def apply(o: OptionOperation): OptionOperation =
@@ -29,6 +30,13 @@ trait StatelessTransformer {
       case OptionForall(a, b, c) => OptionForall(apply(a), b, apply(c))
       case OptionExists(a, b, c) => OptionExists(apply(a), b, apply(c))
       case OptionContains(a, b)  => OptionContains(apply(a), apply(b))
+    }
+
+  def apply(o: TraversableOperation): TraversableOperation =
+    o match {
+      case MapContains(a, b)  => MapContains(apply(a), apply(b))
+      case SetContains(a, b)  => SetContains(apply(a), apply(b))
+      case ListContains(a, b) => ListContains(apply(a), apply(b))
     }
 
   def apply(e: Query): Query =

--- a/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -14,42 +14,25 @@ object RenameProperties extends StatelessTransformer {
       case (q, schema) => q
     }
 
-  private def applySchema(q: Ast): (Ast, Ast) =
-    q match {
-      case q: Action => applySchema(q)
-      case q: Query  => applySchema(q)
-      case q =>
-        CollectAst.byType[Entity](q) match {
-          case schema :: Nil => (q, schema)
-          case _             => (q, Tuple(List.empty))
-        }
-    }
-
   private def applySchema(q: Action): (Action, Ast) =
     q match {
-      case Insert(q, assignments) => applySchema(q, assignments, Insert)
-      case Update(q, assignments) => applySchema(q, assignments, Update)
-      case Delete(q) =>
+      case Insert(q: Query, assignments) => applySchema(q, assignments, Insert)
+      case Update(q: Query, assignments) => applySchema(q, assignments, Update)
+      case Delete(q: Query) =>
         applySchema(q) match {
           case (q, schema) => (Delete(q), schema)
         }
-      case Returning(action, alias, body) =>
+      case Returning(action: Action, alias, body) =>
         applySchema(action) match {
           case (action, schema) =>
             val replace = replacements(alias, schema)
             val bodyr = BetaReduction(body, replace: _*)
             (Returning(action, alias, bodyr), schema)
         }
-      case Foreach(q, alias, body) =>
-        applySchema(q) match {
-          case (q, schema) =>
-            val replace = replacements(alias, schema)
-            val bodyr = BetaReduction(body, replace: _*)
-            (Foreach(q, alias, bodyr), schema)
-        }
+      case q => (q, Tuple(List.empty))
     }
 
-  private def applySchema(q: Ast, a: List[Assignment], f: (Ast, List[Assignment]) => Action): (Action, Ast) =
+  private def applySchema(q: Query, a: List[Assignment], f: (Query, List[Assignment]) => Action): (Action, Ast) =
     applySchema(q) match {
       case (q, schema) =>
         val ar = a.map {
@@ -64,17 +47,17 @@ object RenameProperties extends StatelessTransformer {
 
   private def applySchema(q: Query): (Query, Ast) =
     q match {
-      case e: Entity          => (e, e)
-      case Map(q, x, p)       => applySchema(q, x, p, Map)
-      case Filter(q, x, p)    => applySchema(q, x, p, Filter)
-      case SortBy(q, x, p, o) => applySchema(q, x, p, SortBy(_, _, _, o))
-      case GroupBy(q, x, p)   => applySchema(q, x, p, GroupBy)
-      case Aggregation(op, q) => applySchema(q, Aggregation(op, _))
-      case Take(q, n)         => applySchema(q, Take(_, n))
-      case Drop(q, n)         => applySchema(q, Drop(_, n))
-      case Distinct(q)        => applySchema(q, Distinct)
+      case e: Entity                 => (e, e)
+      case Map(q: Query, x, p)       => applySchema(q, x, p, Map)
+      case Filter(q: Query, x, p)    => applySchema(q, x, p, Filter)
+      case SortBy(q: Query, x, p, o) => applySchema(q, x, p, SortBy(_, _, _, o))
+      case GroupBy(q: Query, x, p)   => applySchema(q, x, p, GroupBy)
+      case Aggregation(op, q: Query) => applySchema(q, Aggregation(op, _))
+      case Take(q: Query, n)         => applySchema(q, Take(_, n))
+      case Drop(q: Query, n)         => applySchema(q, Drop(_, n))
+      case Distinct(q: Query)        => applySchema(q, Distinct)
 
-      case FlatMap(q, x, p) =>
+      case FlatMap(q: Query, x, p) =>
         applySchema(q, x, p, FlatMap) match {
           case (FlatMap(q, x, p: Query), oldSchema) =>
             val (pr, newSchema) = applySchema(p)
@@ -83,7 +66,7 @@ object RenameProperties extends StatelessTransformer {
             (flatMap, Tuple(List.empty))
         }
 
-      case Join(typ, a, b, iA, iB, on) =>
+      case Join(typ, a: Query, b: Query, iA, iB, on) =>
         (applySchema(a), applySchema(b)) match {
           case ((a, schemaA), (b, schemaB)) =>
             val replaceA = replacements(iA, schemaA)
@@ -92,7 +75,7 @@ object RenameProperties extends StatelessTransformer {
             (Join(typ, a, b, iA, iB, onr), Tuple(List(schemaA, schemaB)))
         }
 
-      case FlatJoin(typ, a, iA, on) =>
+      case FlatJoin(typ, a: Query, iA, on) =>
         applySchema(a) match {
           case (a, schemaA) =>
             val replaceA = replacements(iA, schemaA)
@@ -100,21 +83,17 @@ object RenameProperties extends StatelessTransformer {
             (FlatJoin(typ, a, iA, onr), schemaA)
         }
 
-      case Nested(q) =>
-        val (qr, schema) = applySchema(q)
-        (Nested(qr), schema)
-
-      case _: Union | _: UnionAll =>
+      case q =>
         (q, Tuple(List.empty))
     }
 
-  private def applySchema(ast: Ast, f: Ast => Query): (Query, Ast) =
+  private def applySchema(ast: Query, f: Ast => Query): (Query, Ast) =
     applySchema(ast) match {
       case (ast, schema) =>
         (f(ast), schema)
     }
 
-  private def applySchema[T](q: Ast, x: Ident, p: Ast, f: (Ast, Ident, Ast) => T): (T, Ast) =
+  private def applySchema[T](q: Query, x: Ident, p: Ast, f: (Ast, Ident, Ast) => T): (T, Ast) =
     applySchema(q) match {
       case (q, schema) =>
         val replace = replacements(x, schema)

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -20,6 +20,7 @@ trait Liftables {
     case ast: Lift => liftLiftable(ast)
     case ast: Assignment => assignmentLiftable(ast)
     case ast: OptionOperation => optionOperationLiftable(ast)
+    case ast: TraversableOperation => traversableOperationLiftable(ast)
     case Val(name, body) => q"$pack.Val($name, $body)"
     case Block(statements) => q"$pack.Block($statements)"
     case Property(a, b) => q"$pack.Property($a, $b)"
@@ -39,6 +40,12 @@ trait Liftables {
     case OptionForall(a, b, c) => q"$pack.OptionForall($a,$b,$c)"
     case OptionExists(a, b, c) => q"$pack.OptionExists($a,$b,$c)"
     case OptionContains(a, b)  => q"$pack.OptionContains($a,$b)"
+  }
+
+  implicit val traversableOperationLiftable: Liftable[TraversableOperation] = Liftable[TraversableOperation] {
+    case MapContains(a, b)  => q"$pack.MapContains($a,$b)"
+    case SetContains(a, b)  => q"$pack.SetContains($a,$b)"
+    case ListContains(a, b) => q"$pack.ListContains($a,$b)"
   }
 
   implicit val binaryOperatorLiftable: Liftable[BinaryOperator] = Liftable[BinaryOperator] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -17,6 +17,7 @@ trait Unliftables {
     case identUnliftable(ast) => ast
     case orderingUnliftable(ast) => ast
     case optionOperationUnliftable(ast) => ast
+    case traversableOperationUnliftable(ast) => ast
     case q"$pack.Property.apply(${ a: Ast }, ${ b: String })" => Property(a, b)
     case q"$pack.Function.apply(${ a: List[Ident] }, ${ b: Ast })" => Function(a, b)
     case q"$pack.FunctionApply.apply(${ a: Ast }, ${ b: List[Ast] })" => FunctionApply(a, b)
@@ -33,6 +34,12 @@ trait Unliftables {
     case q"$pack.OptionForall.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionForall(a, b, c)
     case q"$pack.OptionExists.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionExists(a, b, c)
     case q"$pack.OptionContains.apply(${ a: Ast }, ${ b: Ast })"              => OptionContains(a, b)
+  }
+
+  implicit val traversableOperationUnliftable: Unliftable[TraversableOperation] = Unliftable[TraversableOperation] {
+    case q"$pack.MapContains.apply(${ a: Ast }, ${ b: Ast })"  => MapContains(a, b)
+    case q"$pack.SetContains.apply(${ a: Ast }, ${ b: Ast })"  => SetContains(a, b)
+    case q"$pack.ListContains.apply(${ a: Ast }, ${ b: Ast })" => ListContains(a, b)
   }
 
   implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -282,6 +282,33 @@ class StatefulTransformerSpec extends Spec {
       }
     }
 
+    "traversable operations" - {
+      "map.contains" in {
+        val ast: Ast = MapContains(Ident("a"), Ident("c"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("c") -> Ident("c'"))(ast) match {
+          case (at, att) =>
+            at mustEqual MapContains(Ident("a'"), Ident("c'"))
+            att.state mustEqual List(Ident("a"), Ident("c"))
+        }
+      }
+      "set.contains" in {
+        val ast: Ast = SetContains(Ident("a"), Ident("c"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("c") -> Ident("c'"))(ast) match {
+          case (at, att) =>
+            at mustEqual SetContains(Ident("a'"), Ident("c'"))
+            att.state mustEqual List(Ident("a"), Ident("c"))
+        }
+      }
+      "list.contains" in {
+        val ast: Ast = ListContains(Ident("a"), Ident("c"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("c") -> Ident("c'"))(ast) match {
+          case (at, att) =>
+            at mustEqual ListContains(Ident("a'"), Ident("c'"))
+            att.state mustEqual List(Ident("a"), Ident("c"))
+        }
+      }
+    }
+
     "if" in {
       val ast: Ast = If(Ident("a"), Ident("b"), Ident("c"))
       Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -176,6 +176,24 @@ class StatelessTransformerSpec extends Spec {
       }
     }
 
+    "traversable operations" - {
+      "map.contains" in {
+        val ast: Ast = MapContains(Ident("a"), Ident("c"))
+        Subject(Ident("a") -> Ident("a'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+          MapContains(Ident("a'"), Ident("c'"))
+      }
+      "set.contains" in {
+        val ast: Ast = SetContains(Ident("a"), Ident("c"))
+        Subject(Ident("a") -> Ident("a'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+          SetContains(Ident("a'"), Ident("c'"))
+      }
+      "list.contains" in {
+        val ast: Ast = ListContains(Ident("a"), Ident("c"))
+        Subject(Ident("a") -> Ident("a'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+          ListContains(Ident("a'"), Ident("c'"))
+      }
+    }
+
     "if" in {
       val ast: Ast = If(Ident("a"), Ident("b"), Ident("c"))
       Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -733,6 +733,26 @@ class QuotationSpec extends Spec {
         quote(unquote(q)).ast.body mustEqual OptionContains(Ident("o"), Ident("v"))
       }
     }
+    "traversable operations" - {
+      "map.contains" in {
+        val q = quote {
+          (m: collection.Map[Int, String], k: Int) => m.contains(k)
+        }
+        quote(unquote(q)).ast.body mustEqual MapContains(Ident("m"), Ident("k"))
+      }
+      "set.contains" in {
+        val q = quote {
+          (s: Set[Int], v: Int) => s.contains(v)
+        }
+        quote(unquote(q)).ast.body mustEqual SetContains(Ident("s"), Ident("v"))
+      }
+      "list.contains" in {
+        val q = quote {
+          (l: List[Int], v: Int) => l.contains(v)
+        }
+        quote(unquote(q)).ast.body mustEqual ListContains(Ident("l"), Ident("v"))
+      }
+    }
     "boxed numbers" - {
       "big decimal" in {
         quote {

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
@@ -60,9 +60,9 @@ trait OrientDBIdiom extends Idiom {
         a.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
-        _: Val | _: Ordering | _: QuotedReference
+        _: Val | _: Ordering | _: QuotedReference | _: TraversableOperation
         ) =>
-        fail(s"Malformed query $a.")
+        fail(s"Malformed or unsupported construct: $a.")
     }
   }
 

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -60,9 +60,9 @@ trait SqlIdiom extends Idiom {
       case a: Assignment => a.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
-        _: Val | _: Ordering | _: QuotedReference
+        _: Val | _: Ordering | _: QuotedReference | _: TraversableOperation
         ) =>
-        fail(s"Malformed query $a.")
+        fail(s"Malformed or unsupported construct: $a.")
     }
 
   implicit def ifTokenizer(implicit strategy: NamingStrategy): Tokenizer[If] = Tokenizer[If] {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -49,7 +49,7 @@ class RenamePropertiesSpec extends Spec {
           val q = quote {
             e.insert(lift(TestEntity("s", 1, 1L, None))).returning(_.i)
           }
-          val mirror = testContext.run(q)
+          val mirror = testContext.run(q.dynamic)
           mirror.returningColumn mustEqual "field_i"
         }
       }
@@ -66,7 +66,7 @@ class RenamePropertiesSpec extends Spec {
         val q = quote {
           e.flatMap(t => qr2.map(u => t)).map(t => t.s)
         }
-        testContext.run(q).string mustEqual
+        testContext.run(q.dynamic).string mustEqual
           "SELECT t.field_s FROM test_entity t, TestEntity2 u"
       }
       "with filter" in {
@@ -237,40 +237,6 @@ class RenamePropertiesSpec extends Spec {
         }
         testContext.run(q).string mustEqual
           "SELECT b.field_i, b.field_s FROM TestEntity2 a RIGHT JOIN test_entity b ON a.s = b.field_s"
-      }
-    }
-
-    "nested" - {
-      "body" in {
-        val q = quote {
-          e.nested
-        }
-        testContext.run(q).string mustEqual
-          "SELECT x.field_s, x.field_i, x.l, x.o FROM (SELECT x.field_s, x.field_i, x.l, x.o FROM test_entity x) x"
-      }
-      "transitive" in {
-        val q = quote {
-          e.nested.map(t => t.s)
-        }
-        testContext.run(q).string mustEqual
-          "SELECT t.field_s FROM (SELECT x.field_s FROM test_entity x) t"
-      }
-    }
-
-    "infix" - {
-      "body" in {
-        val q = quote {
-          infix"$e".as[Query[TestEntity]]
-        }
-        testContext.run(q).string mustEqual
-          "SELECT x.field_s, x.field_i, x.l, x.o FROM (SELECT x.* FROM test_entity x) x"
-      }
-      "transitive" in {
-        val q = quote {
-          infix"$e".as[Query[TestEntity]].map(t => t.s)
-        }
-        testContext.run(q).string mustEqual
-          "SELECT t.field_s FROM (SELECT x.* FROM test_entity x) t"
       }
     }
   }


### PR DESCRIPTION
Fixes partially #774

### Problem

Quill does not provide support for `contains` on collections

### Solution

Provide support for `contains` on collections

### Notes


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
