### PR TITLE
Change release order, remove tut from release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ env:
     - SCALA_VERSION=2.12
 jobs:
   include:
-    - stage: release 2.11
-      env:
-        - SCALA_VERSION=2.11.11
-      script:
-        - docker-compose run sbt bash -c "./build/release.sh"
-
     - stage: release 2.12
       env:
         - SCALA_VERSION=2.12.3
+      script:
+        - docker-compose run sbt bash -c "./build/release.sh"
+
+    - stage: release 2.11
+      env:
+        - SCALA_VERSION=2.11.11
       script:
         - docker-compose run sbt bash -c "./build/release.sh"

--- a/build/release.sh
+++ b/build/release.sh
@@ -23,7 +23,7 @@ then
     git reset --hard origin/master
     git push --delete origin website || true
 
-    sbt ++$SCALA_VERSION tut 'release with-defaults'
+    sbt ++$SCALA_VERSION 'release with-defaults'
 else
     echo Nothing to release
     exit 0


### PR DESCRIPTION
- tut requires additional re-compilation of whole database(observed from logs)
- scala 2.11 release step does version bump, so this one has to be latest
@getquill/maintainers