### PR TITLE
don't generate sqls with aggregation of tuples

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -159,9 +159,9 @@ trait SqlIdiom extends Idiom {
 
     val customAstTokenizer =
       Tokenizer.withFallback[Ast](SqlIdiom.this.astTokenizer(_, strategy)) {
-        case Aggregation(op, Ident(_))       => stmt"${op.token}(*)"
-        case ast @ Aggregation(op, _: Query) => scopedTokenizer(ast)
-        case Aggregation(op, ast)            => stmt"${op.token}(${ast.token})"
+        case Aggregation(op, Ident(_) | Tuple(_)) => stmt"${op.token}(*)"
+        case ast @ Aggregation(op, _: Query)      => scopedTokenizer(ast)
+        case Aggregation(op, ast)                 => stmt"${op.token}(${ast.token})"
       }
 
     tokenizer(customAstTokenizer)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -223,12 +223,23 @@ class SqlIdiomSpec extends Spec {
           testContext.run(q).string mustEqual
             "SELECT SUM(t.i) FROM TestEntity t"
         }
-        "size" in {
-          val q = quote {
-            qr1.size
+        "size" - {
+          "regular" in {
+            val q = quote {
+              qr1.size
+            }
+            testContext.run(q).string mustEqual
+              "SELECT COUNT(*) FROM TestEntity x"
           }
-          testContext.run(q).string mustEqual
-            "SELECT COUNT(*) FROM TestEntity x"
+          "with groupBy" in {
+            val q = quote {
+              qr1.map(t => (t.i, t.s)).groupBy(t => t._1).map {
+                case (i, l) => l.size
+              }
+            }
+            testContext.run(q).string mustEqual
+              "SELECT COUNT(*) FROM TestEntity t GROUP BY t.i"
+          }
         }
         "with filter" in {
           val q = quote {


### PR DESCRIPTION
### Problem

Quill translations aggregations of tuples using invalid syntax. For instance `COUNT(a.i, a.j)`.

### Solution

Render `COUNT(*)` instead.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
