### PR TITLE
cassandra async - return failed future instead of exception

### DIFF
--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
@@ -2,6 +2,7 @@ package io.getquill.context.cassandra
 
 import io.getquill._
 import scala.concurrent.ExecutionContext.Implicits.{ global => ec }
+import scala.util.Try
 
 class CassandraContextSpec extends Spec {
 
@@ -23,5 +24,15 @@ class CassandraContextSpec extends Spec {
       }
       testSyncDB.run(update) mustEqual (())
     }
+  }
+
+  "async - returns failed future if prepare fails" in {
+    import testAsyncDB._
+    case class InvalidTestEntity(id: Int, s: String, i: Int, l: Long, o: Int)
+    val update = quote {
+      query[InvalidTestEntity].filter(_.id == lift(1)).update(_.i -> lift(1))
+    }
+    val fut = testAsyncDB.run(update)
+    Try(await(fut)).isFailure mustEqual true
   }
 }


### PR DESCRIPTION
Fixes #589 

### Problem

The async context for cassandra throws an exception instead of a failed future when the query preparation fails.

### Solution

Lift the execution to a Future and flatten.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
