### PR TITLE
merge filter into the join condition

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/AdHocReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/AdHocReduction.scala
@@ -4,9 +4,11 @@ import io.getquill.ast.BinaryOperation
 import io.getquill.ast.BooleanOperator
 import io.getquill.ast.Filter
 import io.getquill.ast.FlatMap
+import io.getquill.ast.Join
 import io.getquill.ast.Map
 import io.getquill.ast.Query
 import io.getquill.ast.SortBy
+import io.getquill.ast.Tuple
 import io.getquill.ast.Union
 import io.getquill.ast.UnionAll
 
@@ -16,13 +18,19 @@ object AdHocReduction {
     q match {
 
       // ---------------------------
-      // filter.filter
+      // *.filter
 
       // a.filter(b => c).filter(d => e) =>
       //    a.filter(b => c && e[d := b])
       case Filter(Filter(a, b, c), d, e) =>
         val er = BetaReduction(e, d -> b)
         Some(Filter(a, b, BinaryOperation(c, BooleanOperator.`&&`, er)))
+
+      // a.join(b).on((c, d) => e).filter(f => g)
+      //    a.join(b).on((c, d) => e && g[f := (c, d)])
+      case Filter(Join(t, a, b, c, d, e), f, g) =>
+        val gr = BetaReduction(g, f -> Tuple(List(c, d)))
+        Some(Join(t, a, b, c, d, BinaryOperation(e, BooleanOperator.`&&`, gr)))
 
       // ---------------------------
       // flatMap.*

--- a/quill-core/src/test/scala/io/getquill/norm/AdHocReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/AdHocReductionSpec.scala
@@ -9,13 +9,22 @@ import io.getquill.testContext.unquote
 
 class AdHocReductionSpec extends Spec {
 
-  "filter.filter" - {
+  "*.filter" - {
     "a.filter(b => c).filter(d => e)" in {
       val q = quote {
         qr1.filter(b => b.s == "s1").filter(d => d.s == "s2")
       }
       val n = quote {
         qr1.filter(b => b.s == "s1" && b.s == "s2")
+      }
+      AdHocReduction.unapply(q.ast) mustEqual Some(n.ast)
+    }
+    "a.join(b).on((c, d) => e).filter(f => g)" in {
+      val q = quote {
+        qr1.join(qr2).on((c, d) => c.i == d.i).filter(t => t._1.i == 1)
+      }
+      val n = quote {
+        qr1.join(qr2).on((c, d) => c.i == d.i && c.i == 1)
       }
       AdHocReduction.unapply(q.ast) mustEqual Some(n.ast)
     }


### PR DESCRIPTION
Fixes #403 

### Problem

Filter operations after a join aren't merged into the join condition.

### Solution

Add a reduction step for this transformation

### Notes

This fixes this specific issue, but there's still a second bug in `ExpandNestedQueries` that I'll address when fixing https://github.com/getquill/quill/issues/724

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
