### PR TITLE
push filter within joins to outer scope

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/AdHocReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/AdHocReduction.scala
@@ -4,10 +4,8 @@ import io.getquill.ast.BinaryOperation
 import io.getquill.ast.BooleanOperator
 import io.getquill.ast.Filter
 import io.getquill.ast.FlatMap
-import io.getquill.ast.Join
 import io.getquill.ast.Map
 import io.getquill.ast.Query
-import io.getquill.ast.Tuple
 import io.getquill.ast.Union
 import io.getquill.ast.UnionAll
 
@@ -24,12 +22,6 @@ object AdHocReduction {
       case Filter(Filter(a, b, c), d, e) =>
         val er = BetaReduction(e, d -> b)
         Some(Filter(a, b, BinaryOperation(c, BooleanOperator.`&&`, er)))
-
-      // a.join(b).on((c, d) => e).filter(f => g)
-      //    a.join(b).on((c, d) => e && g[f := (c, d)])
-      case Filter(Join(t, a, b, c, d, e), f, g) =>
-        val gr = BetaReduction(g, f -> Tuple(List(c, d)))
-        Some(Join(t, a, b, c, d, BinaryOperation(e, BooleanOperator.`&&`, gr)))
 
       // ---------------------------
       // flatMap.*

--- a/quill-core/src/main/scala/io/getquill/norm/SymbolicReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/SymbolicReduction.scala
@@ -5,6 +5,9 @@ import io.getquill.ast.FlatMap
 import io.getquill.ast.Query
 import io.getquill.ast.Union
 import io.getquill.ast.UnionAll
+import io.getquill.ast.Join
+import io.getquill.ast.Ident
+import io.getquill.ast.Property
 
 object SymbolicReduction {
 
@@ -32,6 +35,22 @@ object SymbolicReduction {
       //      a.flatMap(c => d).unionAll(b.flatMap(c => d))
       case FlatMap(UnionAll(a, b), c, d) =>
         Some(UnionAll(FlatMap(a, c, d), FlatMap(b, c, d)))
+
+      // a.filter(b => c).join(d).on((e, f) => g) =>
+      //      a.join(d).on((e, f) => g).filter(x => c[b := x._1])
+      case Join(tpe, Filter(a, b, c), d, e, f, g) =>
+        val x = Ident("x")
+        val x1 = Property(x, "_1")
+        val cr = BetaReduction(c, b -> x1)
+        Some(Filter(Join(tpe, a, d, e, f, g), x, cr))
+
+      // a.join(b.filter(c => d)).on((e, f) => g) =>
+      //      a.join(b).on((e, f) => g).filter(x => d[c := x._2])
+      case Join(tpe, a, Filter(b, c, d), e, f, g) =>
+        val x = Ident("x")
+        val x2 = Property(x, "_2")
+        val dr = BetaReduction(d, c -> x2)
+        Some(Filter(Join(tpe, a, b, e, f, g), x, dr))
 
       case other => None
     }

--- a/quill-core/src/test/scala/io/getquill/norm/AdHocReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/AdHocReductionSpec.scala
@@ -18,15 +18,6 @@ class AdHocReductionSpec extends Spec {
       }
       AdHocReduction.unapply(q.ast) mustEqual Some(n.ast)
     }
-    "a.join(b).on((c, d) => e).filter(f => g)" in {
-      val q = quote {
-        qr1.join(qr2).on((c, d) => c.i == d.i).filter(t => t._1.i == 1)
-      }
-      val n = quote {
-        qr1.join(qr2).on((c, d) => c.i == d.i && c.i == 1)
-      }
-      AdHocReduction.unapply(q.ast) mustEqual Some(n.ast)
-    }
   }
 
   "flatMap.*" - {

--- a/quill-core/src/test/scala/io/getquill/norm/SymbolicReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/SymbolicReductionSpec.scala
@@ -59,4 +59,24 @@ class SymbolicReductionSpec extends Spec {
     }
     SymbolicReduction.unapply(q.ast) mustEqual Some(n.ast)
   }
+
+  "a.filter(b => c).join(d).on((e, f) => g) => a.join(d).on((e, f) => g).filter(x => c[b := x._1])" in {
+    val q = quote {
+      qr1.filter(a => a.i == 1).join(qr2).on((a, b) => a.i == b.i)
+    }
+    val n = quote {
+      qr1.join(qr2).on((a, b) => a.i == b.i).filter(x => x._1.i == 1)
+    }
+    SymbolicReduction.unapply(q.ast) mustEqual Some(n.ast)
+  }
+
+  "a.join(b.filter(c => d)).on((e, f) => g) => a.join(b).on((e, f) => g).filter(x => d[c := x._2])" in {
+    val q = quote {
+      qr1.join(qr2.filter(b => b.i == 1)).on((a, b) => a.i == b.i)
+    }
+    val n = quote {
+      qr1.join(qr2).on((a, b) => a.i == b.i).filter(x => x._2.i == 1)
+    }
+    SymbolicReduction.unapply(q.ast) mustEqual Some(n.ast)
+  }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -31,6 +31,18 @@ class SqlQuerySpec extends Spec {
         "SELECT a.s, a.i, a.l, a.o, b.s, b.i, b.l, b.o FROM TestEntity a LEFT JOIN TestEntity2 b ON (a.s IS NOT NULL) AND (b.i > a.i)"
     }
 
+    "join + map + filter" in {
+      val q = quote {
+        qr1
+          .leftJoin(qr2)
+          .on((a, b) => a.i == b.i)
+          .map(t => (t._1.i, t._2.map(_.i)))
+          .filter(_._2.forall(_ == 1))
+      }
+      testContext.run(q).string mustEqual
+        "SELECT a.i, b.i FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE (b.i IS NULL) OR (b.i = 1)"
+    }
+
     "flat outer join" in {
       val q = quote {
         for {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -192,21 +192,21 @@ class RenamePropertiesSpec extends Spec {
           e.join(f).on((a, b) => a.s == b.s).map(t => t._1.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT a.field_s FROM test_entity a INNER JOIN (SELECT t.s FROM TestEntity t WHERE t.i = 1) t ON a.field_s = t.s"
+          "SELECT a.field_s FROM test_entity a INNER JOIN TestEntity t ON a.field_s = t.s WHERE t.i = 1"
       }
       "left" in {
         val q = quote {
           e.leftJoin(f).on((a, b) => a.s == b.s).map(t => t._1.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT a.field_s FROM test_entity a LEFT JOIN (SELECT t.s FROM TestEntity t WHERE t.i = 1) t ON a.field_s = t.s"
+          "SELECT a.field_s FROM test_entity a LEFT JOIN TestEntity t ON a.field_s = t.s WHERE t.i = 1"
       }
       "right" in {
         val q = quote {
           f.rightJoin(e).on((a, b) => a.s == b.s).map(t => t._2.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT b.field_s FROM (SELECT t.s FROM TestEntity t WHERE t.i = 1) t RIGHT JOIN test_entity b ON t.s = b.field_s"
+          "SELECT b.field_s FROM TestEntity t RIGHT JOIN test_entity b ON t.s = b.field_s WHERE t.i = 1"
       }
       "flat inner" in {
         val q = quote {


### PR DESCRIPTION
Fixes #919 

### Problem

The normalization rule that fuses `on` with `filter` is wrong.

### Solution

Remove the rule and introduce new ones to avoid nested queries. They push filters to the end of the query.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
