### PR TITLE
Release quill for each scala version sequentially via different travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,16 @@ env:
   matrix:
     - SCALA_VERSION=2.11
     - SCALA_VERSION=2.12
+jobs:
+  include:
+    - stage: release 2.11
+      env:
+        - SCALA_VERSION=2.11.11
+      script:
+        - docker-compose run sbt bash -c "./build/release.sh"
+
+    - stage: release 2.12
+      env:
+        - SCALA_VERSION=2.12.3
+      script:
+        - docker-compose run sbt bash -c "./build/release.sh"

--- a/build/build.sh
+++ b/build/build.sh
@@ -5,12 +5,8 @@ chown root ~/.ssh/config
 chmod 644 ~/.ssh/config
 
 SBT_CMD="sbt clean"
-
-SBT_CMD_2_11_PREFIX="++2.11.11"
-SBT_CMD_2_12_PREFIX="++2.12.2"
-
-SBT_CMD_2_11=" $SBT_CMD_2_11_PREFIX coverage test tut coverageReport coverageAggregate checkUnformattedFiles"
-SBT_CMD_2_12=" $SBT_CMD_2_12_PREFIX test"
+SBT_CMD_2_11=" ++2.11.11 coverage test tut coverageReport coverageAggregate checkUnformattedFiles"
+SBT_CMD_2_12=" ++2.12.2 test"
 SBT_PUBLISH=" coverageOff publish"
 
 if [[ $SCALA_VERSION == "2.11" ]]
@@ -33,24 +29,8 @@ then
 
     if [[ $TRAVIS_BRANCH == "master" && $(cat version.sbt) != *"SNAPSHOT"* ]]
     then
-        eval "$(ssh-agent -s)"
-        chmod 600 local.deploy_key.pem
-        ssh-add local.deploy_key.pem
-        git config --global user.name "Quill CI"
-        git config --global user.email "quillci@getquill.io"
-        git remote set-url origin git@github.com:getquill/quill.git
-        git fetch --unshallow
-        git checkout master || git checkout -b master
-        git reset --hard origin/master
-
-        if [[ $SCALA_VERSION == "2.11" ]]
-        then
-            git push --delete origin website || true
-            sbt $SBT_CMD_2_11_PREFIX tut 'release with-defaults'
-        elif [[ $SCALA_VERSION == "2.12" ]]
-        then
-            sbt $SBT_CMD_2_12_PREFIX tut 'release with-defaults'
-        fi
+        echo Release is scheduled to next jobs
+        exit 0
     elif [[ $TRAVIS_BRANCH == "master" ]]
     then
         $SBT_CMD

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e # Any subsequent(*) commands which fail will cause the shell script to exit immediately
+chown root ~/.ssh/config
+chmod 644 ~/.ssh/config
+
+
+if [[ -n $SCALA_VERSION && $TRAVIS_PULL_REQUEST == "false" &&
+    $TRAVIS_BRANCH == "master" && $(cat version.sbt) != *"SNAPSHOT"* ]]
+then
+    openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/secring.gpg.enc -out local.secring.gpg -d
+    openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/pubring.gpg.enc -out local.pubring.gpg -d
+    openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/credentials.sbt.enc -out local.credentials.sbt -d
+    openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/deploy_key.pem.enc -out local.deploy_key.pem -d
+
+    eval "$(ssh-agent -s)"
+    chmod 600 local.deploy_key.pem
+    ssh-add local.deploy_key.pem
+    git config --global user.name "Quill CI"
+    git config --global user.email "quillci@getquill.io"
+    git remote set-url origin git@github.com:getquill/quill.git
+    git fetch --unshallow
+    git checkout master || git checkout -b master
+    git reset --hard origin/master
+    git push --delete origin website || true
+
+    sbt ++$SCALA_VERSION tut 'release with-defaults'
+else
+    echo Nothing to release
+    exit 0
+fi


### PR DESCRIPTION
### Problem

sbt-sonatype drops stage repository during concurrent release and the whole release process fails.

### Solution

Release quill for each scala version sequentially via different travis jobs

### Notes

release stages do not using docked env, but travis scala plugin

### Checklist

@getquill/maintainers
