### PR TITLE
Add url configuration property for quill-async.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,6 +1355,48 @@ ctx.transaction { implicit ec =>
 
 Note that the global execution context is renamed to ec.
 
+#### application.properties
+
+##### connection configuration
+```
+ctx.host=host
+ctx.port=1234
+ctx.user=root
+ctx.password=root
+ctx.database=database
+`````
+
+or use connection URL with database-specific scheme (see below):
+
+```
+ctx.url=scheme://host:5432/database?user=root&password=root
+```
+
+##### connection pool configuration
+```
+ctx.poolMaxQueueSize=4
+ctx.poolMaxObjects=4
+ctx.poolMaxIdle=999999999
+ctx.poolValidationInterval=10000
+```
+
+Also see [`PoolConfiguration` documentation](https://github.com/mauricio/postgresql-async/blob/master/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PoolConfiguration.scala).
+
+##### SSL configuration
+```
+ctx.sslmode=disable # optional, one of [disable|prefer|require|verify-ca|verify-full]
+ctx.sslrootcert=./path/to/cert/file # optional, required for sslmode=verify-ca or verify-full
+```
+
+##### other
+```
+ctx.charset=UTF-8
+ctx.maximumMessageSize=16777216
+ctx.connectTimeout=5s
+ctx.testTimeout=5s
+ctx.queryTimeout=10m
+```
+
 ### quill-async-mysql
 
 #### sbt dependencies
@@ -1370,18 +1412,13 @@ lazy val ctx = new MysqlAsyncContext[SnakeCase]("ctx")
 ```
 
 #### application.properties
+
+See [above](#applicationproperties-5)
+
+For `url` property use `mysql` scheme:
+
 ```
-ctx.host=host
-ctx.port=3306
-ctx.user=root
-ctx.password=root
-ctx.database=database
-ctx.poolMaxQueueSize=4
-ctx.poolMaxObjects=4
-ctx.poolMaxIdle=999999999
-ctx.poolValidationInterval=10000
-ctx.sslmode=disable # optional, one of [disable|prefer|require|verify-ca|verify-full]
-ctx.sslrootcert=./path/to/cert/file # optional, required for sslmode=verify-ca or verify-full
+ctx.url=mysql://host:3306/database?user=root&password=root
 ```
 
 ### quill-async-postgres
@@ -1399,18 +1436,13 @@ lazy val ctx = new PostgresAsyncContext[SnakeCase]("ctx")
 ```
 
 #### application.properties
+
+See [common properties](#applicationproperties-5)
+
+For `url` property use `postgresql` scheme:
+
 ```
-ctx.host=host
-ctx.port=5432
-ctx.user=root
-ctx.password=root
-ctx.database=database
-ctx.poolMaxQueueSize=4
-ctx.poolMaxObjects=4
-ctx.poolMaxIdle=999999999
-ctx.poolValidationInterval=10000
-ctx.sslmode=disable # optional, one of [disable|prefer|require|verify-ca|verify-full]
-ctx.sslrootcert=./path/to/cert/file # optional, required for sslmode=verify-ca or verify-full
+ctx.url=postgresql://host:5432/database?user=root&password=root
 ```
 
 ### quill-finagle-mysql

--- a/quill-async-mysql/src/main/scala/io/getquill/MysqlAsyncContextConfig.scala
+++ b/quill-async-mysql/src/main/scala/io/getquill/MysqlAsyncContextConfig.scala
@@ -2,9 +2,9 @@ package io.getquill
 
 import com.github.mauricio.async.db.mysql.MySQLConnection
 import com.github.mauricio.async.db.mysql.pool.MySQLConnectionFactory
+import com.github.mauricio.async.db.mysql.util.URLParser
 import com.typesafe.config.Config
-
 import io.getquill.context.async.AsyncContextConfig
 
 case class MysqlAsyncContextConfig(config: Config)
-  extends AsyncContextConfig[MySQLConnection](config, new MySQLConnectionFactory(_))
+  extends AsyncContextConfig[MySQLConnection](config, new MySQLConnectionFactory(_), URLParser)

--- a/quill-async-postgres/src/main/scala/io/getquill/PostgresAsyncContextConfig.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/PostgresAsyncContextConfig.scala
@@ -2,9 +2,9 @@ package io.getquill
 
 import com.github.mauricio.async.db.postgresql.PostgreSQLConnection
 import com.github.mauricio.async.db.postgresql.pool.PostgreSQLConnectionFactory
+import com.github.mauricio.async.db.postgresql.util.URLParser
 import com.typesafe.config.Config
-
 import io.getquill.context.async.AsyncContextConfig
 
 case class PostgresAsyncContextConfig(config: Config)
-  extends AsyncContextConfig[PostgreSQLConnection](config, new PostgreSQLConnectionFactory(_))
+  extends AsyncContextConfig[PostgreSQLConnection](config, new PostgreSQLConnectionFactory(_), URLParser)

--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContextConfig.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContextConfig.scala
@@ -1,39 +1,62 @@
 package io.getquill.context.async
 
+import java.nio.charset.Charset
+
 import com.github.mauricio.async.db.Configuration
 import com.github.mauricio.async.db.Connection
 import com.github.mauricio.async.db.SSLConfiguration
 import com.github.mauricio.async.db.pool.ObjectFactory
 import com.github.mauricio.async.db.pool.PartitionedConnectionPool
 import com.github.mauricio.async.db.pool.PoolConfiguration
+import com.github.mauricio.async.db.util.AbstractURIParser
 import com.typesafe.config.Config
 
+import scala.concurrent.duration.Duration
 import scala.util.Try
 
 abstract class AsyncContextConfig[C <: Connection](
   config:            Config,
-  connectionFactory: Configuration => ObjectFactory[C]
+  connectionFactory: Configuration => ObjectFactory[C],
+  uriParser:         AbstractURIParser
 ) {
-
-  def user = config.getString("user")
+  def url = Try(config.getString("url")).toOption
+  def user = Try(config.getString("user")).toOption
   def password = Try(config.getString("password")).toOption
   def database = Try(config.getString("database")).toOption
-  def port = config.getInt("port")
-  def host = config.getString("host")
+  def port = Try(config.getInt("port")).toOption
+  def host = Try(config.getString("host")).toOption
   def sslProps = Map(
     "sslmode" -> Try(config.getString("sslmode")).toOption,
     "sslrootcert" -> Try(config.getString("sslrootcert")).toOption
   ).collect { case (key, Some(value)) => key -> value }
+  def charset = Try(Charset.forName(config.getString("charset"))).toOption
+  def maximumMessageSize = Try(config.getInt("maximumMessageSize")).toOption
+  def connectTimeout = Try(Duration(config.getString("connectTimeout"))).toOption
+  def testTimeout = Try(Duration(config.getString("testTimeout"))).toOption
+  def queryTimeout = Try(Duration(config.getString("queryTimeout"))).toOption
 
-  def configuration =
-    new Configuration(
-      username = user,
-      password = password,
-      database = database,
-      port = port,
-      host = host,
-      ssl = SSLConfiguration(sslProps)
-    )
+  def configuration = {
+    var c =
+      url match {
+        case Some(url) => uriParser.parseOrDie(url)
+        case _         => uriParser.DEFAULT
+      }
+    user.foreach(p => c = c.copy(username = p))
+    if (password.nonEmpty) {
+      c = c.copy(password = password)
+    }
+    if (database.nonEmpty) {
+      c = c.copy(database = database)
+    }
+    port.foreach(p => c = c.copy(port = p))
+    host.foreach(p => c = c.copy(host = p))
+    c = c.copy(ssl = SSLConfiguration(sslProps))
+    charset.foreach(p => c = c.copy(charset = p))
+    maximumMessageSize.foreach(p => c = c.copy(maximumMessageSize = p))
+    connectTimeout.foreach(p => c = c.copy(connectTimeout = p))
+    testTimeout.foreach(p => c = c.copy(connectTimeout = p))
+    c
+  }
 
   private val defaultPoolConfig = PoolConfiguration.Default
 


### PR DESCRIPTION
Fixes #710

### Solution

- added `url` configuration property (`host`, `port`, etc. properties will change configuration parsed from `url`)
- added other parameters from https://github.com/mauricio/postgresql-async/blob/master/db-async-common/src/main/scala/com/github/mauricio/async/db/Configuration.scala
- merged identical `application.properties` documentation sections from `quill-async-mysql` and `quill-async-postgres` and splitted this section to subsections

I tested url parsing manually by replacing `application.conf` content with:
```
testPostgresDB.url="postgresql://"${?POSTGRES_HOST}":"${?POSTGRES_PORT}"/quill_test?user=postgres"
```
and
```
testMysqlDB.url="mysql://"${?MYSQL_HOST}":"${?MYSQL_PORT}"/quill_test?user=root"
```

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
