### PR TITLE
support implicit class lifting for properties

### DIFF
--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -1022,7 +1022,7 @@ class QuotationSpec extends Spec {
           object implicits extends Implicits
           import implicits._
           val q = quote(1.plusRandom)
-          val l = q.liftings.`implicits.PlusRadom(1).plusRandom.Implicits.this.random`
+          val l = q.liftings.`implicits.PlusRadom(null.asInstanceOf[Int(1)]).plusRandom.Implicits.this.random`
           l.value mustEqual 999
           l.encoder mustEqual intEncoder
         }
@@ -1036,7 +1036,7 @@ class QuotationSpec extends Spec {
           object implicits extends Implicits
           import implicits._
           val q = quote(query[TestEntity].toRandom)
-          val l = q.liftings.`implicits.ToRadom(null).toRandom.Implicits.this.random`
+          val l = q.liftings.`implicits.ToRadom(null.asInstanceOf[io.getquill.testContext.EntityQuery[io.getquill.testContext.TestEntity]]).toRandom.Implicits.this.random`
           l.value mustEqual 999
           l.encoder mustEqual intEncoder
         }


### PR DESCRIPTION
Fixes #916 

### Problem

Implicit quotations with lift that are applied to non-dsl values like case class properties fail to compile.

### Solution

Use a generic placeholder for any value instead of dsl-only values.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
