### PR TITLE
multiple join fixes

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/SymbolicReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/SymbolicReduction.scala
@@ -5,10 +5,6 @@ import io.getquill.ast.FlatMap
 import io.getquill.ast.Query
 import io.getquill.ast.Union
 import io.getquill.ast.UnionAll
-import io.getquill.ast.Join
-import io.getquill.ast.Ident
-import io.getquill.ast.Property
-import io.getquill.ast.InnerJoin
 
 object SymbolicReduction {
 
@@ -36,22 +32,6 @@ object SymbolicReduction {
       //      a.flatMap(c => d).unionAll(b.flatMap(c => d))
       case FlatMap(UnionAll(a, b), c, d) =>
         Some(UnionAll(FlatMap(a, c, d), FlatMap(b, c, d)))
-
-      // a.filter(b => c).join(d).on((e, f) => g) =>
-      //      a.join(d).on((e, f) => g).filter(x => c[b := x._1])
-      case Join(InnerJoin, Filter(a, b, c), d, e, f, g) =>
-        val x = Ident("x")
-        val x1 = Property(x, "_1")
-        val cr = BetaReduction(c, b -> x1)
-        Some(Filter(Join(InnerJoin, a, d, e, f, g), x, cr))
-
-      // a.join(b.filter(c => d)).on((e, f) => g) =>
-      //      a.join(b).on((e, f) => g).filter(x => d[c := x._2])
-      case Join(InnerJoin, a, Filter(b, c, d), e, f, g) =>
-        val x = Ident("x")
-        val x2 = Property(x, "_2")
-        val dr = BetaReduction(d, c -> x2)
-        Some(Filter(Join(InnerJoin, a, b, e, f, g), x, dr))
 
       case other => None
     }

--- a/quill-core/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core/src/main/scala/io/getquill/util/Messages.scala
@@ -9,8 +9,17 @@ object Messages {
       !Option(System.getProperty("quill.macro.log")).filterNot(_.isEmpty).map(_.toLowerCase).contains("false")
   }
 
+  private val traceEnabled = false
+
   def fail(msg: String) =
     throw new IllegalStateException(msg)
+
+  def trace[T](label: String) =
+    (v: T) => {
+      if (traceEnabled)
+        println(s"$label:\n 		$v")
+      v
+    }
 
   implicit class RichContext(c: MacroContext) {
 

--- a/quill-core/src/test/scala/io/getquill/norm/SymbolicReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/SymbolicReductionSpec.scala
@@ -59,39 +59,4 @@ class SymbolicReductionSpec extends Spec {
     }
     SymbolicReduction.unapply(q.ast) mustEqual Some(n.ast)
   }
-
-  "a.filter(b => c).innerJoin(d).on((e, f) => g) => a.innerJoin(d).on((e, f) => g).filter(x => c[b := x._1])" in {
-    val q = quote {
-      qr1.filter(a => a.i == 1).join(qr2).on((a, b) => a.i == b.i)
-    }
-    val n = quote {
-      qr1.join(qr2).on((a, b) => a.i == b.i).filter(x => x._1.i == 1)
-    }
-    SymbolicReduction.unapply(q.ast) mustEqual Some(n.ast)
-  }
-
-  "a.innerJoin(b.filter(c => d)).on((e, f) => g) => a.innerJoin(b).on((e, f) => g).filter(x => d[c := x._2])" in {
-    val q = quote {
-      qr1.join(qr2.filter(b => b.i == 1)).on((a, b) => a.i == b.i)
-    }
-    val n = quote {
-      qr1.join(qr2).on((a, b) => a.i == b.i).filter(x => x._2.i == 1)
-    }
-    SymbolicReduction.unapply(q.ast) mustEqual Some(n.ast)
-  }
-
-  "doesn't reduce non-inner-joins since they aren't commutative" - {
-    "a.filter.*join(b)" in {
-      val q = quote {
-        qr1.filter(a => a.i == 1).leftJoin(qr2).on((a, b) => a.i == b.i)
-      }
-      SymbolicReduction.unapply(q.ast) mustEqual None
-    }
-    "a.*join(b.filter)" in {
-      val q = quote {
-        qr1.rightJoin(qr2.filter(b => b.i == 1)).on((a, b) => a.i == b.i)
-      }
-      SymbolicReduction.unapply(q.ast) mustEqual None
-    }
-  }
 }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -18,7 +18,7 @@ import io.getquill.context.sql.UnaryOperationSqlQuery
 import io.getquill.context.sql.UnionAllOperation
 import io.getquill.context.sql.UnionOperation
 import io.getquill.NamingStrategy
