### PR TITLE
don't allow option comparison

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -340,15 +340,23 @@ trait Parsing {
     case q"${ astParser(a) }.apply[..$t](...$values)" => FunctionApply(a, values.flatten.map(astParser(_)))
   }
 
+  private def rejectOptions(a: Tree, b: Tree) = {
+    if((!is[Null](a) && is[Option[_]](a)) || (!is[Null](b) && is[Option[_]](b))) 
+      c.fail("Can't compare `Option` values since databases have different behavior for null comparison. Use `Option` methods like `forall` and `exists` instead.")
+  }
+  
   val equalityOperationParser: Parser[Operation] = Parser[Operation] {
     case q"$a.==($b)" =>
       checkTypes(a, b)
+      rejectOptions(a, b)
       BinaryOperation(astParser(a), EqualityOperator.`==`, astParser(b))
     case q"$a.equals($b)" =>
       checkTypes(a, b)
+      rejectOptions(a, b)
       BinaryOperation(astParser(a), EqualityOperator.`==`, astParser(b))
     case q"$a.!=($b)" =>
       checkTypes(a, b)
+      rejectOptions(a, b)
       BinaryOperation(astParser(a), EqualityOperator.`!=`, astParser(b))
   }
 

--- a/quill-core/src/test/scala/io/getquill/context/EncodeBindVariablesSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/EncodeBindVariablesSpec.scala
@@ -17,9 +17,9 @@ class EncodeBindVariablesSpec extends Spec {
     "three" in {
       val i = 1
       val j = 2
-      val o = Option(3)
+      val o = 3
       val q = quote {
-        qr1.filter(t => t.i == lift(i) && t.i > lift(j) && t.o == lift(o))
+        qr1.filter(t => t.i == lift(i) && t.i > lift(j) && t.o.forall(_ == lift(o)))
       }
       testContext.run(q).prepareRow mustEqual Row(i, j, o)
     }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -480,6 +480,29 @@ class QuotationSpec extends Spec {
             }
           """ mustNot compile
         }
+        "fails if comparing options" - {
+          "Option/Option" in {
+            """
+              quote {
+                (a: Option[Int], b: Option[Int]) => a == b
+              }
+            """ mustNot compile
+          }
+          "Option/None" in {
+            """
+              quote {
+                (a: Option[Int]) => a == None
+              }
+            """ mustNot compile
+          }
+          "None/Option" in {
+            """
+              quote {
+                (a: Option[Int]) => None == a
+              }
+            """ mustNot compile
+          }
+        }
       }
       "equals" in {
         val q = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
@@ -157,7 +157,7 @@ trait EncodingSpec extends Spec {
   val insertBarCode = quote((b: BarCode) => query[BarCode].insert(b).returning(_.uuid))
   val barCodeEntry = BarCode("returning UUID")
 
-  def findBarCodeByUuid(uuid: UUID) = quote(query[BarCode].filter(_.uuid == lift(Option(uuid))))
+  def findBarCodeByUuid(uuid: UUID) = quote(query[BarCode].filter(_.uuid.forall(_ == lift(uuid))))
 
   def verifyBarcode(barCode: BarCode) = barCode.description mustEqual "returning UUID"
 }


### PR DESCRIPTION
Fixes #659 

### Problem

Databases have different behaviors for null comparison, so `Option` comparison isn't correctly translated.

### Solution

Don't allow `Option` comparison.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
