### PR TITLE
Fix renaming properties for flat joins

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -80,7 +80,7 @@ object RenameProperties extends StatelessTransformer {
           case (a, schemaA) =>
             val replaceA = replacements(iA, schemaA)
             val onr = BetaReduction(on, replaceA: _*)
-            (FlatJoin(typ, a, iA, onr), Tuple(List(schemaA)))
+            (FlatJoin(typ, a, iA, onr), schemaA)
         }
 
       case q =>

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -208,6 +208,36 @@ class RenamePropertiesSpec extends Spec {
         testContext.run(q).string mustEqual
           "SELECT b.field_s FROM (SELECT t.s FROM TestEntity t WHERE t.i = 1) t RIGHT JOIN test_entity b ON t.s = b.field_s"
       }
+      "flat inner" in {
+        val q = quote {
+          for {
+            a <- qr2
+            x <- e.join(b => a.s == b.s)
+          } yield (x.s, x.i)
+        }
+        testContext.run(q).string mustEqual
+          "SELECT b.field_s, b.field_i FROM TestEntity2 a INNER JOIN test_entity b ON a.s = b.field_s"
+      }
+      "flat left" in {
+        val q = quote {
+          for {
+            a <- qr2
+            x <- e.leftJoin(b => a.s == b.s)
+          } yield x.map(x => x.i -> x.s)
+        }
+        testContext.run(q).string mustEqual
+          "SELECT b.field_i, b.field_s FROM TestEntity2 a LEFT JOIN test_entity b ON a.s = b.field_s"
+      }
+      "flat right" in {
+        val q = quote {
+          for {
+            a <- qr2
+            x <- e.rightJoin(b => a.s == b.s)
+          } yield x.map(x => x.i -> x.s)
+        }
+        testContext.run(q).string mustEqual
+          "SELECT b.field_i, b.field_s FROM TestEntity2 a RIGHT JOIN test_entity b ON a.s = b.field_s"
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #859

### Problem

When using flat joins, rename properties via querySchema/schemaMeta didn't work.

### Solution

Fix the issue, more in comments to patch


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
