### PR TITLE
Fix select query for unlimited optional embedded case classes

### DIFF
--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextMacroSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextMacroSpec.scala
@@ -54,20 +54,4 @@ class CassandraContextMacroSpec extends Spec {
       mirror.prepareRow mustEqual Row(2l, 1)
     }
   }
-
-  "multi-level embedded case class with optionals lifting" in {
-    case class TestEntity(level1: Level1)
-    case class Level1(level2: Level2, optionalLevel2: Option[Level2]) extends Embedded
-    case class Level2(level3: Level3, optionalLevel3: Option[Level3]) extends Embedded
-    case class Level3(value: Option[String], optionalLevel4: Option[Level4]) extends Embedded
-    case class Level4(id: Int) extends Embedded
-
-    val e = TestEntity(Level1(Level2(Level3(Some("test"), None), Some(Level3(None, Some(Level4(1))))), None))
-    val q = quote {
-      query[TestEntity].insert(lift(e))
-    }
-    val r = mirrorContext.run(q)
-    r.string mustEqual "INSERT INTO TestEntity (value,id,value,id,value,id,value,id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-    r.prepareRow mustEqual Row(Some("test"), None, Some(None), Some(Some(1)), None, None, None, None)
-  }
 }

--- a/quill-core/src/test/scala/io/getquill/UnlimitedOptionalEmbeddedSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/UnlimitedOptionalEmbeddedSpec.scala
@@ -1,0 +1,112 @@
+package io.getquill
+
+import io.getquill.ast.{ Entity, PropertyAlias }
+import io.getquill.context.mirror.Row
+
+class UnlimitedOptionalEmbeddedSpec extends Spec {
+  val ctx = testContext
+
+  import ctx._
+
+  case class Emb3(value: String) extends Embedded
+  case class Emb2(e1: Emb3, e2: Option[Emb3]) extends Embedded
+  case class Emb1(e1: Emb2, e2: Option[Emb2]) extends Embedded
+  case class OptEmd(e1: Emb1, e2: Option[Emb1])
+
+  lazy val optEmdEnt = OptEmd(
+    Emb1(
+      Emb2(Emb3("111"), Some(Emb3("112"))), Some(Emb2(Emb3("121"), Some(Emb3("122"))))
+    ),
+    Some(Emb1(
+      Emb2(Emb3("211"), Some(Emb3("212"))), Some(Emb2(Emb3("221"), Some(Emb3("222"))))
+    ))
+  )
+
+  val qrOptEmd = quote {
+    querySchema[OptEmd](
+      "OptEmd",
+      _.e1.e1.e1.value -> "value111",
+      _.e1.e1.e2.map(_.value) -> "value112",
+      _.e1.e2.map(_.e1.value) -> "value121",
+      _.e1.e2.map(_.e2.map(_.value)) -> "value122",
+      _.e2.map(_.e1.e1.value) -> "value211",
+      _.e2.map(_.e1.e2.map(_.value)) -> "value212",
+      _.e2.map(_.e2.map(_.e1.value)) -> "value221",
+      _.e2.map(_.e2.map(_.e2.map(_.value))) -> "value222"
+    )
+  }
+
+  "quotation aliases" in {
+    quote(unquote(qrOptEmd)).ast mustEqual Entity("OptEmd", List(
+      PropertyAlias(List("e1", "e1", "e1", "value"), "value111"),
+      PropertyAlias(List("e1", "e1", "e2", "value"), "value112"),
+      PropertyAlias(List("e1", "e2", "e1", "value"), "value121"),
+      PropertyAlias(List("e1", "e2", "e2", "value"), "value122"),
+      PropertyAlias(List("e2", "e1", "e1", "value"), "value211"),
+      PropertyAlias(List("e2", "e1", "e2", "value"), "value212"),
+      PropertyAlias(List("e2", "e2", "e1", "value"), "value221"),
+      PropertyAlias(List("e2", "e2", "e2", "value"), "value222")
+    ))
+  }
+
+  "meta" - {
+    "query" in {
+      materializeQueryMeta[OptEmd].expand.toString mustEqual "(q) => q.map(x => (" +
+        "x.e1.e1.e1.value, " +
+        "x.e1.e1.e2.map((v) => v.value), " +
+        "x.e1.e2.map((v) => v.e1.value), " +
+        "x.e1.e2.map((v) => v.e2.map((v) => v.value)), " +
+        "x.e2.map((v) => v.e1.e1.value), " +
+        "x.e2.map((v) => v.e1.e2.map((v) => v.value)), " +
+        "x.e2.map((v) => v.e2.map((v) => v.e1.value)), " +
+        "x.e2.map((v) => v.e2.map((v) => v.e2.map((v) => v.value)))))"
+    }
+    "update" in {
+      materializeUpdateMeta[OptEmd].expand.toString mustEqual "(q, value) => q.update(" +
+        "v => v.e1.e1.e1.value -> value.e1.e1.e1.value, " +
+        "v => v.e1.e1.e2.map((v) => v.value) -> value.e1.e1.e2.map((v) => v.value), " +
+        "v => v.e1.e2.map((v) => v.e1.value) -> value.e1.e2.map((v) => v.e1.value), " +
+        "v => v.e1.e2.map((v) => v.e2.map((v) => v.value)) -> value.e1.e2.map((v) => v.e2.map((v) => v.value)), " +
+        "v => v.e2.map((v) => v.e1.e1.value) -> value.e2.map((v) => v.e1.e1.value), " +
+        "v => v.e2.map((v) => v.e1.e2.map((v) => v.value)) -> value.e2.map((v) => v.e1.e2.map((v) => v.value)), " +
+        "v => v.e2.map((v) => v.e2.map((v) => v.e1.value)) -> value.e2.map((v) => v.e2.map((v) => v.e1.value)), " +
+        "v => v.e2.map((v) => v.e2.map((v) => v.e2.map((v) => v.value))) -> value.e2.map((v) => v.e2.map((v) => v.e2.map((v) => v.value))))"
+    }
+    "insert" in {
+      materializeInsertMeta[OptEmd].expand.toString mustEqual "(q, value) => q.insert(" +
+        "v => v.e1.e1.e1.value -> value.e1.e1.e1.value, " +
+        "v => v.e1.e1.e2.map((v) => v.value) -> value.e1.e1.e2.map((v) => v.value), " +
+        "v => v.e1.e2.map((v) => v.e1.value) -> value.e1.e2.map((v) => v.e1.value), " +
+        "v => v.e1.e2.map((v) => v.e2.map((v) => v.value)) -> value.e1.e2.map((v) => v.e2.map((v) => v.value)), " +
+        "v => v.e2.map((v) => v.e1.e1.value) -> value.e2.map((v) => v.e1.e1.value), " +
+        "v => v.e2.map((v) => v.e1.e2.map((v) => v.value)) -> value.e2.map((v) => v.e1.e2.map((v) => v.value)), " +
+        "v => v.e2.map((v) => v.e2.map((v) => v.e1.value)) -> value.e2.map((v) => v.e2.map((v) => v.e1.value)), " +
+        "v => v.e2.map((v) => v.e2.map((v) => v.e2.map((v) => v.value))) -> value.e2.map((v) => v.e2.map((v) => v.e2.map((v) => v.value))))"
+    }
+  }
+
+  "action" - {
+    val resultString = """querySchema("OptEmd", _.e1.e1.e1.value -> "value111", _.e1.e1.e2.value -> "value112", """ +
+      """_.e1.e2.e1.value -> "value121", _.e1.e2.e2.value -> "value122", _.e2.e1.e1.value -> "value211", """ +
+      """_.e2.e1.e2.value -> "value212", _.e2.e2.e1.value -> "value221", _.e2.e2.e2.value -> "value222").insert(""" +
+      "v => v.e1.e1.e1.value -> ?, " +
+      "v => v.e1.e1.e2.map((v) => v.value) -> ?, " +
+      "v => v.e1.e2.map((v) => v.e1.value) -> ?, " +
+      "v => v.e1.e2.map((v) => v.e2.map((v) => v.value)) -> ?, " +
+      "v => v.e2.map((v) => v.e1.e1.value) -> ?, " +
+      "v => v.e2.map((v) => v.e1.e2.map((v) => v.value)) -> ?, " +
+      "v => v.e2.map((v) => v.e2.map((v) => v.e1.value)) -> ?, " +
+      "v => v.e2.map((v) => v.e2.map((v) => v.e2.map((v) => v.value))) -> ?)"
+    val resultRow = Row("111", Some("112"), Some("121"), Some(Some("122")), Some("211"), Some(Some("212")), Some(Some("221")), Some(Some(Some("222"))))
+
+    "non-batched" in {
+      val r = testContext.run(qrOptEmd.insert(lift(optEmdEnt)))
+      r.string mustEqual resultString
+      r.prepareRow mustEqual resultRow
+    }
+    "batched" in {
+      val r = testContext.run(liftQuery(List(optEmdEnt)).foreach(e => qrOptEmd.insert(e)))
+      r.groups mustEqual List(resultString -> List(resultRow))
+    }
+  }
+}

