### PR TITLE
fix implicit class with liftings support

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Rebind.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Rebind.scala
@@ -1,7 +1,6 @@
 package io.getquill.quotation
 
 import scala.reflect.macros.whitebox.Context
-
 import io.getquill.ast.Ast
 import io.getquill.ast.Function
 import io.getquill.ast.FunctionApply
@@ -19,13 +18,20 @@ object Rebind {
     def paramIdents(method: MethodSymbol) =
       method.paramLists.flatten.map(toIdent)
 
+    def reify(t: Tree): Tree =
+      if (t.tpe.typeSymbol.fullName.toString.startsWith("io.getquill.dsl"))
+        q"null"
+      else
+        t
+
     tree match {
       case q"$conv($orig).$m[..$t](...$params)" =>
         val convMethod = conv.symbol.asMethod
         val origIdent = paramIdents(convMethod).head
         val paramsIdents = paramIdents(convMethod.returnType.member(m).asMethod)
         val paramsAsts = params.flatten.map(astParser)
-        val function = QuotedReference(tree, Function(origIdent :: paramsIdents, ast))
+        val reifiedTree = q"$conv(${reify(orig)}).$m[..$t](...${params.map(_.map(reify(_)))})"
+        val function = QuotedReference(reifiedTree, Function(origIdent :: paramsIdents, ast))
         val apply = FunctionApply(function, astParser(orig) :: paramsAsts)
         Some(apply)
       case _ =>

--- a/quill-core/src/test/scala/io/getquill/quotation/RebindSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/RebindSpec.scala
@@ -11,7 +11,7 @@ class RebindSpec extends Spec {
       def returnId = quote(infix"$action RETURNING ID".as[Action[T]])
     }
     val q = quote {
-      unquote(query[TestEntity].insert(e => e.i -> lift(1)).returnId)
+      query[TestEntity].insert(e => e.i -> lift(1)).returnId
     }
     testContext.run(q).string mustEqual s"""infix"$${querySchema("TestEntity").insert(e => e.i -> ?)} RETURNING ID""""
   }


### PR DESCRIPTION
 
### Problem

While working on https://github.com/getquill/quill/pull/892, I introduced a bug. Implicit quotations with lifted values don't work if applied to queries.

### Solution

Implement a workaround that uses a `null` value to create the quotation instance in order to access the lifting.

### Notes

This is ugly, but I think it's good enough for now. A proper fix would involve reimplementing the implicit quotation mechanism

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
