### PR TITLE
fix implicit class rebind

### DIFF
--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -961,6 +961,17 @@ class QuotationSpec extends Spec {
         l.value mustEqual 1
         l.encoder mustEqual intEncoder
       }
+      "with implicit class" in {
+        trait Implicits {
+          def random = util.Random.nextInt
+          implicit class PlusRadom(q: Int) {
+            def plusRandom = quote(q + lift(random))
+          }
+        }
+        object implicits extends Implicits
+        import implicits._
+        val q = quote(1.plusRandom)
+      }
       "embedded" in {
         case class EmbeddedTestEntity(id: String) extends Embedded
         case class TestEntity(embedded: EmbeddedTestEntity)


### PR DESCRIPTION
Fixes #704 

### Problem

Quill doesn't properly rebind `lift`ed values defined in traits.

### Solution

Use a `QuotedReference` to a function that represents the implicit transformation so the rebind will happen naturally.

### Notes

This was a hard bug to fix, we need to revisit this code at some point. I'm pretty sure there's a simpler way to handle the liftings and quotations.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
