### PR TITLE
[WIP] Introduce `headOption` in query dsl

### DIFF
--- a/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/ProductMysqlAsyncSpec.scala
+++ b/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/ProductMysqlAsyncSpec.scala
@@ -97,5 +97,19 @@ class ProductMysqlAsyncSpec extends ProductSpec {
         queried.sku mustEqual 1004L
       }
     }
+
+    "headOption" in {
+      val prd = Product(0L, "test1", 1)
+      val inserted = await(testContext.run(productInsert(lift(prd))))
+      val byRightId = await(testContext.run(productById(lift(inserted)).headOption))
+      val byWrongId = await(testContext.run(productById(lift(1234567L)).headOption))
+      byRightId mustEqual Some(prd.copy(id = inserted))
+      byWrongId mustEqual None
+
+      await(testContext.run(productInsert(lift(Product(0L, "test2", 2)))))
+      intercept[IllegalStateException] {
+        await(testContext.run(query[Product].headOption))
+      }
+    }
   }
 }

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ProductPostgresAsyncSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ProductPostgresAsyncSpec.scala
@@ -96,5 +96,19 @@ class ProductPostgresAsyncSpec extends ProductSpec {
         queried.sku mustEqual 1004L
       }
     }
+
+    "headOption" in {
+      val prd = Product(0L, "test1", 1)
+      val inserted = await(testContext.run(productInsert(lift(prd))))
+      val byRightId = await(testContext.run(productById(lift(inserted)).headOption))
+      val byWrongId = await(testContext.run(productById(lift(1234567L)).headOption))
+      byRightId mustEqual Some(prd.copy(id = inserted))
+      byWrongId mustEqual None
+
+      await(testContext.run(productInsert(lift(Product(0L, "test2", 2)))))
+      intercept[IllegalStateException] {
+        await(testContext.run(query[Product].headOption))
+      }
+    }
   }
 }

--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
@@ -26,6 +26,7 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
 
   override type RunQueryResult[T] = Future[List[T]]
   override type RunQuerySingleResult[T] = Future[T]
+  override type RunQueryHeadOptionResult[T] = Future[Option[T]]
   override type RunActionResult = Future[Long]
   override type RunActionReturningResult[T] = Future[T]
   override type RunBatchActionResult = Future[List[Long]]
@@ -69,6 +70,9 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
 
   def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[T] =
     executeQuery(sql, prepare, extractor).map(handleSingleResult)
