### PR TITLE
avoid alias conflict when an entity query is wrapped into other non-aliasing queries

### DIFF
--- a/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
@@ -125,6 +125,25 @@ class AvoidAliasConflictSpec extends Spec {
         }
         AvoidAliasConflict(q.ast) mustEqual n.ast
       }
+      "nested unaliased" in {
+        val q = quote {
+          for {
+            a <- qr1.nested.groupBy(a => a.i).map(t => (t._1, t._2.map(v => v.i).sum))
+            b <- qr1.nested.groupBy(a => a.i).map(t => (t._1, t._2.map(v => v.i).sum))
+          } yield {
+            (a, b)
+          }
+        }
+        val n = quote {
+          for {
+            a <- qr1.nested.groupBy(a => a.i).map(t => (t._1, t._2.map(v => v.i).sum))
+            b <- qr1.nested.groupBy(a1 => a1.i).map(t => (t._1, t._2.map(v => v.i).sum))
+          } yield {
+            (a, b)
+          }
+        }
+        AvoidAliasConflict(q.ast) mustEqual n.ast
+      }
       "multiple" in {
         val q = quote {
           qr1.leftJoin(qr2).on((a, b) => a.i == b.i)


### PR DESCRIPTION
Fixes #663 

### Problem

`AvoidAliasConflict` doesn't take into consideration the alias of queries that are wrapped into other queries like `.distinct`.

### Solution

Fix the issue.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
