### PR TITLE
better error message about the invariance of encoders/decoders

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/EncodingDslMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/EncodingDslMacro.scala
@@ -46,7 +46,7 @@ class EncodingDslMacro(val c: MacroContext) {
     }
 
   private def fail(enc: String, t: Type) =
-    c.fail(s"Can't find $enc for type '$t'")
+    c.fail(s"Can't find $enc for type '$t'. Note that ${enc}s are invariant. For example, use `lift(Option(1))` instead of `lift(Some(1))` since the available encoder is for `Option`, not `Some`. As an alternative for types that don't provide a method like `Option.apply`, you can use type widening: `lift(MyEnum.SomeValue: MyEnum.Value)`")
 
   private def withAnyValParam[R](tpe: Type)(f: Symbol => R): Option[R] =
     tpe.baseType(c.symbolOf[AnyVal]) match {


### PR DESCRIPTION
Fixes #584 

### Problem

Decoders and encoders are invariant, so they don't support reading/writing super/sub classes.

### Solution

When an encoder is not found, fail with an error message that will help the user to fix the issue with the invariance.

### Notes

I've tried making the encoding variant (`Encoder[-T]`/`Decoder[+T]`) but it doesn't play well with the macro-based encodings. I think it's reasonable to keep them invariant and give a nice error message.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
