### PR TITLE
[WIP] Add ZonedDateTime support to async and jdbc contexts

### DIFF
--- a/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayDecoders.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayDecoders.scala
@@ -1,12 +1,12 @@
 package io.getquill.context.async
 
-import java.time.LocalDate
+import java.time.{ LocalDate, ZonedDateTime }
 import java.util.Date
 
 import io.getquill.PostgresAsyncContext
 import io.getquill.context.sql.encoding.ArrayEncoding
 import io.getquill.util.Messages.fail
-import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
+import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime, DateTime => JodaDateTime }
 
 import scala.reflect.ClassTag
 
@@ -27,6 +27,8 @@ trait ArrayDecoders extends ArrayEncoding {
   implicit def arrayLocalDateJodaDecoder[Col <: Seq[JodaLocalDate]](implicit bf: CBF[JodaLocalDate, Col]): Decoder[Col] = arrayRawEncoder[JodaLocalDate, Col]
   implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: CBF[LocalDate, Col]): Decoder[Col] =
     arrayDecoder[JodaLocalDate, LocalDate, Col](d => LocalDate.of(d.getYear, d.getMonthOfYear, d.getDayOfMonth))
+  implicit def arrayZonedDateTimeDecoder[Col <: Seq[ZonedDateTime]](implicit bf: CBF[ZonedDateTime, Col]): Decoder[Col] =
+    arrayDecoder[JodaDateTime, ZonedDateTime, Col](d => ZonedDateTime.ofInstant(d.toDate.toInstant, d.getZone.toTimeZone.toZoneId))
 
   def arrayDecoder[I, O, Col <: Seq[O]](mapper: I => O)(implicit bf: CBF[O, Col], iTag: ClassTag[I], oTag: ClassTag[O]): Decoder[Col] =
     AsyncDecoder[Col](SqlTypes.ARRAY)(new BaseDecoder[Col] {

--- a/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayEncoders.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayEncoders.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.async
 
-import java.time.LocalDate
+import java.time.{ LocalDate, ZonedDateTime }
 import java.util.Date
 
 import io.getquill.PostgresAsyncContext
@@ -23,6 +23,7 @@ trait ArrayEncoders extends ArrayEncoding {
   implicit def arrayLocalDateTimeJodaEncoder[Col <: Seq[JodaLocalDateTime]]: Encoder[Col] = arrayRawEncoder[JodaLocalDateTime, Col]
   implicit def arrayLocalDateJodaEncoder[Col <: Seq[JodaLocalDate]]: Encoder[Col] = arrayRawEncoder[JodaLocalDate, Col]
   implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] = arrayRawEncoder[LocalDate, Col]
+  implicit def arrayZonedDateTimeEncoder[Col <: Seq[ZonedDateTime]]: Encoder[Col] = arrayRawEncoder[ZonedDateTime, Col]
 
   def arrayEncoder[T, Col <: Seq[T]](mapper: T => Any): Encoder[Col] =
     encoder[Col]((col: Col) => col.toIndexedSeq.map(mapper), SqlTypes.ARRAY)

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ArrayExtraAsyncEncodingSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ArrayExtraAsyncEncodingSpec.scala
@@ -1,0 +1,56 @@
+package io.getquill.context.async.postgres
+
+import java.time.{ ZonedDateTime }
+
+import io.getquill.context.sql.encoding.ArrayEncodingExtraSpec
+import org.joda.time.{ DateTime => JodaDateTime }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ArrayExtraAsyncEncodingSpec extends ArrayEncodingExtraSpec {
+  val ctx = testContext
+  import ctx._
+
+  val q = quote(query[ArraysExtraTestEntity])
+
+  "Support all sql base types and `Traversable` implementers" in {
+    await(ctx.run(q.insert(lift(e))))
+    val actual = await(ctx.run(q)).head
+    actual mustEqual e
+    baseEntityDeepCheck(actual, e)
+  }
+
+  "Joda times" in {
+    case class JodaTimes(dates: Seq[JodaDateTime])
+    val jE = JodaTimes(Seq(JodaDateTime.now()))
+    val jQ = quote(querySchema[JodaTimes]("ArraysExtraTestEntity"))
+    await(ctx.run(jQ.insert(lift(jE))))
+    val actual = await(ctx.run(jQ)).head
+    actual.dates mustBe jE.dates
+  }
+
+  "Support Traversable encoding basing on MappedEncoding" in {
+    val wrapQ = quote(querySchema[WrapEntity]("ArraysExtraTestEntity"))
+    await(ctx.run(wrapQ.insert(lift(wrapE))))
+    await(ctx.run(wrapQ)).head mustBe wrapE
+  }
+
+  "Catch invalid decoders" in {
+    val newCtx = new TestContext {
+      // avoid transforming from org.joda.time.DateTime to java.time.ZonedDateTime
+      override implicit def arrayZonedDateTimeDecoder[Col <: Seq[ZonedDateTime]](implicit bf: CBF[ZonedDateTime, Col]): Decoder[Col] =
+        arrayDecoder[ZonedDateTime, ZonedDateTime, Col](identity)
+    }
+    import newCtx._
+    await(newCtx.run(query[ArraysExtraTestEntity].insert(lift(e))))
+    intercept[IllegalStateException] {
+      await(newCtx.run(query[ArraysExtraTestEntity])).head mustBe e
+    }
+    newCtx.close()
+  }
+
+  override protected def beforeEach(): Unit = {
+    await(ctx.run(q.delete))
+    ()
+  }
+}

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.async.postgres
 
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{ LocalDate, LocalDateTime, ZonedDateTime }
 
 import io.getquill.context.sql.EncodingSpec
 
@@ -107,6 +107,28 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
     Await.result(r, Duration.Inf)
+  }
+
+  "encodes zoneddatetime type" in {
+    case class DateEncodingTestEntity(v1: ZonedDateTime, v2: ZonedDateTime)
+    val entity = DateEncodingTestEntity(ZonedDateTime.now, ZonedDateTime.now)
+    val r = for {
+      _ <- testContext.run(query[DateEncodingTestEntity].delete)
+      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      result <- testContext.run(query[DateEncodingTestEntity])
+    } yield result
+    Await.result(r, Duration.Inf)
+  }
+
+  "encodes zoneddatetime type to/from timestampz" in {
+    case class ZonedDateEncodingTestEntity(v1: ZonedDateTime)
+    val entity = ZonedDateEncodingTestEntity(ZonedDateTime.now)
+    val r = for {
+      _ <- testContext.run(query[ZonedDateEncodingTestEntity].delete)
+      _ <- testContext.run(query[ZonedDateEncodingTestEntity].insert(lift(entity)))
+      result <- testContext.run(query[ZonedDateEncodingTestEntity])
+    } yield result
+    Await.result(r, Duration.Inf) must contain(entity)
   }
 
   "encodes custom type inside singleton object" in {

--- a/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
@@ -1,10 +1,10 @@
 package io.getquill.context.async
 
-import java.time.{ LocalDate, LocalDateTime, ZoneId }
+import java.time.{ LocalDate, LocalDateTime, ZoneId, ZonedDateTime }
 import java.util.Date
 
 import io.getquill.util.Messages.fail
-import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
+import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime, DateTime => JodaDateTime }
 
 import scala.reflect.{ ClassTag, classTag }
 
@@ -161,4 +161,22 @@ trait Decoders {
         )
     }, SqlTypes.TIMESTAMP)
 
