### PR TITLE
don't expand nested queries that use

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
@@ -21,7 +21,10 @@ object ExpandNestedQueries {
   def apply(q: SqlQuery, references: collection.Set[Property]): SqlQuery =
     q match {
       case q: FlattenSqlQuery =>
-        expandNested(q.copy(select = expandSelect(q.select, references)))
+        q.distinct match {
+          case false => expandNested(q.copy(select = expandSelect(q.select, references)))
+          case true  => q
+        }
       case SetOperationSqlQuery(a, op, b) =>
         SetOperationSqlQuery(apply(a, references), op, apply(b, references))
       case UnaryOperationSqlQuery(op, q) =>

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -37,7 +37,7 @@ class SqlIdiomSpec extends Spec {
             qr1.distinct
           }
           testContext.run(q).string mustEqual
-            "SELECT x.s, x.i, x.l, x.o FROM (SELECT DISTINCT x.s, x.i, x.l, x.o FROM TestEntity x) x"
+            "SELECT x.s, x.i, x.l, x.o FROM (SELECT DISTINCT x.* FROM TestEntity x) x"
         }
 
         "single" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -55,4 +55,18 @@ class ExpandNestedQueriesSpec extends Spec {
     testContext.run(q).string mustEqual
       "SELECT s.i, s.s, COUNT(*) FROM TestEntity s GROUP BY s.i, s.s"
   }
+
+  "doesn't expand nested distinct query" in {
+    import testContext._
+    val q = quote {
+      (for {
+        a <- qr1
+        b <- qr2
+      } yield {
+        (a, b)
+      }).distinct
+    }
+    testContext.run(q).string mustEqual
+      "SELECT x.s, x.i, x.l, x.o, x.s, x.i, x.l, x.o FROM (SELECT DISTINCT x.* FROM (SELECT a.*, b.* FROM TestEntity a, TestEntity2 b) x) x"
+  }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -168,14 +168,14 @@ class RenamePropertiesSpec extends Spec {
           e.distinct
         }
         testContext.run(q).string mustEqual
-          "SELECT x.field_s, x.field_i, x.l, x.o FROM (SELECT DISTINCT x.field_s, x.field_i, x.l, x.o FROM test_entity x) x"
+          "SELECT x.field_s, x.field_i, x.l, x.o FROM (SELECT DISTINCT x.* FROM test_entity x) x"
       }
       "transitive" in {
         val q = quote {
           e.distinct.map(t => t.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT t.field_s FROM (SELECT DISTINCT x.field_s FROM test_entity x) t"
+          "SELECT t.field_s FROM (SELECT DISTINCT x.* FROM test_entity x) t"
       }
     }
 


### PR DESCRIPTION
Fixes #724 

### Problem

`ExpandNestedQueries` tries to expand nested queries that have a `DISTINCT` clause. It doesn't make sense because it changes the meaning of t.he distinct operation. For instance:

```scala
qr1.distinct.nested.map(t => t.I) 

// is not semantic equal to the current normalized form:

qr1.map(t => t.I).distinct.nested.map(t => t.I) 

// since `qr1` also has other columns that are considered by the distinct criteria.
```

### Solution

Don't perform the expansion. There's still a potential problem of column name conflict if the nested distinct query selects from multiple tables. I think it's a reasonable tradeoff.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
