### PR TITLE
Add support of java.time.Instant/java.time.LocalDate for quill-casandra

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/CassandraMirrorContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraMirrorContext.scala
@@ -1,5 +1,8 @@
 package io.getquill
 
+import java.util.Date
+
+import com.datastax.driver.core.LocalDate
 import io.getquill.context.cassandra.encoding.{ CassandraMapper, CassandraType }
 import io.getquill.context.cassandra.{ CassandraContext, CqlIdiom, Udt }
 
@@ -9,6 +12,11 @@ class CassandraMirrorContextWithQueryProbing extends CassandraMirrorContext(Lite
 
 class CassandraMirrorContext[Naming <: NamingStrategy](naming: Naming)
   extends MirrorContext[CqlIdiom, Naming](CqlIdiom, naming) with CassandraContext[Naming] {
+
+  implicit val timestampDecoder: Decoder[Date] = decoder[Date]
+  implicit val timestampEncoder: Encoder[Date] = encoder[Date]
+  implicit val cassandraLocalDateDecoder: Decoder[LocalDate] = decoder[LocalDate]
+  implicit val cassandraLocalDateEncoder: Encoder[LocalDate] = encoder[LocalDate]
 
   implicit def listDecoder[T, Cas: ClassTag](implicit mapper: CassandraMapper[Cas, T]): Decoder[List[T]] = decoderUnsafe[List[T]]
   implicit def setDecoder[T, Cas: ClassTag](implicit mapper: CassandraMapper[Cas, T]): Decoder[Set[T]] = decoderUnsafe[Set[T]]

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContext.scala
@@ -2,16 +2,16 @@ package io.getquill.context.cassandra
 
 import java.util.{ Date, UUID }
 
+import com.datastax.driver.core.LocalDate
 import io.getquill.NamingStrategy
 import io.getquill.context.Context
-import io.getquill.context.cassandra.encoding.{ CassandraMapper, CassandraMapperConversions, CassandraTypes }
+import io.getquill.context.cassandra.encoding.{ CassandraMapper, Encodings }
 
 import scala.reflect.ClassTag
 
 trait CassandraContext[N <: NamingStrategy]
   extends Context[CqlIdiom, N]
-  with CassandraMapperConversions
-  with CassandraTypes
+  with Encodings
   with UdtMetaDsl
   with Ops {
 
@@ -27,7 +27,8 @@ trait CassandraContext[N <: NamingStrategy]
   implicit val doubleDecoder: Decoder[Double]
   implicit val byteArrayDecoder: Decoder[Array[Byte]]
   implicit val uuidDecoder: Decoder[UUID]
-  implicit val dateDecoder: Decoder[Date]
+  implicit val timestampDecoder: Decoder[Date]
+  implicit val cassandraLocalDateDecoder: Decoder[LocalDate]
 
   implicit val stringEncoder: Encoder[String]
   implicit val bigDecimalEncoder: Encoder[BigDecimal]
@@ -38,7 +39,8 @@ trait CassandraContext[N <: NamingStrategy]
   implicit val doubleEncoder: Encoder[Double]
   implicit val byteArrayEncoder: Encoder[Array[Byte]]
   implicit val uuidEncoder: Encoder[UUID]
-  implicit val dateEncoder: Encoder[Date]
+  implicit val timestampEncoder: Encoder[Date]
+  implicit val cassandraLocalDateEncoder: Encoder[LocalDate]
 
   implicit def listDecoder[T, Cas: ClassTag](implicit mapper: CassandraMapper[Cas, T]): Decoder[List[T]]
   implicit def setDecoder[T, Cas: ClassTag](implicit mapper: CassandraMapper[Cas, T]): Decoder[Set[T]]

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
@@ -54,6 +54,6 @@ trait Decoders extends CollectionDecoders {
       b
     })
   implicit val uuidDecoder: Decoder[UUID] = decoder(_.getUUID)
-  implicit val dateDecoder: Decoder[Date] = decoder(_.getTimestamp)
-  implicit val localDateDecoder: Decoder[LocalDate] = decoder(_.getDate)
+  implicit val timestampDecoder: Decoder[Date] = decoder(_.getTimestamp)
+  implicit val cassandraLocalDateDecoder: Decoder[LocalDate] = decoder(_.getDate)
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
@@ -46,6 +46,6 @@ trait Encoders extends CollectionEncoders {
   implicit val byteArrayEncoder: Encoder[Array[Byte]] =
     encoder((index, value, row) => row.setBytes(index, ByteBuffer.wrap(value)))
   implicit val uuidEncoder: Encoder[UUID] = encoder(_.setUUID)
-  implicit val dateEncoder: Encoder[Date] = encoder(_.setTimestamp)
-  implicit val localDateEncoder: Encoder[LocalDate] = encoder(_.setDate)
+  implicit val timestampEncoder: Encoder[Date] = encoder(_.setTimestamp)
+  implicit val cassandraLocalDateEncoder: Encoder[LocalDate] = encoder(_.setDate)
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encodings.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encodings.scala
@@ -1,0 +1,19 @@
+package io.getquill.context.cassandra.encoding
+
+import java.time.{ Instant, LocalDate }
+import java.util.Date
+
+import com.datastax.driver.core.{ LocalDate => CasLocalDate }
+import io.getquill.context.cassandra.CassandraContext
+
+trait Encodings extends CassandraMapperConversions with CassandraTypes {
+  this: CassandraContext[_] =>
+
+  implicit val encodeJava8LocalDate: MappedEncoding[LocalDate, CasLocalDate] = MappedEncoding(ld =>
+    CasLocalDate.fromYearMonthDay(ld.getYear, ld.getMonthValue, ld.getDayOfMonth))
+  implicit val decodeJava8LocalDate: MappedEncoding[CasLocalDate, LocalDate] = MappedEncoding(ld =>
+    LocalDate.of(ld.getYear, ld.getMonth, ld.getDay))
+
+  implicit val encodeJava8Instant: MappedEncoding[Instant, Date] = MappedEncoding(Date.from)
+  implicit val decodeJava8Instant: MappedEncoding[Date, Instant] = MappedEncoding(_.toInstant)
+}


### PR DESCRIPTION
Fixes #947

### Problem
No default java8 support for quill-cassandra

### Solution

Provide implicit mapped encoding for Instant and LocalDate

### Notes

renamed `dateEncoder` to `timestampEncoder` to not confuse users since driver encodes timestmap as `java.util.Date`
renamed `localDateDecoder` to `cassandraLocalDateDecoder` to avoid confusions also


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
