### PR TITLE
Add mappedEncoder and mappedDecoder for AnyVal

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/EncodingDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/EncodingDsl.scala
@@ -9,9 +9,9 @@ import scala.language.higherKinds
 trait LowPriorityImplicits {
   this: EncodingDsl =>
 
-  implicit def materializeEncoder[T <: AnyVal]: Encoder[T] = macro EncodingDslMacro.materializeEncoder[T]
+  implicit def anyValEncoder[T <: AnyVal]: Encoder[T] = macro EncodingDslMacro.anyValEncoder[T]
 
-  implicit def materializeDecoder[T <: AnyVal]: Decoder[T] = macro EncodingDslMacro.materializeDecoder[T]
+  implicit def anyValDecoder[T <: AnyVal]: Decoder[T] = macro EncodingDslMacro.anyValDecoder[T]
 }
 
 trait EncodingDsl extends LowPriorityImplicits {
@@ -54,6 +54,10 @@ trait EncodingDsl extends LowPriorityImplicits {
 
   type MappedEncoding[I, O] = io.getquill.MappedEncoding[I, O]
   val MappedEncoding = io.getquill.MappedEncoding
+
+  implicit def anyValMappedEncoder[I <: AnyVal, O](implicit mapped: MappedEncoding[I, O], encoder: Encoder[O]): Encoder[I] = mappedEncoder
+
+  implicit def anyValMappedDecoder[I, O <: AnyVal](implicit mapped: MappedEncoding[I, O], decoder: Decoder[I]): Decoder[O] = mappedDecoder
 
   implicit def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], encoder: Encoder[O]): Encoder[I]
 

