### PR TITLE
release 2.12 in separate job

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -300,22 +300,37 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
   pgpSecretRing := file("local.secring.gpg"),
   pgpPublicRing := file("local.pubring.gpg"),
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    setReleaseVersion,
-    updateReadmeVersion(_._1),
-    commitReleaseVersion,
-    updateWebsiteTag,
-    tagRelease,
-    publishArtifacts,
-    setNextVersion,
-    updateReadmeVersion(_._2),
-    commitNextVersion,
-    ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
-    pushChanges
-  ),
+  releaseProcess := {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 11)) =>
+        Seq[ReleaseStep](
+          checkSnapshotDependencies,
+          inquireVersions,
+          runClean,
+          setReleaseVersion,
+          updateReadmeVersion(_._1),
+          commitReleaseVersion,
+          updateWebsiteTag,
+          tagRelease,
+          publishArtifacts,
+          setNextVersion,
+          updateReadmeVersion(_._2),
+          commitNextVersion,
+          ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+          pushChanges
+        )
+      case Some((2, 12)) =>
+        Seq[ReleaseStep](
+          checkSnapshotDependencies,
+          inquireVersions,
+          runClean,
+          setReleaseVersion,
+          publishArtifacts,
+          ReleaseStep(action = Command.process("sonatypeReleaseAll", _))
+        )
+      case _ => Seq[ReleaseStep]()
+    }
+  },
   pomExtra := (
     <url>http://github.com/getquill/quill</url>
     <licenses>

--- a/build/build.sh
+++ b/build/build.sh
@@ -5,8 +5,12 @@ chown root ~/.ssh/config
 chmod 644 ~/.ssh/config
 
 SBT_CMD="sbt clean"
-SBT_CMD_2_11=" ++2.11.11 coverage test tut coverageReport coverageAggregate checkUnformattedFiles"
-SBT_CMD_2_12=" ++2.12.2 test"
+
+SBT_CMD_2_11_PREFIX="++2.11.11"
+SBT_CMD_2_12_PREFIX="++2.12.2"
+
+SBT_CMD_2_11=" $SBT_CMD_2_11_PREFIX coverage test tut coverageReport coverageAggregate checkUnformattedFiles"
+SBT_CMD_2_12=" $SBT_CMD_2_12_PREFIX test"
 SBT_PUBLISH=" coverageOff publish"
 
 if [[ $SCALA_VERSION == "2.11" ]]
@@ -29,20 +33,23 @@ then
 
     if [[ $TRAVIS_BRANCH == "master" && $(cat version.sbt) != *"SNAPSHOT"* ]]
     then
-        # Run release step only for one build job. Other build jobs in this case do nothing and always succeed.
+        eval "$(ssh-agent -s)"
+        chmod 600 local.deploy_key.pem
+        ssh-add local.deploy_key.pem
+        git config --global user.name "Quill CI"
+        git config --global user.email "quillci@getquill.io"
+        git remote set-url origin git@github.com:getquill/quill.git
+        git fetch --unshallow
+        git checkout master || git checkout -b master
+        git reset --hard origin/master
+
         if [[ $SCALA_VERSION == "2.11" ]]
         then
-            eval "$(ssh-agent -s)"
-            chmod 600 local.deploy_key.pem
-            ssh-add local.deploy_key.pem
-            git config --global user.name "Quill CI"
-            git config --global user.email "quillci@getquill.io"
-            git remote set-url origin git@github.com:getquill/quill.git
-            git fetch --unshallow
-            git checkout master || git checkout -b master
-            git reset --hard origin/master
-            git push --delete origin website
-            sbt tut 'release cross with-defaults'
+            git push --delete origin website || true
+            sbt $SBT_CMD_2_11_PREFIX tut 'release with-defaults'
+        elif [[ $SCALA_VERSION == "2.12" ]]
+        then
+            sbt $SBT_CMD_2_12_PREFIX tut 'release with-defaults'
         fi
     elif [[ $TRAVIS_BRANCH == "master" ]]
     then


### PR DESCRIPTION
Fixes release

### Problem

Either Travis or slow connection to Sonatype dramatically slow down release process. 

### Solution

Move release for 2.12 into separate travis job

### Notes

modified release steps for 2.12 to remove everything connected to git and repo state changing. 

@getquill/maintainers
