### PR TITLE
fail if expression uses a table

### DIFF
--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -124,6 +124,9 @@ class MirrorIdiom extends Idiom {
     case OptionForall(ast, alias, body) => stmt"${ast.token}.forall((${alias.token}) => ${body.token})"
     case OptionExists(ast, alias, body) => stmt"${ast.token}.exists((${alias.token}) => ${body.token})"
     case OptionContains(ast, body)      => stmt"${ast.token}.contains(${body.token})"
+    case OptionIsEmpty(ast)             => stmt"${ast.token}.isEmpty"
+    case OptionNonEmpty(ast)            => stmt"${ast.token}.nonEmpty"
+    case OptionIsDefined(ast)           => stmt"${ast.token}.isDefined"
   }
 
   implicit def traversableOperationTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[TraversableOperation] = Tokenizer[TraversableOperation] {

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -74,6 +74,9 @@ case class OptionMap(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
 case class OptionForall(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
 case class OptionExists(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
 case class OptionContains(ast: Ast, body: Ast) extends OptionOperation
+case class OptionIsEmpty(ast: Ast) extends OptionOperation
+case class OptionNonEmpty(ast: Ast) extends OptionOperation
+case class OptionIsDefined(ast: Ast) extends OptionOperation
 
 sealed trait TraversableOperation extends Ast
 case class MapContains(ast: Ast, body: Ast) extends TraversableOperation

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -70,6 +70,15 @@ trait StatefulTransformer[T] {
         val (at, att) = apply(a)
         val (ct, ctt) = att.apply(c)
         (OptionContains(at, ct), ctt)
+      case OptionIsEmpty(a) =>
+        val (at, att) = apply(a)
+        (OptionIsEmpty(at), att)
+      case OptionNonEmpty(a) =>
+        val (at, att) = apply(a)
+        (OptionNonEmpty(at), att)
+      case OptionIsDefined(a) =>
+        val (at, att) = apply(a)
+        (OptionIsDefined(at), att)
     }
 
   def apply(e: TraversableOperation): (TraversableOperation, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -30,6 +30,9 @@ trait StatelessTransformer {
       case OptionForall(a, b, c) => OptionForall(apply(a), b, apply(c))
       case OptionExists(a, b, c) => OptionExists(apply(a), b, apply(c))
       case OptionContains(a, b)  => OptionContains(apply(a), apply(b))
+      case OptionIsEmpty(a)      => OptionIsEmpty(apply(a))
+      case OptionNonEmpty(a)     => OptionNonEmpty(apply(a))
+      case OptionIsDefined(a)    => OptionIsDefined(apply(a))
     }
 
   def apply(o: TraversableOperation): TraversableOperation =

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -40,6 +40,9 @@ trait Liftables {
     case OptionForall(a, b, c) => q"$pack.OptionForall($a,$b,$c)"
     case OptionExists(a, b, c) => q"$pack.OptionExists($a,$b,$c)"
     case OptionContains(a, b)  => q"$pack.OptionContains($a,$b)"
+    case OptionIsEmpty(a)      => q"$pack.OptionIsEmpty($a)"
+    case OptionNonEmpty(a)     => q"$pack.OptionNonEmpty($a)"
+    case OptionIsDefined(a)    => q"$pack.OptionIsDefined($a)"
   }
 
   implicit val traversableOperationLiftable: Liftable[TraversableOperation] = Liftable[TraversableOperation] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -46,9 +46,9 @@ trait Parsing {
     case `orderingParser`(value)             => value
     case `operationParser`(value)            => value
     case `identParser`(value)                => value
+    case `optionOperationParser`(value)      => value
     case `propertyParser`(value)             => value
     case `stringInterpolationParser`(value)  => value
-    case `optionOperationParser`(value)      => value
     case `traversableOperationParser`(value) => value
     case `boxingParser`(value)               => value
     case `ifParser`(value)                   => value
@@ -295,6 +295,12 @@ trait Parsing {
       OptionExists(astParser(o), identParser(alias), astParser(body))
     case q"$o.contains[$t]($body)" if is[Option[Any]](o) =>
       OptionContains(astParser(o), astParser(body))
+    case q"$o.isEmpty" if is[Option[Any]](o) =>
+      OptionIsEmpty(astParser(o))
+    case q"$o.nonEmpty" if is[Option[Any]](o) =>
+      OptionNonEmpty(astParser(o))
+    case q"$o.isDefined" if is[Option[Any]](o) =>
+      OptionIsDefined(astParser(o))
   }
 
   val traversableOperationParser: Parser[TraversableOperation] = Parser[TraversableOperation] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -34,6 +34,9 @@ trait Unliftables {
     case q"$pack.OptionForall.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionForall(a, b, c)
     case q"$pack.OptionExists.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionExists(a, b, c)
     case q"$pack.OptionContains.apply(${ a: Ast }, ${ b: Ast })"              => OptionContains(a, b)
+    case q"$pack.OptionIsEmpty.apply(${ a: Ast })"                            => OptionIsEmpty(a)
+    case q"$pack.OptionNonEmpty.apply(${ a: Ast })"                           => OptionNonEmpty(a)
+    case q"$pack.OptionIsDefined.apply(${ a: Ast })"                          => OptionIsDefined(a)
   }
 
   implicit val traversableOperationUnliftable: Unliftable[TraversableOperation] = Unliftable[TraversableOperation] {

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -280,6 +280,30 @@ class StatefulTransformerSpec extends Spec {
             att.state mustEqual List(Ident("a"), Ident("c"))
         }
       }
+      "isEmpty" in {
+        val ast: Ast = OptionIsEmpty(Ident("a"))
+        Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionIsEmpty(Ident("a'"))
+            att.state mustEqual List(Ident("a"))
+        }
+      }
+      "nonEmpty" in {
+        val ast: Ast = OptionNonEmpty(Ident("a"))
+        Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionNonEmpty(Ident("a'"))
+            att.state mustEqual List(Ident("a"))
+        }
+      }
+      "isDefined" in {
+        val ast: Ast = OptionIsDefined(Ident("a"))
+        Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionIsDefined(Ident("a'"))
+            att.state mustEqual List(Ident("a"))
+        }
+      }
     }
 
     "traversable operations" - {

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -174,6 +174,21 @@ class StatelessTransformerSpec extends Spec {
         Subject(Ident("a") -> Ident("a'"), Ident("c") -> Ident("c'"))(ast) mustEqual
           OptionContains(Ident("a'"), Ident("c'"))
       }
+      "isEmpty" in {
+        val ast: Ast = OptionIsEmpty(Ident("a"))
+        Subject(Ident("a") -> Ident("a'"))(ast) mustEqual
+          OptionIsEmpty(Ident("a'"))
+      }
+      "nonEmpty" in {
+        val ast: Ast = OptionNonEmpty(Ident("a"))
+        Subject(Ident("a") -> Ident("a'"))(ast) mustEqual
+          OptionNonEmpty(Ident("a'"))
+      }
+      "isDefined" in {
+        val ast: Ast = OptionIsDefined(Ident("a"))
+        Subject(Ident("a") -> Ident("a'"))(ast) mustEqual
+          OptionIsDefined(Ident("a'"))
+      }
     }
 
     "traversable operations" - {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -763,6 +763,24 @@ class QuotationSpec extends Spec {
         }
         quote(unquote(q)).ast.body mustEqual OptionContains(Ident("o"), Ident("v"))
       }
+      "isEmpty" in {
+        val q = quote {
+          (o: Option[Boolean]) => o.isEmpty
+        }
+        quote(unquote(q)).ast.body mustEqual OptionIsEmpty(Ident("o"))
+      }
+      "nonEmpty" in {
+        val q = quote {
+          (o: Option[Boolean]) => o.nonEmpty
+        }
+        quote(unquote(q)).ast.body mustEqual OptionNonEmpty(Ident("o"))
+      }
+      "isDefined" in {
+        val q = quote {
+          (o: Option[Boolean]) => o.isDefined
+        }
+        quote(unquote(q)).ast.body mustEqual OptionIsDefined(Ident("o"))
+      }
     }
     "traversable operations" - {
       "map.contains" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/VerifySqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/VerifySqlQuerySpec.scala
@@ -22,5 +22,15 @@ class VerifySqlQuerySpec extends Spec {
       VerifySqlQuery(SqlQuery(q.ast)).toString mustEqual
         "Some(The monad composition can't be expressed using applicative joins. Faulty expression: 'b.s == a.s'. Free variables: 'List(a)'.)"
     }
+
+    "invalid table reference" in {
+      val q = quote {
+        qr1.leftJoin(qr2).on((a, b) => a.i == b.i).filter {
+          case (a, b) => b.isDefined
+        }
+      }
+      VerifySqlQuery(SqlQuery(q.ast)).toString mustEqual
+        "Some(The monad composition can't be expressed using applicative joins. Faulty expression: 'x01._2.isDefined'. Free variables: 'List(x01)'., Faulty expression: 'x01'. Free variables: 'List(x01)'.)"
+    }
   }
 }


### PR DESCRIPTION
Fixes #702 
Fixes #248 

### Problem

Quill doesn't fail if the user query uses a table instead of a specific column. See #702 for more details.

### Solution

Fail if this kind of AST is being compiled into a query.

### Notes

I had to fix #248 in order to fix the bug.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
