### PR TITLE
OrientDB Document support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1534,6 +1534,34 @@ ctx.session.maxSchemaAgreementWaitSeconds=1
 ctx.session.addressTranslator=com.datastax.driver.core.policies.IdentityTranslator
 ```
 
+### OrientDB Contexts
+
+#### sbt dependencies
+```
+libraryDependencies ++= Seq(
+  "io.getquill" %% "quill-orientdb" % "1.2.2-SNAPSHOT"
+)
+```
+
+#### synchronous context
+```scala
+lazy val ctx = new OrientDBSyncContext[SnakeCase]("ctx")
+```
+
+#### asynchronous context
+```scala
+lazy val ctx = new OrientDBAsyncContext[SnakeCase]("ctx")
+```
+
+The configurations are set using [`OPartitionedDatabasePool`](http://orientdb.com/javadoc/latest/com/orientechnologies/orient/core/db/OPartitionedDatabasePool.html) which creates a pool of DB connections from which an instance of connection can be acquired. It is possible to set DB credentials using the parameter called `username` and `password`.
+
+#### application.properties
+```
+ctx.dbUrl=remote:127.0.0.1:2424/GratefulDeadConcerts
+ctx.username=root
+ctx.password=root
+```
+
 # Logging
 
 ## Compile-time

--- a/build.sbt
+++ b/build.sbt
@@ -10,11 +10,11 @@ lazy val `quill` =
     .dependsOn(
       `quill-core-jvm`, `quill-core-js`, `quill-sql-jvm`, `quill-sql-js`,
       `quill-jdbc`, `quill-finagle-mysql`, `quill-finagle-postgres`, `quill-async`,
-      `quill-async-mysql`, `quill-async-postgres`, `quill-cassandra`
+      `quill-async-mysql`, `quill-async-postgres`, `quill-cassandra`, `quill-orientdb`
     ).aggregate(
       `quill-core-jvm`, `quill-core-js`, `quill-sql-jvm`, `quill-sql-js`,
       `quill-jdbc`, `quill-finagle-mysql`, `quill-finagle-postgres`, `quill-async`,
-      `quill-async-mysql`, `quill-async-postgres`, `quill-cassandra`
+      `quill-async-mysql`, `quill-async-postgres`, `quill-cassandra`, `quill-orientdb`
     )
 
 lazy val superPure = new org.scalajs.sbtplugin.cross.CrossType {
@@ -146,6 +146,18 @@ lazy val `quill-cassandra` =
       )
     )
     .dependsOn(`quill-core-jvm` % "compile->compile;test->test")
+
+lazy val `quill-orientdb` =
+  (project in file("quill-orientdb"))
+      .settings(commonSettings: _*)
+      .settings(mimaSettings: _*)
+      .settings(
+        fork in Test := true,
+        libraryDependencies ++= Seq(
+          "com.orientechnologies" % "orientdb-graphdb" % "2.2.21"
+        )
+      )
+      .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
 
 lazy val `tut-sources` = Seq(
   "CASSANDRA.md",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,14 @@ services:
       - MAX_HEAP_SIZE=512m
       - HEAP_NEWSIZE=256m
 
+  orientdb:
+    image: orientdb:latest
+    ports:
+      - "12424:2424"
+      - "12480:2480"
+    environment:
+      - ORIENTDB_ROOT_PASSWORD=root
+
 #  sqlserver:
 #    image: microsoft/mssql-server-linux
 #    ports:
@@ -45,6 +53,7 @@ services:
       - postgres:postgres
       - mysql:mysql
       - cassandra:cassandra
+      - orientdb:orientdb
 #     - sqlserver:sqlserver
     volumes:
       - ./:/app
@@ -65,6 +74,7 @@ services:
       - postgres:postgres
       - mysql:mysql
       - cassandra:cassandra
+      - orientdb:orientdb
 #     - sqlserver:sqlserver
     volumes:
       - ./:/app

--- a/quill-orientdb/src/main/scala/io/getquill/OrientDBAsyncContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/OrientDBAsyncContext.scala
@@ -1,0 +1,107 @@
+package io.getquill
+
+import java.util.concurrent.Future
+
+import com.orientechnologies.orient.core.command.OCommandResultListener
+import com.orientechnologies.orient.core.record.impl.ODocument
+import com.orientechnologies.orient.core.replication.OAsyncReplicationError
+import com.orientechnologies.orient.core.sql.OCommandSQL
+import com.orientechnologies.orient.core.sql.query.OSQLNonBlockingQuery
+import com.typesafe.config.Config
+import io.getquill.context.orientdb.OrientDBSessionContext
+import io.getquill.util.LoadConfig
+import io.getquill.util.Messages.fail
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+class OrientDBAsyncContext[N <: NamingStrategy](
+  dbUrl:    String,
+  username: String,
+  password: String
+)
+  extends OrientDBSessionContext[N](dbUrl, username, password) {
+
+  def this(context: OrientDBContextConfig) = this(context.dbUrl, context.username, context.password)
+  def this(config: Config) = this(OrientDBContextConfig(config))
+  def this(configPrefix: String) = this(LoadConfig(configPrefix))
+
+  override type RunQueryResult[T] = Future[List[T]]
+  override type RunQuerySingleResult[T] = Future[T]
+  override type RunActionResult = Unit
+  override type RunBatchActionResult = Unit
+
+  def executeQuery[T](orientQl: String, prepare: ArrayBuffer[Any] => ArrayBuffer[Any] = identity, extractor: ODocument => T = identity[ODocument] _): Future[List[T]] = {
+    val objects = prepare(super.prepare()).asJava
+    oDatabase.command(new OSQLNonBlockingQuery[ODocument](
+      checkInFilter(orientQl, objects.size()),
+      new OCommandResultListener {
+        var records: List[T] = List()
+
+        override def result(iRecord: scala.Any): Boolean = {
+          iRecord match {
+            case record: ODocument =>
+              records :+= extractor(record)
+            case _ =>
+              fail("invalid record received")
+          }
+          true
+        }
+
+        override def getResult: AnyRef = records
+
+        override def end(): Unit = ()
+      }
+    )).execute[Future[List[T]]](objects)
+  }
+
+  def executeQuerySingle[T](orientQl: String, prepare: ArrayBuffer[Any] => ArrayBuffer[Any] = identity, extractor: ODocument => T = identity[ODocument] _): Future[T] = {
+    val objects = prepare(super.prepare()).asJava
+    oDatabase.command(new OSQLNonBlockingQuery[ODocument](
+      checkInFilter(orientQl, objects.size()),
+      new OCommandResultListener {
+        var record: T = _
+
+        override def result(iRecord: scala.Any): Boolean = {
+          iRecord match {
+            case oRecord: ODocument =>
+              record = extractor(oRecord)
+              false
+            case _ =>
+              fail("invalid record received")
+          }
+        }
+
+        override def getResult: Object = record.asInstanceOf[Object]
+
+        override def end(): Unit = ()
+      }
+    )).execute[Future[T]](objects)
+  }
+
+  def executeAction[T](orientQl: String, prepare: ArrayBuffer[Any] => ArrayBuffer[Any] = identity): Unit = {
+    oDatabase.command(new OCommandSQL(orientQl).onAsyncReplicationError(new OAsyncReplicationError {
+      override def onAsyncReplicationError(iException: Throwable, iRetry: Index): OAsyncReplicationError.ACTION = {
+        fail("OrientDB action failed to execute")
+      }
+    })).execute(prepare(super.prepare()).toArray)
+  }
+
+  def executeBatchAction[T](groups: List[BatchGroup]): Unit = {
+    groups.foreach {
+      case BatchGroup(orientQl, prepare) =>
+        prepare.foreach(executeAction(orientQl, _))
+    }
+  }
+
+  private def checkInFilter(orientQl: String, noOfLifts: Int): String = {
+    // Issue with OrientDB IN: https://stackoverflow.com/questions/34391006/orientdb-passing-an-array-to-a-query-using-in-on-an-otype-linklist-field
+    val orientInFilterString = s"IN (?)"
+    val inFilterString = s"IN (${List.fill(noOfLifts)("?").mkString(", ")})"
+    if (orientQl.contains(inFilterString)) {
+      orientQl.replace(inFilterString, orientInFilterString)
+    } else {
+      orientQl
+    }
+  }
+}

--- a/quill-orientdb/src/main/scala/io/getquill/OrientDBContextConfig.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/OrientDBContextConfig.scala
@@ -1,0 +1,9 @@
+package io.getquill
+
+import com.typesafe.config.Config
+
+case class OrientDBContextConfig(config: Config) {
+  def dbUrl: String = config.getString("dbUrl")
+  def username: String = config.getString("username")
+  def password: String = config.getString("password")
+}

--- a/quill-orientdb/src/main/scala/io/getquill/OrientDBMirrorContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/OrientDBMirrorContext.scala
@@ -1,0 +1,15 @@
+package io.getquill
+
+import io.getquill.context.orientdb.{ OrientDBContext, OrientDBIdiom }
+
+class OrientDBMirrorContext[Naming <: NamingStrategy]
+  extends MirrorContext[OrientDBIdiom, Naming] with OrientDBContext[Naming] {
+
+  implicit def listDecoder[T]: Decoder[List[T]] = decoderUnsafe[List[T]]
+  implicit def setDecoder[T]: Decoder[Set[T]] = decoderUnsafe[Set[T]]
+  implicit def mapDecoder[K, V]: Decoder[Map[K, V]] = decoderUnsafe[Map[K, V]]
+
+  implicit def listEncoder[T]: Encoder[List[T]] = encoder[List[T]]
+  implicit def setEncoder[T]: Encoder[Set[T]] = encoder[Set[T]]
+  implicit def mapEncoder[K, V]: Encoder[Map[K, V]] = encoder[Map[K, V]]
+}

--- a/quill-orientdb/src/main/scala/io/getquill/OrientDBSyncContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/OrientDBSyncContext.scala
@@ -1,0 +1,57 @@
+package io.getquill
+
+import com.orientechnologies.orient.core.record.impl.ODocument
+import com.orientechnologies.orient.core.sql.OCommandSQL
+import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery
+import com.typesafe.config.Config
+import io.getquill.context.orientdb.OrientDBSessionContext
+import io.getquill.util.LoadConfig
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+class OrientDBSyncContext[N <: NamingStrategy](
+  dbUrl:    String,
+  username: String,
+  password: String
+) extends OrientDBSessionContext[N](dbUrl, username, password) {
+
+  def this(config: OrientDBContextConfig) = this(config.dbUrl, config.username, config.password)
+  def this(config: Config) = this(OrientDBContextConfig(config))
+  def this(configPrefix: String) = this(LoadConfig(configPrefix))
+
+  override type RunQueryResult[T] = List[T]
+  override type RunQuerySingleResult[T] = T
+  override type RunActionResult = Unit
+  override type RunBatchActionResult = Unit
+
+  def executeQuery[T](orientQl: String, prepare: ArrayBuffer[Any] => ArrayBuffer[Any] = identity, extractor: ODocument => T = identity[ODocument] _): List[T] = {
+    val objects = prepare(super.prepare()).asJava
+    oDatabase.query[java.util.List[ODocument]](new OSQLSynchQuery[ODocument](checkInFilter(orientQl, objects.size())), objects).asScala.map(extractor).toList
+  }
+
+  def executeQuerySingle[T](orientQl: String, prepare: ArrayBuffer[Any] => ArrayBuffer[Any] = identity, extractor: ODocument => T = identity[ODocument] _): T =
+    handleSingleResult(executeQuery(orientQl, prepare, extractor))
+
+  def executeAction[T](orientQl: String, prepare: ArrayBuffer[Any] => ArrayBuffer[Any] = identity): Unit = {
+    oDatabase.command(new OCommandSQL(orientQl)).execute(prepare(super.prepare()).toArray)
+  }
+
+  def executeBatchAction[T](groups: List[BatchGroup]): Unit = {
+    groups.foreach {
+      case BatchGroup(orientQl, prepare) =>
+        prepare.foreach(executeAction(orientQl, _))
+    }
+  }
+
+  private def checkInFilter(orientQl: String, noOfLifts: Int): String = {
+    // Issue with OrientDB IN: https://stackoverflow.com/questions/34391006/orientdb-passing-an-array-to-a-query-using-in-on-an-otype-linklist-field
+    val orientInFilterString = s"IN (?)"
+    val inFilterString = s"IN (${List.fill(noOfLifts)("?").mkString(", ")})"
+    if (orientQl.contains(inFilterString)) {
+      orientQl.replace(inFilterString, orientInFilterString)
+    } else {
+      orientQl
+    }
+  }
+}

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBContext.scala
@@ -1,0 +1,45 @@
+package io.getquill.context.orientdb
+
+import java.util.Date
+
+import io.getquill.NamingStrategy
+import io.getquill.context.Context
+import io.getquill.context.orientdb.dsl.OrientDBDsl
+
+trait OrientDBContext[Naming <: NamingStrategy]
+  extends Context[OrientDBIdiom, Naming]
+  with OrientDBDsl {
+
+  implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]]
+  implicit def optionEncoder[T](implicit d: Encoder[T]): Encoder[Option[T]]
+
+  implicit val stringDecoder: Decoder[String]
+  implicit val doubleDecoder: Decoder[Double]
+  implicit val bigDecimalDecoder: Decoder[BigDecimal]
+  implicit val booleanDecoder: Decoder[Boolean]
+  implicit val shortDecoder: Decoder[Short]
+  implicit val intDecoder: Decoder[Int]
+  implicit val longDecoder: Decoder[Long]
+  implicit val floatDecoder: Decoder[Float]
+  implicit val byteArrayDecoder: Decoder[Array[Byte]]
+  implicit val dateDecoder: Decoder[Date]
+
+  implicit val stringEncoder: Encoder[String]
+  implicit val bigDecimalEncoder: Encoder[BigDecimal]
+  implicit val booleanEncoder: Encoder[Boolean]
+  implicit val shortEncoder: Encoder[Short]
+  implicit val intEncoder: Encoder[Int]
+  implicit val longEncoder: Encoder[Long]
+  implicit val floatEncoder: Encoder[Float]
+  implicit val doubleEncoder: Encoder[Double]
+  implicit val dateEncoder: Encoder[Date]
+  implicit val byteArrayEncoder: Encoder[Array[Byte]]
+
+  implicit def listDecoder[T]: Decoder[List[T]]
+  implicit def setDecoder[T]: Decoder[Set[T]]
+  implicit def mapDecoder[K, V]: Decoder[Map[K, V]]
+
+  implicit def listEncoder[T]: Encoder[List[T]]
+  implicit def setEncoder[T]: Encoder[Set[T]]
+  implicit def mapEncoder[K, V]: Encoder[Map[K, V]]
+}

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
@@ -1,0 +1,309 @@
+package io.getquill.context.orientdb
+
+import io.getquill.idiom.StatementInterpolator._
+import io.getquill.context.sql.norm._
+import io.getquill.ast.{ AggregationOperator, Lift, _ }
+import io.getquill.context.sql._
+import io.getquill.NamingStrategy
+import io.getquill.util.Messages.fail
+import io.getquill.idiom._
+import io.getquill.context.sql.norm.SqlNormalize
+import io.getquill.util.Interleave
+import io.getquill.context.sql.idiom.VerifySqlQuery
+
+object OrientDBIdiom extends OrientDBIdiom
+
+trait OrientDBIdiom extends Idiom {
+
+  override def liftingPlaceholder(index: Int): String = "?"
+
+  override def emptySetContainsToken(field: Token): Token = StringToken(s"$field IS NULL")
+
+  override def prepareForProbing(string: String): String = string
+
+  override def translate(ast: Ast)(implicit naming: NamingStrategy): (Ast, Statement) = {
+    val normalizedAst = SqlNormalize(ast)
+    val token =
+      normalizedAst match {
+        case q: Query =>
+          val sql = SqlQuery(q)
+          VerifySqlQuery(sql).map(fail)
+          ExpandNestedQueries(sql, collection.Set.empty).token
+        case other =>
+          other.token
+      }
+
+    (normalizedAst, stmt"$token")
+  }
+
+  implicit def astTokenizer(implicit strategy: NamingStrategy, queryTokenizer: Tokenizer[Query]): Tokenizer[Ast] = {
+    Tokenizer[Ast] {
+      case a: Query =>
+        SqlQuery(a).token
+      case a: Operation =>
+        a.token
+      case a: Infix =>
+        a.token
+      case a: Action =>
+        a.token
+      case a: Ident =>
+        a.token
+      case a: Property =>
+        a.token
+      case a: Value =>
+        a.token
+      case a: If =>
+        a.token
+      case a: Lift =>
+        a.token
+      case a: Assignment =>
+        a.token
+      case a @ (
+        _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
+        _: Val | _: Ordering | _: QuotedReference
+        ) =>
+        fail(s"Malformed query $a.")
+    }
+  }
+
+  implicit def ifTokenizer(implicit strategy: NamingStrategy): Tokenizer[If] = Tokenizer[If] {
+    case ast: If =>
+      def flatten(ast: Ast): (List[(Ast, Ast)], Ast) =
+        ast match {
+          case If(cond, a, b) =>
+            val (l, e) = flatten(b)
+            ((cond, a) +: l, e)
+          case other =>
+            (List(), other)
+        }
+
+      val (l, e) = flatten(ast)
+      val conditions =
+        for ((cond, body) <- l) yield {
+          stmt"if(${cond.token}, ${body.token}, ${e.token})"
+        }
+      conditions.head
+  }
+
+  implicit def queryTokenizer(implicit strategy: NamingStrategy): Tokenizer[Query] = Tokenizer[Query] {
+    case q => SqlQuery(q).token
+  }
+
+  implicit def orientDBQueryTokenizer(implicit strategy: NamingStrategy): Tokenizer[SqlQuery] = Tokenizer[SqlQuery] {
+    case FlattenSqlQuery(from, where, groupBy, orderBy, limit, offset, select, distinct) =>
+
+      val distinctTokenizer = (if (distinct) "DISTINCT" else "").token
+
+      val selectClause =
+        select match {
+          case Nil => if (!distinct) stmt"SELECT *" else fail("OrientDB DISTINCT with multiple columns is not supported")
+          case _ =>
+            if (!distinct) stmt"SELECT ${select.token}"
+            else if (select.size == 1) stmt"SELECT $distinctTokenizer(${select.token})"
+            else fail("OrientDB DISTINCT with multiple columns is not supported")
+        }
+
+      val withFrom =
+        from match {
+          case Nil => selectClause
+          case head :: tail =>
+            val t = tail.foldLeft(stmt"${head.token}") {
+              case (a, b: FlatJoinContext) =>
+                stmt"$a ${(b: FromContext).token}"
+              case (a, b) =>
+                stmt"$a"
+            }
+            stmt"$selectClause FROM $t"
+        }
+
+      val withWhere =
+        where match {
+          case None => withFrom
+          case Some(where) =>
+            stmt"$withFrom WHERE ${where.token}"
+        }
+
+      val withGroupBy =
+        groupBy match {
+          case Nil     => withWhere
+          case groupBy => stmt"$withWhere GROUP BY ${groupBy.token}"
+        }
+
+      val withOrderBy =
+        orderBy match {
+          case Nil     => withGroupBy
+          case orderBy => stmt"$withGroupBy ${tokenOrderBy(orderBy)}"
+        }
+      (limit, offset) match {
+        case (None, None)                => withOrderBy
+        case (Some(limit), None)         => stmt"$withOrderBy LIMIT ${limit.token}"
+        case (Some(limit), Some(offset)) => stmt"$withOrderBy SKIP ${offset.token} LIMIT ${limit.token}"
+        case (None, Some(offset))        => stmt"$withOrderBy SKIP ${offset.token}"
+      }
+    case SetOperationSqlQuery(a, op, b) =>
+      val str = f"SELECT $$c LET $$a = (${a.token}), $$b = (${b.token}), $$c = UNIONALL($$a, $$b)"
+      str.token
+    case _ =>
+      fail("Other operators are not supported yet. Please raise a ticket to support more operations")
+  }
+
+  implicit def operationTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy): Tokenizer[Operation] = Tokenizer[Operation] {
+    case UnaryOperation(op, ast)                              => stmt"${op.token} (${ast.token})"
+    case BinaryOperation(a, EqualityOperator.`==`, NullValue) => stmt"${scopedTokenizer(a)} IS NULL"
+    case BinaryOperation(NullValue, EqualityOperator.`==`, b) => stmt"${scopedTokenizer(b)} IS NULL"
+    case BinaryOperation(a, EqualityOperator.`!=`, NullValue) => stmt"${scopedTokenizer(a)} IS NOT NULL"
+    case BinaryOperation(NullValue, EqualityOperator.`!=`, b) => stmt"${scopedTokenizer(b)} IS NOT NULL"
+    case BinaryOperation(a, op @ SetOperator.`contains`, b)   => SetContainsToken(scopedTokenizer(b), op.token, a.token)
+    case BinaryOperation(a, op, b) =>
+      stmt"${scopedTokenizer(a)} ${op.token} ${scopedTokenizer(b)}"
+    case e: FunctionApply => fail(s"Can't translate the ast to sql: '$e'")
+  }
+
+  implicit val setOperationTokenizer: Tokenizer[SetOperation] = Tokenizer[SetOperation] {
+    case UnionOperation    => stmt"UNION"
+    case UnionAllOperation => stmt"UNION ALL"
+  }
+
+  protected def tokenOrderBy(criterias: List[OrderByCriteria])(implicit strategy: NamingStrategy) =
+    stmt"ORDER BY ${criterias.token}"
+
+  implicit def sourceTokenizer(implicit strategy: NamingStrategy): Tokenizer[FromContext] = Tokenizer[FromContext] {
+    case TableContext(name, alias)  => stmt"${name.token}"
+    case QueryContext(query, alias) => stmt"(${query.token})"
+    case InfixContext(infix, alias) => stmt"(${(infix: Ast).token})"
+    case _                          => fail("OrientDB sql doesn't support joins")
+  }
+
+  implicit def orderByCriteriaTokenizer(implicit strategy: NamingStrategy): Tokenizer[OrderByCriteria] = Tokenizer[OrderByCriteria] {
+    case OrderByCriteria(ast, Asc | AscNullsFirst | AscNullsLast)    => stmt"${scopedTokenizer(ast)} ASC"
+    case OrderByCriteria(ast, Desc | DescNullsFirst | DescNullsLast) => stmt"${scopedTokenizer(ast)} DESC"
+  }
+
+  implicit val unaryOperatorTokenizer: Tokenizer[UnaryOperator] = Tokenizer[UnaryOperator] {
+    case StringOperator.`toUpperCase` => stmt"toUpperCase()"
+    case StringOperator.`toLowerCase` => stmt"toLowerCase()"
+    case _                            => fail("OrientDB sql doesn't support other unary operators")
+  }
+
+  implicit val aggregationOperatorTokenizer: Tokenizer[AggregationOperator] = Tokenizer[AggregationOperator] {
+    case AggregationOperator.`min`  => stmt"MIN"
+    case AggregationOperator.`max`  => stmt"MAX"
+    case AggregationOperator.`avg`  => stmt"AVG"
+    case AggregationOperator.`sum`  => stmt"SUM"
+    case AggregationOperator.`size` => stmt"COUNT"
+  }
+
+  implicit val binaryOperatorTokenizer: Tokenizer[BinaryOperator] = Tokenizer[BinaryOperator] {
+    case EqualityOperator.`==`  => stmt"="
+    case BooleanOperator.`&&`   => stmt"AND"
+    case NumericOperator.`>`    => stmt">"
+    case NumericOperator.`>=`   => stmt">="
+    case NumericOperator.`<`    => stmt"<"
+    case NumericOperator.`<=`   => stmt"<="
+    case NumericOperator.`+`    => stmt"+"
+    case SetOperator.`contains` => stmt"IN"
+    case NumericOperator.`*`    => stmt"*"
+    case NumericOperator.`-`    => stmt"-"
+    case NumericOperator.`/`    => stmt"/"
+    case NumericOperator.`%`    => stmt"%"
+    case other                  => fail(s"OrientDB QL doesn't support the '$other' operator.")
+  }
+
+  implicit def selectValueTokenizer(implicit strategy: NamingStrategy): Tokenizer[SelectValue] = {
+    def tokenValue(ast: Ast) =
+      ast match {
+        case Aggregation(op, Ident(_)) => stmt"${op.token}(*)"
+        case Aggregation(op, _: Query) => scopedTokenizer(ast)
+        case Aggregation(op, ast)      => stmt"${op.token}(${ast.token})"
+        case _                         => ast.token
+      }
+    Tokenizer[SelectValue] {
+      case SelectValue(ast, Some(alias)) => stmt"${tokenValue(ast)} ${strategy.column(alias).token}"
+      case SelectValue(Ident("?"), None) => "?".token
+      case SelectValue(ast: Ident, None) => stmt"*" //stmt"${tokenValue(ast)}.*"
+      case SelectValue(ast, None)        => tokenValue(ast)
+    }
+  }
+
+  implicit def propertyTokenizer(implicit valueTokenizer: Tokenizer[Value], identTokenizer: Tokenizer[Ident], strategy: NamingStrategy): Tokenizer[Property] = {
+    def unnest(ast: Ast): Ast = {
+      ast match {
+        case Property(a, _) => unnest(a)
+        case a              => a
+      }
+    }
+    Tokenizer[Property] {
+      case Property(ast, "isEmpty")   => stmt"${ast.token} IS NULL"
+      case Property(ast, "nonEmpty")  => stmt"${ast.token} IS NOT NULL"
+      case Property(ast, "isDefined") => stmt"${ast.token} IS NOT NULL"
+      case Property(ast, name)        => stmt"${strategy.column(name).token}"
+    }
+  }
+
+  implicit def valueTokenizer(implicit strategy: NamingStrategy): Tokenizer[Value] = Tokenizer[Value] {
+    case Constant(v: String) => stmt"'${v.token}'"
+    case Constant(())        => stmt"1"
+    case Constant(v)         => stmt"${v.toString.token}"
+    case NullValue           => stmt"null"
+    case Tuple(values)       => stmt"${values.token}"
+  }
+
+  implicit def infixTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy): Tokenizer[Infix] = Tokenizer[Infix] {
+    case Infix(parts, params) =>
+      val pt = parts.map(_.token)
+      val pr = params.map(_.token)
+      Statement(Interleave(pt, pr))
+  }
+
+  implicit def identTokenizer(implicit strategy: NamingStrategy): Tokenizer[Ident] =
+    Tokenizer[Ident](e => strategy.default(e.name).token)
+
+  implicit def assignmentTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy): Tokenizer[Assignment] = Tokenizer[Assignment] {
+    case Assignment(alias, prop, value) =>
+      stmt"${prop.token} = ${scopedTokenizer(value)}"
+  }
+
+  implicit def actionTokenizer(implicit strategy: NamingStrategy): Tokenizer[Action] = {
+
+    implicit def propertyTokenizer: Tokenizer[Property] = Tokenizer[Property] {
+      case Property(Property(_, name), "isEmpty")   => stmt"${strategy.column(name).token} IS NULL"
+      case Property(Property(_, name), "isDefined") => stmt"${strategy.column(name).token} IS NOT NULL"
+      case Property(Property(_, name), "nonEmpty")  => stmt"${strategy.column(name).token} IS NOT NULL"
+      case Property(_, name)                        => strategy.column(name).token
+    }
+
+    Tokenizer[Action] {
+      case Insert(table: Entity, assignments) =>
+        val columns = assignments.map(_.property.token)
+        val values = assignments.map(_.value)
+        stmt"INSERT INTO ${table.token} (${columns.mkStmt(", ")}) VALUES(${values.map(scopedTokenizer(_)).mkStmt(", ")})"
+
+      case Update(table: Entity, assignments) =>
+        stmt"UPDATE ${table.token} SET ${assignments.token}"
+
+      case Update(Filter(table: Entity, x, where), assignments) =>
+        stmt"UPDATE ${table.token} SET ${assignments.token} WHERE ${where.token}"
+
+      case Delete(Filter(table: Entity, x, where)) =>
+        stmt"DELETE FROM ${table.token} WHERE ${where.token}"
+
+      case Delete(table: Entity) =>
+        stmt"DELETE FROM ${table.token}"
+
+      case other =>
+        fail(s"Action ast can't be translated to sql: '$other'")
+    }
+  }
+
+  implicit def entityTokenizer(implicit strategy: NamingStrategy): Tokenizer[Entity] = Tokenizer[Entity] {
+    case Entity(name, _) => strategy.table(name).token
+  }
+
+  protected def scopedTokenizer[A <: Ast](ast: A)(implicit token: Tokenizer[A]) =
+    ast match {
+      case _: Query           => stmt"(${ast.token})"
+      case _: BinaryOperation => stmt"(${ast.token})"
+      case _: Tuple           => stmt"(${ast.token})"
+      case _                  => ast.token
+    }
+}

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBSessionContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBSessionContext.scala
@@ -1,0 +1,56 @@
+package io.getquill.context.orientdb
+
+import com.orientechnologies.orient.core.db.OPartitionedDatabasePool
+import com.orientechnologies.orient.core.record.impl.ODocument
+import com.orientechnologies.orient.core.sql.query.OSQLQuery
+import com.typesafe.scalalogging.Logger
+import io.getquill.NamingStrategy
+import io.getquill.context.mirror.Row
+import io.getquill.context.orientdb.encoding.{ Decoders, Encoders }
+import io.getquill.util.Messages.fail
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Try
+
+abstract class OrientDBSessionContext[N <: NamingStrategy](
+  dbUrl:    String,
+  username: String,
+  password: String
+) extends OrientDBContext[N]
+  with Encoders
+  with Decoders {
+
+  override type PrepareRow = ArrayBuffer[Any]
+  override type ResultRow = ODocument
+
+  override type RunActionReturningResult[T] = Unit
+  override type RunBatchActionReturningResult[T] = Unit
+
+  protected val logger: Logger =
+    Logger(LoggerFactory.getLogger(classOf[OrientDBSessionContext[_]]))
+
+  protected val session = new OPartitionedDatabasePool(dbUrl, username, password)
+  protected val oDatabase = session.acquire()
+
+  protected def prepare() = new ArrayBuffer[Any]()
+
+  override def close(): Unit = {
+    oDatabase.close()
+    session.close()
+  }
+
+  override def probe(orientDBQl: String) =
+    Try {
+      prepare()
+      ()
+    }
+
+  def executeActionReturning[O](orientDBQl: String, prepare: OSQLQuery[ODocument] => OSQLQuery[ODocument] = identity, extractor: Row => O, returningColumn: String): Unit = {
+    fail("OrientDB doesn't support `returning`.")
+  }
+
+  def executeBatchActionReturning[T](groups: List[BatchGroup], extractor: Row => T): Unit = {
+    fail("OrientDB doesn't support `returning`.")
+  }
+}

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/dsl/OrientDBDsl.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/dsl/OrientDBDsl.scala
@@ -1,0 +1,11 @@
+package io.getquill.context.orientdb.dsl
+
+import io.getquill.context.orientdb.OrientDBContext
+
+trait OrientDBDsl {
+  this: OrientDBContext[_] =>
+
+  implicit class Like(s1: String) {
+    def like(s2: String) = quote(infix"$s1 like $s2".as[Boolean])
+  }
+}

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/CollectionDecoders.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/CollectionDecoders.scala
@@ -1,0 +1,18 @@
+package io.getquill.context.orientdb.encoding
+
+import io.getquill.context.orientdb.OrientDBSessionContext
+import scala.collection.JavaConverters._
+
+trait CollectionDecoders {
+  this: OrientDBSessionContext[_] =>
+
+  implicit def listDecoder[T]: Decoder[List[T]] = decoder((index, row) => {
+    row.field[java.util.List[T]](row.fieldNames()(index)).asScala.toList
+  })
+  implicit def setDecoder[T]: Decoder[Set[T]] = decoder((index, row) => {
+    row.field[java.util.List[T]](row.fieldNames()(index)).asScala.toSet
+  })
+  implicit def mapDecoder[K, V]: Decoder[Map[K, V]] = decoder((index, row) => {
+    row.field[java.util.Map[K, V]](row.fieldNames()(index)).asScala.toMap[K, V]
+  })
+}

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/CollectionEncoders.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/CollectionEncoders.scala
@@ -1,0 +1,18 @@
+package io.getquill.context.orientdb.encoding
+
+import io.getquill.context.orientdb.OrientDBSessionContext
+import scala.collection.JavaConverters._
+
+trait CollectionEncoders {
+  this: OrientDBSessionContext[_] =>
+
+  implicit def listEncoder[T]: Encoder[List[T]] = encoder((index, value, row) => {
+    row.insert(index, value.asJava); row
+  })
+  implicit def setEncoder[T]: Encoder[Set[T]] = encoder((index, value, row) => {
+    row.insert(index, value.asJava); row
+  })
+  implicit def mapEncoder[K, V]: Encoder[Map[K, V]] = encoder((index, value, row) => {
+    row.insert(index, mapAsJavaMapConverter[K, V](value).asJava); row
+  })
+}

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/Decoders.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/Decoders.scala
@@ -1,0 +1,61 @@
+package io.getquill.context.orientdb.encoding
+
+import java.util.Date
+
+import io.getquill.context.orientdb.OrientDBSessionContext
+import io.getquill.util.Messages.fail
+
+trait Decoders extends CollectionDecoders {
+  this: OrientDBSessionContext[_] =>
+
+  type Decoder[T] = OrientDBDecoder[T]
+
+  case class OrientDBDecoder[T](decoder: BaseDecoder[T]) extends BaseDecoder[T] {
+    override def apply(index: Index, row: ResultRow) =
+      decoder(index, row)
+  }
+
+  def decoder[T](d: BaseDecoder[T]): Decoder[T] = OrientDBDecoder(
+    (index, row) =>
+      if (index >= row.fieldNames().length || row.fieldValues()(index) == null) {
+        fail(s"Expected column at index $index to be defined but is was empty")
+      } else
+        d(index, row)
+  )
+
+  def decoder[T](f: ResultRow => Index => T): Decoder[T] =
+    decoder((index, row) => f(row)(index))
+
+  implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] =
+    OrientDBDecoder((index, row) => {
+      if (index < row.fieldValues().length) {
+        row.fieldValues()(index) == null match {
+          case true  => None
+          case false => Some(d(index, row))
+        }
+      } else None
+    })
+
+  implicit def mappedDecoder[I, O](implicit mapped: MappedEncoding[I, O], decoder: Decoder[I]): Decoder[O] =
+    OrientDBDecoder(mappedBaseDecoder(mapped, decoder.decoder))
+
+  implicit val stringDecoder: Decoder[String] = decoder((index, row) => {
+    row.field[String](row.fieldNames()(index))
+  })
+  implicit val doubleDecoder: Decoder[Double] = decoder((index, row) => row.field[Double](row.fieldNames()(index)))
+  implicit val bigDecimalDecoder: Decoder[BigDecimal] = decoder((index, row) => BigDecimal.apply(row.field[Double](row.fieldNames()(index))))
+  implicit val booleanDecoder: Decoder[Boolean] = decoder((index, row) => row.field[Boolean](row.fieldNames()(index)))
+  implicit val intDecoder: Decoder[Int] = decoder((index, row) => row.field[Int](row.fieldNames()(index)))
+  implicit val shortDecoder: Decoder[Short] = decoder((index, row) => row.field[Short](row.fieldNames()(index)))
+  implicit val longDecoder: Decoder[Long] = decoder((index, row) => {
+    if (row.fieldValues()(index).isInstanceOf[Int]) {
+      row.field[Int](row.fieldNames()(index)).toLong
+    } else
+      row.field[Long](row.fieldNames()(index))
+  })
+  implicit val floatDecoder: Decoder[Float] = decoder((index, row) => row.field[Double](row.fieldNames()(index)).toFloat)
+  implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoder((index, row) => {
+    row.field[Array[Byte]](row.fieldNames()(index))
+  })
+  implicit val dateDecoder: Decoder[Date] = decoder((index, row) => row.field[Date](row.fieldNames()(index)))
+}

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/Encoders.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/Encoders.scala
@@ -1,0 +1,46 @@
+package io.getquill.context.orientdb.encoding
+
+import java.util.Date
+
+import io.getquill.context.orientdb.OrientDBSessionContext
+
+trait Encoders extends CollectionEncoders {
+  this: OrientDBSessionContext[_] =>
+
+  type Encoder[T] = OrientDBEncoder[T]
+
+  case class OrientDBEncoder[T](encoder: BaseEncoder[T]) extends BaseEncoder[T] {
+    override def apply(index: Index, value: T, row: PrepareRow) =
+      encoder(index, value, row)
+  }
+
+  def encoder[T](e: BaseEncoder[T]): Encoder[T] = OrientDBEncoder(e)
+
+  def encoder[T](f: PrepareRow => (Index, T) => PrepareRow): Encoder[T] =
+    encoder((index, value, row) => f(row)(index, value))
+
+  private[this] val nullEncoder: Encoder[Null] =
+    encoder((index, value, row) => { row.insert(index, null); row })
+
+  implicit def optionEncoder[T](implicit d: Encoder[T]): Encoder[Option[T]] =
+    encoder { (index, value, row) =>
+      value match {
+        case None    => nullEncoder(index, null, row)
+        case Some(v) => d(index, v, row)
+      }
+    }
+
+  implicit def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], encoder: Encoder[O]): Encoder[I] =
+    OrientDBEncoder(mappedBaseEncoder(mapped, encoder.encoder))
+
+  implicit val stringEncoder: Encoder[String] = encoder((index, value, row) => { row.insert(index, value); row })
+  implicit val bigDecimalEncoder: Encoder[BigDecimal] = encoder((index, value, row) => { row.insert(index, value.bigDecimal); row })
+  implicit val booleanEncoder: Encoder[Boolean] = encoder((index, value, row) => { row.insert(index, value); row })
+  implicit val intEncoder: Encoder[Int] = encoder((index, value, row) => { row.insert(index, value); row })
+  implicit val shortEncoder: Encoder[Short] = encoder((index, value, row) => { row.insert(index, value); row })
+  implicit val longEncoder: Encoder[Long] = encoder((index, value, row) => { row.insert(index, value); row })
+  implicit val floatEncoder: Encoder[Float] = encoder((index, value, row) => { row.insert(index, value); row })
+  implicit val doubleEncoder: Encoder[Double] = encoder((index, value, row) => { row.insert(index, value); row })
+  implicit val dateEncoder: Encoder[Date] = encoder((index, value, row) => { row.insert(index, value); row })
+  implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder((index, value, row) => { row.insert(index, value); row })
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/BindVariablesSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/BindVariablesSpec.scala
@@ -1,0 +1,19 @@
+package io.getquill.context.orientdb
+
+import io.getquill.Spec
+import io.getquill.context.mirror.Row
+
+class BindVariablesSpec extends Spec {
+
+  "binds lifted values" in {
+    val mirrorContext = orientdb.mirrorContext
+    import mirrorContext._
+    def q(i: Int) =
+      quote {
+        query[TestEntity].filter(e => e.i == lift(i))
+      }
+    val mirror = mirrorContext.run(q(2))
+    mirror.string mustEqual "SELECT s, i, l, o FROM TestEntity WHERE i = ?"
+    mirror.prepareRow mustEqual Row(2)
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/DecodeNullSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/DecodeNullSpec.scala
@@ -1,0 +1,28 @@
+package io.getquill.context.orientdb
+
+import io.getquill.Spec
+
+class DecodeNullSpec extends Spec {
+
+  "no default values when reading null" - {
+
+    "sync" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      val writeEntities = quote(querySchema[DecodeNullTestWriteEntity]("DecodeNullTestEntity"))
+
+      ctx.run(writeEntities.delete)
+      ctx.run(writeEntities.insert(lift(insertValue)))
+
+      intercept[IllegalStateException] {
+        ctx.run(query[DecodeNullTestEntity])
+      }
+    }
+  }
+
+  case class DecodeNullTestEntity(id: Int, value: Int)
+
+  case class DecodeNullTestWriteEntity(id: Int, value: Option[Int])
+
+  val insertValue = DecodeNullTestWriteEntity(0, None)
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/EncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/EncodingSpec.scala
@@ -1,0 +1,158 @@
+package io.getquill.context.orientdb
+
+import java.util.Date
+
+import io.getquill.Spec
+
+class EncodingSpec extends Spec {
+
+  "encodes and decodes types" - {
+
+    "sync" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      ctx.run(query[EncodingTestEntity].delete)
+      ctx.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+      verify(ctx.run(query[EncodingTestEntity]))
+      ctx.close()
+    }
+
+    "async" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      ctx.run(query[EncodingTestEntity].delete)
+      ctx.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+      verify(ctx.run(query[EncodingTestEntity]).get())
+      ctx.close()
+    }
+  }
+
+  "encodes collections" - {
+
+    "sync" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      val q = quote {
+        (list: Query[Int]) =>
+          query[EncodingTestEntity].filter(t => list.contains(t.id))
+      }
+      ctx.run(query[EncodingTestEntity].delete)
+      ctx.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+      verify(ctx.run(q(liftQuery(insertValues.map(_.id)))))
+      ctx.close()
+    }
+
+    "async" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      val q = quote {
+        (list: Query[Int]) =>
+          query[EncodingTestEntity].filter(t => list.contains(t.id))
+      }
+      ctx.run(query[EncodingTestEntity].delete)
+      ctx.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+      verify(ctx.run(q(liftQuery(insertValues.map(_.id)))).get())
+      ctx.close()
+    }
+  }
+
+  private def verify(result: List[EncodingTestEntity]): Unit = {
+    result.zip(insertValues) match {
+      case List((e1, a1), (e2, a2)) =>
+        verify(e1, a1)
+        verify(e2, a2)
+    }
+  }
+
+  private def verify(e: EncodingTestEntity, a: EncodingTestEntity): Unit = {
+    e.id mustEqual a.id
+
+    e.v1 mustEqual a.v1
+    e.v2 mustEqual a.v2
+    e.v3 mustEqual a.v3
+    e.v4 mustEqual a.v4
+    e.v5 mustEqual a.v5
+    e.v6 mustEqual a.v6
+    e.v7 mustEqual a.v7
+    e.v8.toList mustEqual a.v8.toList
+    e.v11.isInstanceOf[Date]
+    e.o1 mustEqual a.o1
+    e.o2 mustEqual a.o2
+    e.o3 mustEqual a.o3
+    e.o4 mustEqual a.o4
+    e.o5 mustEqual a.o5
+    e.o6 mustEqual a.o6
+    e.o7 mustEqual a.o7
+    e.o8.map(_.toList) mustEqual a.o8.map(_.toList)
+
+    ()
+  }
+
+  case class EncodingTestEntity(
+    id:  Int,
+    v1:  String,
+    v2:  BigDecimal,
+    v3:  Boolean,
+    v4:  Int,
+    v5:  Long,
+    v6:  Float,
+    v7:  Double,
+    v8:  Array[Byte],
+    v11: Date,
+    o1:  Option[String],
+    o2:  Option[BigDecimal],
+    o3:  Option[Boolean],
+    o4:  Option[Int],
+    o5:  Option[Long],
+    o6:  Option[Float],
+    o7:  Option[Double],
+    o8:  Option[Array[Byte]],
+    o9:  Option[Date]
+  )
+
+  val insertValues =
+    List(
+      EncodingTestEntity(
+        id = 1,
+        v1 = "s",
+        v2 = BigDecimal(1.1),
+        v3 = true,
+        v4 = 33,
+        v5 = 431L,
+        v6 = 34.4f,
+        v7 = 42.4d,
+        v8 = Array(1.toByte, 2.toByte),
+        v11 = new Date(31202000),
+        o1 = Some("s"),
+        o2 = Some(BigDecimal(1.1)),
+        o3 = Some(true),
+        o4 = Some(33),
+        o5 = Some(431L),
+        o6 = Some(34.4f),
+        o7 = Some(42.4d),
+        o8 = Some(Array(1.toByte, 2.toByte)),
+        o9 = Some(new Date(31200000))
+      ),
+      EncodingTestEntity(
+        id = 2,
+        v1 = "",
+        v2 = BigDecimal(0.0),
+        v3 = false,
+        v4 = 0,
+        v5 = 0L,
+        v6 = 0.0F,
+        v7 = 0.0D,
+        v8 = Array(),
+        v11 = new Date(0),
+        o1 = None,
+        o2 = None,
+        o3 = None,
+        o4 = None,
+        o5 = None,
+        o6 = None,
+        o7 = None,
+        o8 = None,
+        o9 = None
+      )
+    )
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/ListsEncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/ListsEncodingSpec.scala
@@ -1,0 +1,79 @@
+package io.getquill.context.orientdb
+
+import java.util.Date
+
+import io.getquill.Spec
+
+class ListsEncodingSpec extends Spec {
+
+  case class ListsEntity(
+    id:         Int,
+    texts:      List[String],
+    bools:      List[Boolean],
+    ints:       List[Int],
+    longs:      List[Long],
+    floats:     List[Float],
+    doubles:    List[Double],
+    timestamps: List[Date]
+  )
+  val e = ListsEntity(1, List("c"), List(true), List(1, 2), List(2, 3), List(1.2f, 3.2f),
+    List(5.1d), List(new Date()))
+
+  private def verify(expected: ListsEntity, actual: ListsEntity): Boolean = {
+    expected.id mustEqual actual.id
+    expected.texts mustEqual actual.texts
+    expected.bools mustEqual actual.bools
+    expected.ints mustEqual actual.ints
+    expected.longs mustEqual actual.longs
+    expected.doubles mustEqual actual.doubles
+    actual.timestamps.head.isInstanceOf[Date]
+    true
+  }
+
+  "List encoders/decoders for OrientDB Types" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    val q = quote(query[ListsEntity])
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    verify(e, ctx.run(q.filter(_.id == 1)).head)
+  }
+
+  "Empty Lists and optional fields" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    case class Entity(id: Int, texts: Option[List[String]], bools: Option[List[Boolean]])
+    val e = Entity(1, Some(List("1", "2")), None)
+    val q = quote(querySchema[Entity]("ListEntity"))
+
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+
+    ctx.run(q.filter(_.id == 1)).head mustBe e
+  }
+
+  "Blob (Array[Byte]) support" ignore {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    case class BlobsEntity(id: Int, blobs: List[Array[Byte]])
+    val e = BlobsEntity(1, List(Array(1.toByte, 2.toByte), Array(2.toByte)))
+    val q = quote(querySchema[BlobsEntity]("BlobsEntity"))
+
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    ctx.run(q.filter(_.id == 1))
+      .head.blobs.map(_.toList) mustBe e.blobs.map(_.toList)
+  }
+
+  "List in where clause" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    case class ListFrozen(id: List[Int])
+    val e = ListFrozen(List(1, 2))
+    val q = quote(query[ListFrozen])
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    ctx.run(q.filter(p => liftQuery(Set(1)).contains(p.id))) mustBe List(e)
+    ctx.run(q.filter(_.id == lift(List(1)))) mustBe Nil
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/MapsEncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/MapsEncodingSpec.scala
@@ -1,0 +1,61 @@
+package io.getquill.context.orientdb
+
+import java.util.Date
+
+import io.getquill.Spec
+
+class MapsEncodingSpec extends Spec {
+
+  case class MapsEntity(
+    id:         Int,
+    longDouble: Map[Long, Double],
+    intDouble:  Map[Int, Double],
+    boolDate:   Map[Boolean, Date]
+  )
+  val e = MapsEntity(1, Map(1L -> 1.1), Map(1 -> 1.1d), Map(true -> new Date()))
+
+  private def verify(expected: MapsEntity, actual: MapsEntity): Boolean = {
+    expected.id mustEqual actual.id
+    expected.longDouble.head._2 mustEqual actual.longDouble.head._2
+    expected.intDouble.head._2 mustEqual actual.intDouble.head._2
+    actual.boolDate.head._2.isInstanceOf[Date]
+    true
+  }
+
+  "Map encoders/decoders" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    val q = quote(query[MapsEntity])
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    verify(e, ctx.run(q.filter(_.id == 1)).head)
+  }
+
+  "Empty maps and optional fields" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    case class Entity(
+      id:         Int,
+      intDouble:  Option[Map[Int, Double]],
+      longDouble: Option[Map[Long, Double]]
+    )
+    val e = Entity(1, None, None)
+    val q = quote(querySchema[Entity]("MapEntity"))
+
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    ctx.run(q.filter(_.id == 1)).head mustBe e
+  }
+
+  "Map in where clause" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    case class MapFrozen(id: Map[Int, Boolean])
+    val e = MapFrozen(Map(1 -> true))
+    val q = quote(query[MapFrozen])
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    ctx.run(q.filter(p => liftQuery(Set(1))
+      .contains(p.id))).head.id.head._2 mustBe e.id.head._2
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBContextMacroSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBContextMacroSpec.scala
@@ -1,0 +1,53 @@
+package io.getquill.context.orientdb
+
+import io.getquill.Spec
+import io.getquill.context.mirror.Row
+
+class OrientDBContextMacroSpec extends Spec {
+
+  "runs queries" - {
+    "static" in {
+      val mirrorContext = orientdb.mirrorContext
+      import mirrorContext._
+      val q = quote {
+        qr1.filter(t => t.i == lift(1))
+      }
+      val mirror = mirrorContext.run(q)
+      mirror.string mustEqual "SELECT s, i, l, o FROM TestEntity WHERE i = ?"
+      mirror.prepareRow mustEqual Row(1)
+    }
+    "dynamic" in {
+      val mirrorContext = orientdb.mirrorContext
+      import mirrorContext._
+      val q: Quoted[Query[TestEntity]] = quote {
+        qr1.filter(t => t.i == lift(1))
+      }
+      val mirror = mirrorContext.run(q)
+      mirror.string mustEqual "SELECT s, i, l, o FROM TestEntity WHERE i = ?"
+      mirror.prepareRow mustEqual Row(1)
+    }
+  }
+
+  "binds inputs according to the orientQl terms order" - {
+    "filter.update" in {
+      val mirrorContext = orientdb.mirrorContext
+      import mirrorContext._
+      val q = quote {
+        qr1.filter(t => t.i == lift(1)).update(t => t.l -> lift(2L))
+      }
+      val mirror = mirrorContext.run(q)
+      mirror.string mustEqual "UPDATE TestEntity SET l = ? WHERE i = ?"
+      mirror.prepareRow mustEqual Row(2L, 1)
+    }
+    "filter.map" in {
+      val mirrorContext = orientdb.mirrorContext
+      import mirrorContext._
+      val q = quote {
+        qr1.filter(t => t.i == lift(1)).map(t => lift(2L))
+      }
+      val mirror = mirrorContext.run(q)
+      mirror.string mustEqual "SELECT ? FROM TestEntity WHERE i = ?"
+      mirror.prepareRow mustEqual Row(2L, 1)
+    }
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBContextSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBContextSpec.scala
@@ -1,0 +1,38 @@
+package io.getquill.context.orientdb
+
+import io.getquill.Spec
+
+class OrientDBContextSpec extends Spec {
+
+  "run non-batched select" - {
+
+    "async" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      case class TestEntity(id: Int, s: String, i: Int, l: Long, o: Int)
+      val select = quote {
+        query[TestEntity].filter(_.id == lift(1))
+      }
+      ctx.run(select).get() mustEqual List()
+    }
+    "sync" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      case class TestEntity(id: Int, s: String, i: Int, l: Long, o: Int)
+      val select = quote {
+        query[TestEntity].filter(_.id == lift(1))
+      }
+      ctx.run(select) mustEqual List()
+    }
+  }
+
+  "run non-batched action" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    case class TestEntity(id: Int, s: String, i: Int, l: Long, o: Int)
+    val update = quote {
+      query[TestEntity].filter(_.id == lift(1)).update(_.i -> lift(1))
+    }
+    ctx.run(update) mustEqual (())
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
@@ -1,0 +1,342 @@
+package io.getquill.context.orientdb
+
+import io.getquill.Spec
+
+class OrientDBIdiomSpec extends Spec {
+
+  val ctx = orientdb.mirrorContext
+  import ctx._
+
+  "query" - {
+    "map" in {
+      val q = quote {
+        qr1.map(t => t.i)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT i FROM TestEntity"
+    }
+    "take" in {
+      val q = quote {
+        qr1.take(1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity LIMIT 1"
+    }
+    "sortBy" in {
+      val q = quote {
+        qr1.sortBy(t => t.i)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity ORDER BY i ASC"
+    }
+    "allTerms" in {
+      val q = quote {
+        qr1.filter(t => t.i == 1).sortBy(t => t.s).take(1).map(t => t.s)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s FROM TestEntity WHERE i = 1 ORDER BY s ASC LIMIT 1"
+    }
+  }
+
+  "distinct" - {
+    "simple" in {
+      val q = quote {
+        qr1.distinct
+      }
+      "mirrorContext.run(q).string" mustNot compile
+    }
+    "distinct single" in {
+      val q = quote {
+        qr1.map(i => i.i).distinct
+      }
+      ctx.run(q).string mustEqual
+        "SELECT DISTINCT(i) FROM TestEntity"
+    }
+
+    "distinct tuple" in {
+      val q = quote {
+        qr1.map(i => (i.i, i.l)).distinct
+      }
+      "mirrorContext.run(q).string" mustNot compile
+    }
+  }
+
+  "order by criteria" - {
+    "asc" in {
+      val q = quote {
+        qr1.sortBy(t => t.i)(Ord.asc)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity ORDER BY i ASC"
+    }
+    "desc" in {
+      val q = quote {
+        qr1.sortBy(t => t.i)(Ord.desc)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity ORDER BY i DESC"
+    }
+    "ascNullsFirst" in {
+      val q = quote {
+        qr1.sortBy(t => t.i)(Ord.ascNullsFirst)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity ORDER BY i ASC"
+    }
+    "descNullsFirst" in {
+      val q = quote {
+        qr1.sortBy(t => t.i)(Ord.descNullsFirst)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity ORDER BY i DESC"
+    }
+    "ascNullsLast" in {
+      val q = quote {
+        qr1.sortBy(t => t.i)(Ord.ascNullsLast)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity ORDER BY i ASC"
+    }
+    "descNullsLast" in {
+      val q = quote {
+        qr1.sortBy(t => t.i)(Ord.descNullsLast)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity ORDER BY i DESC"
+    }
+  }
+
+  "operation" - {
+    "binary" in {
+      val q = quote {
+        qr1.filter(t => t.i == 1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE i = 1"
+    }
+    "unary (not supported)" in {
+      val q = quote {
+        qr1.filter(t => !(t.i == 1))
+      }
+      "mirrorContext.run(q)" mustNot compile
+    }
+    "function apply (not supported)" in {
+      val q = quote {
+        qr1.filter(t => infix"f".as[Int => Boolean](t.i))
+      }
+      "mirrorContext.run(q)" mustNot compile
+    }
+  }
+
+  "aggregation" - {
+    "count" in {
+      val q = quote {
+        qr1.filter(t => t.i == 1).size
+      }
+      ctx.run(q).string mustEqual
+        "SELECT COUNT(*) FROM TestEntity WHERE i = 1"
+    }
+    "max" in {
+      val q = quote {
+        qr1.map(t => t.i).max
+      }
+      ctx.run(q).string mustEqual
+        "SELECT MAX(i) FROM TestEntity"
+    }
+  }
+
+  "binary operation" - {
+    "==" in {
+      val q = quote {
+        qr1.filter(t => t.i == 1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE i = 1"
+    }
+    "&&" in {
+      val q = quote {
+        qr1.filter(t => t.i == 1 && t.s == "s")
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE (i = 1) AND (s = 's')"
+    }
+    ">" in {
+      val q = quote {
+        qr1.filter(t => t.i > 1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE i > 1"
+    }
+    ">=" in {
+      val q = quote {
+        qr1.filter(t => t.i >= 1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE i >= 1"
+    }
+    "<" in {
+      val q = quote {
+        qr1.filter(t => t.i < 1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE i < 1"
+    }
+    "<=" in {
+      val q = quote {
+        qr1.filter(t => t.i <= 1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE i <= 1"
+    }
+    "+" in {
+      val q = quote {
+        qr1.update(t => t.i -> 1)
+      }
+      ctx.run(q).string mustEqual
+        "UPDATE TestEntity SET i = 1"
+    }
+    "*" in {
+      val q = quote {
+        qr1.filter(t => t.i * 2 == 4)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE (i * 2) = 4"
+    }
+    "-" in {
+      val q = quote {
+        qr1.filter(t => t.i - 1 == 1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE (i - 1) = 1"
+    }
+    "/" in {
+      val q = quote {
+        qr1.filter(t => t.i / 1 == 1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE (i / 1) = 1"
+    }
+    "%" in {
+      val q = quote {
+        qr1.filter(t => t.i % 1 == 0)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE (i % 1) = 0"
+    }
+  }
+  "value" - {
+    "string" in {
+      val q = quote {
+        qr1.filter(t => t.s == "a")
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE s = 'a'"
+    }
+    "unit" in {
+      case class Test(u: Unit)
+      val q = quote {
+        query[Test].filter(t => t.u == (())).size
+      }
+      ctx.run(q).string mustEqual
+        "SELECT COUNT(*) FROM Test WHERE u = 1"
+    }
+    "int" in {
+      val q = quote {
+        qr1.filter(t => t.i == 1)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE i = 1"
+    }
+    "tuple" in {
+      val q = quote {
+        qr1.map(t => (t.i, t.s))
+      }
+      ctx.run(q).string mustEqual
+        "SELECT i, s FROM TestEntity"
+    }
+    "null" in {
+      val q = quote {
+        qr1.filter(t => t.s == null)
+      }
+      ctx.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity WHERE s IS NULL"
+    }
+  }
+
+  "action" - {
+    "insert" in {
+      val q = quote {
+        qr1.insert(lift(TestEntity("a", 1, 1L, None)))
+      }
+      ctx.run(q).string mustEqual
+        "INSERT INTO TestEntity (s, i, l, o) VALUES(?, ?, ?, ?)"
+    }
+    "update" - {
+      "all" in {
+        val q = quote {
+          qr1.update(lift(TestEntity("a", 1, 1L, None)))
+        }
+        ctx.run(q).string mustEqual
+          "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ?"
+      }
+      "filtered" in {
+        val q = quote {
+          qr1.filter(t => t.i == 1).update(lift(TestEntity("a", 1, 1L, None)))
+        }
+        ctx.run(q).string mustEqual
+          "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? WHERE i = 1"
+      }
+    }
+    "delete" - {
+      "filtered" in {
+        val q = quote {
+          qr1.filter(t => t.i == 1).delete
+        }
+        ctx.run(q).string mustEqual
+          "DELETE FROM TestEntity WHERE i = 1"
+      }
+      "all" in {
+        val q = quote {
+          qr1.delete
+        }
+        ctx.run(q).string mustEqual
+          "DELETE FROM TestEntity"
+      }
+    }
+  }
+
+  "infix" - {
+    "query" - {
+      "partial" in {
+        val q = quote {
+          qr1.filter(t => infix"${t.i} = 1".as[Boolean])
+        }
+        ctx.run(q).string mustEqual
+          "SELECT s, i, l, o FROM TestEntity WHERE i = 1"
+      }
+      "full" in {
+        val q = quote {
+          infix"SELECT MODE(i) FROM TestEntity".as[Query[Int]]
+        }
+        ctx.run(q).string mustEqual
+          "SELECT * FROM (SELECT MODE(i) FROM TestEntity)"
+      }
+    }
+    "action" - {
+      "partial" in {
+        val q = quote {
+          qr1.filter(t => infix"${t.i} = 1".as[Boolean]).update(lift(TestEntity("a", 1, 1L, None)))
+        }
+        ctx.run(q).string mustEqual
+          "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? WHERE i = 1"
+      }
+      "full" in {
+        val q = quote {
+          infix"DELETE FROM TestEntity".as[Action[Int]]
+        }
+        ctx.run(q).string mustEqual
+          "DELETE FROM TestEntity"
+      }
+    }
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBQuerySpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBQuerySpec.scala
@@ -1,0 +1,175 @@
+package io.getquill.context.orientdb
+
+import io.getquill._
+
+class OrientDBQuerySpec extends Spec {
+
+  val mirrorContext = orientdb.mirrorContext
+  import mirrorContext._
+
+  "map" - {
+    "property" in {
+      val q = quote {
+        qr1.map(t => t.i)
+      }
+      mirrorContext.run(q).string mustEqual
+        "SELECT i FROM TestEntity"
+    }
+    "tuple" in {
+      val q = quote {
+        qr1.map(t => (t.i, t.s))
+      }
+      mirrorContext.run(q).string mustEqual
+        "SELECT i, s FROM TestEntity"
+    }
+    "other" in {
+      val q = quote {
+        qr1.map(t => "s")
+      }
+      mirrorContext.run(q).string mustEqual
+        "SELECT 's' FROM TestEntity"
+    }
+  }
+
+  "take" in {
+    val q = quote {
+      qr1.take(1)
+    }
+    mirrorContext.run(q).string mustEqual
+      "SELECT s, i, l, o FROM TestEntity LIMIT 1"
+  }
+
+  "sortBy" - {
+    "property" in {
+      val q = quote {
+        qr1.sortBy(t => t.i)
+      }
+      mirrorContext.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity ORDER BY i ASC"
+    }
+    "tuple" in {
+      val q = quote {
+        qr1.sortBy(t => (t.i, t.s))
+      }
+      mirrorContext.run(q).string mustEqual
+        "SELECT s, i, l, o FROM TestEntity ORDER BY i ASC, s ASC"
+    }
+    "custom ordering" - {
+      "property" in {
+        val q = quote {
+          qr1.sortBy(t => t.i)(Ord.desc)
+        }
+        mirrorContext.run(q).string mustEqual
+          "SELECT s, i, l, o FROM TestEntity ORDER BY i DESC"
+      }
+      "tuple" in {
+        val q = quote {
+          qr1.sortBy(t => (t.i, t.s))(Ord(Ord.asc, Ord.desc))
+        }
+        mirrorContext.run(q).string mustEqual
+          "SELECT s, i, l, o FROM TestEntity ORDER BY i ASC, s DESC"
+      }
+      "tuple single ordering" in {
+        val q = quote {
+          qr1.sortBy(t => (t.i, t.s))(Ord.desc)
+        }
+        mirrorContext.run(q).string mustEqual
+          "SELECT s, i, l, o FROM TestEntity ORDER BY i DESC, s DESC"
+      }
+    }
+  }
+
+  "filter" in {
+    val q = quote {
+      qr1.filter(t => t.i == 1)
+    }
+    mirrorContext.run(q).string mustEqual
+      "SELECT s, i, l, o FROM TestEntity WHERE i = 1"
+  }
+
+  "entity" in {
+    mirrorContext.run(qr1).string mustEqual
+      "SELECT s, i, l, o FROM TestEntity"
+  }
+
+  "aggregation" - {
+    "min" in {
+      val q = quote {
+        qr1.map(t => t.i).min
+      }
+
+      mirrorContext.run(q).string mustEqual
+        "SELECT MIN(i) FROM TestEntity"
+    }
+    "max" in {
+      val q = quote {
+        qr1.map(t => t.i).max
+      }
+
+      mirrorContext.run(q).string mustEqual
+        "SELECT MAX(i) FROM TestEntity"
+    }
+    "sum" in {
+      val q = quote {
+        qr1.map(t => t.i).sum
+      }
+
+      mirrorContext.run(q).string mustEqual
+        "SELECT SUM(i) FROM TestEntity"
+    }
+    "avg" in {
+      val q = quote {
+        qr1.map(t => t.i).avg
+      }
+      mirrorContext.run(q).string mustEqual
+        "SELECT AVG(i) FROM TestEntity"
+    }
+    "count" in {
+      val q = quote {
+        qr1.filter(t => t.i == 1).size
+      }
+      mirrorContext.run(q).string mustEqual
+        "SELECT COUNT(*) FROM TestEntity WHERE i = 1"
+    }
+  }
+
+  "distinct query" in {
+    val q = quote {
+      qr1.map(t => t.i).distinct
+    }
+    mirrorContext.run(q).string mustEqual
+      "SELECT DISTINCT(i) FROM TestEntity"
+  }
+
+  "all terms" in {
+    val q = quote {
+      qr1.filter(t => t.i == 1).sortBy(t => t.s).take(1).map(t => t.s)
+    }
+    mirrorContext.run(q).string mustEqual
+      "SELECT s FROM TestEntity WHERE i = 1 ORDER BY s ASC LIMIT 1"
+  }
+
+  "groupBy supported" in {
+    val q = quote {
+      qr1.groupBy(t => t.s).map(t => t._1)
+    }
+    mirrorContext.run(q).string mustEqual
+      "SELECT s FROM TestEntity GROUP BY s"
+  }
+
+  "union supported" in {
+    val q = quote {
+      qr1.filter(_.i == 0).union(qr1.filter(_.i == 1))
+    }
+    mirrorContext.run(q).string mustEqual
+      f"SELECT s, i, l, o FROM (SELECT $$c LET $$a = (SELECT s, i, l, o FROM TestEntity WHERE i = 0), $$b = (SELECT s, i, l, o FROM TestEntity WHERE i = 1), $$c = UNIONALL($$a, $$b))"
+  }
+
+  "unionall supported" in {
+    val q = quote {
+      qr1.filter(_.i == 0).unionAll(qr1.filter(_.i == 1))
+    }
+    mirrorContext.run(q).string mustEqual
+      f"SELECT s, i, l, o FROM (SELECT $$c LET $$a = (SELECT s, i, l, o FROM TestEntity WHERE i = 0), $$b = (SELECT s, i, l, o FROM TestEntity WHERE i = 1), $$c = UNIONALL($$a, $$b))"
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/PeopleOrientDBSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/PeopleOrientDBSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.orientdb
+
+import io.getquill.Spec
+
+class PeopleOrientDBSpec extends Spec {
+
+  case class Person(id: Int, name: String, age: Int)
+
+  override protected def beforeAll(): Unit = {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    val entries = List(
+      Person(1, "Bob", 30),
+      Person(2, "Gus", 40),
+      Person(3, "Pet", 20),
+      Person(4, "Don", 50),
+      Person(5, "Dre", 60)
+    )
+    ctx.run(query[Person].delete)
+    ctx.run(liftQuery(entries).foreach(e => query[Person].insert(e)))
+    ()
+  }
+
+  "Contains id" - {
+    "empty" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      val q = quote {
+        (ids: Query[Int]) => query[Person].filter(p => ids.contains(p.id))
+      }
+      ctx.run(q(liftQuery(Set.empty[Int]))) mustEqual List.empty[Person]
+    }
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBAsync.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBAsync.scala
@@ -1,0 +1,73 @@
+package io.getquill.context.orientdb
+
+import io.getquill.Spec
+
+class QueryResultTypeOrientDBAsync extends Spec {
+
+  case class OrderTestEntity(id: Int, i: Int)
+
+  val entries = List(
+    OrderTestEntity(1, 1),
+    OrderTestEntity(2, 2),
+    OrderTestEntity(3, 3)
+  )
+
+  override protected def beforeAll(): Unit = {
+    val ctx = orientdb.testAsyncDB
+    import ctx._
+    ctx.run(quote(query[OrderTestEntity].delete))
+    entries.foreach(e => ctx.run(quote { query[OrderTestEntity].insert(lift(e)) }))
+  }
+
+  "return list" - {
+    "select" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity])).get() must contain theSameElementsAs (entries)
+      ctx.close()
+    }
+    "map" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].map(_.id))).get() must contain theSameElementsAs (entries.map(_.id))
+      ctx.close()
+    }
+    "filter" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].filter(_.id == 1))).get() mustEqual entries.take(1)
+      ctx.close()
+    }
+    "withFilter" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].withFilter(_.id == 1))).get() mustEqual entries.take(1)
+      ctx.close()
+    }
+    "sortBy" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].filter(_.id == 1).sortBy(_.i)(Ord.asc))).get() mustEqual entries.take(1)
+      ctx.close()
+    }
+    "take" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].take(10))).get() must contain theSameElementsAs (entries)
+      ctx.close()
+    }
+  }
+
+  "return single result" - {
+    "size" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].size)).get() == entries.size
+    }
+    "paramlize size" in {
+      val ctx = orientdb.testAsyncDB
+      import ctx._
+      ctx.run(quote { query[OrderTestEntity].filter(_.id == lift(0)).size }).get() == 0
+    }
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBSync.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBSync.scala
@@ -1,0 +1,73 @@
+package io.getquill.context.orientdb
+
+import io.getquill.Spec
+
+class QueryResultTypeOrientDBSync extends Spec {
+
+  case class OrderTestEntity(id: Int, i: Int)
+
+  val entries = List(
+    OrderTestEntity(1, 1),
+    OrderTestEntity(2, 2),
+    OrderTestEntity(3, 3)
+  )
+
+  override protected def beforeAll(): Unit = {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    ctx.run(quote(query[OrderTestEntity].delete))
+    entries.foreach(e => ctx.run(quote { query[OrderTestEntity].insert(lift(e)) }))
+  }
+
+  "return list" - {
+    "select" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity])) must contain theSameElementsAs (entries)
+      ctx.close()
+    }
+    "map" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].map(_.id))) must contain theSameElementsAs (entries.map(_.id))
+      ctx.close()
+    }
+    "filter" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].filter(_.id == 1))) mustEqual entries.take(1)
+      ctx.close()
+    }
+    "withFilter" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].withFilter(_.id == 1))) mustEqual entries.take(1)
+      ctx.close()
+    }
+    "sortBy" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].filter(_.id == 1).sortBy(_.i)(Ord.asc))) mustEqual entries.take(1)
+      ctx.close()
+    }
+    "take" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].take(10))) must contain theSameElementsAs (entries)
+      ctx.close()
+    }
+  }
+
+  "return single result" - {
+    "size" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      ctx.run(quote(query[OrderTestEntity].size)) mustEqual entries.size
+    }
+    "paramlize size" in {
+      val ctx = orientdb.testSyncDB
+      import ctx._
+      ctx.run(quote { query[OrderTestEntity].filter(_.id == lift(0)).size }) mustEqual 0
+    }
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/SetsEncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/SetsEncodingSpec.scala
@@ -1,0 +1,77 @@
+package io.getquill.context.orientdb
+
+import java.util.Date
+
+import io.getquill.Spec
+
+class SetsEncodingSpec extends Spec {
+
+  case class SetsEntity(
+    id:         Int,
+    texts:      Set[String],
+    bools:      Set[Boolean],
+    ints:       Set[Int],
+    longs:      Set[Long],
+    doubles:    Set[Double],
+    timestamps: Set[Date]
+  )
+
+  val e = SetsEntity(1, Set("c"), Set(true), Set(1), Set(2),
+    Set(5.5d), Set(new Date()))
+
+  private def verify(expected: SetsEntity, actual: SetsEntity): Boolean = {
+    expected.id mustEqual actual.id
+    expected.texts mustEqual actual.texts
+    expected.bools mustEqual actual.bools
+    expected.ints mustEqual actual.ints
+    expected.longs mustEqual actual.longs
+    expected.doubles mustEqual actual.doubles
+    expected.timestamps.isInstanceOf[Date]
+  }
+
+  "Set encoders/decoders" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    val q = quote(query[SetsEntity])
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    verify(e, ctx.run(q.filter(_.id == 1)).head)
+  }
+
+  "Empty Lists and optional fields" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    case class Entity(id: Int, texts: Option[List[String]], bools: Option[List[String]])
+    val e = Entity(1, Some(List("1", "2")), None)
+    val q = quote(querySchema[Entity]("ListEntity"))
+
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    ctx.run(q.filter(_.id == 1)).head mustBe e
+  }
+
+  "Blob (Array[Byte]) support" ignore {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    case class BlobsEntity(id: Int, blobs: List[Array[Byte]])
+    val e = BlobsEntity(1, List(Array(1.toByte, 2.toByte), Array(2.toByte)))
+    val q = quote(querySchema[BlobsEntity]("BlobsEntity"))
+
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    ctx.run(q.filter(_.id == 1))
+      .head.blobs.map(_.toList) mustBe e.blobs.map(_.toList)
+  }
+
+  "Set in where clause" in {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    case class ListFrozen(id: List[Int])
+    val e = ListFrozen(List(1, 2))
+    val q = quote(query[ListFrozen])
+    ctx.run(q.delete)
+    ctx.run(q.insert(lift(e)))
+    ctx.run(q.filter(p => liftQuery(Set(1)).contains(p.id))) mustBe List(e)
+    ctx.run(q.filter(_.id == lift(List(1)))) mustBe Nil
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/orientdb.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/orientdb.scala
@@ -1,0 +1,66 @@
+package io.getquill.context.orientdb
+
+import com.orientechnologies.orient.client.remote.OServerAdmin
+import com.orientechnologies.orient.core.db.OPartitionedDatabasePool
+import com.orientechnologies.orient.core.metadata.schema.OSchemaProxy
+import io.getquill._
+
+object orientdb {
+  private val dbUrl = "remote:orientdb:2424"
+  private val databaseName = "GratefulDeadConcerts"
+  private val databaseType = "document"
+  private val storageMode = "memory"
+  private val username = "root"
+  private val password = "root"
+  private var setupDone = false
+
+  private def setup(): Unit = {
+    val existsDatabase = new OServerAdmin(dbUrl)
+      .connect(username, password)
+      .existsDatabase(databaseName, storageMode)
+
+    if (!existsDatabase) {
+      new OServerAdmin(dbUrl)
+        .connect(username, password)
+        .createDatabase(databaseName, databaseType, storageMode).close()
+    }
+    val dbConnection = new OPartitionedDatabasePool(s"$dbUrl/$databaseName", username, password).acquire()
+    val schema = dbConnection.getMetadata.getSchema
+    getOrCreateClass(schema, "DecodeNullTestEntity")
+    getOrCreateClass(schema, "EncodingTestEntity")
+    getOrCreateClass(schema, "ListEntity")
+    getOrCreateClass(schema, "ListsEntity")
+    getOrCreateClass(schema, "ListFrozen")
+    getOrCreateClass(schema, "MapEntity")
+    getOrCreateClass(schema, "MapsEntity")
+    getOrCreateClass(schema, "MapFrozen")
+    getOrCreateClass(schema, "TestEntity")
+    getOrCreateClass(schema, "TestEntity2")
+    getOrCreateClass(schema, "TestEntity3")
+    getOrCreateClass(schema, "Person")
+    getOrCreateClass(schema, "OrderTestEntity")
+    getOrCreateClass(schema, "SetsEntity")
+  }
+
+  private def getOrCreateClass(iSchema: OSchemaProxy, iClassName: String): Unit = {
+    if (!iSchema.existsClass(iClassName)) {
+      iSchema.createClass(iClassName)
+      ()
+    }
+  }
+
+  def mirrorContext = {
+    if (!setupDone) { setup(); setupDone = true }
+    new OrientDBMirrorContext with TestEntities
+  }
+
+  def testSyncDB = {
+    if (!setupDone) { setup(); setupDone = true }
+    new OrientDBSyncContext[Literal](s"$dbUrl/$databaseName", username, password)
+  }
+
+  def testAsyncDB = {
+    if (!setupDone) { setup(); setupDone = true }
+    new OrientDBAsyncContext[Literal](s"$dbUrl/$databaseName", username, password)
+  }
+}


### PR DESCRIPTION
Partially Fixes #46 

### Problem
OrientDB provides support for both documents & graphs.
There is no support for OrientDB document as of now.

### Solution
This PR enables quill to support OrientDB documents.

### Notes

Supports almost all the features that OrientDB documents currently support.

### Checklist

- Unit test all changes
- `README.md` not yet updated.

@getquill/maintainers

### Checklist

- Unit test all changes
- Update `README.md` still not done

@getquill/maintainers