--- a/quill-core/src/main/scala/io/getquill/dsl/EncodingDslMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/EncodingDslMacro.scala
@@ -7,13 +7,25 @@ import scala.reflect.macros.blackbox.{ Context => MacroContext }
 class EncodingDslMacro(val c: MacroContext) {
   import c.universe._
 
-  def materializeEncoder[T](implicit t: WeakTypeTag[T]): Tree =
-    anyValEncoder(t.tpe)
-      .getOrElse(fail("Encoder", t.tpe))
+  def anyValEncoder[T](implicit t: WeakTypeTag[T]): Tree =
+    withAnyValParam(t.tpe) { param =>
+      q"""
+        ${c.prefix}.mappedEncoder(
+          io.getquill.MappedEncoding((v: ${t.tpe}) => v.${param.name.toTermName}),
+          implicitly[${c.prefix}.Encoder[${param.typeSignature}]]
+        )
+      """
+    }.getOrElse(fail("Encoder", t.tpe))
 
-  def materializeDecoder[T](implicit t: WeakTypeTag[T]): Tree =
-    anyValDecoder(t.tpe)
-      .getOrElse(fail("Decoder", t.tpe))
+  def anyValDecoder[T](implicit t: WeakTypeTag[T]): Tree =
+    withAnyValParam(t.tpe) { param =>
+      q"""
+        ${c.prefix}.mappedDecoder(
+          io.getquill.MappedEncoding((p: ${param.typeSignature}) => new ${t.tpe}(p)),
+          implicitly[${c.prefix}.Decoder[${param.typeSignature}]]
+        )
+      """
+    }.getOrElse(fail("Decoder", t.tpe))
 
   def lift[T](v: Tree)(implicit t: WeakTypeTag[T]): Tree =
     lift[T](v, "lift")
@@ -35,26 +47,6 @@ class EncodingDslMacro(val c: MacroContext) {
 
   private def fail(enc: String, t: Type) =
     c.fail(s"Can't find $enc for type '$t'")
-
-  private def anyValDecoder(tpe: Type): Option[Tree] =
-    withAnyValParam(tpe) { param =>
-      q"""
-        ${c.prefix}.mappedDecoder(
-          io.getquill.MappedEncoding((p: ${param.typeSignature}) => new $tpe(p)),
-          implicitly[${c.prefix}.Decoder[${param.typeSignature}]]
-        )
-      """
-    }
-
-  private def anyValEncoder(tpe: Type): Option[Tree] =
-    withAnyValParam(tpe) { param =>
-      q"""
-        ${c.prefix}.mappedEncoder(
-          io.getquill.MappedEncoding((v: $tpe) => v.${param.name.toTermName}),
-          implicitly[${c.prefix}.Encoder[${param.typeSignature}]]
-        )
-      """
-    }
 
   private def withAnyValParam[R](tpe: Type)(f: Symbol => R): Option[R] =
     tpe.baseType(c.symbolOf[AnyVal]) match {

--- a/quill-core/src/test/scala/io/getquill/dsl/EncodingDslSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/dsl/EncodingDslSpec.scala
@@ -11,6 +11,12 @@ case class CustomValue(i: Int) extends AnyVal
 
 case class CustomGenericValue[T](v: T) extends AnyVal
 
+class CustomPrivateConstructorValue private (val i: Int) extends AnyVal
+
+object CustomPrivateConstructorValue {
+  def apply(i: Int) = new CustomPrivateConstructorValue(i)
+}
+
 // Tests self lifting of `AnyVal`
 case class Address(id: AddressId)
 
@@ -107,6 +113,47 @@ class EncodingDslSpec extends Spec {
     "decoder" in {
       val dec = implicitly[Decoder[CustomGenericValue[Int]]]
       dec(0, Row(1)) mustEqual CustomGenericValue(1)
+    }
+  }
+
+  "materializes encoding for AnyVal with custom MappedEncoding" - {
+    "encoder" in {
+      implicit val encodeCustomValue = MappedEncoding[CustomPrivateConstructorValue, Int](_.i + 1)
+      val enc = implicitly[Encoder[CustomPrivateConstructorValue]]
+      enc(0, CustomPrivateConstructorValue.apply(1), Row()) mustEqual Row(2)
+    }
+    "decoder" in {
+      implicit val decodeCustomValue = MappedEncoding[Int, CustomPrivateConstructorValue](i => CustomPrivateConstructorValue(i + 1))
+      val dec = implicitly[Decoder[CustomPrivateConstructorValue]]
+      dec(0, Row(1)) mustEqual CustomPrivateConstructorValue.apply(2)
+    }
+  }
+
+  "materializes encoding for tagged type" - {
+    object tag {
+      def apply[U] = new Tagger[U]
+
+      trait Tagged[U]
+      type @@[+T, U] = T with Tagged[U]
+
+      class Tagger[U] {
+        def apply[T](t: T): T @@ U = t.asInstanceOf[T @@ U]
+      }
+    }
+
+    import tag._
+    sealed trait CustomTag
+    type CustomInt = Int @@ CustomTag
+
+    "encoder" in {
+      implicit val encodeCustomValue = MappedEncoding[CustomInt, Int](_ + 1)
+      val enc = implicitly[Encoder[CustomInt]]
+      enc(0, tag[CustomTag][Int](1), Row()) mustEqual Row(2)
+    }
+    "decoder" in {
+      implicit val decodeCustomValue = MappedEncoding[Int, CustomInt](i => tag[CustomTag][Int](i + 1))
+      val dec = implicitly[Decoder[CustomInt]]
+      dec(0, Row(1)) mustEqual tag[CustomTag][Int](2)
     }
   }
 }


### PR DESCRIPTION
Fixes #698, #793

### Problem

When having implicit `MappedEncoding` for `AnyVal` `mappedEncoder` has lower priority then `materializeEncoder` so this `MappedEncoding` is ignored.  

[Build reproducing the issues](https://travis-ci.org/getquill/quill/builds/254220872).

### Solution

Add `anyValMappedEncoder` and `anyValMappedDecoder` to give them higher priority then `anyValEncoder` and `anyValDecoder`.

### Notes

Also I renamed `materializeEncoder` and `materializeDecoder` to `anyValEncoder` and `anyValDecoder` because it's what they actually do.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
