### PR TITLE
expand nested queries that select tuples

### DIFF
--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -43,4 +43,16 @@ class ExpandNestedQueriesSpec extends Spec {
     ).string mustEqual
       "SELECT e.camel_case, 1 FROM (SELECT x.camel_case FROM entity x) e"
   }
+
+  "expands nested tuple select" in {
+    import testContext._
+    val q = quote {
+      qr1.groupBy(s => (s.i, s.s)).map {
+        case (group, items) =>
+          (group, items.size)
+      }
+    }
+    testContext.run(q).string mustEqual
+      "SELECT s._1_1, s._1_2, s._2 FROM (SELECT s.i _1_1, s.s _1_2, COUNT(*) _2 FROM TestEntity s GROUP BY s.i, s.s) s"
+  }
 }


### PR DESCRIPTION
Fixes #662 

### Problem

`ExpandNestedQuery` can't expand nested queries that select tuples.

### Solution

Describe the modifications you've done.

### Notes

I had to implement a workaround in `SqlIdiom` to keep the previous behavior for non-tuple properties that ignores embedded columns. We should revisit this in the future and make embedded values a first-class ast information.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
