### PR TITLE
fix nested option map

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
@@ -9,7 +9,7 @@ object FlattenOptionOperation extends StatelessTransformer {
       case OptionMap(ast, alias, body) =>
         apply(BetaReduction(body, alias -> ast))
       case OptionForall(ast, alias, body) =>
-        val isEmpty = BinaryOperation(ast, EqualityOperator.`==`, NullValue)
+        val isEmpty = apply(BinaryOperation(ast, EqualityOperator.`==`, NullValue): Ast)
         val exists = apply(BetaReduction(body, alias -> ast))
         BinaryOperation(isEmpty, BooleanOperator.`||`, exists)
       case OptionExists(ast, alias, body) =>

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -26,7 +26,17 @@ class FlattenOptionOperationSpec extends Spec {
           BinaryOperation(Ident("o"), EqualityOperator.`!=`, Constant(1))
         )
     }
-
+    "map + forall" in {
+      val q = quote {
+        (o: Option[TestEntity]) => o.map(_.i).forall(i => i != 1)
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        BinaryOperation(
+          BinaryOperation(Property(Ident("o"), "i"), EqualityOperator.`==`, NullValue),
+          BooleanOperator.`||`,
+          BinaryOperation(Property(Ident("o"), "i"), EqualityOperator.`!=`, Constant(1))
+        )
+    }
     "exists" in {
       val q = quote {
         (o: Option[Int]) => o.exists(i => i > 1)
@@ -34,7 +44,6 @@ class FlattenOptionOperationSpec extends Spec {
       FlattenOptionOperation(q.ast.body: Ast) mustEqual
         BinaryOperation(Ident("o"), NumericOperator.`>`, Constant(1))
     }
-
     "contains" in {
       val q = quote {
         (o: Option[Int]) => o.contains(1)

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/VerifySqlQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/VerifySqlQuery.scala
@@ -51,7 +51,7 @@ object VerifySqlQuery {
           require(
             invalid.isEmpty,
             s"Found an `ON` table reference of a table that is not available: $invalid. " +
-              "The `ON` condition can only use tables defined through explicit joins.."
+              "The `ON` condition can only use tables defined through explicit joins."
           )
           nav
       }


### PR DESCRIPTION
Fixes #918 

### Problem

`FlattenOptionOperation` doesn't flatten nested maps.

### Solution

Recursively apply the transformation for the `isEmpty` tree

### Notes

@mxl you report the exception in your ticket, but it's actually correct. The query can't be translated to sql because it uses a table in a condition instead of a property. I've fixed only the map operation.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
