### PR TITLE
fix group by alias conflict and don't apply join(groupby.map)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target
 **/.tmpBin
 local.*
 quill_test.db
+Bug.scala

--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ commands += Command.command("checkUnformattedFiles") { st =>
   val vcs = Project.extract(st).get(releaseVcs).get
   val modified = vcs.cmd("ls-files", "--modified", "--exclude-standard").!!.trim.split('\n').filter(_.contains(".scala"))
   if(modified.nonEmpty)
-    throw new IllegalStateException(s"Please run `sbt scalariformFormat test:scalariformFormat` and resubmit your pull request. Found unformatted files: $modified")
+    throw new IllegalStateException(s"Please run `sbt scalariformFormat test:scalariformFormat` and resubmit your pull request. Found unformatted files: ${modified.toList}")
   st
 }
 

--- a/quill-core/src/main/scala/io/getquill/norm/ApplyMap.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/ApplyMap.scala
@@ -7,70 +7,73 @@ object ApplyMap {
   private def isomorphic(e: Ast, c: Ast, alias: Ident) =
     BetaReduction(e, alias -> c) == c
 
+  object DetachableMap {
+    def unapply(ast: Ast): Option[(Ast, Ident, Ast)] =
+      ast match {
+        case Map(a: GroupBy, b, c) => None
+        case Map(a, b, c)          => Some((a, b, c))
+        case _                     => None
+      }
+  }
+
   def unapply(q: Query): Option[Query] =
     q match {
 
-      case Map(Map(a: GroupBy, b, c), d, e)       => None
-      case FlatMap(Map(a: GroupBy, b, c), d, e)   => None
-      case Filter(Map(a: GroupBy, b, c), d, e)    => None
-      case SortBy(Map(a: GroupBy, b, c), d, e, f) => None
-      case Take(Map(a: GroupBy, b, c), d)         => None
-      case Drop(Map(a: GroupBy, b, c), d)         => None
-      case Map(a: GroupBy, b, c) if (b == c)      => None
-      case Map(a: Nested, b, c) if (b == c)       => None
+      case Map(a: GroupBy, b, c) if (b == c) => None
+      case Map(a: Nested, b, c) if (b == c)  => None
 
       //  map(i => (i.i, i.l)).distinct.map(x => (x._1, x._2)) =>
       //    map(i => (i.i, i.l)).distinct
-      case Map(Distinct(Map(a, b, c)), d, e) if isomorphic(e, c, d) =>
+      case Map(Distinct(DetachableMap(a, b, c)), d, e) if isomorphic(e, c, d) =>
         Some(Distinct(Map(a, b, c)))
+
+      // a.map(b => c).map(d => e) =>
+      //    a.map(b => e[d := c])
+      case Map(DetachableMap(a, b, c), d, e) =>
+        val er = BetaReduction(e, d -> c)
+        Some(Map(a, b, er))
 
       // a.map(b => b) =>
       //    a
       case Map(a: Query, b, c) if (b == c) =>
         Some(a)
 
-      // a.map(b => c).map(d => e) =>
-      //    a.map(b => e[d := c])
-      case Map(Map(a, b, c), d, e) =>
-        val er = BetaReduction(e, d -> c)
-        Some(Map(a, b, er))
-
       // a.map(b => c).flatMap(d => e) =>
       //    a.flatMap(b => e[d := c])
-      case FlatMap(Map(a, b, c), d, e) =>
+      case FlatMap(DetachableMap(a, b, c), d, e) =>
         val er = BetaReduction(e, d -> c)
         Some(FlatMap(a, b, er))
 
       // a.map(b => c).filter(d => e) =>
       //    a.filter(b => e[d := c]).map(b => c)
-      case Filter(Map(a, b, c), d, e) =>
+      case Filter(DetachableMap(a, b, c), d, e) =>
         val er = BetaReduction(e, d -> c)
         Some(Map(Filter(a, b, er), b, c))
 
       // a.map(b => c).sortBy(d => e) =>
       //    a.sortBy(b => e[d := c]).map(b => c)
-      case SortBy(Map(a, b, c), d, e, f) =>
+      case SortBy(DetachableMap(a, b, c), d, e, f) =>
         val er = BetaReduction(e, d -> c)
         Some(Map(SortBy(a, b, er, f), b, c))
 
       // a.map(b => c).drop(d) =>
       //    a.drop(d).map(b => c)
-      case Drop(Map(a, b, c), d) =>
+      case Drop(DetachableMap(a, b, c), d) =>
         Some(Map(Drop(a, d), b, c))
 
       // a.map(b => c).take(d) =>
       //    a.drop(d).map(b => c)
-      case Take(Map(a, b, c), d) =>
+      case Take(DetachableMap(a, b, c), d) =>
         Some(Map(Take(a, d), b, c))
 
       // a.map(b => c).nested =>
       //    a.nested.map(b => c)
-      case Nested(Map(a, b, c)) =>
+      case Nested(DetachableMap(a, b, c)) =>
         Some(Map(Nested(a), b, c))
 
       // a.map(b => c).*join(d.map(e => f)).on((iA, iB) => on)
       //    a.*join(d).on((b, e) => on[iA := c, iB := f]).map(t => (c[b := t._1], f[e := t._2]))
-      case Join(tpe, Map(a, b, c), Map(d, e, f), iA, iB, on) =>
+      case Join(tpe, DetachableMap(a, b, c), DetachableMap(d, e, f), iA, iB, on) =>
         val onr = BetaReduction(on, iA -> c, iB -> f)
         val t = Ident("t")
         val t1 = BetaReduction(c, b -> Property(t, "_1"))
@@ -79,7 +82,7 @@ object ApplyMap {
 
       // a.*join(b.map(c => d)).on((iA, iB) => on)
       //    a.*join(b).on((iA, c) => on[iB := d]).map(t => (t._1, d[c := t._2]))
-      case Join(tpe, a, Map(b, c, d), iA, iB, on) =>
+      case Join(tpe, a, DetachableMap(b, c, d), iA, iB, on) =>
         val onr = BetaReduction(on, iB -> d)
         val t = Ident("t")
         val t1 = Property(t, "_1")
@@ -88,7 +91,7 @@ object ApplyMap {
 
       // a.map(b => c).*join(d).on((iA, iB) => on)
       //    a.*join(d).on((b, iB) => on[iA := c]).map(t => (c[b := t._1], t._2))
-      case Join(tpe, Map(a, b, c), d, iA, iB, on) =>
+      case Join(tpe, DetachableMap(a, b, c), d, iA, iB, on) =>
         val onr = BetaReduction(on, iA -> c)
         val t = Ident("t")
         val t1 = BetaReduction(c, b -> Property(t, "_1"))

--- a/quill-core/src/test/scala/io/getquill/norm/ApplyMapSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ApplyMapSpec.scala
@@ -26,7 +26,7 @@ class ApplyMapSpec extends Spec {
     }
     "map" in {
       val q = quote {
-        qr1.groupBy(t => t.i).map(y => y._1).map(s => s)
+        qr1.groupBy(t => t.i).map(y => y._1).filter(i => i == 1)
       }
       ApplyMap.unapply(q.ast) mustEqual None
     }
@@ -48,11 +48,32 @@ class ApplyMapSpec extends Spec {
       }
       ApplyMap.unapply(q.ast) mustEqual None
     }
+
     "identity map" in {
       val q = quote {
         qr1.groupBy(t => t.i).map(y => y)
       }
       ApplyMap.unapply(q.ast) mustEqual None
+    }
+    "mapped join" - {
+      "left" in {
+        val q = quote {
+          qr1.groupBy(t => t.i).map(t => t._1).join(qr2).on((a, b) => a == b.i)
+        }
+        ApplyMap.unapply(q.ast) mustEqual None
+      }
+      "right" in {
+        val q = quote {
+          qr1.join(qr2.groupBy(t => t.i).map(t => t._1)).on((a, b) => a.i == b)
+        }
+        ApplyMap.unapply(q.ast) mustEqual None
+      }
+      "both" in {
+        val q = quote {
+          qr1.groupBy(t => t.i).map(t => t._1).join(qr2.groupBy(t => t.i).map(t => t._1)).on((a, b) => a == b)
+        }
+        ApplyMap.unapply(q.ast) mustEqual None
+      }
     }
   }
 

--- a/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
@@ -47,6 +47,15 @@ class AvoidAliasConflictSpec extends Spec {
       }
       AvoidAliasConflict(q.ast) mustEqual n.ast
     }
+    "groupBy" in {
+      val q = quote {
+        qr1.flatMap(a => qr2.groupBy(a => a.s))
+      }
+      val n = quote {
+        qr1.flatMap(a => qr2.groupBy(a1 => a1.s))
+      }
+      AvoidAliasConflict(q.ast) mustEqual n.ast
+    }
     "outer join" - {
       "both sides" in {
         val q = quote {

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
@@ -62,7 +62,7 @@ object ExpandNestedQueries {
               case List(SelectValue(i: Ident, _)) =>
                 SelectValue(Property(i, name))
               case other =>
-                SelectValue(Ident(name))
+                SelectValue(Ident(name), Some(name))
             }
         }
     }


### PR DESCRIPTION
Fixes #410 

### Problem

#410 involves two bugs:

- `AvoidAliasConflict` doesn't consider `GroupBy`
- `ApplyMap` doesn't avoid applying maps that are associated to a groupby

### Solution

Fix the issues

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
