### PR TITLE
Remove client.ping from the FinagleMysqlContext constructor

### DIFF
--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -70,8 +70,6 @@ class FinagleMysqlContext[N <: NamingStrategy](
       extractionTimeZone
     )
 
-  Await.result(client.ping)
-
   override def close = Await.result(client.close())
 
   private val currentClient = new Local[Client]


### PR DESCRIPTION
### Problem

Forcing a client.ping during FinagleMysqlContext construction causes servers to fail to start if they cannot connect to MySQL, and makes it difficult to run network-isolated startup tests.

### Solution

Remove the client.ping. As far as I can tell, it is not necessary.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
