### PR TITLE
Update scalafiddle link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import io.getquill._
 val ctx = new SqlMirrorContext[MirrorSqlDialect, Literal]
 ```
 
-> ### **Note:** [Scalafiddle](http://scalafiddle.io) is a great tool to try out Quill without having to prepare a local environment. It works with [mirror contexts](#mirror-context), see [this](https://scalafiddle.io/sf/pMg4JvY/1) fiddle as an example.
+> ### **Note:** [Scalafiddle](http://scalafiddle.io) is a great tool to try out Quill without having to prepare a local environment. It works with [mirror contexts](#mirror-context), see [this](https://scalafiddle.io/sf/lsmX57J/0) fiddle as an example.
 
 The context instance provides all types and methods to deal quotations:
 


### PR DESCRIPTION
### Problem

The scalafiddle example link uses Quill `0.10.0`.

### Solution

Update the link to use a new fiddle with Quill `1.2.1`

### Notes

Ideally this should happen automatically, but I'm not sure how.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
