### PR TITLE
give a better error message for option.get

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -307,6 +307,8 @@ trait Parsing {
   }
 
   val propertyParser: Parser[Ast] = Parser[Ast] {
+    case q"$e.get" if is[Option[Any]](e) =>
+      c.fail("Option.get is not supported since it's an unsafe operation. Use `forall` or `exists` instead.")
     case q"$e.$property" => Property(astParser(e), property.decodedName.toString)
   }
 

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -421,11 +421,20 @@ class QuotationSpec extends Spec {
       }
       quote(unquote(q)).ast.body mustEqual Ident("s")
     }
-    "property" in {
-      val q = quote {
-        qr1.map(t => t.s)
+    "property" - {
+      "class field" in {
+        val q = quote {
+          qr1.map(t => t.s)
+        }
+        quote(unquote(q)).ast.body mustEqual Property(Ident("t"), "s")
       }
-      quote(unquote(q)).ast.body mustEqual Property(Ident("t"), "s")
+      "option.get fails" in {
+        """
+          quote {
+            (o: Option[Int]) => o.get
+          }
+        """ mustNot compile
+      }
     }
     "property anonymous" in {
       val q = quote {


### PR DESCRIPTION
### Problem

It's common to have questions on gitter on why `option.get` doesn't work.

### Solution

Give an error message that explains how to fix the issue

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
