### PR TITLE
Make `withConnection` method protected in AsyncContext

### DIFF
--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
@@ -36,7 +36,7 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
     ()
   }
 
-  private def withConnection[T](f: Connection => Future[T])(implicit ec: ExecutionContext) =
+  protected def withConnection[T](f: Connection => Future[T])(implicit ec: ExecutionContext) =
     ec match {
       case TransactionalExecutionContext(ec, conn) => f(conn)
       case other                                   => f(pool)


### PR DESCRIPTION
Users have been asking for that enhancemet. JdbcContext has it also as protected

@getquill/maintainers