--- a/quill-core/src/test/scala/io/getquill/context/ActionMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/ActionMacroSpec.scala
@@ -67,29 +67,6 @@ class ActionMacroSpec extends Spec {
       r.prepareRow mustEqual Row("s", 1, None)
       r.returningColumn mustEqual "l"
     }
-    "multi-level embedded case class with optionals lifting" in {
-      case class TestEntity(level1: Level1)
-      case class Level1(level2: Level2, optionalLevel2: Option[Level2]) extends Embedded
-      case class Level2(level3: Level3, optionalLevel3: Option[Level3]) extends Embedded
-      case class Level3(value: Option[String], optionalLevel4: Option[Level4]) extends Embedded
-      case class Level4(id: Int) extends Embedded
-
-      val e = TestEntity(Level1(Level2(Level3(Some("test"), None), Some(Level3(None, Some(Level4(1))))), None))
-      val q = quote {
-        query[TestEntity].insert(lift(e))
-      }
-      val r = testContext.run(q)
-      r.string mustEqual
-        "querySchema(\"TestEntity\").insert(v => v.level1.level2.level3.value -> ?, " +
-        "v => v.level1.level2.level3.optionalLevel4.map((v) => v.id) -> ?, " +
-        "v => v.level1.level2.optionalLevel3.map((v) => v.value) -> ?, " +
-        "v => v.level1.level2.optionalLevel3.map((v) => v.optionalLevel4.map((v) => v.id)) -> ?, " +
-        "v => v.level1.optionalLevel2.map((v) => v.level3.value) -> ?, " +
-        "v => v.level1.optionalLevel2.map((v) => v.level3.optionalLevel4.map((v) => v.id)) -> ?, " +
-        "v => v.level1.optionalLevel2.map((v) => v.optionalLevel3.map((v) => v.value)) -> ?, " +
-        "v => v.level1.optionalLevel2.map((v) => v.optionalLevel3.map((v) => v.optionalLevel4.map((v) => v.id))) -> ?)"
-      r.prepareRow mustEqual Row(Some("test"), None, Some(None), Some(Some(1)), None, None, None, None)
-    }
   }
 
   "runs batched action" - {
@@ -190,33 +167,6 @@ class ActionMacroSpec extends Spec {
       r.groups mustEqual List(
         ("""querySchema("TestEntity").insert(v => v.s -> ?, v => v.i -> ?, v => v.o -> ?).returning((t) => t.l)""", "l",
           List(Row("s1", 2, Some(4)), Row("s5", 6, Some(8))))
-      )
-    }
-    "multi-level embedded case class with optionals lifting" in {
-      case class TestEntity(level1: Level1)
-      case class Level1(level2: Level2, optionalLevel2: Option[Level2]) extends Embedded
-      case class Level2(level3: Level3, optionalLevel3: Option[Level3]) extends Embedded
-      case class Level3(value: Option[String], optionalLevel4: Option[Level4]) extends Embedded
-      case class Level4(id: Int) extends Embedded
-
-      val e = TestEntity(Level1(Level2(Level3(Some("test"), None), Some(Level3(None, Some(Level4(1))))), None))
-      val q = quote {
-        query[TestEntity].insert(lift(e))
-      }
-
-      val r = testContext.run(liftQuery(List(e)).foreach(e => query[TestEntity].insert(e)))
-      r.groups mustEqual List(
-        (
-          "querySchema(\"TestEntity\").insert(v => v.level1.level2.level3.value -> ?, " +
-          "v => v.level1.level2.level3.optionalLevel4.map((v) => v.id) -> ?, " +
-          "v => v.level1.level2.optionalLevel3.map((v) => v.value) -> ?, " +
-          "v => v.level1.level2.optionalLevel3.map((v) => v.optionalLevel4.map((v) => v.id)) -> ?, " +
-          "v => v.level1.optionalLevel2.map((v) => v.level3.value) -> ?, " +
-          "v => v.level1.optionalLevel2.map((v) => v.level3.optionalLevel4.map((v) => v.id)) -> ?, " +
-          "v => v.level1.optionalLevel2.map((v) => v.optionalLevel3.map((v) => v.value)) -> ?, " +
-          "v => v.level1.optionalLevel2.map((v) => v.optionalLevel3.map((v) => v.optionalLevel4.map((v) => v.id))) -> ?)",
-          List(Row(Some("test"), None, Some(None), Some(Some(1)), None, None, None, None))
-        )
       )
     }
   }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -48,36 +48,6 @@ class QuotationSpec extends Spec {
           }
           quote(unquote(q)).ast mustEqual Entity("SomeAlias", List(PropertyAlias(List("ev", "s"), "theS"), PropertyAlias(List("ev", "i"), "theI")))
         }
