### PR TITLE
Remove unnecessary java.sql.Types usage in JDBC decoders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,7 +983,7 @@ trait UUIDEncodingExample {
   import jdbcContext._
 
   implicit val uuidDecoder: Decoder[UUID] =
-    decoder(java.sql.Types.OTHER, (index, row) => 
+    decoder((index, row) =>
       UUID.fromString(row.getObject(index).toString)) // database-specific implementation
     
   implicit val uuidEncoder: Encoder[UUID] =

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayDecoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayDecoders.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.jdbc
 
-import java.sql.{ Timestamp, Types }
+import java.sql.Timestamp
 import java.time.LocalDate
 import java.util.Date
 import java.sql.{ Date => SqlDate }
@@ -39,7 +39,7 @@ trait ArrayDecoders extends ArrayEncoding {
    * @return JDBC array decoder
    */
   def arrayDecoder[I, O, Col <: Seq[O]](mapper: I => O)(implicit bf: CanBuildFrom[Nothing, O, Col], tag: ClassTag[I]): Decoder[Col] = {
-    decoder[Col](Types.ARRAY, (idx: Index, row: ResultRow) => {
+    decoder[Col]((idx: Index, row: ResultRow) => {
       val arr = row.getArray(idx)
       if (arr == null) bf().result()
       else arr.getArray.asInstanceOf[Array[AnyRef]].foldLeft(bf()) {

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDObjectEncoding.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDObjectEncoding.scala
@@ -6,5 +6,5 @@ import java.util.UUID
 trait UUIDObjectEncoding {
   this: JdbcContext[_, _] =>
   implicit val uuidEncoder: Encoder[UUID] = encoder(Types.OTHER, (index, value, row) => row.setObject(index, value, Types.OTHER))
-  implicit val uuidDecoder: Decoder[UUID] = decoder(Types.OTHER, (index, row) => UUID.fromString(row.getObject(index).toString))
+  implicit val uuidDecoder: Decoder[UUID] = decoder((index, row) => UUID.fromString(row.getObject(index).toString))
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDStringEncoding.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/UUIDStringEncoding.scala
@@ -6,5 +6,5 @@ import java.util.UUID
 trait UUIDStringEncoding {
   this: JdbcContext[_, _] =>
   implicit val uuidEncoder: Encoder[UUID] = encoder(Types.VARCHAR, (index, value, row) => row.setString(index, value.toString))
-  implicit val uuidDecoder: Decoder[UUID] = decoder(Types.VARCHAR, (index, row) => UUID.fromString(row.getString(index)))
+  implicit val uuidDecoder: Decoder[UUID] = decoder((index, row) => UUID.fromString(row.getString(index)))
 }


### PR DESCRIPTION
In some way fixes #834

### Problem

Confuses people because `JdbcDecoder.sqlType` is not used anywhere.

Usage of `java.sql.Types` in JDBC decoders was introduced in #588 by @mdedetrich by analogy with JDBC encoders where `java.sql.Types` is [used](https://github.com/getquill/quill/blob/0768ff158b09d6879a40d9caaf711cbde40a06d1/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala#L40) for encoding `None` with `PreparedStatement.setNull()`.

### Solution

Since array encoding and decoding for quill-jdbc support was added by @mentegy and decoding does not use `sqlType` and also [quill-pg JDBC Traversable decoder](https://github.com/mdedetrich/quill-pg/blob/master/quill-pg-jdbc/src/main/scala/quill/pg/jdbc/ArrayExtensions.scala#L47) does not use `sqlType` I removed java.sql.Types usage in JDBC decoders.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
