### PR TITLE
fail query compilation if flatjoin uses invalid table

### DIFF
--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/VerifySqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/VerifySqlQuerySpec.scala
@@ -3,6 +3,7 @@ package io.getquill.context.sql.idiom
 import io.getquill.Spec
 import io.getquill.context.sql.testContext._
 import io.getquill.context.sql.SqlQuery
+import scala.util.Try
 
 class VerifySqlQuerySpec extends Spec {
 
@@ -32,5 +33,17 @@ class VerifySqlQuerySpec extends Spec {
       VerifySqlQuery(SqlQuery(q.ast)).toString mustEqual
         "Some(The monad composition can't be expressed using applicative joins. Faulty expression: 'x01._2.isDefined'. Free variables: 'List(x01)'., Faulty expression: 'x01'. Free variables: 'List(x01)'.)"
     }
+
+    "invalid flatJoin on" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if a.i == b.i
+          c <- qr1.leftJoin(_.i == a.i)
+        } yield (a.i, b.i, c.map(_.i))
+      }
+      Try(VerifySqlQuery(SqlQuery(q.ast))).isFailure mustEqual true
+    }
+
   }
 }


### PR DESCRIPTION
Fixes #636 

### Problem

See bug description.

### Solution

Implement a query validation to fail in this scenario.

### Notes

This is the last known bug!!

![](https://www.walldevil.com/wallpapers/w02/859963-happy-meme-white-background.jpg)

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
