### PR TITLE
Prepare and Extractor types.

### DIFF
--- a/quill-async-mysql/src/main/scala/io/getquill/MysqlAsyncContext.scala
+++ b/quill-async-mysql/src/main/scala/io/getquill/MysqlAsyncContext.scala
@@ -1,6 +1,6 @@
 package io.getquill
 
-import com.github.mauricio.async.db.{ RowData, QueryResult => DBQueryResult }
+import com.github.mauricio.async.db.{ QueryResult => DBQueryResult }
 import com.github.mauricio.async.db.mysql.MySQLConnection
 import com.github.mauricio.async.db.mysql.MySQLQueryResult
 import com.github.mauricio.async.db.pool.PartitionedConnectionPool
@@ -16,7 +16,7 @@ class MysqlAsyncContext[N <: NamingStrategy](pool: PartitionedConnectionPool[MyS
   def this(config: Config) = this(MysqlAsyncContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 
-  override protected def extractActionResult[O](returningColumn: String, returningExtractor: RowData => O)(result: DBQueryResult): O = {
+  override protected def extractActionResult[O](returningColumn: String, returningExtractor: Extractor[O])(result: DBQueryResult): O = {
     result match {
       case r: MySQLQueryResult =>
         returningExtractor(new ArrayRowData(0, Map.empty, Array(r.lastInsertId)))

--- a/quill-async-postgres/src/main/scala/io/getquill/PostgresAsyncContext.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/PostgresAsyncContext.scala
@@ -1,6 +1,6 @@
 package io.getquill
 
-import com.github.mauricio.async.db.{ RowData, QueryResult => DBQueryResult }
+import com.github.mauricio.async.db.{ QueryResult => DBQueryResult }
 import com.github.mauricio.async.db.pool.PartitionedConnectionPool
 import com.github.mauricio.async.db.postgresql.PostgreSQLConnection
 import com.typesafe.config.Config
@@ -17,7 +17,7 @@ class PostgresAsyncContext[N <: NamingStrategy](pool: PartitionedConnectionPool[
   def this(config: Config) = this(PostgresAsyncContextConfig(config))
   def this(configPrefix: String) = this(LoadConfig(configPrefix))
 
-  override protected def extractActionResult[O](returningColumn: String, returningExtractor: RowData => O)(result: DBQueryResult): O =
+  override protected def extractActionResult[O](returningColumn: String, returningExtractor: Extractor[O])(result: DBQueryResult): O =
     returningExtractor(result.rows.get(0))
 
   override protected def expandAction(sql: String, returningColumn: String): String =

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
@@ -43,9 +43,9 @@ abstract class CassandraSessionContext[N <: NamingStrategy](
       ()
     }
 
-  def executeActionReturning[O](sql: String, prepare: BoundStatement => (List[Any], BoundStatement) = row => (Nil, row), extractor: Row => O, returningColumn: String): Unit =
+  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningColumn: String): Unit =
     fail("Cassandra doesn't support `returning`.")
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Row => T): Unit =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Unit =
     fail("Cassandra doesn't support `returning`.")
 }

--- a/quill-core/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorContext.scala
@@ -35,24 +35,24 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
 
   case class ActionMirror(string: String, prepareRow: PrepareRow)
 
-  case class ActionReturningMirror[T](string: String, prepareRow: Row, extractor: Row => T, returningColumn: String)
+  case class ActionReturningMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T], returningColumn: String)
 
   case class BatchActionMirror(groups: List[(String, List[Row])])
 
-  case class BatchActionReturningMirror[T](groups: List[(String, String, List[Row])], extractor: Row => T)
+  case class BatchActionReturningMirror[T](groups: List[(String, String, List[PrepareRow])], extractor: Extractor[T])
 
-  case class QueryMirror[T](string: String, prepareRow: Row, extractor: Row => T)
+  case class QueryMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T])
 
-  def executeQuery[T](string: String, prepare: Row => (List[Any], Row) = row => (Nil, row), extractor: Row => T = identity[Row] _) =
+  def executeQuery[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor) =
     QueryMirror(string, prepare(Row())._2, extractor)
 
-  def executeQuerySingle[T](string: String, prepare: Row => (List[Any], Row) = row => (Nil, row), extractor: Row => T = identity[Row] _) =
+  def executeQuerySingle[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor) =
     QueryMirror(string, prepare(Row())._2, extractor)
 
-  def executeAction(string: String, prepare: Row => (List[Any], Row) = row => (Nil, row)) =
+  def executeAction(string: String, prepare: Prepare = identityPrepare) =
     ActionMirror(string, prepare(Row())._2)
 
-  def executeActionReturning[O](string: String, prepare: Row => (List[Any], Row) = row => (Nil, row), extractor: Row => O,
+  def executeActionReturning[O](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[O],
                                 returningColumn: String) =
     ActionReturningMirror[O](string, prepare(Row())._2, extractor, returningColumn)
 
@@ -64,7 +64,7 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
       }
     }
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Row => T) =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]) =
     BatchActionReturningMirror[T](
       groups.map {
         case BatchGroupReturning(string, column, prepare) =>

--- a/quill-core/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Context.scala
@@ -18,8 +18,11 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
   type RunBatchActionResult
   type RunBatchActionReturningResult[T]
 
-  case class BatchGroup(string: String, prepare: List[PrepareRow => (List[Any], PrepareRow)])
-  case class BatchGroupReturning(string: String, column: String, prepare: List[PrepareRow => (List[Any], PrepareRow)])
+  type Prepare = PrepareRow => (List[Any], PrepareRow)
+  type Extractor[T] = ResultRow => T
+
+  case class BatchGroup(string: String, prepare: List[Prepare])
+  case class BatchGroupReturning(string: String, column: String, prepare: List[Prepare])
 
   def probe(statement: String): Try[_]
 
@@ -29,6 +32,9 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
   def run[T](quoted: Quoted[ActionReturning[_, T]]): RunActionReturningResult[T] = macro ActionMacro.runActionReturning[T]
   def run(quoted: Quoted[BatchAction[Action[_]]]): RunBatchActionResult = macro ActionMacro.runBatchAction
   def run[T](quoted: Quoted[BatchAction[ActionReturning[_, T]]]): RunBatchActionReturningResult[T] = macro ActionMacro.runBatchActionReturning[T]
+
+  protected val identityPrepare: Prepare = (Nil, _)
+  protected val identityExtractor = identity[ResultRow] _
 
   protected def handleSingleResult[T](list: List[T]) =
     list match {

--- a/quill-orientdb/src/main/scala/io/getquill/OrientDBAsyncContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/OrientDBAsyncContext.scala
@@ -13,7 +13,6 @@ import io.getquill.util.{ ContextLogger, LoadConfig }
 import io.getquill.util.Messages.fail
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 
 class OrientDBAsyncContext[N <: NamingStrategy](
   dbUrl:    String,
@@ -33,7 +32,7 @@ class OrientDBAsyncContext[N <: NamingStrategy](
 
   private val logger = ContextLogger(classOf[OrientDBSyncContext[_]])
 
-  def executeQuery[T](orientQl: String, prepare: ArrayBuffer[Any] => (List[Any], ArrayBuffer[Any]) = row => (Nil, row), extractor: ODocument => T = identity[ODocument] _): Future[List[T]] = {
+  def executeQuery[T](orientQl: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[List[T]] = {
     val (params, objects) = prepare(super.prepare())
     logger.logQuery(orientQl, params)
     oDatabase.command(new OSQLNonBlockingQuery[ODocument](
@@ -58,7 +57,7 @@ class OrientDBAsyncContext[N <: NamingStrategy](
     )).execute[Future[List[T]]](objects.asJava)
   }
 
-  def executeQuerySingle[T](orientQl: String, prepare: ArrayBuffer[Any] => (List[Any], ArrayBuffer[Any]) = row => (Nil, row), extractor: ODocument => T = identity[ODocument] _): Future[T] = {
+  def executeQuerySingle[T](orientQl: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[T] = {
     val (params, objects) = prepare(super.prepare())
     logger.logQuery(orientQl, params)
     oDatabase.command(new OSQLNonBlockingQuery[ODocument](
@@ -83,7 +82,7 @@ class OrientDBAsyncContext[N <: NamingStrategy](
     )).execute[Future[T]](objects.asJava)
   }
 
-  def executeAction[T](orientQl: String, prepare: ArrayBuffer[Any] => (List[Any], ArrayBuffer[Any]) = row => (Nil, row)): Unit = {
+  def executeAction[T](orientQl: String, prepare: Prepare = identityPrepare): Unit = {
     val (params, objects) = prepare(super.prepare())
     logger.logQuery(orientQl, params)
 

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBSessionContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBSessionContext.scala
@@ -2,9 +2,7 @@ package io.getquill.context.orientdb
 
 import com.orientechnologies.orient.core.db.OPartitionedDatabasePool
 import com.orientechnologies.orient.core.record.impl.ODocument
-import com.orientechnologies.orient.core.sql.query.OSQLQuery
 import io.getquill.NamingStrategy
-import io.getquill.context.mirror.Row
 import io.getquill.context.orientdb.encoding.{ Decoders, Encoders }
 import io.getquill.util.Messages.fail
 
@@ -41,11 +39,11 @@ abstract class OrientDBSessionContext[N <: NamingStrategy](
       ()
     }
 
-  def executeActionReturning[O](orientDBQl: String, prepare: OSQLQuery[ODocument] => OSQLQuery[ODocument] = identity, extractor: Row => O, returningColumn: String): Unit = {
+  def executeActionReturning[T](orientDBQl: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor, returningColumn: String): Unit = {
     fail("OrientDB doesn't support `returning`.")
   }
 
-  def executeBatchActionReturning[T](groups: List[BatchGroup], extractor: Row => T): Unit = {
+  def executeBatchActionReturning[T](groups: List[BatchGroup], extractor: Extractor[T]): Unit = {
     fail("OrientDB doesn't support `returning`.")
   }
 }


### PR DESCRIPTION
Introduce `Prepare` and `Extractor[T]` type aliases to simplify and unify signatures of `execute*` methods.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
