### PR TITLE
avoid identifier shadowing

### DIFF
--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -54,10 +54,6 @@ class BetaReductionSpec extends Spec {
       }
     }
     "avoids replacing idents of an outer scope" - {
-      "function" in {
-        val ast: Ast = Function(List(Ident("a")), Ident("a"))
-        BetaReduction(ast, Ident("a") -> Ident("a'")) mustEqual ast
-      }
       "filter" in {
         val ast: Ast = Filter(Ident("a"), Ident("b"), Ident("b"))
         BetaReduction(ast, Ident("b") -> Ident("b'")) mustEqual ast
@@ -96,6 +92,19 @@ class BetaReductionSpec extends Spec {
           BetaReduction(ast, Ident("b") -> Ident("b'")) mustEqual ast
         }
       }
+    }
+  }
+
+  "doesn't shadow identifiers" - {
+    "function apply" in {
+      val ast: Ast = FunctionApply(Function(List(Ident("a"), Ident("b")), BinaryOperation(Ident("a"), NumericOperator.`/`, Ident("b"))), List(Ident("b"), Ident("a")))
+      BetaReduction(ast) mustEqual BinaryOperation(Ident("b"), NumericOperator.`/`, Ident("a"))
+    }
+    "nested function apply" in {
+      val f1 = Function(List(Ident("b")), BinaryOperation(Ident("a"), NumericOperator.`/`, Ident("b")))
+      val f2 = Function(List(Ident("a")), f1)
+      val ast: Ast = FunctionApply(FunctionApply(f2, List(Ident("b"))), List(Ident("a")))
+      BetaReduction(ast) mustEqual BinaryOperation(Ident("b"), NumericOperator.`/`, Ident("a"))
     }
   }
 


### PR DESCRIPTION
Fixes #291 

### Problem

The beta reduction doesn't handle the case when a function is applied to values that have conflicts with values defined by within the function.

### Solution

Rename identifier conflicts to a temporary name during the reduction.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