+
+  def executeQueryHeadOption[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[Option[T]] =
+    executeQuery(sql, prepare, extractor).map(handleHeadOptionResult)
 
   def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Long] = {
     val (params, values) = prepare(Nil)

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -24,6 +24,7 @@ class CassandraAsyncContext[N <: NamingStrategy](
 
   override type RunQueryResult[T] = Future[List[T]]
   override type RunQuerySingleResult[T] = Future[T]
+  override type RunQueryHeadOptionResult[T] = Future[Option[T]]
   override type RunActionResult = Future[Unit]
   override type RunBatchActionResult = Future[Unit]
 
@@ -36,6 +37,9 @@ class CassandraAsyncContext[N <: NamingStrategy](
 
   def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[T] =
     executeQuery(cql, prepare, extractor).map(handleSingleResult)
+
+  def executeQueryHeadOption[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[Option[T]] =
+    executeQuery(cql, prepare, extractor).map(handleHeadOptionResult)
 
   def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Unit] = {
     val (params, bs) = prepare(super.prepare(cql))

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
@@ -21,6 +21,7 @@ class CassandraSyncContext[N <: NamingStrategy](
 
   override type RunQueryResult[T] = List[T]
   override type RunQuerySingleResult[T] = T
+  override type RunQueryHeadOptionResult[T] = Option[T]
   override type RunActionResult = Unit
   override type RunBatchActionResult = Unit
 
@@ -33,6 +34,9 @@ class CassandraSyncContext[N <: NamingStrategy](
 
   def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): T =
     handleSingleResult(executeQuery(cql, prepare, extractor))
+
+  def executeQueryHeadOption[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Option[T] =
+    handleHeadOptionResult(executeQuery(cql, prepare, extractor))
 
   def executeAction[T](cql: String, prepare: Prepare = identityPrepare): Unit = {
     val (params, bs) = prepare(super.prepare(cql))

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
@@ -39,6 +39,7 @@ trait CqlIdiom extends Idiom {
       case a: Infix      => a.token
       case a: Lift       => a.token
       case a: Assignment => a.token
+      case a: HeadOption => a.ast.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
         _: Val | _: Ordering | _: QuotedReference | _: If

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraAsyncSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraAsyncSpec.scala
@@ -43,4 +43,12 @@ class QueryResultTypeCassandraAsyncSpec extends QueryResultTypeCassandraSpec {
       await(context.run(parametrizedSize(lift(10000)))) mustEqual 0
     }
   }
+
+  "headOption" - {
+    await(context.run(headOptionSome)) mustEqual Some(entries.head)
+    await(context.run(headOptionNone)) mustEqual None
+    intercept[IllegalStateException] {
+      await(context.run(headOptionError))
+    }
+  }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraSpec.scala
@@ -30,4 +30,7 @@ trait QueryResultTypeCassandraSpec extends Spec {
     query[OrderTestEntity].filter(_.id == id).size
   }
   val distinct = quote(query[OrderTestEntity].map(_.id).distinct)
+  val headOptionSome = quote(query[OrderTestEntity].filter(_.id == 1).headOption)
+  val headOptionNone = quote(query[OrderTestEntity].filter(_.id == 4).headOption)
+  val headOptionError = quote(query[OrderTestEntity].headOption)
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraStreamSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraStreamSpec.scala
@@ -30,4 +30,10 @@ class QueryResultTypeCassandraStreamSpec extends QueryResultTypeCassandraSpec {
       result(context.run(parametrizedSize(lift(10000)))) mustEqual List(0)
     }
   }
+
+  "headOption" - {
+    result(context.run(headOptionSome)) mustEqual List(Some(entries.head))
+    result(context.run(headOptionNone)) mustEqual List(None)
+    result(context.run(headOptionError)) mustEqual List(Some(entries.head))
+  }
 }

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraSyncSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/QueryResultTypeCassandraSyncSpec.scala
@@ -41,4 +41,12 @@ class QueryResultTypeCassandraSyncSpec extends QueryResultTypeCassandraSpec {
       context.run(parametrizedSize(lift(10000))) mustEqual 0
     }
   }
+
+  "headOption" - {
+    context.run(headOptionSome) mustEqual Some(entries.head)
+    context.run(headOptionNone) mustEqual None
+    intercept[IllegalStateException] {
+      context.run(headOptionError)
+    }
+  }
 }

--- a/quill-core/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorContext.scala
@@ -18,6 +18,7 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
   override type ResultRow = Row
   override type RunQueryResult[T] = QueryMirror[T]
   override type RunQuerySingleResult[T] = QueryMirror[T]
+  override type RunQueryHeadOptionResult[T] = QueryMirror[T]
   override type RunActionResult = ActionMirror
   override type RunActionReturningResult[T] = ActionReturningMirror[T]
   override type RunBatchActionResult = BatchActionMirror
@@ -47,6 +48,9 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy]
     QueryMirror(string, prepare(Row())._2, extractor)
 
   def executeQuerySingle[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor) =
+    QueryMirror(string, prepare(Row())._2, extractor)
+
+  def executeQueryHeadOption[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor) =
     QueryMirror(string, prepare(Row())._2, extractor)
 
   def executeAction(string: String, prepare: Prepare = identityPrepare) =

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -39,6 +39,7 @@ class MirrorIdiom extends Idiom {
     case ast: QuotedReference => ast.ast.token
     case ast: Lift            => ast.token
     case ast: Assignment      => ast.token
+    case ast: HeadOption      => ast.token
   }
 
   implicit def ifTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[If] = Tokenizer[If] {
@@ -55,6 +56,10 @@ class MirrorIdiom extends Idiom {
 
   implicit def valTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Val] = Tokenizer[Val] {
     case Val(name, body) => stmt"val ${name.token} = ${body.token}"
+  }
+
+  implicit def headOptionTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[HeadOption] = Tokenizer[HeadOption] {
+    case HeadOption(body) => stmt"${body.token}"
   }
 
   implicit def queryTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Query] = Tokenizer[Query] {

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -135,3 +135,5 @@ case class ScalarQueryLift(name: String, value: Any, encoder: Any) extends Scala
 sealed trait CaseClassLift extends Lift
 case class CaseClassValueLift(name: String, value: Any) extends CaseClassLift
 case class CaseClassQueryLift(name: String, value: Any) extends CaseClassLift
+
+case class HeadOption(ast: Ast) extends Ast

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -49,6 +49,10 @@ trait StatefulTransformer[T] {
         (Val(a, at), att)
 
       case o: Ordering => (o, this)
+
+      case HeadOption(a) =>
+        val (at, att) = apply(a)
+        (HeadOption(at), att)
     }
 
   def apply(o: OptionOperation): (OptionOperation, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -21,6 +21,7 @@ trait StatelessTransformer {
       case Block(statements)      => Block(statements.map(apply))
       case Val(name, body)        => Val(name, apply(body))
       case o: Ordering            => o
+      case HeadOption(ast)        => HeadOption(apply(ast))
     }
 
   def apply(o: OptionOperation): OptionOperation =

--- a/quill-core/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Context.scala
@@ -12,6 +12,7 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
   with CoreDsl {
 
   type RunQuerySingleResult[T]
+  type RunQueryHeadOptionResult[T]
   type RunQueryResult[T]
   type RunActionResult
   type RunActionReturningResult[T]
@@ -27,6 +28,7 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
   def probe(statement: String): Try[_]
 
   def run[T](quoted: Quoted[T]): RunQuerySingleResult[T] = macro QueryMacro.runQuerySingle[T]
+  def run[T](quoted: Quoted[OptionQuery[T]]): RunQueryHeadOptionResult[T] = macro QueryMacro.runQueryHeadOption[T]
   def run[T](quoted: Quoted[Query[T]]): RunQueryResult[T] = macro QueryMacro.runQuery[T]
   def run(quoted: Quoted[Action[_]]): RunActionResult = macro ActionMacro.runAction
   def run[T](quoted: Quoted[ActionReturning[_, T]]): RunActionReturningResult[T] = macro ActionMacro.runActionReturning[T]
@@ -40,5 +42,12 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
     list match {
       case value :: Nil => value
       case other        => throw new IllegalStateException(s"Expected a single result but got $other")
+    }
+
+  protected def handleHeadOptionResult[T](list: List[T]) =
+    list match {
+      case Nil          => None
+      case value :: Nil => Some(value)
+      case other        => throw new IllegalStateException(s"Expected a single result or none but got $other")
     }
 }

--- a/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
@@ -14,6 +14,9 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
   def runQuerySingle[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
     expandQuery[T](quoted, "executeQuerySingle")
 
+  def runQueryHeadOption[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
+    expandQuery[T](quoted, "executeQueryHeadOption")
+
   private def expandQuery[T](quoted: Tree, method: String)(implicit t: WeakTypeTag[T]) =
     OptionalTypecheck(c)(q"implicitly[${c.prefix}.Decoder[$t]]") match {
       case Some(decoder) => expandQueryWithDecoder(quoted, method, decoder)

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -53,6 +53,9 @@ private[dsl] trait QueryDsl {
 
     def nested: Query[T]
 
+    // TODO we should return Query but not with provided methods above. So new trait ?
+    def headOption: OptionQuery[T]
+
     /**
      *
      * @param unquote is used for conversion of [[Quoted[A]]] to [[A]] with [[unquote]]
@@ -60,6 +63,8 @@ private[dsl] trait QueryDsl {
      */
     def foreach[A <: Action[_], B](f: T => B)(implicit unquote: B => A): BatchAction[A]
   }
+
+  sealed trait OptionQuery[+T] extends Query[T]
 
   sealed trait JoinQuery[A, B, R] extends Query[R] {
     def on(f: (A, B) => Boolean): Query[R]

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -32,6 +32,7 @@ trait Liftables {
     case Dynamic(tree: Tree) if (tree.tpe <:< c.weakTypeOf[CoreDsl#Quoted[Any]]) => q"$tree.ast"
     case Dynamic(tree: Tree) => q"$pack.Constant($tree)"
     case QuotedReference(tree: Tree, ast) => q"$ast"
+    case HeadOption(ast) => q"$ast"
   }
 
   implicit val optionOperationLiftable: Liftable[OptionOperation] = Liftable[OptionOperation] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -219,6 +219,8 @@ trait Parsing {
     case q"$source.nested" if (is[CoreDsl#Query[Any]](source)) =>
       Nested(astParser(source))
 
+    case q"$source.headOption" if (is[CoreDsl#Query[Any]](source)) =>
+      HeadOption(astParser(source))
   }
 
   implicit val propertyAliasParser: Parser[PropertyAlias] = Parser[PropertyAlias] {

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -51,6 +51,7 @@ class FinagleMysqlContext[N <: NamingStrategy](
 
   override type RunQueryResult[T] = Future[List[T]]
   override type RunQuerySingleResult[T] = Future[T]
+  override type RunQueryHeadOptionResult[T] = Future[Option[T]]
   override type RunActionResult = Future[Long]
   override type RunActionReturningResult[T] = Future[T]
   override type RunBatchActionResult = Future[List[Long]]
@@ -86,6 +87,9 @@ class FinagleMysqlContext[N <: NamingStrategy](
 
   def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[T] =
     executeQuery(sql, prepare, extractor).map(handleSingleResult)
+
+  def executeQueryHeadOption[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[Option[T]] =
+    executeQuery(sql, prepare, extractor).map(handleHeadOptionResult)
 
   def executeAction[T](sql: String, prepare: Prepare = identityPrepare): Future[Long] = {
     val (params, prepared) = prepare(Nil)

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/ProductFinagleMysqlSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/ProductFinagleMysqlSpec.scala
@@ -93,5 +93,19 @@ class ProductFinagleMysqlSpec extends ProductSpec {
         queried.sku mustEqual 1004L
       }
     }
+
+    "headOption" in {
+      val prd = Product(0L, "test1", 1)
+      val inserted = await(testContext.run(productInsert(lift(prd))))
+      val byRightId = await(testContext.run(productById(lift(inserted)).headOption))
+      val byWrongId = await(testContext.run(productById(lift(1234567L)).headOption))
+      byRightId mustEqual Some(prd.copy(id = inserted))
+      byWrongId mustEqual None
+
+      await(testContext.run(productInsert(lift(Product(0L, "test2", 2)))))
+      intercept[IllegalStateException] {
+        await(testContext.run(query[Product].headOption))
+      }
+    }
   }
 }

--- a/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
@@ -22,6 +22,7 @@ class FinaglePostgresContext[N <: NamingStrategy](client: PostgresClient) extend
   override type ResultRow = Row
   override type RunQueryResult[T] = Future[List[T]]
   override type RunQuerySingleResult[T] = Future[T]
+  override type RunQueryHeadOptionResult[T] = Future[Option[T]]
   override type RunActionResult = Future[Long]
   override type RunActionReturningResult[T] = Future[T]
   override type RunBatchActionResult = Future[List[Long]]
@@ -49,6 +50,9 @@ class FinaglePostgresContext[N <: NamingStrategy](client: PostgresClient) extend
 
   def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[T] =
     executeQuery(sql, prepare, extractor).map(handleSingleResult)
+
+  def executeQueryHeadOption[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[Option[T]] =
+    executeQuery(sql, prepare, extractor).map(handleHeadOptionResult)
 
   def executeAction[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[Long] = {
     val (params, prepared) = prepare(Nil)

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/ProductFinaglePostgresSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/ProductFinaglePostgresSpec.scala
@@ -93,5 +93,19 @@ class ProductFinaglePostgresSpec extends ProductSpec {
         queried.sku mustEqual 1004L
       }
     }
+
+    "headOption" in {
+      val prd = Product(0L, "test1", 1)
+      val inserted = await(testContext.run(productInsert(lift(prd))))
+      val byRightId = await(testContext.run(productById(lift(inserted)).headOption))
+      val byWrongId = await(testContext.run(productById(lift(1234567L)).headOption))
+      byRightId mustEqual Some(prd.copy(id = inserted))
+      byWrongId mustEqual None
+
+      await(testContext.run(productInsert(lift(Product(0L, "test2", 2)))))
+      intercept[IllegalStateException] {
+        await(testContext.run(query[Product].headOption))
+      }
+    }
   }
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
@@ -25,6 +25,7 @@ abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](dataSo
 
   override type RunQueryResult[T] = List[T]
   override type RunQuerySingleResult[T] = T
+  override type RunQueryHeadOptionResult[T] = Option[T]
   override type RunActionResult = Long
   override type RunActionReturningResult[T] = T
   override type RunBatchActionResult = List[Long]
@@ -78,6 +79,9 @@ abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](dataSo
 
   def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): T =
     handleSingleResult(executeQuery(sql, prepare, extractor))
+
+  def executeQueryHeadOption[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Option[T] =
+    handleHeadOptionResult(executeQuery(sql, prepare, extractor))
 
   def executeAction[T](sql: String, prepare: Prepare = identityPrepare): Long =
     withConnection { conn =>

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/ProductJdbcSpec.scala
@@ -78,5 +78,19 @@ class ProductJdbcSpec extends ProductSpec {
         queried.sku mustEqual 1004L
       }
     }
+
+    "headOption" in {
+      val prd = Product(0L, "test1", 1)
+      val inserted = testContext.run(productInsert(lift(prd)))
+      val byRightId = testContext.run(productById(lift(inserted)).headOption)
+      val byWrongId = testContext.run(productById(lift(1234567L)).headOption)
+      byRightId mustEqual Some(prd.copy(id = inserted))
+      byWrongId mustEqual None
+
+      testContext.run(productInsert(lift(Product(0L, "test2", 2))))
+      intercept[IllegalStateException] {
+        testContext.run(query[Product].headOption)
+      }
+    }
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/ProductJdbcSpec.scala
@@ -72,6 +72,20 @@ class ProductJdbcSpec extends ProductSpec {
         queried.sku mustEqual 1004L
       }
     }
+
+    "headOption" in {
+      val prd = Product(0L, "test1", 1)
+      val inserted = testContext.run(productInsert(lift(prd)))
+      val byRightId = testContext.run(productById(lift(inserted)).headOption)
+      val byWrongId = testContext.run(productById(lift(1234567L)).headOption)
+      byRightId mustEqual Some(prd.copy(id = inserted))
+      byWrongId mustEqual None
+
+      testContext.run(productInsert(lift(Product(0L, "test2", 2))))
+      intercept[IllegalStateException] {
+        testContext.run(query[Product].headOption)
+      }
+    }
   }
 
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/ProductJdbcSpec.scala
@@ -74,5 +74,19 @@ class ProductJdbcSpec extends ProductSpec {
         queried.sku mustEqual 1004L
       }
     }
+
+    "headOption" in {
+      val prd = Product(0L, "test1", 1)
+      val inserted = testContext.run(productInsert(lift(prd)))
+      val byRightId = testContext.run(productById(lift(inserted)).headOption)
+      val byWrongId = testContext.run(productById(lift(1234567L)).headOption)
+      byRightId mustEqual Some(prd.copy(id = inserted))
+      byWrongId mustEqual None
+
+      testContext.run(productInsert(lift(Product(0L, "test2", 2))))
+      intercept[IllegalStateException] {
+        testContext.run(query[Product].headOption)
+      }
+    }
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/ProductJdbcSpec.scala
@@ -74,5 +74,19 @@ class ProductJdbcSpec extends ProductSpec {
         queried.sku mustEqual 1004L
       }
     }
+
+    "headOption" in {
+      val prd = Product(0L, "test1", 1)
+      val inserted = testContext.run(productInsert(lift(prd)))
+      val byRightId = testContext.run(productById(lift(inserted)).headOption)
+      val byWrongId = testContext.run(productById(lift(1234567L)).headOption)
+      byRightId mustEqual Some(prd.copy(id = inserted))
+      byWrongId mustEqual None
+
+      testContext.run(productInsert(lift(Product(0L, "test2", 2))))
+      intercept[IllegalStateException] {
+        testContext.run(query[Product].headOption)
+      }
+    }
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/ProductJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/ProductJdbcSpec.scala
@@ -78,5 +78,19 @@ class ProductJdbcSpec extends ProductSpec {
         queried.sku mustEqual 1004L
       }
     }
+
+    "headOption" in {
+      val prd = Product(0L, "test1", 1)
+      val inserted = testContext.run(productInsert(lift(prd)))
+      val byRightId = testContext.run(productById(lift(inserted)).headOption)
+      val byWrongId = testContext.run(productById(lift(1234567L)).headOption)
+      byRightId mustEqual Some(prd.copy(id = inserted))
+      byWrongId mustEqual None
+
+      testContext.run(productInsert(lift(Product(0L, "test2", 2))))
+      intercept[IllegalStateException] {
+        testContext.run(query[Product].headOption)
+      }
+    }
   }
 }

--- a/quill-orientdb/src/main/scala/io/getquill/OrientDBSyncContext.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/OrientDBSyncContext.scala
@@ -21,6 +21,7 @@ class OrientDBSyncContext[N <: NamingStrategy](
 
   override type RunQueryResult[T] = List[T]
   override type RunQuerySingleResult[T] = T
+  override type RunQueryHeadOptionResult[T] = Option[T]
   override type RunActionResult = Unit
   override type RunBatchActionResult = Unit
 
@@ -34,6 +35,9 @@ class OrientDBSyncContext[N <: NamingStrategy](
 
   def executeQuerySingle[T](orientQl: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): T =
     handleSingleResult(executeQuery(orientQl, prepare, extractor))
+
+  def executeQueryHeadOption[T](orientQl: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Option[T] =
+    handleHeadOptionResult(executeQuery(orientQl, prepare, extractor))
 
   def executeAction[T](orientQl: String, prepare: Prepare = identityPrepare): Unit = {
     val (params, objects) = prepare(super.prepare())

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
@@ -58,6 +58,7 @@ trait OrientDBIdiom extends Idiom {
         a.token
       case a: Assignment =>
         a.token
+      case a: HeadOption => a.ast.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
         _: Val | _: Ordering | _: QuotedReference

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBAsync.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBAsync.scala
@@ -70,4 +70,15 @@ class QueryResultTypeOrientDBAsync extends Spec {
       ctx.run(quote { query[OrderTestEntity].filter(_.id == lift(0)).size }).get() == 0
     }
   }
+
+  "headOption" - {
+    val ctx = orientdb.testAsyncDB
+    import ctx._
+    ctx.run(quote(query[OrderTestEntity].filter(_.id == 1)).headOption).get() mustEqual Some(entries(1))
+    ctx.run(quote(query[OrderTestEntity].filter(_.id == 4)).headOption).get() mustEqual None
+    intercept[IllegalStateException] {
+      ctx.run(quote(query[OrderTestEntity].headOption))
+    }
+    ctx.run(quote(query[OrderTestEntity])).get()
+  }
 }

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBSync.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/QueryResultTypeOrientDBSync.scala
@@ -70,4 +70,15 @@ class QueryResultTypeOrientDBSync extends Spec {
       ctx.run(quote { query[OrderTestEntity].filter(_.id == lift(0)).size }) mustEqual 0
     }
   }
+
+  "headOption" - {
+    val ctx = orientdb.testSyncDB
+    import ctx._
+    ctx.run(quote(query[OrderTestEntity].filter(_.id == 1)).headOption) mustEqual Some(entries(1))
+    ctx.run(quote(query[OrderTestEntity].filter(_.id == 4)).headOption) mustEqual None
+    intercept[IllegalStateException] {
+      ctx.run(quote(query[OrderTestEntity].headOption))
+    }
+    ctx.run(quote(query[OrderTestEntity]))
+  }
 }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -58,6 +58,7 @@ trait SqlIdiom extends Idiom {
       case a: If         => a.token
       case a: Lift       => a.token
       case a: Assignment => a.token
+      case a: HeadOption => a.ast.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
         _: Val | _: Ordering | _: QuotedReference


### PR DESCRIPTION
### Problem

TODO
headOption is missing in Query dsl, users should execute action and then map result to headOption.

### Solution

Add `headOption` to Query dsl.
return None on empty result, Some on single result and fail on 2 or more.

### Notes
 
@getquill/maintainers 

1. I'd like nothing to be called after `headOption`, how should we implement this?
- [ ] Add new parent to `Query` which will be just a marker of query dsl. Then `OptionQuery` will extends this parent and users won't be able to call anything after `headOption`
- [ ] add some tricks in normalization which will ban calling anything after `headOption` (this could somehow confuse users )

2. Does this feature worth all of these changes at all?

### Checklist

- [ ] Unit test core module, parsers etc.
- [x] Unit test available contexts
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
