### PR TITLE
Cassandra UDT encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,34 @@ ctx.run(query[Book])
 // SELECT id, notes, pages, history FROM Book
 ```
 
+### User-Defined Types
+
+The cassandra context provides encoding of UDT (user-defined types).
+```scala
+import io.getquill.context.cassandra.Udt
+
+case class Name(firstName: String, lastName: String) extends Udt
+```
+
+To encode UDT and bind it into the query (insert/update queries), context needs to retrieve UDT metadata from
+cluster object. By default, context looks for UDT within currently logged keyspace, but it's also possible to specify
+concrete keyspace with `udtMeta`:
+
+```scala
+implicit val nameMeta = udtMeta[Name]("keyspace2.my_name")
+```
+When keyspace is not set in `udtMeta` then the currently logged is used.
+
+Since it's possible to create context without
+specifying keyspace, e.g. keyspace parameter is null and session is not bound to any keyspace, UDT metadata is being
+resolved among all cluster.
+
+It's also possible to rename UDT columns with `udtMeta`:
+
+```scala
+implicit val nameMeta = udtMeta[Name]("name", _.firstName -> "first", _.lastName -> "last")
+```
+
 ## Cassandra-specific operations
 
 The cassandra context also provides a few additional operations:

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraMirrorContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraMirrorContext.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
-import io.getquill.context.cassandra.encoding.CassandraMapper
-import io.getquill.context.cassandra.{ CassandraContext, CqlIdiom }
+import io.getquill.context.cassandra.encoding.{ CassandraMapper, CassandraType }
+import io.getquill.context.cassandra.{ CassandraContext, CqlIdiom, Udt }
 
 import scala.reflect.ClassTag
 
@@ -25,4 +25,8 @@ class CassandraMirrorContext[Naming <: NamingStrategy](naming: Naming)
     keyMapper: CassandraMapper[K, KCas],
     valMapper: CassandraMapper[V, VCas]
   ): Encoder[Map[K, V]] = encoder[Map[K, V]]
+
+  implicit def udtCassandraType[T <: Udt]: CassandraType[T] = CassandraType.of[T]
+  implicit def udtDecoder[T <: Udt: ClassTag]: Decoder[T] = decoder[T]
+  implicit def udtEncoder[T <: Udt]: Encoder[T] = encoder[T]
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContext.scala
@@ -12,6 +12,7 @@ trait CassandraContext[N <: NamingStrategy]
   extends Context[CqlIdiom, N]
   with CassandraMapperConversions
   with CassandraTypes
+  with UdtMetaDsl
   with Ops {
 
   implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]]

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/Udt.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/Udt.scala
@@ -1,0 +1,3 @@
+package io.getquill.context.cassandra
+
+trait Udt

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/UdtMetaDsl.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/UdtMetaDsl.scala
@@ -1,0 +1,22 @@
+package io.getquill.context.cassandra
+
+import scala.language.experimental.macros
+
+trait UdtMetaDsl {
+  this: CassandraContext[_] =>
+
+  /**
+   * Creates udt meta to override udt name / keyspace and rename columns
+   *
+   * @param path - either `udt_name` or `keyspace.udt_name`
+   * @param columns - columns to rename
+   * @return udt meta
+   */
+  def udtMeta[T <: Udt](path: String, columns: (T => (Any, String))*): UdtMeta[T] = macro UdtMetaDslMacro.udtMeta[T]
+
+  trait UdtMeta[T <: Udt] {
+    def keyspace: Option[String]
+    def name: String
+    def alias(col: String): Option[String]
+  }
+}

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/UdtMetaDslMacro.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/UdtMetaDslMacro.scala
@@ -1,0 +1,26 @@
+package io.getquill.context.cassandra
+
+import scala.reflect.macros.blackbox.{ Context => MacroContext }
+
+class UdtMetaDslMacro(val c: MacroContext) {
+
+  import c.universe._
+
+  def udtMeta[T](path: Tree, columns: Tree*)(implicit t: WeakTypeTag[T]): Tree = {
+    val pairs = columns.map {
+      case q"(($x1) => $pack.Predef.ArrowAssoc[$t]($prop).$arrow[$v](${ alias: String }))" =>
+        q"(${prop.symbol.name.decodedName.toString}, $alias)"
+    }
+    c.untypecheck {
+      q"""
+         new ${c.prefix}.UdtMeta[$t] {
+           private[this] val (nm, ks) = io.getquill.context.cassandra.util.UdtMetaUtils.parse($path)
+           private[this] val map = Map[String, String](..$pairs)
+           def name = nm
+           def keyspace = ks
+           def alias(col: String) = map.get(col)
+         }
+       """
+    }
+  }
+}

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/UdtEncoding.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/UdtEncoding.scala
@@ -1,0 +1,17 @@
+package io.getquill.context.cassandra.encoding
+
+import com.datastax.driver.core.UDTValue
+import io.getquill.context.cassandra.{ CassandraSessionContext, Udt }
+
+import scala.language.experimental.macros
+
+trait UdtEncoding {
+  this: CassandraSessionContext[_] =>
+
+  implicit def udtDecoder[T <: Udt]: Decoder[T] = macro UdtEncodingMacro.udtDecoder[T]
+  implicit def udtEncoder[T <: Udt]: Encoder[T] = macro UdtEncodingMacro.udtEncoder[T]
+
+  implicit def udtDecodeMapper[T <: Udt]: CassandraMapper[UDTValue, T] = macro UdtEncodingMacro.udtDecodeMapper[T]
+  implicit def udtEncodeMapper[T <: Udt]: CassandraMapper[T, UDTValue] = macro UdtEncodingMacro.udtEncodeMapper[T]
+
+}

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/UdtEncodingMacro.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/UdtEncodingMacro.scala
@@ -1,0 +1,123 @@
+package io.getquill.context.cassandra.encoding
+
+import com.datastax.driver.core.UDTValue
+import io.getquill.util.Messages._
+import io.getquill.util.OptionalTypecheck
+
+import scala.reflect.macros.blackbox.{ Context => MacroContext }
+
+class UdtEncodingMacro(val c: MacroContext) {
+
+  import c.universe._
+
+  private val encoding = q"io.getquill.context.cassandra.encoding"
+  private val udtRaw = typeOf[UDTValue]
+  private def prefix = c.prefix
+
+  def udtDecoder[T](implicit t: WeakTypeTag[T]): Tree = {
+    val (typeDefs, params, getters) = decodeUdt(t.tpe)
+    c.untypecheck {
+      q"""
+         ${buildUdtMeta(t.tpe)}
+         def udtdecoder[..$typeDefs](implicit ..${params.flatten}): $prefix.Decoder[${t.tpe}] = {
+           $prefix.decoder { (index, row) =>
+             val udt = row.getUDTValue(index)
+             new ${t.tpe}(..$getters)
+           }
+         }
+         udtdecoder
+       """
+    }
+  }
+
+  def udtDecodeMapper[T](implicit t: WeakTypeTag[T]): Tree = {
+    val (typeDefs, params, getters) = decodeUdt(t.tpe)
+    c.untypecheck {
+      q"""
+         ${buildUdtMeta(t.tpe)}
+         def udtdecodemapper[..$typeDefs](implicit ..${params.flatten}): $encoding.CassandraMapper[$udtRaw, ${t.tpe}] = {
+           $encoding.CassandraMapper(udt => new ${t.tpe}(..$getters))
+         }
+         udtdecodemapper
+       """
+    }
+  }
+
+  def udtEncoder[T](implicit t: WeakTypeTag[T]): Tree = {
+    val (typeDefs, params, body) = encodeUdt(t.tpe)
+    c.untypecheck {
+      q"""
+         ${buildUdtMeta(t.tpe)}
+         def udtencoder[..$typeDefs](implicit ..${params.flatten}): $prefix.Encoder[${t.tpe}] = {
+           $prefix.encoder[$t]((i: $prefix.Index, x: ${t.tpe}, row: $prefix.PrepareRow) => row.setUDTValue(i, $body))
+         }
+         udtencoder
+       """
+    }
+  }
+
+  def udtEncodeMapper[T](implicit t: WeakTypeTag[T]): Tree = {
+    val (typeDefs, params, body) = encodeUdt(t.tpe)
+    c.untypecheck {
+      q"""
+         ${buildUdtMeta(t.tpe)}
+         def udtencodemapper[..$typeDefs](implicit ..${params.flatten}): $encoding.CassandraMapper[${t.tpe}, $udtRaw] = {
+           $encoding.CassandraMapper(x => $body)
+         }
+         udtencodemapper
+       """
+    }
+  }
+
+  private def decodeUdt[T](udtType: Type) = {
+    udtFields(udtType).map {
+      case (name, _, tpe, mapper, absType, absTypeDef, tag) => (
+        absTypeDef,
+        List(q"$mapper: $encoding.CassandraMapper[$absType, $tpe]", q"$tag: scala.reflect.ClassTag[$absType]"),
+        q"$mapper.f(udt.get[$absType]($name, $tag.runtimeClass.asInstanceOf[Class[$absType]]))"
+      )
+    }.unzip3
+  }
+
+  private def encodeUdt[T](udtType: Type) = {
+    var acc = q"$prefix.udtValueOf(meta.name, meta.keyspace)"
+    val (typeDefs, params) = udtFields(udtType).map {
+      case (name, field, tpe, mapper, absType, absTypeDef, tag) =>
+        acc = q"$acc.set[$absType]($name, $mapper.f(x.$field), $tag.runtimeClass.asInstanceOf[Class[$absType]])"
+        absTypeDef -> List(
+          q"$mapper: $encoding.CassandraMapper[$tpe, $absType]",
+          q"$tag: scala.reflect.ClassTag[$absType]"
+        )
+    }.unzip
+    (typeDefs, params, acc)
+  }
+
+  private def udtFields(udt: Type) = {
+    val fields = udt.decls.collectFirst {
+      case m: MethodSymbol if m.isPrimaryConstructor => m.paramLists.flatten
+    }.getOrElse(c.fail(s"Could not find primary constructor of $udt"))
+
+    fields.zipWithIndex.map {
+      case (f, i) =>
+        val name = f.name.decodedName.toString
+        (
+          q"meta.alias($name).getOrElse($prefix.naming.default($name))",
+          f.name.toTermName,
+          f.typeSignature.asSeenFrom(udt, udt.typeSymbol),
+          TermName(s"m$i"),
+          TypeName(s"T$i"),
+          TypeDef(Modifiers(Flag.PARAM), TypeName(s"T$i"), Nil, TypeBoundsTree(EmptyTree, EmptyTree)),
+          TermName(s"t$i")
+        )
+    }
+  }
+
+  private def buildUdtMeta(tpe: Type): Tree = {
+    val meta = OptionalTypecheck(c)(q"implicitly[$prefix.UdtMeta[$tpe]]") getOrElse {
+      q"$prefix.udtMeta[$tpe]($prefix.naming.default(${typeName(tpe)}))"
+    }
+    c.typecheck(q"val meta: $prefix.UdtMeta[$tpe] = $meta")
+  }
+
+  private def typeName(tpe: Type): String = tpe.typeSymbol.name.decodedName.toString
+}

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/util/UdtMetaUtils.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/util/UdtMetaUtils.scala
@@ -1,0 +1,18 @@
+package io.getquill.context.cassandra.util
+
+import io.getquill.util.Messages
+
+object UdtMetaUtils {
+  /**
+   * Extracts udt name and keyspace from given path
+   *
+   * @param path udt path
+   * @return (name, keyspace)
+   */
+  def parse(path: String): (String, Option[String]) = {
+    val arr = path.split('.')
+    if (arr.length == 1) arr(0) -> None
+    else if (arr.length == 2) arr(1) -> Some(arr(0))
+    else Messages.fail(s"Cannot parse udt path `$path`")
+  }
+}

--- a/quill-cassandra/src/test/cql/cassandra-schema.cql
+++ b/quill-cassandra/src/test/cql/cassandra-schema.cql
@@ -137,3 +137,36 @@ CREATE TABLE MapsEntity(
 CREATE TABLE MapFrozen(
     id frozen <MAP<INT, BOOLEAN>> PRIMARY KEY
 );
+
+CREATE TYPE Name(
+    firstName TEXT,
+    lastName TEXT
+);
+
+CREATE TYPE Personal(
+    number INT,
+    street TEXT,
+    name frozen<Name>
+);
+
+CREATE TABLE WithEverything(
+    id INT PRIMARY KEY,
+    name Name,
+    frozenName frozen <Name>,
+    nameList LIST<frozen <Name>>,
+    nameSet SET<frozen <Name>>,
+    nameMap MAP<INT, frozen <Name>>,
+    personal frozen<Personal>
+);
+
+CREATE KEYSPACE quill_test_2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+
+CREATE TYPE quill_test_2.name(
+    first_name TEXT,
+    last_name TEXT
+);
+
+CREATE TABLE quill_test_2.with_udt(
+    id INT PRIMARY KEY,
+    name frozen <quill_test_2.Name>
+);

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtEncodingMirrorContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtEncodingMirrorContextSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.cassandra.udt
+
+import io.getquill.context.cassandra.mirrorContext
+
+class UdtEncodingMirrorContextSpec extends UdtSpec {
+
+  import mirrorContext._
+
+  "Provide implicit decoders/encoders" - {
+
+    "UDT raw columns" in {
+      implicitly[Decoder[Name]]
+      implicitly[Encoder[Name]]
+    }
+
+    "UDT collections columns" in {
+      implicitly[Decoder[List[Name]]]
+      implicitly[Encoder[List[Name]]]
+
+      implicitly[Decoder[Set[Name]]]
+      implicitly[Encoder[Set[Name]]]
+
+      implicitly[Decoder[Map[String, Name]]]
+      implicitly[Encoder[Map[Name, String]]]
+    }
+  }
+
+  "Encode/decode UDT within entity" in {
+    case class User(id: Int, name: Name, names: List[Name])
+    mirrorContext.run(query[User]).string mustBe "SELECT id, name, names FROM User"
+    mirrorContext.run(query[User]
+      .insert(lift(User(1, Name("1", "2"), Nil)))).string mustBe "INSERT INTO User (id,name,names) VALUES (?, ?, ?)"
+  }
+}

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtEncodingSessionContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtEncodingSessionContextSpec.scala
@@ -1,0 +1,117 @@
+package io.getquill.context.cassandra.udt
+
+import io.getquill.{ CassandraContextConfig, CassandraSyncContext, SnakeCase }
+import io.getquill.context.cassandra.{ Udt, testSyncDB }
+import io.getquill.util.LoadConfig
+
+class UdtEncodingSessionContextSpec extends UdtSpec {
+
+  val ctx1 = testSyncDB
+  val cluster = CassandraContextConfig(LoadConfig("testSyncDB")).cluster
+  val ctx2 = new CassandraSyncContext(SnakeCase, cluster, "quill_test_2", 1000)
+
+  "Provide encoding for UDT" - {
+    import ctx1._
+    "raw" in {
+      implicitly[Decoder[Name]]
+      implicitly[Encoder[Name]]
+    }
+    "collections" in {
+      implicitly[Decoder[List[Name]]]
+      implicitly[Decoder[Set[Name]]]
+      implicitly[Decoder[Map[String, Name]]]
+      implicitly[Encoder[List[Name]]]
+      implicitly[Encoder[Set[Name]]]
+      implicitly[Encoder[Map[String, Name]]]
+    }
+    "nested" in {
+      implicitly[Decoder[Personal]]
+      implicitly[Encoder[Personal]]
+      implicitly[Decoder[List[Personal]]]
+      implicitly[Encoder[List[Personal]]]
+    }
+    "MappedEncoding" in {
+      case class FirstName(name: String)
+      case class MyName(firstName: FirstName) extends Udt
+
+      implicit val encodeFirstName = MappedEncoding[FirstName, String](_.name)
+      implicit val decodeFirstName = MappedEncoding[String, FirstName](FirstName)
+
+      implicitly[Encoder[MyName]]
+      implicitly[Decoder[MyName]]
+      implicitly[Encoder[List[MyName]]]
+      implicitly[Decoder[List[MyName]]]
+    }
+  }
+
+  "Complete examples" - {
+    import ctx1._
+    "without meta" in {
+      case class WithEverything(id: Int, personal: Personal, nameList: List[Name])
+
+      val e = WithEverything(1, Personal(1, "strt", Name("first", "last")), List(Name("first", "last")))
+      ctx1.run(query[WithEverything].insert(lift(e)))
+      ctx1.run(query[WithEverything].filter(_.id == 1)).headOption must contain(e)
+    }
+    "with meta" in {
+      case class MyName(first: String) extends Udt
+      case class WithEverything(id: Int, name: MyName, nameList: List[MyName])
+      implicit val myNameMeta = udtMeta[MyName]("Name", _.first -> "firstName")
+
+      val e = WithEverything(2, MyName("first"), List(MyName("first")))
+      ctx1.run(query[WithEverything].insert(lift(e)))
+      ctx1.run(query[WithEverything].filter(_.id == 2)).headOption must contain(e)
+    }
+  }
+
+  "fail on inconsistent states" - {
+    val ctx0 = new CassandraSyncContext(SnakeCase, cluster, null, 1000)
+    "found several UDT with the same name, but not in current session" in {
+      intercept[IllegalStateException](ctx0.udtValueOf("Name")).getMessage mustBe
+        "Could not determine to which keyspace `Name` UDT belongs. Please specify desired keyspace using UdtMeta"
+
+      // but ok when specified
+      ctx0.udtValueOf("Name", Some("quill_test")).getType.getKeyspace mustBe "quill_test"
+      // "nAmE" - identifiers are case insensitive
+      ctx0.udtValueOf("nAmE", Some("quill_test_2")).getType.getKeyspace mustBe "quill_test_2"
+    }
+    "could not find UDT with given name" in {
+      intercept[IllegalStateException](ctx0.udtValueOf("Whatever")).getMessage mustBe
+        "Could not find UDT `Whatever` in any keyspace"
+    }
+  }
+
+  "return udt if it's found in another keyspace" in {
+    ctx2.udtValueOf("Personal").getType.getKeyspace mustBe "quill_test"
+  }
+
+  "naming strategy" in {
+    import ctx2._
+    case class WithUdt(id: Int, name: Name)
+    val e = WithUdt(1, Name("first", "second"))
+    // quill_test_2 uses snake case
+    ctx2.run(query[WithUdt].insert(lift(e)))
+    ctx2.run(query[WithUdt].filter(_.id == 1)).headOption must contain(e)
+  }
+
+  override protected def beforeAll(): Unit = {
+    clean1()
+    clean2()
+  }
+
+  private def clean1(): Unit = {
+    import ctx1._
+    ctx1.run(querySchema[Name]("WithEverything").delete)
+    ()
+  }
+
+  private def clean2(): Unit = {
+    import ctx2._
+    ctx2.run(querySchema[Name]("with_udt").delete)
+    ()
+  }
+
+  override protected def afterAll(): Unit = {
+    ctx2.close()
+  }
+}

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtMetaDslSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtMetaDslSpec.scala
@@ -1,0 +1,27 @@
+package io.getquill.context.cassandra.udt
+
+import io.getquill.context.cassandra.mirrorContext._
+
+class UdtMetaDslSpec extends UdtSpec {
+  "name" in {
+    udtMeta[Name]("my_name").name mustBe "my_name"
+
+    // allows dynamic renaming
+    val x: String = 123.toString
+    udtMeta[Name](x).name mustBe x
+  }
+
+  "keyspace" in {
+    udtMeta[Name]("ks.name").keyspace mustBe Some("ks")
+    udtMeta[Name]("name").keyspace mustBe None
+    intercept[IllegalStateException] {
+      udtMeta[Name]("ks.name.name")
+    }.getMessage mustBe "Cannot parse udt path `ks.name.name`"
+  }
+
+  "alias" in {
+    val meta = udtMeta[Name]("name", _.lastName -> "last")
+    meta.alias("firstName") mustBe None
+    meta.alias("lastName") mustBe Some("last")
+  }
+}

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/udt/UdtSpec.scala
@@ -1,0 +1,9 @@
+package io.getquill.context.cassandra.udt
+
+import io.getquill.Spec
+import io.getquill.context.cassandra.Udt
+
+trait UdtSpec extends Spec {
+  case class Name(firstName: String, lastName: String) extends Udt
+  case class Personal(number: Int, street: String, name: Name) extends Udt
+}


### PR DESCRIPTION
Fixes #311

### Problem
Quill does not provide encoding for Cassandra [UDT (User Defined Types)](http://docs.datastax.com/en/cql/3.1/cql/cql_using/cqlUseUDT.html)

### Solution
Add encoding for UDT. 
Create macros to generate udt encoders/decoders:
```scala
case class MyName(firstName: String, lastName: String) extends Udt

