### PR TITLE
Change error message for "Can't expand nested value ..." error.

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
@@ -194,8 +194,10 @@ class MetaDslMacro(val c: MacroContext) {
             tpe match {
               case tpe if !is[Embedded](tpe) && nested =>
                 c.fail(
-                  s"Can't expand nested value '$tpe', please make it an `Embedded` " +
-                    s"case class or provide an implicit $encoding for it."
+                  s"""Can't find implicit `$encoding[$tpe]`. Please, do one of the following things:
+                     |1. ensure that implicit `$encoding[$tpe]` is provided and there are no other conflicting implicits;
+                     |2. make `$tpe` `Embedded` case class or `AnyVal`.
+                   """.stripMargin
                 )
 
               case tpe =>


### PR DESCRIPTION
Fixes #834.

### Problem

1. words "Can't expand..." say nothing to users not familiar with Quill source code;
2. this error also happens when implicit can not be resolved due to resolution conflict, so error message should say something about that;
3. another way to resolve this error is to make user type extend `AnyVal`.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
