### PR TITLE
remove anonymous class support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Sources now take a parameter for idiom and naming strategy instead of just type parameters. For instance, `new SqlSource[MysqlDialect, Literal]` becomes `new SqlSource(MysqlDialect, Literal)`.
 - Composite naming strategies don't use mixing anymore. Instead of the type `Literal with UpperCase`, use parameter value `NamingStrategy(Literal, UpperCase)`.
+- Anonymous classes aren't supported for function declaration anymore. Use a method with a type parameter instead. For instance, replace `val q = quote { new { def apply[T](q: Query[T]) = ... } }` by `def q[T] = quote { (q: Query[T] => ... }`
 
 # 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -86,14 +86,12 @@ val areas = quote {
 }
 ```
 
-Scala doesn't have support for high-order functions with type parameters. Quill supports anonymous classes with an apply method for this purpose:
+Scala doesn't have support for high-order functions with type parameters. It's possible to use method type parameter for this purpose:
 
 ```scala
-val existsAny = quote {
-  new {
-    def apply[T](xs: Query[T])(p: T => Boolean) =
+def existsAny[T] = quote {
+  (xs: Query[T]) => (p: T => Boolean) =>
     	xs.filter(p(_)).nonEmpty
-  }
 }
 
 val q = quote {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -268,8 +268,6 @@ trait Parsing {
   }
 
   val functionParser: Parser[Function] = Parser[Function] {
-    case q"new { def apply[..$t1](...$params) = $body }" =>
-      Function(params.flatten.map(p => p: Tree).map(identParser(_)), astParser(body))
     case q"(..$params) => $body" =>
       Function(params.map(identParser(_)), astParser(body))
   }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -440,12 +440,11 @@ class QuotationSpec extends Spec {
         }
         quote(unquote(q)).ast mustEqual Function(List(Ident("s")), Ident("s"))
       }
-      "anonymous class" in {
-        val q = quote {
-          new {
-            def apply[T](q: Query[T]) = q
-          }
+      "with type parameter" in {
+        def q[T] = quote {
+          (q: Query[T]) => q
         }
+        IsDynamic(q.ast) mustEqual false
         quote(unquote(q)).ast mustEqual Function(List(Ident("q")), Ident("q"))
       }
     }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/DepartmentsSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/DepartmentsSpec.scala
@@ -1,7 +1,5 @@
 package io.getquill.context.sql
 
-import scala.language.reflectiveCalls
-
 import io.getquill.Spec
 
 trait DepartmentsSpec extends Spec {
@@ -84,14 +82,11 @@ trait DepartmentsSpec extends Spec {
 
   val `Example 8 expected result` = List("Quality", "Research")
 
-  val any =
-    quote {
-      new {
-        def apply[T](xs: Query[T])(p: T => Boolean) =
-          (for {
-            x <- xs if (p(x))
-          } yield {}).nonEmpty
-      }
+  def any[T] =
+    quote { (xs: Query[T]) => (p: T => Boolean) =>
+      (for {
+        x <- xs if (p(x))
+      } yield {}).nonEmpty
     }
 
   val `Example 9 expertise` = {
@@ -114,20 +109,14 @@ trait DepartmentsSpec extends Spec {
         }
       }
 
-    val all =
-      quote {
-        new {
-          def apply[T](xs: Query[T])(p: T => Boolean) =
-            !any(xs)(x => !p(x))
-        }
+    def all[T] =
+      quote { (xs: Query[T]) => (p: T => Boolean) =>
+        !any(xs)(x => !p(x))
       }
 
-    def contains =
-      quote {
-        new {
-          def apply[T](xs: Query[T])(u: T) =
-            any(xs)(x => x == u)
-        }
+    def contains[T] =
+      quote { (xs: Query[T]) => (u: T) =>
+        any(xs)(x => x == u)
       }
 
     quote {


### PR DESCRIPTION
Fixes #778 

### Problem

For some obscure reason, functions declared as anonymous classes have a different behavior.

### Solution

Remove support for this syntax.

### Notes

I'm not sure why I added this syntax at the beginning of the project. It definitely isn't necessary right now; maybe it was at the time.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