import ctx._
implicitly[Encoder[MyName]]
// will be expanded into
{
  val meta: UdtMeta[MyName] = udtMeta[MyName]("MyName")
  def udtencoder[T0, T1](implicit m0: CassandraMapper[String, T0], t0: ClassTag[T0],
                                  m1: CassandraMapper[String, T1], t1: ClassTag[T1]): Encoder[MyName] = {
    encoder[MyName](((i: Index, x: MyName, row: PrepareRow) => row.setUDTValue(i, ctx.udtValueOf(meta.name, meta.keyspace)
      .set[T0](meta.alias("firstName").getOrElse(ctx.naming.default("firstName")), m0.f(x.firstName), t0.runtimeClass.asInstanceOf[Class[T0]])
      .set[T1](meta.alias("lastName").getOrElse(ctx.naming.default("lastName")), m1.f(x.lastName), t1.runtimeClass.asInstanceOf[Class[T1]]))));
    }
  udtencoder  
}

// when specifying udt meta
implicit val meta = udtMeta[MyName]("my_name", _.lastName -> "my_last_name") implicitly[Decoder[MyName]]
// will be expanded into
{  
  val meta: UdtMeta[MyName] = implicitly[UdtMeta[MyName]](meta)
  def udtdecoder[T0, T1](implicit m0: CassandraMapper[T0, String], t0: ClassTag[T0], 
                                  m1: CassandraMapper[T1, String], t1: ClassTag[T1]): Decoder[MyName] =
    decoder(((index, row) => {
      val udt = row.getUDTValue(index);
      new MyName(
        m0.f(udt.get[T0](meta.alias("firstName").getOrElse(naming.default("firstName")), t0.runtimeClass.asInstanceOf[Class[T0]])),
        m1.f(udt.get[T1](meta.alias("lastName").getOrElse(naming.default("lastName")), t1.runtimeClass.asInstanceOf[Class[T1]])))
    }))
  udtdecoder
}
```
Note: `CassandraMapper` is a [dev api mapper](https://github.com/getquill/quill/blob/master/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/CassandraMapper.scala) introduced with collections support. By default encoding implicit functions provide mappers for each supported type by cassandra (identity func), scala-to-java and user defined MappedEncoding. 
Such mechanism allows easy way to encode/decode types within collection and now UDT, moreover, nested UDTs are also supported!

#### UdtMeta
In order to rename UDT name / its fields or to specify keyspace, `UdtMeta` is introduced. It very close to `schemaMeta` however it omits issue as described in #766, e.g. naming strategy does not override udtMeta definitions. Besides, it allows dynamic strings! 
UdtMeta API described in readme


### Checklist
- [X] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

