### PR TITLE
Batch with `Quoted[Action[T]]` (fixes using infix with batch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,21 @@ implicit class DateQuotes(left: Date) {
 }
 ```
 
+### batch with infix
+
+```scala
+implicit class OnDuplicateKeyIgnore[T](q: Insert[T]) {
+  def ignoreDuplicate = quote(infix"$q ON DUPLICATE KEY UPDATE id=id".as[Insert[T]])
+}
+
+ctx.run(
+  liftQuery(List(
+    Person(1, "Test1", 30),
+    Person(2, "Test2", 31)
+  )).foreach(row => query[Person].insert(row).ignoreDuplicate)
+)
+```
+
 ## Custom encoding
 
 Quill uses `Encoder`s to encode query inputs and `Decoder`s to read values returned by queries. The library provides a few built-in encodings and two mechanisms to define custom encodings: mapped encoding and raw encoding.

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -169,7 +169,7 @@ class MirrorIdiom extends Idiom {
     case Insert(query, assignments)    => stmt"${query.token}.insert(${assignments.token})"
     case Delete(query)                 => stmt"${query.token}.delete"
     case Returning(query, alias, body) => stmt"${query.token}.returning((${alias.token}) => ${body.token})"
-    case Foreach(query, alias, body)   => stmt"${query.token}.forach((${alias.token}) => ${body.token})"
+    case Foreach(query, alias, body)   => stmt"${query.token}.foreach((${alias.token}) => ${body.token})"
   }
 
   implicit def assignmentTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Assignment] = Tokenizer[Assignment] {

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -53,7 +53,12 @@ private[dsl] trait QueryDsl {
 
     def nested: Query[T]
 
-    def foreach[A <: Action[_]](f: T => A): BatchAction[A]
+    /**
+     *
+     * @param unquote is used for conversion of [[Quoted[A]]] to [[A]] with [[unquote]]
+     * @return
+     */
+    def foreach[A <: Action[_], B](f: T => B)(implicit unquote: B => A): BatchAction[A]
   }
 
   sealed trait JoinQuery[A, B, R] extends Query[R] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -416,7 +416,7 @@ trait Parsing {
       Delete(astParser(query))
     case q"$action.returning[$r](($alias) => $body)" =>
       Returning(astParser(action), identParser(alias), astParser(body))
-    case tree @ q"$query.foreach[$t](($alias) => $body)" if (is[CoreDsl#Query[Any]](query)) =>
+    case q"$query.foreach[$t1, $t2](($alias) => $body)($f)" if (is[CoreDsl#Query[Any]](query)) =>
       Foreach(astParser(query), identParser(alias), astParser(body))
   }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -353,6 +353,17 @@ class QuotationSpec extends Spec {
           quote(unquote(q)).ast mustEqual
             Foreach(ScalarQueryLift("q.list", list, intEncoder), Ident("i"), delete.ast.body)
         }
+        "batch with Quoted[Action[T]]" in {
+          case class TestEntity(id: Int)
+          val list = List(
+            TestEntity(1),
+            TestEntity(2)
+          )
+          val insert = quote((row: TestEntity) => query[TestEntity].insert(row))
+          val q = quote(liftQuery(list).foreach(row => quote(insert(row))))
+          quote(unquote(q)).ast mustEqual
+            Foreach(CaseClassQueryLift("q.list", list), Ident("row"), insert.ast.body)
+        }
         "unicode arrow must compile" in {
           """|quote {
              |  qr1.insert(_.s → "new", _.i → 0)


### PR DESCRIPTION
Fixes #705

### Problem

`foreach` has the following signature:

```scala
def foreach[A <: Action[_]](f: T => A): BatchAction[A]
```

When passing value of type `(T) => Insert[T]` as `f`:

```scala
val insert = quote((row: Person) => query[Person].insert(row))
ctx.run(
  liftQuery(List(
    Person("Test1", 30),
    Person("Test2", 31)))
    .foreach(row => insert(row))
)
```

then the compiler sees that we try to use `insert` (which has `Quoted[(Person) => Insert[Person]]` type) as function and applies [`implicit def unquote[T](quoted: Quoted[T]): T`](https://github.com/getquill/quill/blob/77180f9db01bf05e06b379722636e663d862b516/quill-core/src/main/scala/io/getquill/dsl/QuotationDsl.scala#L34) conversion.

But when passing value of type `(T) => Quoted[Insert[Person]]` to `foreach` then the compiler can not determine `foreach` type parameter `A`: 

```scala
import io.getquill._

val ctx = new SqlMirrorContext[PostgresDialect, SnakeCase]

import ctx._

case class Person(name: String, age: Int)

implicit class OnDuplicateKeyIgnore[T](q: Insert[T]) {
  def ignoreDuplicate = quote(infix"$q ON DUPLICATE KEY UPDATE id=id".as[Insert[T]])
}

ctx.run(
  liftQuery(List(
    Person("Test1", 30),
    Person("Test2", 31)))
    .foreach(row => query[Person].insert(row).ignoreDuplicate)
)
```

fails with:
```
inferred type arguments [ScalaFiddle.ctx.Quoted[ScalaFiddle.ctx.Insert[ScalaFiddle.Person]]{def quoted: io.getquill.ast.Infix; def ast: io.getquill.ast.Infix; def id111929041(): Unit; val liftings: Object}] do not conform to method foreach's type parameter bounds [A <: ScalaFiddle.ctx.Action[_]]
      .foreach(row => query[Person].insert(row).ignoreDuplicate)
       ^
type mismatch;
 found   : ScalaFiddle.Person => ScalaFiddle.ctx.Quoted[ScalaFiddle.ctx.Insert[ScalaFiddle.Person]]{def quoted: io.getquill.ast.Infix; def ast: io.getquill.ast.Infix; def id111929041(): Unit; val liftings: Object}
 required: ScalaFiddle.Person => A
      .foreach(row => query[Person].insert(row).ignoreDuplicate)
                   ^
```
[Scalafiddle](https://scalafiddle.io/sf/sBlUKDq/9).

### Solution

There are two workarounds:

1. Specify `foreach` type parameter:
```scala
  .foreach[Insert[Person]](row => query[Person].insert(row).ignoreDuplicate)
```
2. `unquote`:
```scala
   .foreach(row => unquote(query[Person].insert(row).ignoreDuplicate))
```

And two solutions:

3. remove `<: Action[_]` upper type bound [here](https://github.com/getquill/quill/blob/77180f9db01bf05e06b379722636e663d862b516/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala#L90) and [here](https://github.com/getquill/quill/blob/77180f9db01bf05e06b379722636e663d862b516/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala#L56).

4. add implicit conversion function parameter to `foreach` which will consume `unquote` or `identity` to make compiler happy:

```scala
def foreach[A <: Action[_], B](f: T => B)(implicit f2: B => A): BatchAction[A]
```

I implemented solution 4.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