+  implicit val zonedDateTimeDecoder: Decoder[ZonedDateTime] =
+    decoder[ZonedDateTime]({
+      case localDateTime: JodaLocalDateTime =>
+        ZonedDateTime.ofInstant(
+          localDateTime.toDate.toInstant,
+          ZoneId.systemDefault()
+        )
+      case localDate: JodaLocalDate =>
+        ZonedDateTime.ofInstant(
+          localDate.toDate.toInstant,
+          ZoneId.systemDefault()
+        )
+      case dateTime: JodaDateTime =>
+        ZonedDateTime.ofInstant(
+          dateTime.toDate.toInstant,
+          dateTime.getZone.toTimeZone.toZoneId
+        )
+    }, SqlTypes.TIMESTAMP_WITH_TIMEZONE)
 }

--- a/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
@@ -1,9 +1,9 @@
 package io.getquill.context.async
 
-import java.time.{ LocalDate, LocalDateTime, ZoneId }
+import java.time.{ LocalDate, LocalDateTime, ZoneId, ZonedDateTime }
 import java.util.Date
 
-import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
+import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime, DateTime => JodaDateTime }
 
 trait Encoders {
   this: AsyncContext[_, _, _] =>
@@ -73,4 +73,11 @@ trait Encoders {
         value.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli
       )
     }, SqlTypes.TIMESTAMP)
