### PR TITLE
Add raw joda time encoding to `quill-async`

### DIFF
--- a/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncEncodingSpec.scala
+++ b/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncEncodingSpec.scala
@@ -3,6 +3,7 @@ package io.getquill.context.async.mysql
 import java.time.{ LocalDate, LocalDateTime }
 
 import io.getquill.context.sql.EncodingSpec
+import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
@@ -85,21 +86,21 @@ class MysqlAsyncEncodingSpec extends EncodingSpec {
     ()
   }
 
-  "decode local date types" in {
-    case class DateEncodingTestEntity(v1: LocalDate, v2: LocalDate, v3: LocalDate)
-    val entity = DateEncodingTestEntity(LocalDate.now, LocalDate.now, LocalDate.now)
+  "decode joda LocalDate and LocalDateTime types" in {
+    case class DateEncodingTestEntity(v1: JodaLocalDate, v2: JodaLocalDateTime)
+    val entity = DateEncodingTestEntity(JodaLocalDate.now, JodaLocalDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
       _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
-    Await.result(r, Duration.Inf) must contain(entity)
+    Await.result(r, Duration.Inf)
   }
 
-  "decode local date time types" in {
-    case class DateEncodingTestEntity(v1: LocalDateTime, v2: LocalDateTime, v3: LocalDateTime)
+  "decode LocalDate and LocalDateTime types" in {
+    case class DateEncodingTestEntity(v1: LocalDate, v2: LocalDateTime, v3: LocalDateTime)
     //since localdatetime is converted to joda which doesn't store nanos need to zero the nano part
-    val entity = DateEncodingTestEntity(LocalDate.now().atStartOfDay(), LocalDateTime.now.withNano(0), LocalDateTime.now.withNano(0))
+    val entity = DateEncodingTestEntity(LocalDate.now(), LocalDateTime.now.withNano(0), LocalDateTime.now.withNano(0))
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
       _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))

--- a/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayDecoders.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayDecoders.scala
@@ -25,8 +25,7 @@ trait ArrayDecoders extends ArrayEncoding {
   implicit def arrayDateDecoder[Col <: Seq[Date]](implicit bf: CBF[Date, Col]): Decoder[Col] = arrayDecoder[JodaLocalDateTime, Date, Col](_.toDate)
   implicit def arrayLocalDateTimeJodaDecoder[Col <: Seq[JodaLocalDateTime]](implicit bf: CBF[JodaLocalDateTime, Col]): Decoder[Col] = arrayRawEncoder[JodaLocalDateTime, Col]
   implicit def arrayLocalDateJodaDecoder[Col <: Seq[JodaLocalDate]](implicit bf: CBF[JodaLocalDate, Col]): Decoder[Col] = arrayRawEncoder[JodaLocalDate, Col]
-  implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: CBF[LocalDate, Col]): Decoder[Col] =
-    arrayDecoder[JodaLocalDate, LocalDate, Col](d => LocalDate.of(d.getYear, d.getMonthOfYear, d.getDayOfMonth))
+  implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: CBF[LocalDate, Col]): Decoder[Col] = arrayDecoder[JodaLocalDate, LocalDate, Col](decodeLocalDate.f)
 
   def arrayDecoder[I, O, Col <: Seq[O]](mapper: I => O)(implicit bf: CBF[O, Col], iTag: ClassTag[I], oTag: ClassTag[O]): Decoder[Col] =
     AsyncDecoder[Col](SqlTypes.ARRAY)(new BaseDecoder[Col] {

--- a/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayEncoders.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayEncoders.scala
@@ -22,7 +22,7 @@ trait ArrayEncoders extends ArrayEncoding {
   implicit def arrayDateEncoder[Col <: Seq[Date]]: Encoder[Col] = arrayRawEncoder[Date, Col]
   implicit def arrayLocalDateTimeJodaEncoder[Col <: Seq[JodaLocalDateTime]]: Encoder[Col] = arrayRawEncoder[JodaLocalDateTime, Col]
   implicit def arrayLocalDateJodaEncoder[Col <: Seq[JodaLocalDate]]: Encoder[Col] = arrayRawEncoder[JodaLocalDate, Col]
-  implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] = arrayRawEncoder[LocalDate, Col]
+  implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] = arrayEncoder[LocalDate, Col](encodeLocalDate.f)
 
   def arrayEncoder[T, Col <: Seq[T]](mapper: T => Any): Encoder[Col] =
     encoder[Col]((col: Col) => col.toIndexedSeq.map(mapper), SqlTypes.ARRAY)

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ArrayAsyncEncodingSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ArrayAsyncEncodingSpec.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.async.postgres
 
-import java.time.LocalDate
+import java.time.{ LocalDate, LocalDateTime }
 
 import io.getquill.context.sql.encoding.ArrayEncodingBaseSpec
 import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
@@ -24,6 +24,16 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
     case class JodaTimes(timestamps: Seq[JodaLocalDateTime], dates: Seq[JodaLocalDate])
     val jE = JodaTimes(Seq(JodaLocalDateTime.now()), Seq(JodaLocalDate.now()))
     val jQ = quote(querySchema[JodaTimes]("ArraysTestEntity"))
+    await(ctx.run(jQ.insert(lift(jE))))
+    val actual = await(ctx.run(jQ)).head
+    actual.timestamps mustBe jE.timestamps
+    actual.dates mustBe jE.dates
+  }
+
+  "Java8 times" in {
+    case class Java8Times(timestamps: Seq[LocalDateTime], dates: Seq[LocalDate])
+    val jE = Java8Times(Seq(LocalDateTime.now()), Seq(LocalDate.now()))
+    val jQ = quote(querySchema[Java8Times]("ArraysTestEntity"))
     await(ctx.run(jQ.insert(lift(jE))))
     val actual = await(ctx.run(jQ)).head
     actual.timestamps mustBe jE.timestamps

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/PostgresAsyncEncodingSpec.scala
@@ -3,6 +3,7 @@ package io.getquill.context.async.postgres
 import java.time.{ LocalDate, LocalDateTime }
 
 import io.getquill.context.sql.EncodingSpec
+import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
@@ -87,20 +88,20 @@ class PostgresAsyncEncodingSpec extends EncodingSpec {
     success must not be empty
   }
 
-  "encodes localdate type" in {
-    case class DateEncodingTestEntity(v1: LocalDate, v2: LocalDate)
-    val entity = DateEncodingTestEntity(LocalDate.now, LocalDate.now)
+  "decode joda LocalDate and LocalDateTime types" in {
+    case class DateEncodingTestEntity(v1: JodaLocalDate, v2: JodaLocalDateTime)
+    val entity = DateEncodingTestEntity(JodaLocalDate.now, JodaLocalDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
       _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
       result <- testContext.run(query[DateEncodingTestEntity])
     } yield result
-    Await.result(r, Duration.Inf) must contain(entity)
+    Await.result(r, Duration.Inf)
   }
 
-  "encodes localdatetime type" in {
-    case class DateEncodingTestEntity(v1: LocalDateTime, v2: LocalDateTime)
-    val entity = DateEncodingTestEntity(LocalDateTime.now, LocalDateTime.now)
+  "decode LocalDate and LocalDateTime types" in {
+    case class DateEncodingTestEntity(v1: LocalDate, v2: LocalDateTime)
+    val entity = DateEncodingTestEntity(LocalDate.now, LocalDateTime.now)
     val r = for {
       _ <- testContext.run(query[DateEncodingTestEntity].delete)
       _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))

--- a/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
@@ -55,22 +55,15 @@ trait Encoders {
   implicit val floatEncoder: Encoder[Float] = encoder[Float](SqlTypes.FLOAT)
   implicit val doubleEncoder: Encoder[Double] = encoder[Double](SqlTypes.DOUBLE)
   implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder[Array[Byte]](SqlTypes.VARBINARY)
-  implicit val dateEncoder: Encoder[Date] =
-    encoder[Date]({ (value: Date) =>
-      new JodaLocalDateTime(value)
-    }, SqlTypes.TIMESTAMP)
-  implicit val localDateEncoder: Encoder[LocalDate] =
-    encoder[LocalDate]({ (value: LocalDate) =>
-      new JodaLocalDate(
-        value.getYear,
-        value.getMonthValue,
-        value.getDayOfMonth
-      )
-    }, SqlTypes.DATE)
-  implicit val localDateTimeEncoder: Encoder[LocalDateTime] =
-    encoder[LocalDateTime]({ (value: LocalDateTime) =>
-      new JodaLocalDateTime(
-        value.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli
-      )
-    }, SqlTypes.TIMESTAMP)
+  implicit val jodaLocalDateEncoder: Encoder[JodaLocalDate] = encoder[JodaLocalDate](SqlTypes.DATE)
+  implicit val jodaLocalDateTimeEncoder: Encoder[JodaLocalDateTime] = encoder[JodaLocalDateTime](SqlTypes.TIMESTAMP)
+  implicit val dateEncoder: Encoder[Date] = encoder[Date]((d: Date) => new JodaLocalDateTime(d), SqlTypes.TIMESTAMP)
+
+  implicit val encodeLocalDate: MappedEncoding[LocalDate, JodaLocalDate] =
+    MappedEncoding(ld => new JodaLocalDate(ld.getYear, ld.getMonthValue, ld.getDayOfMonth))
+
+  implicit val encodeLocalDateTime: MappedEncoding[LocalDateTime, JodaLocalDateTime] =
+    MappedEncoding(ldt => new JodaLocalDateTime(ldt.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli))
+
+  implicit val localDateEncoder: Encoder[LocalDate] = mappedEncoder(encodeLocalDate, jodaLocalDateEncoder)
 }


### PR DESCRIPTION
Fixes #836

### Problem
Async driver support joda time by default but raw encoders are missing

### Solution

- Add raw encoder/decoder for joda types
- Provide implicit mapped encoding for other date types (java 8).

### Notes

**Breaking Changes!**
`java.time.LocalDate` now supports only date sql types, `java.time.LocalDateTime` - only `timestamp` sql types. Joda times follow this conventions accordingly.

Exception is made to `java.util.Date` it supports both `date` and `timestamp` types due to historical moments (`java.sql.Timestamp` extents `java.util.Date`)


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