-import io.getquill.util.Messages.fail
+import io.getquill.util.Messages.{ fail, trace }
 import io.getquill.idiom.Idiom
 import io.getquill.idiom.SetContainsToken
 import io.getquill.idiom.Statement
@@ -40,8 +40,11 @@ trait SqlIdiom extends Idiom {
       normalizedAst match {
         case q: Query =>
           val sql = SqlQuery(q)
+          trace("sql")(sql)
           VerifySqlQuery(sql).map(fail)
-          ExpandNestedQueries(sql, collection.Set.empty).token
+          val expanded = ExpandNestedQueries(sql, collection.Set.empty).token
+          trace("expanded sql")(expanded)
+          expanded
         case other =>
           other.token
       }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandJoin.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandJoin.scala
@@ -1,63 +1,51 @@
 package io.getquill.context.sql.norm
 
 import io.getquill.ast.Ast
-import io.getquill.ast.Filter
 import io.getquill.ast.Ident
 import io.getquill.ast.Join
 import io.getquill.ast.Map
-import io.getquill.ast.Query
-import io.getquill.ast.StatelessTransformer
+import io.getquill.ast.Transform
 import io.getquill.ast.Tuple
 import io.getquill.norm.BetaReduction
+import io.getquill.norm.Normalize
 
-object ExpandJoin extends StatelessTransformer {
+object ExpandJoin {
 
-  override def apply(q: Query) =
-    q match {
-      case Filter(Expand(ar, at), b, c) =>
-        val id = ident(at)
-        val cr = BetaReduction(c, b -> at)
-        Map(Filter(ar, id, cr), id, at)
-      case Expand(qr, map) =>
-        Map(qr, ident(map), map)
-      case other => super.apply(other)
+  def apply(q: Ast) = expand(q, None)
+
+  def expand(q: Ast, id: Option[Ident]) =
+    Transform(q) {
+      case q @ Join(_, _, _, Ident(a), Ident(b), _) =>
+        val (qr, tuple) = expandedTuple(q)
+        Map(qr, id.getOrElse(Ident(s"$a$b")), tuple)
     }
 
-  object Expand {
-    def unapply(q: Ast): Option[(Ast, Ast)] =
-      q match {
-        case Join(t, Expand(ar, at), Expand(br, bt), tA, tB, o) =>
-          val or = BetaReduction(o, tA -> at, tB -> bt)
-          Some((Join(t, ar, br, tA, tB, or), Tuple(List(at, bt))))
+  private def expandedTuple(q: Join): (Join, Tuple) =
+    q match {
 
-        case Join(t, Expand(ar, at), b, tA, tB, o) =>
-          val or = BetaReduction(o, tA -> at)
-          Some((Join(t, ar, b, tA, tB, or), Tuple(List(at, tB))))
+      case Join(t, a: Join, b: Join, tA, tB, o) =>
+        val (ar, at) = expandedTuple(a)
+        val (br, bt) = expandedTuple(b)
+        val or = BetaReduction(o, tA -> at, tB -> bt)
+        (Join(t, ar, br, tA, tB, or), Tuple(List(at, bt)))
 
-        case Join(t, a, Expand(br, bt), tA, tB, o) =>
-          val or = BetaReduction(o, tB -> bt)
-          Some((Join(t, a, br, tA, tB, or), Tuple(List(tA, bt))))
+      case Join(t, a: Join, b, tA, tB, o) =>
+        val (ar, at) = expandedTuple(a)
+        val or = BetaReduction(o, tA -> at)
+        (Join(t, ar, b, tA, tB, or), Tuple(List(at, tB)))
 
-        case q @ Join(t, a, b, tA, tB, on) =>
-          Some((q, Tuple(List(tA, tB))))
+      case Join(t, a, b: Join, tA, tB, o) =>
+        val (br, bt) = expandedTuple(b)
+        val or = BetaReduction(o, tB -> bt)
+        (Join(t, a, br, tA, tB, or), Tuple(List(tA, bt)))
 
-        case Filter(Expand(ar, at), b, c) =>
-          val id = ident(at)
-          val cr = BetaReduction(c, b -> at)
-          Some((Filter(ar, id, cr), id))
+      case q @ Join(t, a, b, tA, tB, on) =>
+        (Join(t, nestedExpand(a, tA), nestedExpand(b, tB), tA, tB, on), Tuple(List(tA, tB)))
+    }
 
-        case _ => None
-      }
-  }
-
-  private def ident(ast: Ast): Ident =
-    ast match {
-      case Tuple(values) =>
-        values.map(ident).foldLeft(Ident("")) {
-          case (Ident(a), Ident(b)) =>
-            Ident(s"$a$b")
-        }
-      case i: Ident => i
-      case other    => Ident(other.toString)
+  private def nestedExpand(q: Ast, id: Ident) =
+    Normalize(expand(q, Some(id))) match {
+      case Map(q, _, _) => q
+      case q            => q
     }
 }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
@@ -23,7 +23,7 @@ object ExpandNestedQueries {
       case q: FlattenSqlQuery =>
         q.distinct match {
           case false => expandNested(q.copy(select = expandSelect(q.select, references)))
-          case true  => q
+          case true  => expandNested(q.copy(select = expandSelect(q.select, Set.empty)))
         }
       case SetOperationSqlQuery(a, op, b) =>
         SetOperationSqlQuery(apply(a, references), op, apply(b, references))

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
@@ -4,29 +4,23 @@ import io.getquill.norm.FlattenOptionOperation
 import io.getquill.norm.Normalize
 import io.getquill.ast.Ast
 import io.getquill.norm.RenameProperties
+import io.getquill.util.Messages.trace
 
 object SqlNormalize {
 
-  private val debugEnabled = false
-
   private val normalize =
     (identity[Ast] _)
-      .andThen(debug("original"))
+      .andThen(trace("original"))
       .andThen(FlattenOptionOperation.apply _)
-      .andThen(debug("FlattenOptionOperation"))
+      .andThen(trace("FlattenOptionOperation"))
       .andThen(Normalize.apply _)
-      .andThen(debug("Normalize"))
+      .andThen(trace("Normalize"))
       .andThen(RenameProperties.apply _)
-      .andThen(debug("RenameProperties"))
+      .andThen(trace("RenameProperties"))
       .andThen(ExpandJoin.apply _)
-      .andThen(debug("ExpandJoin"))
+      .andThen(trace("ExpandJoin"))
       .andThen(Normalize.apply _)
-      .andThen(debug("Normalize"))
-
-  def debug(name: String)(ast: Ast) = {
-    if (debugEnabled) println(s"$name:\n 		$ast")
-    ast
-  }
+      .andThen(trace("Normalize"))
 
   def apply(ast: Ast) = normalize(ast)
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -57,7 +57,7 @@ class SqlQuerySpec extends Spec {
         }
       }
       testContext.run(q).string mustEqual
-        "SELECT x01x11.s, x01x11.i, x01x11.l, x01x11.o, x01x11.s, x01x11.i, x01x11.l, x01x11.o, x12.s, x12.i, x12.l, x12.o FROM (SELECT x01.s s, x01.i i, x01.o o, x01.l l, x11.s s, x11.i i, x11.l l, x11.o o FROM TestEntity x01 LEFT JOIN TestEntity2 x11 ON x01.i = x11.i WHERE x11.l = 3) x01x11 LEFT JOIN TestEntity3 x12 ON (x01x11.i = x01x11.i) AND (x01x11.i = x12.i)"
+        "SELECT x02.s, x02.i, x02.l, x02.o, x02.s, x02.i, x02.l, x02.o, x12.s, x12.i, x12.l, x12.o FROM (SELECT x01.s s, x01.l l, x01.o o, x01.i i, x11.i i, x11.o o, x11.l l, x11.s s FROM TestEntity x01 LEFT JOIN TestEntity2 x11 ON x01.i = x11.i WHERE x11.l = 3) x02 LEFT JOIN TestEntity3 x12 ON (x02.i = x02.i) AND (x02.i = x12.i)"
     }
 
     "flat outer join" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandJoinSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandJoinSpec.scala
@@ -23,28 +23,28 @@ class ExpandJoinSpec extends Spec {
           qr1.join(qr2).on((a, b) => a.s == b.s).join(qr3).on((c, d) => c._1.s == d.s)
         }
         ExpandJoin(q.ast).toString mustEqual
-          """querySchema("TestEntity").join(querySchema("TestEntity2")).on((a, b) => a.s == b.s).join(querySchema("TestEntity3")).on((c, d) => a.s == d.s).map(abd => ((a, b), d))"""
+          """querySchema("TestEntity").join(querySchema("TestEntity2")).on((a, b) => a.s == b.s).join(querySchema("TestEntity3")).on((c, d) => a.s == d.s).map(cd => ((a, b), d))"""
       }
       "left" in {
         val q = quote {
           qr1.leftJoin(qr2).on((a, b) => a.s == b.s).leftJoin(qr3).on((c, d) => c._1.s == d.s)
         }
         ExpandJoin(q.ast).toString mustEqual
-          """querySchema("TestEntity").leftJoin(querySchema("TestEntity2")).on((a, b) => a.s == b.s).leftJoin(querySchema("TestEntity3")).on((c, d) => a.s == d.s).map(abd => ((a, b), d))"""
+          """querySchema("TestEntity").leftJoin(querySchema("TestEntity2")).on((a, b) => a.s == b.s).leftJoin(querySchema("TestEntity3")).on((c, d) => a.s == d.s).map(cd => ((a, b), d))"""
       }
       "right" in {
         val q = quote {
           qr1.leftJoin(qr2.leftJoin(qr3).on((a, b) => a.s == b.s)).on((c, d) => c.s == d._1.s)
         }
         ExpandJoin(q.ast).toString mustEqual
-          """querySchema("TestEntity").leftJoin(querySchema("TestEntity2").leftJoin(querySchema("TestEntity3")).on((a, b) => a.s == b.s)).on((c, d) => c.s == a.s).map(cab => (c, (a, b)))"""
+          """querySchema("TestEntity").leftJoin(querySchema("TestEntity2").leftJoin(querySchema("TestEntity3")).on((a, b) => a.s == b.s)).on((c, d) => c.s == a.s).map(cd => (c, (a, b)))"""
       }
       "both" in {
         val q = quote {
           qr1.leftJoin(qr2).on((a, b) => a.s == b.s).leftJoin(qr3.leftJoin(qr2).on((c, d) => c.s == d.s)).on((e, f) => e._1.s == f._1.s)
         }
         ExpandJoin(q.ast).toString mustEqual
-          """querySchema("TestEntity").leftJoin(querySchema("TestEntity2")).on((a, b) => a.s == b.s).leftJoin(querySchema("TestEntity3").leftJoin(querySchema("TestEntity2")).on((c, d) => c.s == d.s)).on((e, f) => a.s == c.s).map(abcd => ((a, b), (c, d)))"""
+          """querySchema("TestEntity").leftJoin(querySchema("TestEntity2")).on((a, b) => a.s == b.s).leftJoin(querySchema("TestEntity3").leftJoin(querySchema("TestEntity2")).on((c, d) => c.s == d.s)).on((e, f) => a.s == c.s).map(ef => ((a, b), (c, d)))"""
       }
     }
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinSpec.scala
@@ -1,0 +1,84 @@
+package io.getquill.context.sql.norm
+
+import io.getquill.Spec
+import io.getquill.context.sql.testContext._
+import io.getquill.context.sql.testContext
+
+class JoinSpec extends Spec {
+
+  "join + filter" in {
+    val q = quote {
+      qr1.leftJoin(qr2)
+        .on((a, b) => a.i == b.i)
+        .filter(_._2.map(_.i).forall(_ == 1))
+    }
+    testContext.run(q).string mustEqual
+      "SELECT a.s, a.i, a.l, a.o, b.s, b.i, b.l, b.o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE (b.i IS NULL) OR (b.i = 1)"
+  }
+
+  "join + map + filter" in {
+    val q = quote {
+      qr1.leftJoin(qr2)
+        .on((a, b) => a.i == b.i)
+        .map(t => (t._1.i, t._2.map(_.i)))
+        .filter(_._2.forall(_ == 1))
+    }
+    testContext.run(q).string mustEqual
+      "SELECT a.i, b.i FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE (b.i IS NULL) OR (b.i = 1)"
+  }
+
+  "join + filter + leftjoin" in {
+    val q = quote {
+      qr1.leftJoin(qr2).on {
+        (a, b) => a.i == b.i
+      }.filter {
+        ab =>
+          ab._2.map(_.l).contains(3L)
+      }.leftJoin(qr3).on {
+        (ab, c) =>
+          ab._2.map(_.i).contains(ab._1.i) && ab._2.map(_.i).contains(c.i)
+      }
+    }
+    testContext.run(q).string mustEqual
+      "SELECT ab.s, ab.i, ab.l, ab.o, ab.s, ab.i, ab.l, ab.o, c.s, c.i, c.l, c.o FROM (SELECT a.s s, a.o o, a.l l, a.i i, b.l l, b.i i, b.o o, b.s s FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.l = 3) ab LEFT JOIN TestEntity3 c ON (ab.i = ab.i) AND (ab.i = c.i)"
+  }
+
+  "join + distinct + leftjoin" in {
+    val q = quote {
+      qr1.leftJoin(qr2).on {
+        (a, b) => a.i == b.i
+      }.distinct.leftJoin(qr3).on {
+        (ab, c) =>
+          ab._2.map(_.i).contains(ab._1.i) && ab._2.map(_.i).contains(c.i)
+      }
+    }
+    testContext.run(q).string mustEqual
+      "SELECT ab.s, ab.i, ab.l, ab.o, ab.s, ab.i, ab.l, ab.o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.*, b.* FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i) ab LEFT JOIN TestEntity3 c ON (ab.i = ab.i) AND (ab.i = c.i)"
+  }
+
+  "multiple joins + filter + map + distinct" in {
+    val q = quote {
+      qr1.join(qr2)
+        .on { (d, a) => d.i == a.i }
+        .join {
+          qr3.filter(rp => rp.s == lift("a"))
+        }
+        .on { (da, p) => da._1.i == p.i }
+        .leftJoin(qr4)
+        .on { (dap, n) => dap._2.l == n.i }
+        .map { case (dap, n) => (dap._1._2.s, dap._1._1.l, n.map(_.i)) }
+        .distinct
+    }
+    testContext.run(q).string mustEqual
+      "SELECT DISTINCT a.s, d.l, n.i FROM TestEntity d INNER JOIN TestEntity2 a ON d.i = a.i INNER JOIN (SELECT rp.l, rp.i FROM TestEntity3 rp WHERE rp.s = ?) rp ON d.i = rp.i LEFT JOIN TestEntity4 n ON rp.l = n.i"
+  }
+
+  "multiple joins + map" in {
+    val q = quote {
+      qr1.leftJoin(qr2).on((a, b) => a.s == b.s).leftJoin(qr2).on((a, b) => a._1.s == b.s).map(_._1._1)
+    }
+    testContext.run(q).string mustEqual
+      "SELECT a.s, a.i, a.l, a.o FROM TestEntity a LEFT JOIN TestEntity2 b ON a.s = b.s LEFT JOIN TestEntity2 b1 ON a.s = b1.s"
+  }
+
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -192,7 +192,7 @@ class RenamePropertiesSpec extends Spec {
           e.join(f).on((a, b) => a.s == b.s).map(t => t._1.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT a.field_s FROM test_entity a INNER JOIN TestEntity t ON a.field_s = t.s WHERE t.i = 1"
+          "SELECT a.field_s FROM test_entity a INNER JOIN (SELECT t.s FROM TestEntity t WHERE t.i = 1) t ON a.field_s = t.s"
       }
       "left" in {
         val q = quote {


### PR DESCRIPTION
### Problem

The last fixes related to join queries introduced regressions as reported by @zifeo.

### Solution

- Rollback `ExpandJoins` to the previous implementation and add recursive expansions for nestes queries that have joins
- Remove the reduction that moves filters out of nested queries. It generates more nested queries
- Fix `ExpandNestedQueries` to continue expanding nested queries but not the distinct select

### Notes

- I've also improved a little bit the query compilation debugging mechanism. It's a flag in `Messages.scala` and covers the sql transformations

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