+  implicit val zonedDateTimeEncoder: Encoder[ZonedDateTime] =
+    encoder[ZonedDateTime]({ (value: ZonedDateTime) =>
+      new JodaDateTime(
+        value.toInstant.toEpochMilli
+      )
+    }, SqlTypes.TIMESTAMP_WITH_TIMEZONE)
+
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc
 
 import java.sql.Types
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{ LocalDate, LocalDateTime, ZonedDateTime }
 import java.util
 import java.util.Calendar
 
@@ -83,5 +83,13 @@ trait Decoders {
         LocalDate.ofEpochDay(0).atStartOfDay()
       else
         v.toLocalDateTime
+    })
+  implicit val zonedDateTimeDecoder: Decoder[ZonedDateTime] =
+    decoder(Types.TIMESTAMP_WITH_TIMEZONE, (index, row) => {
+      val v = row.getTimestamp(index, Calendar.getInstance(dateTimeZone))
+      if (v == null)
+        LocalDate.ofEpochDay(0).atStartOfDay(dateTimeZone.toZoneId)
+      else
+        ZonedDateTime.ofInstant(v.toInstant, dateTimeZone.toZoneId)
     })
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc
 
 import java.sql.{ Date, Timestamp, Types }
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{ LocalDate, LocalDateTime, ZonedDateTime }
 import java.util.{ Calendar, TimeZone }
 import java.{ sql, util }
 
@@ -61,4 +61,8 @@ trait Encoders {
   implicit val localDateTimeEncoder: Encoder[LocalDateTime] =
     encoder(Types.TIMESTAMP, (index, value, row) =>
       row.setTimestamp(index, Timestamp.valueOf(value), Calendar.getInstance(dateTimeZone)))
+  implicit val zonedDateTimeEncoder: Encoder[ZonedDateTime] =
+    encoder(Types.TIMESTAMP_WITH_TIMEZONE, (index, value, row) =>
+      row.setTimestamp(index, Timestamp.valueOf(value.toLocalDateTime),
+        Calendar.getInstance(TimeZone.getTimeZone(value.getZone))))
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingExtraSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingExtraSpec.scala
@@ -1,0 +1,28 @@
+package io.getquill.context.sql.encoding
+
+import java.time.{ ZonedDateTime }
+
+import io.getquill.{ MappedEncoding, Spec }
+import org.scalatest.{ Assertion, BeforeAndAfterEach }
+
+trait ArrayEncodingExtraSpec extends Spec with BeforeAndAfterEach {
+
+  // Support all sql base types and `Seq` implementers
+  case class ArraysExtraTestEntity(
+    dates: Seq[ZonedDateTime]
+  )
+
+  val e = ArraysExtraTestEntity(Seq(ZonedDateTime.now()))
+
+  // casting types can be dangerous so we need to ensure that everything is ok
+  def baseEntityDeepCheck(e1: ArraysExtraTestEntity, e2: ArraysExtraTestEntity): Assertion = {
+    e1.dates.head mustBe e2.dates.head
+  }
+
+  // Support Seq encoding basing on MappedEncoding
+  case class StrWrap(str: String)
+  implicit val strWrapEncode: MappedEncoding[StrWrap, String] = MappedEncoding(_.str)
+  implicit val strWrapDecode: MappedEncoding[String, StrWrap] = MappedEncoding(StrWrap.apply)
+  case class WrapEntity(texts: Seq[StrWrap])
+  val wrapE = WrapEntity(List("hey", "ho").map(StrWrap.apply))
+}

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -95,6 +95,10 @@ CREATE TABLE DateEncodingTestEntity (
     v2 TIMESTAMP
 );
 
+CREATE TABLE ZonedDateEncodingTestEntity (
+  v1 TIMESTAMP WITH TIME ZONE
+);
+
 CREATE TABLE ArraysTestEntity (
     texts TEXT[],
     decimals DECIMAL(5,2)[],

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -113,3 +113,7 @@ CREATE TABLE ArraysTestEntity (
     dates DATE[],
     uuids UUID[]
 );
+
+CREATE TABLE ArraysExtraTestEntity (
+  dates TIMESTAMP WITH TIME ZONE[]
+);


### PR DESCRIPTION
Fixes #820. This PR for review only and to help fix me `io/getquill/context/async/postgres/ArrayExtraAsyncEncodingSpec.scala`. I can't figure out why it is crashed on `Joda times` test

### Problem
Java `ZonedDateTime` type is not working out of the box.
### Solution
1. This PR adds `ZonedDateTime` support to Async context and to JDBC context.
2. Add `ZonedDateTime` to PostgreSQL arrays support.
3. Adds some test for PostgreSQL

### Notes

Additional notes.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
