### PR TITLE
Add support of postgres sql arrays operators

### DIFF
--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ArrayOpsAsyncSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ArrayOpsAsyncSpec.scala
@@ -1,0 +1,25 @@
+package io.getquill.context.async.postgres
+
+import io.getquill.context.sql.ArrayOpsSpec
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ArrayOpsAsyncSpec extends ArrayOpsSpec {
+  val ctx = testContext
+
+  import ctx._
+
+  "contains" in {
+    await(ctx.run(`contains`.`Ex 1 return all`)) mustBe `contains`.`Ex 1 expected`
+    await(ctx.run(`contains`.`Ex 2 return 1`)) mustBe `contains`.`Ex 2 expected`
+    await(ctx.run(`contains`.`Ex 3 return 2,3`)) mustBe `contains`.`Ex 3 expected`
+    await(ctx.run(`contains`.`Ex 4 return empty`)) mustBe `contains`.`Ex 4 expected`
+  }
+
+  override protected def beforeAll(): Unit = {
+    await(ctx.run(entity.delete))
+    await(ctx.run(insertEntries))
+    ()
+  }
+
+}

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -310,7 +310,7 @@ trait Parsing {
       MapContains(astParser(col), astParser(body))
     case q"$col.contains($body)" if isBaseType[Set[Any]](col) =>
       SetContains(astParser(col), astParser(body))
-    case q"$col.contains[$t]($body)" if is[List[Any]](col) =>
+    case q"$col.contains[$t]($body)" if is[Seq[Any]](col) =>
       ListContains(astParser(col), astParser(body))
   }
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcArrayOpsSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcArrayOpsSpec.scala
@@ -1,0 +1,21 @@
+package io.getquill.context.jdbc.postgres
+
+import io.getquill.context.sql.ArrayOpsSpec
+
+class JdbcArrayOpsSpec extends ArrayOpsSpec {
+  val ctx = testContext
+  import ctx._
+
+  "contains" in {
+    ctx.run(`contains`.`Ex 1 return all`) mustBe `contains`.`Ex 1 expected`
+    ctx.run(`contains`.`Ex 2 return 1`) mustBe `contains`.`Ex 2 expected`
+    ctx.run(`contains`.`Ex 3 return 2,3`) mustBe `contains`.`Ex 3 expected`
+    ctx.run(`contains`.`Ex 4 return empty`) mustBe `contains`.`Ex 4 expected`
+  }
+
+  override protected def beforeAll(): Unit = {
+    ctx.run(entity.delete)
+    ctx.run(insertEntries)
+    ()
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
@@ -1,17 +1,20 @@
 package io.getquill
 
-import io.getquill.idiom.StatementInterpolator._
 import java.util.concurrent.atomic.AtomicInteger
-import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.ast.UnaryOperation
-import io.getquill.ast.Operation
-import io.getquill.ast.StringOperator
-import io.getquill.context.sql.idiom.QuestionMarkBindVariables
-import io.getquill.ast.Ast
+
+import io.getquill.ast._
+import io.getquill.context.sql.idiom.{ QuestionMarkBindVariables, SqlIdiom }
+import io.getquill.idiom.StatementInterpolator._
 
 trait PostgresDialect
   extends SqlIdiom
   with QuestionMarkBindVariables {
+
+  override def astTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Ast] =
+    Tokenizer[Ast] {
+      case ListContains(ast, body) => stmt"${body.token} = ANY(${ast.token})"
+      case ast                     => super.astTokenizer.token(ast)
+    }
 
   override implicit def operationTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Operation] =
     Tokenizer[Operation] {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/ArrayOpsSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/ArrayOpsSpec.scala
@@ -1,0 +1,41 @@
+package io.getquill.context.sql
+
+import io.getquill.Spec
+import io.getquill.context.sql.encoding.ArrayEncoding
+
+trait ArrayOpsSpec extends Spec {
+
+  val ctx: SqlContext[_, _] with ArrayEncoding
+
+  import ctx._
+
+  case class ArrayOps(id: Int, numbers: Seq[Int])
+
+  val entriesList = List(
+    ArrayOps(1, List(1, 2, 3)),
+    ArrayOps(2, List(1, 4, 5)),
+    ArrayOps(3, List(1, 4, 6))
+  )
+
+  val entity = quote(query[ArrayOps])
+
+  val insertEntries = quote {
+    liftQuery(entriesList).foreach(e => entity.insert(e))
+  }
+
+  object `contains` {
+    def idByContains(x: Int) = quote(entity.filter(_.numbers.contains(lift(x))).map(_.id))
+
+    val `Ex 1 return all` = quote(idByContains(1))
+    val `Ex 1 expected` = List(1, 2, 3)
+
+    val `Ex 2 return 1` = quote(idByContains(3))
+    val `Ex 2 expected` = List(1)
+
+    val `Ex 3 return 2,3` = quote(idByContains(4))
+    val `Ex 3 expected` = List(2, 3)
+
+    val `Ex 4 return empty` = quote(idByContains(10))
+    val `Ex 4 expected` = Nil
+  }
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
@@ -25,4 +25,12 @@ class PostgresDialectSpec extends Spec {
       context.run(q).string mustEqual "SELECT t.s::integer FROM TestEntity t"
     }
   }
+
+  "Array Operations" - {
+    case class ArrayOps(id: Int, numbers: Vector[Int])
+    "contains" in {
+      context.run(query[ArrayOps].filter(_.numbers.contains(10))).string mustEqual
+        "SELECT x1.id, x1.numbers FROM ArrayOps x1 WHERE 10 = ANY(x1.numbers)"
+    }
+  }
 }

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -114,3 +114,8 @@ CREATE TABLE ArraysTestEntity (
     dates DATE[],
     uuids UUID[]
 );
+
+CREATE TABLE ArrayOps (
+  id int,
+  numbers int[]
+);


### PR DESCRIPTION
Fixes #936

### Problem
Quill provides only encoding for sql arrays in postgres, however operators are missing

### Solution

Implement requested operators


### Operators checklist
- [x] contains

### Checklist
- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
