### PR TITLE
Support contains, exists, forall for optional embedded case classes with optional fields. 

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
@@ -10,13 +10,13 @@ object FlattenOptionOperation extends StatelessTransformer {
         apply(BetaReduction(body, alias -> ast))
       case OptionForall(ast, alias, body) =>
         val isEmpty = BinaryOperation(ast, EqualityOperator.`==`, NullValue)
-        val exists = BetaReduction(body, alias -> ast)
+        val exists = apply(BetaReduction(body, alias -> ast))
         BinaryOperation(isEmpty, BooleanOperator.`||`, exists)
       case OptionExists(ast, alias, body) =>
-        BetaReduction(body, alias -> ast)
+        apply(BetaReduction(body, alias -> ast))
       case OptionContains(ast, body) =>
         BinaryOperation(ast, EqualityOperator.`==`, body)
       case other =>
-        super.apply(ast)
+        super.apply(other)
     }
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -1,7 +1,9 @@
 package io.getquill.quotation
 
+
 import scala.reflect.ClassTag
 import io.getquill.ast._
+import io.getquill.Embedded
 import io.getquill.norm.BetaReduction
 import io.getquill.util.Messages.RichContext
 import io.getquill.util.Interleave
@@ -282,13 +284,17 @@ trait Parsing {
   private def ident(x: TermName): Ident = identClean(Ident(x.decodedName.toString))
 
   val optionOperationParser: Parser[OptionOperation] = Parser[OptionOperation] {
-    case q"$o.map[$t]({($alias) => $body})" if (is[Option[Any]](o)) =>
+    case q"$o.map[$t]({($alias) => $body})" if is[Option[Any]](o) =>
       OptionMap(astParser(o), identParser(alias), astParser(body))
-    case q"$o.forall({($alias) => $body})" if (is[Option[Any]](o)) =>
-      OptionForall(astParser(o), identParser(alias), astParser(body))
-    case q"$o.exists({($alias) => $body})" if (is[Option[Any]](o)) =>
+    case q"$o.forall({($alias) => $body})"  if is[Option[Any]](o) =>
+      if (is[Option[Embedded]](o)) {
+        c.fail("Please use Option.exists() instead of Option.forall() with embedded case classes.")
+      } else {
+        OptionForall(astParser(o), identParser(alias), astParser(body))
+      }
+    case q"$o.exists({($alias) => $body})" if is[Option[Any]](o) =>
       OptionExists(astParser(o), identParser(alias), astParser(body))
-    case q"$o.contains[$t]($body)" if (is[Option[Any]](o)) =>
+    case q"$o.contains[$t]($body)" if is[Option[Any]](o) =>
       OptionContains(astParser(o), astParser(body))
   }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -698,17 +698,33 @@ class QuotationSpec extends Spec {
         }
         quote(unquote(q)).ast.body mustEqual OptionMap(Ident("o"), Ident("v"), Ident("v"))
       }
-      "forall" in {
-        val q = quote {
-          (o: Option[Boolean]) => o.forall(v => v)
+      "forall" - {
+        "simple" in {
+          val q = quote {
+            (o: Option[Boolean]) => o.forall(v => v)
+          }
+          quote(unquote(q)).ast.body mustEqual OptionForall(Ident("o"), Ident("v"), Ident("v"))
         }
-        quote(unquote(q)).ast.body mustEqual OptionForall(Ident("o"), Ident("v"), Ident("v"))
+        "embedded" in {
+          case class EmbeddedEntity(id: Int) extends Embedded
+          "quote((o: Option[EmbeddedEntity]) => o.forall(v => v.id == 1))" mustNot compile
+        }
       }
-      "exists" in {
-        val q = quote {
-          (o: Option[Boolean]) => o.exists(v => v)
+      "exists" - {
+        "simple" in {
+          val q = quote {
+            (o: Option[Boolean]) => o.exists(v => v)
+          }
+          quote(unquote(q)).ast.body mustEqual OptionExists(Ident("o"), Ident("v"), Ident("v"))
         }
-        quote(unquote(q)).ast.body mustEqual OptionExists(Ident("o"), Ident("v"), Ident("v"))
+        "embedded" in {
+          case class EmbeddedEntity(id: Int) extends Embedded
+          val q = quote {
+            (o: Option[EmbeddedEntity]) => o.exists(v => v.id == 1)
+          }
+          quote(unquote(q)).ast.body mustEqual OptionExists(Ident("o"), Ident("v"),
+            BinaryOperation(Property(Ident("v"), "id"), EqualityOperator.`==`, Constant(1)))
+        }
       }
       "contains" in {
         val q = quote {


### PR DESCRIPTION
Fixes #785 

### Solution

- flatten option operations recursively to support optional embedded case classes with optional fields
- parse `embedded.forall(...)` as `OptionExists` AST

### Notes

`embedded.forall(...)` currently generates invalid query like `(t.embedded IS NULL) || ...`.
One option is to generate instead - `((t.a IS NULL) && (t.b IS NULL)) || ...` where a, b is embedded fields, but it's too hard because on `FlattenOptionOperation` stage there is no info about embedded case classes and their fields. Also this behavior will be too complex and unexpected (especially if there will be nested embedded case classes). Without this behavior `embedded.forall(...)` is equivalent to `embedded.exists(...)`. I thought about adding warning on parsing stage to motivate developers use `exists()` instead of `forall()` with embedded case classes but I do not think that someone will expect from `forall()` the behavior that I described above (with generating `((t.a IS NULL) && (t.b IS NULL)) || ...`).

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
