### PR TITLE
fix branch build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -193,9 +193,9 @@ lazy val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
 
 commands += Command.command("checkUnformattedFiles") { st =>
   val vcs = Project.extract(st).get(releaseVcs).get
-  val modified = vcs.cmd("ls-files", "--modified", "--exclude-standard").!!.trim
+  val modified = vcs.cmd("ls-files", "--modified", "--exclude-standard").!!.trim.split('\n').filter(_.contains(".scala"))
   if(modified.nonEmpty)
-    throw new IllegalStateException(s"Please run `sbt scalariformFormat test:scalariformFormat` and resubmit your pull request. Found unformatted files: \n$modified")
+    throw new IllegalStateException(s"Please run `sbt scalariformFormat test:scalariformFormat` and resubmit your pull request. Found unformatted files: $modified")
   st
 }
 


### PR DESCRIPTION
### Problem

The 2.12 build is failing for branches. See https://travis-ci.org/getquill/quill/builds/273726166?utm_source=github_status&utm_medium=notification

### Solution

It fails because `version.sbt` is detected as an unformatted file. I've changed the sbt build to consider changes only to scala files

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
