### PR TITLE
don't merge sortBy into flatMap

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/AdHocReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/AdHocReduction.scala
@@ -7,7 +7,6 @@ import io.getquill.ast.FlatMap
 import io.getquill.ast.Join
 import io.getquill.ast.Map
 import io.getquill.ast.Query
-import io.getquill.ast.SortBy
 import io.getquill.ast.Tuple
 import io.getquill.ast.Union
 import io.getquill.ast.UnionAll
@@ -44,11 +43,6 @@ object AdHocReduction {
       //    a.flatMap(b => c.filter(d => e))
       case Filter(FlatMap(a, b, c), d, e) =>
         Some(FlatMap(a, b, Filter(c, d, e)))
-
-      // a.flatMap(b => c).sortBy(d => e) =>
-      //    a.flatMap(b => c.sortBy(d => e))
-      case SortBy(FlatMap(a, b, c), d, e, f) =>
-        Some(FlatMap(a, b, SortBy(c, d, e, f)))
 
       // a.flatMap(b => c.union(d))
       //    a.flatMap(b => c).union(a.flatMap(b => d))

--- a/quill-core/src/test/scala/io/getquill/norm/AdHocReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/AdHocReductionSpec.scala
@@ -1,7 +1,6 @@
 package io.getquill.norm
 
 import io.getquill.Spec
-import io.getquill.testContext.implicitOrd
 import io.getquill.testContext.qr1
 import io.getquill.testContext.qr2
 import io.getquill.testContext.quote
@@ -46,15 +45,6 @@ class AdHocReductionSpec extends Spec {
       }
       val n = quote {
         qr1.flatMap(b => qr2.filter(d => d.s == "s2"))
-      }
-      AdHocReduction.unapply(q.ast) mustEqual Some(n.ast)
-    }
-    "a.flatMap(b => c).sortBy(d => e)" in {
-      val q = quote {
-        qr1.flatMap(b => qr2).sortBy(d => d.s)
-      }
-      val n = quote {
-        qr1.flatMap(b => qr2.sortBy(d => d.s))
       }
       AdHocReduction.unapply(q.ast) mustEqual Some(n.ast)
     }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -159,6 +159,19 @@ class SqlQuerySpec extends Spec {
             "SELECT t.s, t.i, t.l, t.o FROM TestEntity t ORDER BY (t.l - t.i) ASC NULLS FIRST"
         }
       }
+      "after flatMap" in {
+        val q = quote {
+          (for {
+            a <- qr1
+            b <- qr2 if a.i == b.i
+          } yield {
+            (a.s, b.s)
+          })
+            .sortBy(_._2)(Ord.desc)
+        }
+        testContext.run(q).string mustEqual
+          "SELECT b._1, b._2 FROM (SELECT b.s _2, a.s _1 FROM TestEntity a, TestEntity2 b WHERE a.i = b.i) b ORDER BY b._2 DESC"
+      }
       "fails if the sortBy criteria is malformed" in {
         case class Test(a: (Int, Int))
         implicit val o: Ordering[TestEntity] = null


### PR DESCRIPTION
Fixes #495 

### Problem

The normalization merges `sortBy` operations into previous `flatMap` body.

### Solution

Remove normalization rule.

### Notes

@mentegy thanks for the analysis on the issue! Indeed, the issue was the normalization.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
