### PR TITLE
fix queries that use map after groupby

### DIFF
--- a/quill-core/src/test/scala/io/getquill/norm/ApplyMapSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ApplyMapSpec.scala
@@ -48,7 +48,6 @@ class ApplyMapSpec extends Spec {
       }
       ApplyMap.unapply(q.ast) mustEqual None
     }
-
     "identity map" in {
       val q = quote {
         qr1.groupBy(t => t.i).map(y => y)
@@ -77,11 +76,19 @@ class ApplyMapSpec extends Spec {
     }
   }
 
-  "avoids applying the identity map with nested query" in {
-    val q = quote {
-      qr1.map(x => x.i).nested.map(x => x)
+  "avoids applying map with nested query" - {
+    "identity map" in {
+      val q = quote {
+        qr1.map(x => x.i).nested.map(x => x)
+      }
+      ApplyMap.unapply(q.ast) mustEqual None
     }
-    ApplyMap.unapply(q.ast) mustEqual None
+    "join" in {
+      val q = quote {
+        qr1.join(qr2).on((a, b) => a.i == b.i).map(t => t).nested
+      }
+      ApplyMap.unapply(q.ast) mustEqual None
+    }
   }
 
   "applies intermediate map" - {

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
@@ -7,13 +7,26 @@ import io.getquill.norm.RenameProperties
 
 object SqlNormalize {
 
+  private val debugEnabled = false
+
   private val normalize =
     (identity[Ast] _)
+      .andThen(debug("original"))
       .andThen(FlattenOptionOperation.apply _)
+      .andThen(debug("FlattenOptionOperation"))
       .andThen(Normalize.apply _)
+      .andThen(debug("Normalize"))
       .andThen(RenameProperties.apply _)
+      .andThen(debug("RenameProperties"))
       .andThen(ExpandJoin.apply _)
+      .andThen(debug("ExpandJoin"))
       .andThen(Normalize.apply _)
+      .andThen(debug("Normalize"))
+
+  def debug(name: String)(ast: Ast) = {
+    if (debugEnabled) println(s"$name:\n 		$ast")
+    ast
+  }
 
   def apply(ast: Ast) = normalize(ast)
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -156,7 +156,7 @@ class SqlIdiomSpec extends Spec {
             }
           }
           testContext.run(q).string mustEqual
-            "SELECT t._1, t._2 FROM (SELECT t.i _1, COUNT(*) _2 FROM TestEntity t GROUP BY t.i) t"
+            "SELECT t.i, COUNT(*) FROM TestEntity t GROUP BY t.i"
         }
         "nested" in {
           val q = quote {
@@ -258,7 +258,7 @@ class SqlIdiomSpec extends Spec {
             }
           }
           testContext.run(q).string mustEqual
-            "SELECT t._1, t._2 FROM (SELECT t.i _1, (COUNT(*)) + 1 _2 FROM TestEntity t GROUP BY t.i) t"
+            "SELECT t.i, (COUNT(*)) + 1 FROM TestEntity t GROUP BY t.i"
         }
       }
       "unary operation" - {
@@ -428,7 +428,7 @@ class SqlIdiomSpec extends Spec {
       val q = quote {
         qr1.map(t => t.i).nested.filter(i => i > 1)
       }
-      testContext.run(q).string mustEqual
+      testContext.run(q.dynamic).string mustEqual
         "SELECT t.i FROM (SELECT x.i FROM TestEntity x) t WHERE t.i > 1"
     }
     "operations" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -53,6 +53,6 @@ class ExpandNestedQueriesSpec extends Spec {
       }
     }
     testContext.run(q).string mustEqual
-      "SELECT s._1_1, s._1_2, s._2 FROM (SELECT s.i _1_1, s.s _1_2, COUNT(*) _2 FROM TestEntity s GROUP BY s.i, s.s) s"
+      "SELECT s.i, s.s, COUNT(*) FROM TestEntity s GROUP BY s.i, s.s"
   }
 }


### PR DESCRIPTION
Fixes #689 

### Problem

Groupby preceded by a map operation isn't properly normalized.

### Solution

fix it! :)

### Notes

I've also included a debugging util in `SqlNormalize`. Change the flag to `true` to enable normalization debugging messages.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
