### PR TITLE
fix alias conflict

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/AvoidAliasConflict.scala
@@ -86,20 +86,19 @@ private case class AvoidAliasConflict(state: collection.Set[Ident])
     (f(fresh, prr), t)
   }
 
-  private def freshIdent(x: Ident, state: collection.Set[Ident] = state): Ident =
+  private def freshIdent(x: Ident, state: collection.Set[Ident] = state): Ident = {
+    def loop(x: Ident, n: Int): Ident = {
+      val fresh = Ident(s"${x.name}$n")
+      if (!state.contains(fresh))
+        fresh
+      else
+        loop(x, n + 1)
+    }
     if (!state.contains(x))
       x
     else
-      freshIdent(x, 1)
-
-  private def freshIdent(x: Ident, n: Int): Ident = {
-    val fresh = Ident(s"${x.name}$n")
-    if (!state.contains(fresh))
-      fresh
-    else
-      freshIdent(x, n + 1)
+      loop(x, 1)
   }
-
 }
 
 private[capture] object AvoidAliasConflict {

--- a/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/capture/AvoidAliasConflictSpec.scala
@@ -226,6 +226,19 @@ class AvoidAliasConflictSpec extends Spec {
         AvoidAliasConflict(q.ast) mustEqual n.ast
       }
     }
+    "join + filter" in {
+      val q = quote {
+        qr1.filter(x1 => x1.i == 1)
+          .join(qr2.filter(x1 => x1.i == 1))
+          .on((a, b) => a.i == b.i)
+      }
+      val n = quote {
+        qr1.filter(x1 => x1.i == 1)
+          .join(qr2.filter(x11 => x11.i == 1))
+          .on((a, b) => a.i == b.i)
+      }
+      AvoidAliasConflict(q.ast) mustEqual n.ast
+    }
   }
 
   "handles many alias conflicts" in {


### PR DESCRIPTION
Fixes #703 

### Problem

`AvoidAliasConflict` can generate non-unique aliases

### Solution

Fix `freshIdent` to use the passed state.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
