### PR TITLE
report the exactly tree position while typechecking

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -449,7 +449,7 @@ trait Parsing {
       """,
       c.TYPEmode
     ) catch {
-      case t: TypecheckException => c.error(t.msg)
+      case t: TypecheckException => c.error(lhs.pos, t.msg)
     }
     ()
   }


### PR DESCRIPTION
Current type checking erorrs are always reported at the end of quotation
 This makes it hard to point the error