-        "with mixing embedded option/raw property alias" in {
-          case class Emb3(value: String) extends Embedded
-          case class Emb2(e1: Emb3, e2: Option[Emb3]) extends Embedded
-          case class Emb1(e1: Emb2, e2: Option[Emb2]) extends Embedded
-          case class TestEnt(e1: Emb1, e2: Option[Emb1])
-          val q = quote {
-            querySchema[TestEnt](
-              "Entity",
-              _.e1.e1.e1.value -> "value111",
-              _.e1.e1.e2.map(_.value) -> "value112",
-              _.e1.e2.map(_.e1.value) -> "value121",
-              _.e1.e2.map(_.e2.map(_.value)) -> "value122",
-              _.e2.map(_.e1.e1.value) -> "value211",
-              _.e2.map(_.e1.e2.map(_.value)) -> "value212",
-              _.e2.map(_.e2.map(_.e1.value)) -> "value221",
-              _.e2.map(_.e2.map(_.e2.map(_.value))) -> "value222"
-            )
-          }
-
-          quote(unquote(q)).ast mustEqual Entity("Entity", List(
-            PropertyAlias(List("e1", "e1", "e1", "value"), "value111"),
-            PropertyAlias(List("e1", "e1", "e2", "value"), "value112"),
-            PropertyAlias(List("e1", "e2", "e1", "value"), "value121"),
-            PropertyAlias(List("e1", "e2", "e2", "value"), "value122"),
-            PropertyAlias(List("e2", "e1", "e1", "value"), "value211"),
-            PropertyAlias(List("e2", "e1", "e2", "value"), "value212"),
-            PropertyAlias(List("e2", "e2", "e1", "value"), "value221"),
-            PropertyAlias(List("e2", "e2", "e2", "value"), "value222")
-          ))
-        }
         "explicit `Predef.ArrowAssoc`" in {
           val q = quote {
             querySchema[TestEntity]("TestEntity", e => Predef.ArrowAssoc(e.s). -> [String]("theS"))

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
@@ -77,21 +77,4 @@ class SqlActionMacroSpec extends Spec {
     mirror.string mustEqual "INSERT INTO test_entity4 (text_col) VALUES (?)"
     mirror.returningColumn mustEqual "int_id"
   }
-  "multi-level embedded case class with optionals lifting" in {
-    import testContext._
-
-    case class TestEntity(level1: Level1)
-    case class Level1(level2: Level2, optionalLevel2: Option[Level2]) extends Embedded
-    case class Level2(level3: Level3, optionalLevel3: Option[Level3]) extends Embedded
-    case class Level3(value: Option[String], optionalLevel4: Option[Level4]) extends Embedded
-    case class Level4(id: Int) extends Embedded
-
-    val e = TestEntity(Level1(Level2(Level3(Some("test"), None), Some(Level3(None, Some(Level4(1))))), None))
-    val q = quote {
-      query[TestEntity].insert(lift(e))
-    }
-    val r = testContext.run(q)
-    r.string mustEqual "INSERT INTO TestEntity (value,id,value,id,value,id,value,id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-    r.prepareRow mustEqual Row(Some("test"), None, Some(None), Some(Some(1)), None, None, None, None)
-  }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ObservationMirrorSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ObservationMirrorSpec.scala
@@ -1,0 +1,42 @@
+package io.getquill.context.sql.mirror
+
+import io.getquill.Spec
+import io.getquill.context.mirror.Row
+
+class ObservationMirrorSpec extends Spec {
+
+  val ctx = io.getquill.context.sql.testContext
+  import ctx._
+
+  case class LatLon(lat: Int, lon: Int) extends Embedded
+  case class ScalarData(value: Long, position: Option[LatLon]) extends Embedded
+  case class Observation(data: Option[ScalarData], foo: Option[String])
+
+  val obs = quote {
+    querySchema[Observation](
+      "observation",
+      _.data.map(_.value) -> "obs_value",
+      _.data.map(_.position.map(_.lat)) -> "obs_lat",
+      _.data.map(_.position.map(_.lon)) -> "obs_lon"
+    )
+  }
+
+  val obsEntry = Observation(Some(ScalarData(123, Some(LatLon(2, 3)))), None)
+
+  "select query" in {
+    ctx.run(obs).string mustEqual
+      "SELECT x.obs_value, x.obs_lat, x.obs_lon, x.foo FROM observation x"
+  }
+
+  "insert query" in {
+    val r = ctx.run(obs.insert(lift(obsEntry)))
+    r.string mustEqual "INSERT INTO observation (obs_value,obs_lat,obs_lon,foo) VALUES (?, ?, ?, ?)"
+    r.prepareRow mustEqual Row(Some(123), Some(Some(2)), Some(Some(3)), None)
+  }
+
+  "update query" in {
+    val r = ctx.run(obs.update(lift(obsEntry)))
+    r.string mustEqual "UPDATE observation SET obs_value = ?, obs_lat = ?, obs_lon = ?, foo = ?"
+    r.prepareRow mustEqual Row(Some(123), Some(Some(2)), Some(Some(3)), None)
+  }
+}


### PR DESCRIPTION
Fixes #948

### Problem

renaming props and insert actions works fine, but select fails, more details in issue

### Solution

`expand` failed at the deepest raw value where the impl didnt wrap last call with `Some(..)` hence typecheck failed. Fix it :)


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
