### PR TITLE
Ad-Hoc Tuple Support in Quotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,8 +593,7 @@ ctx.run(q)
     1. Using the `new` keyword: `new Person("Joe", "Bloggs")`
     2. Using a companion object's apply method:  `Person("Joe", "Bloggs")`
     3. Using a companion object's apply method explicitly: `Person.apply("Joe", "Bloggs")`
-4. The case class *must* be defined in either the root scope or another object. Ad-Hoc Case Classes defined in a local method cannot be constructed with an 'apply' method.
-5. Any custom logic in a constructor/apply-method of a Ad-Hoc case class would not be invoked when it is 'constructed' inside a quotation.
+4. Any custom logic in a constructor/apply-method of a Ad-Hoc case class will not be invoked when it is 'constructed' inside a quotation. To construct an Ad-Hoc case class with custom logic inside a quotation, you can use a quoted method.
 
 ## Query probing
 

--- a/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/CaseClassQueryAsyncSpec.scala
+++ b/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/CaseClassQueryAsyncSpec.scala
@@ -1,0 +1,41 @@
+package io.getquill.context.async.mysql
+
+import scala.concurrent.ExecutionContext.Implicits.{ global => ec }
+import io.getquill.context.sql.CaseClassQuerySpec
+import org.scalatest.Matchers._
+
+class CaseClassQueryAsyncSpec extends CaseClassQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll =
+    await {
+      testContext.transaction { implicit ec =>
+        for {
+          _ <- testContext.run(query[Contact].delete)
+          _ <- testContext.run(query[Address].delete)
+          _ <- testContext.run(liftQuery(peopleEntries).foreach(e => peopleInsert(e)))
+          _ <- testContext.run(liftQuery(addressEntries).foreach(e => addressInsert(e)))
+        } yield {}
+      }
+    }
+
+  "Example 1 - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1 CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1A - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1A CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1B - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1B CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Single Record Mapped Join" in {
+    await(testContext.run(`Ex 2 Single-Record Join`)) should contain theSameElementsAs `Ex 2 Single-Record Join expected result`
+  }
+
+  "Example 3 - Inline Record as Filter" in {
+    await(testContext.run(`Ex 3 Inline Record Usage`)) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/CaseClassQueryAsyncSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/CaseClassQueryAsyncSpec.scala
@@ -1,0 +1,41 @@
+package io.getquill.context.async.postgres
+
+import scala.concurrent.ExecutionContext.Implicits.{ global => ec }
+import io.getquill.context.sql.CaseClassQuerySpec
+import org.scalatest.Matchers._
+
+class CaseClassQueryAsyncSpec extends CaseClassQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll =
+    await {
+      testContext.transaction { implicit ec =>
+        for {
+          _ <- testContext.run(query[Contact].delete)
+          _ <- testContext.run(query[Address].delete)
+          _ <- testContext.run(liftQuery(peopleEntries).foreach(e => peopleInsert(e)))
+          _ <- testContext.run(liftQuery(addressEntries).foreach(e => addressInsert(e)))
+        } yield {}
+      }
+    }
+
+  "Example 1 - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1 CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1A - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1A CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1B - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1B CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Single Record Mapped Join" in {
+    await(testContext.run(`Ex 2 Single-Record Join`)) should contain theSameElementsAs `Ex 2 Single-Record Join expected result`
+  }
+
+  "Example 3 - Inline Record as Filter" in {
+    await(testContext.run(`Ex 3 Inline Record Usage`)) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
@@ -120,6 +120,7 @@ trait CqlIdiom extends Idiom {
     case Constant(())        => stmt"1"
     case Constant(v)         => stmt"${v.toString.token}"
     case Tuple(values)       => stmt"${values.token}"
+    case CaseClass(values)   => stmt"${values.map(_._2).token}"
     case NullValue           => fail("Cql doesn't support null values.")
   }
 

--- a/quill-cassandra/src/test/cql/cassandra-schema.cql
+++ b/quill-cassandra/src/test/cql/cassandra-schema.cql
@@ -170,3 +170,19 @@ CREATE TABLE quill_test_2.with_udt(
     id INT PRIMARY KEY,
     name frozen <quill_test_2.Name>
 );
+
+CREATE TABLE Contact(
+    id INT PRIMARY KEY,
+    firstName VARCHAR,
+    lastName VARCHAR,
+    age INT,
+    addressFk INT,
+    extraInfo VARCHAR
+);
+
+CREATE TABLE Address(
+    id INT PRIMARY KEY,
+    street VARCHAR,
+    zip INT,
+    otherExtraInfo VARCHAR
+);

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CaseClassQueryCassandraSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CaseClassQueryCassandraSpec.scala
@@ -1,0 +1,68 @@
+package io.getquill.context.cassandra
+
+import io.getquill.Spec
+
+class CaseClassQueryCassandraSpec extends Spec {
+
+  import testSyncDB._
+
+  case class Contact(id: Int, firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: String)
+  case class Address(id: Int, street: String, zip: Int, otherExtraInfo: String)
+
+  val peopleInsert =
+    quote((p: Contact) => query[Contact].insert(p))
+
+  val peopleEntries = List(
+    Contact(1, "Alex", "Jones", 60, 2, "foo"),
+    Contact(2, "Bert", "James", 55, 3, "bar"),
+    Contact(3, "Cora", "Jasper", 33, 3, "baz")
+  )
+
+  val addressInsert =
+    quote((c: Address) => query[Address].insert(c))
+
+  val addressEntries = List(
+    Address(1, "123 Fake Street", 11234, "something"),
+    Address(2, "456 Old Street", 45678, "something else"),
+    Address(3, "789 New Street", 89010, "another thing")
+  )
+
+  case class ContactSimplified(firstName: String, lastName: String, age: Int)
+  case class AddressableContact(firstName: String, lastName: String, age: Int, street: String, zip: Int)
+
+  val `Ex 1 CaseClass Record Output` = quote {
+    query[Contact].map(p => new ContactSimplified(p.firstName, p.lastName, p.age))
+  }
+
+  val `Ex 1 CaseClass Record Output expected result` = List(
+    ContactSimplified("Alex", "Jones", 60),
+    ContactSimplified("Bert", "James", 55),
+    ContactSimplified("Cora", "Jasper", 33)
+  )
+
+  case class FiltrationObject(idFilter: Int)
+
+  val `Ex 3 Inline Record Usage` = quote {
+    val filtrationObject = new FiltrationObject(1)
+    query[Contact].filter(p => p.id == filtrationObject.idFilter)
+  }
+
+  val `Ex 3 Inline Record Usage exepected result` = List(
+    new Contact(1, "Alex", "Jones", 60, 2, "foo")
+  )
+
+  override def beforeAll = {
+    testSyncDB.run(query[Contact].delete)
+    testSyncDB.run(query[Address].delete)
+    testSyncDB.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+    testSyncDB.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+  }
+
+  "Example 1 - Single Case Class Mapping" in {
+    testSyncDB.run(`Ex 1 CaseClass Record Output`) mustEqual `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Inline Record as Filter" in {
+    testSyncDB.run(`Ex 3 Inline Record Usage`) mustEqual `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
@@ -384,6 +384,9 @@ class CqlIdiomSpec extends Spec {
     "value" in {
       implicitly[Tokenizer[Value]].token(Tuple(List(Ident("a")))) mustBe stmt"a"
     }
+    "value in caseclass" in {
+      implicitly[Tokenizer[Value]].token(CaseClass(List(("value", Ident("a"))))) mustBe stmt"a"
+    }
     "action" in {
       val t = implicitly[Tokenizer[AstAction]]
       intercept[IllegalStateException](t.token(null: AstAction))

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -171,6 +171,7 @@ class MirrorIdiom extends Idiom {
     case Constant(v)         => stmt"${v.toString.token}"
     case NullValue           => stmt"null"
     case Tuple(values)       => stmt"(${values.token})"
+    case CaseClass(values)   => stmt"(${values.map(_._2).token})"
   }
 
   implicit val identTokenizer: Tokenizer[Ident] = Tokenizer[Ident] {

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -106,6 +106,7 @@ case class Constant(v: Any) extends Value
 object NullValue extends Value
 
 case class Tuple(values: List[Ast]) extends Value
+case class CaseClass(values: List[(String, Ast)]) extends Value
 
 //************************************************************
 

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -190,6 +190,10 @@ trait StatefulTransformer[T] {
       case Tuple(a) =>
         val (at, att) = apply(a)(_.apply)
         (Tuple(at), att)
+      case CaseClass(a) =>
+        val (keys, values) = a.unzip
+        val (at, att) = apply(values)(_.apply)
+        (CaseClass(keys.zip(at)), att)
     }
 
   def apply(e: Action): (Action, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -81,6 +81,10 @@ trait StatelessTransformer {
       case e: Constant   => e
       case NullValue     => NullValue
       case Tuple(values) => Tuple(values.map(apply))
+      case CaseClass(tuples) => {
+        val (keys, values) = tuples.unzip
+        CaseClass(keys.zip(values.map(apply)))
+      }
     }
 
   def apply(e: Action): Action =

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -19,6 +19,9 @@ case class BetaReduction(map: collection.Map[Ast, Ast])
           case _ => apply(values(name.drop(1).toInt - 1))
         }
 
+      case Property(CaseClass(tuples), name) =>
+        apply(tuples.toMap.apply(name))
+
       case FunctionApply(Function(params, body), values) =>
         val conflicts = values.flatMap(CollectAst.byType[Ident]).map { i =>
           i -> Ident(s"tmp_${i.name}")

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -143,9 +143,10 @@ trait Liftables {
   }
 
   implicit val valueLiftable: Liftable[Value] = Liftable[Value] {
-    case NullValue   => q"$pack.NullValue"
-    case Constant(a) => q"$pack.Constant(${Literal(c.universe.Constant(a))})"
-    case Tuple(a)    => q"$pack.Tuple($a)"
+    case NullValue    => q"$pack.NullValue"
+    case Constant(a)  => q"$pack.Constant(${Literal(c.universe.Constant(a))})"
+    case Tuple(a)     => q"$pack.Tuple($a)"
+    case CaseClass(a) => q"$pack.CaseClass($a)"
   }
   implicit val identLiftable: Liftable[Ident] = Liftable[Ident] {
     case Ident(a) => q"$pack.Ident($a)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -491,7 +491,10 @@ trait Parsing {
         isModuleClass(c.WeakTypeTag(firstChild.tpe.erasure)),
         asClass(c.WeakTypeTag(firstChild.tpe.erasure))
       )
-    } yield (moduleClass.companion == resultType.typeSymbol)
+      // Fix for SI-7567 Ideally this should be
+      // moduleClass.companion == resultType.typeSymbol but .companion
+      // returns NoSymbol where in a local context (e.g. inside a method).
+    } yield (resultType.typeSymbol.name.toTypeName == moduleClass.name.toTypeName)
     output.getOrElse(false)
   }
 

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -181,6 +181,14 @@ class StatefulTransformerSpec extends Spec {
             att.state mustEqual List(Ident("a"), Ident("b"), Ident("c"))
         }
       }
+      "caseclass" in {
+        val ast: Ast = CaseClass(List(("foo", Ident("a")), ("bar", Ident("b")), ("baz", Ident("c"))))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {
+          case (at, att) =>
+            at mustEqual CaseClass(List(("foo", Ident("a'")), ("bar", Ident("b'")), ("baz", Ident("c'"))))
+            att.state mustEqual List(Ident("a"), Ident("b"), Ident("c"))
+        }
+      }
     }
 
     "action" - {

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -119,6 +119,11 @@ class StatelessTransformerSpec extends Spec {
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
           Tuple(List(Ident("a'"), Ident("b'"), Ident("c'")))
       }
+      "caseclass" in {
+        val ast: Ast = CaseClass(List(("foo", Ident("a")), ("bar", Ident("b")), ("baz", Ident("c"))))
+        Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+          CaseClass(List(("foo", Ident("a'")), ("bar", Ident("b'")), ("baz", Ident("c'"))))
+      }
     }
 
     "Assignment" in {

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -10,6 +10,10 @@ class BetaReductionSpec extends Spec {
       val ast: Ast = Property(Tuple(List(Ident("a"))), "_1")
       BetaReduction(ast) mustEqual Ident("a")
     }
+    "caseclass field" in {
+      val ast: Ast = Property(CaseClass(List(("foo", Ident("a")))), "foo")
+      BetaReduction(ast) mustEqual Ident("a")
+    }
     "function apply" in {
       val function = Function(List(Ident("a")), Ident("a"))
       val ast: Ast = FunctionApply(function, List(Ident("b")))
@@ -50,6 +54,21 @@ class BetaReductionSpec extends Spec {
           c
         ))
         BetaReduction(outer) mustEqual Tuple(List(entity, c2, c3))
+      }
+      "nested blocks caseclass" in {
+        val inner = Block(List(
+          Val(a, entity),
+          Val(b, c2),
+          Val(c, c3),
+          CaseClass(List(("foo", a), ("bar", b), ("baz", c)))
+        ))
+        val outer = Block(List(
+          Val(a, inner),
+          Val(b, a),
+          Val(c, b),
+          c
+        ))
+        BetaReduction(outer) mustEqual CaseClass(List(("foo", entity), ("bar", c2), ("baz", c3)))
       }
     }
     "avoids replacing idents of an outer scope" - {
@@ -120,6 +139,12 @@ class BetaReductionSpec extends Spec {
   "reapplies the beta reduction if the structure changes" in {
     val ast: Ast = Property(Ident("a"), "_1")
     BetaReduction(ast, Ident("a") -> Tuple(List(Ident("a'")))) mustEqual
+      Ident("a'")
+  }
+
+  "reapplies the beta reduction if the structure changes caseclass" in {
+    val ast: Ast = Property(Ident("a"), "foo")
+    BetaReduction(ast, Ident("a") -> CaseClass(List(("foo", Ident("a'"))))) mustEqual
       Ident("a'")
   }
 

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/CaseClassQueryFinagleSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/CaseClassQueryFinagleSpec.scala
@@ -1,0 +1,43 @@
+package io.getquill.context.finagle.mysql
+
+import com.twitter.util.{ Await, Future }
+import io.getquill.context.sql.CaseClassQuerySpec
+import org.scalatest.Matchers._
+
+class CaseClassQueryFinagleSpec extends CaseClassQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](future: Future[T]) = Await.result(future)
+
+  override def beforeAll =
+    await {
+      testContext.transaction {
+        for {
+          _ <- testContext.run(query[Contact].delete)
+          _ <- testContext.run(query[Address].delete)
+          _ <- testContext.run(liftQuery(peopleEntries).foreach(e => peopleInsert(e)))
+          _ <- testContext.run(liftQuery(addressEntries).foreach(e => addressInsert(e)))
+        } yield {}
+      }
+    }
+
+  "Example 1 - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1 CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1A - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1A CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1B - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1B CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Single Record Mapped Join" in {
+    await(testContext.run(`Ex 2 Single-Record Join`)) should contain theSameElementsAs `Ex 2 Single-Record Join expected result`
+  }
+
+  "Example 3 - Inline Record as Filter" in {
+    await(testContext.run(`Ex 3 Inline Record Usage`)) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/CaseClassQueryFinagleSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/CaseClassQueryFinagleSpec.scala
@@ -1,0 +1,43 @@
+package io.getquill.context.finagle.postgres
+
+import com.twitter.util.{ Await, Future }
+import io.getquill.context.sql.CaseClassQuerySpec
+import org.scalatest.Matchers._
+
+class CaseClassQueryFinagleSpec extends CaseClassQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  def await[T](future: Future[T]) = Await.result(future)
+
+  override def beforeAll =
+    await {
+      testContext.transaction {
+        for {
+          _ <- testContext.run(query[Contact].delete)
+          _ <- testContext.run(query[Address].delete)
+          _ <- testContext.run(liftQuery(peopleEntries).foreach(e => peopleInsert(e)))
+          _ <- testContext.run(liftQuery(addressEntries).foreach(e => addressInsert(e)))
+        } yield {}
+      }
+    }
+
+  "Example 1 - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1 CaseClass Record Output`)) should contain theSameElementsAs (`Ex 1 CaseClass Record Output expected result`)
+  }
+  "Example 1A - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1A CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1B - Single Case Class Mapping" in {
+    await(testContext.run(`Ex 1B CaseClass Record Output`)) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Single Record Mapped Join" in {
+    await(testContext.run(`Ex 2 Single-Record Join`)) should contain theSameElementsAs `Ex 2 Single-Record Join expected result`
+  }
+
+  "Example 3 - Inline Record as Filter" in {
+    await(testContext.run(`Ex 3 Inline Record Usage`)) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-jdbc/src/test/resources/sql/h2-schema.sql
+++ b/quill-jdbc/src/test/resources/sql/h2-schema.sql
@@ -82,3 +82,33 @@ CREATE TABLE IF NOT EXISTS Product(
     id identity,
     sku BIGINT
 );
+
+CREATE TABLE IF NOT EXISTS Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);

--- a/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
+++ b/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
@@ -82,3 +82,33 @@ CREATE TABLE IF NOT EXISTS Product(
     description VARCHAR(255),
     sku BIGINT
 );
+
+CREATE TABLE IF NOT EXISTS Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/CaseClassQueryJdbcSpec.scala
@@ -1,0 +1,38 @@
+package io.getquill.context.jdbc.h2
+
+import io.getquill.context.sql.CaseClassQuerySpec
+import org.scalatest.Matchers._
+
+class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Contact].delete)
+      testContext.run(query[Address].delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+    }
+    ()
+  }
+
+  "Example 1 - Single Case Class Mapping" in {
+    testContext.run(`Ex 1 CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1A - Single Case Class Mapping" in {
+    testContext.run(`Ex 1A CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1B - Single Case Class Mapping" in {
+    testContext.run(`Ex 1B CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Single Record Mapped Join" in {
+    testContext.run(`Ex 2 Single-Record Join`) should contain theSameElementsAs `Ex 2 Single-Record Join expected result`
+  }
+
+  "Example 3 - Inline Record as Filter" in {
+    testContext.run(`Ex 3 Inline Record Usage`) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/CaseClassQueryJdbcSpec.scala
@@ -1,0 +1,38 @@
+package io.getquill.context.jdbc.mysql
+
+import io.getquill.context.sql.CaseClassQuerySpec
+import org.scalatest.Matchers._
+
+class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Contact].delete)
+      testContext.run(query[Address].delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+    }
+    ()
+  }
+
+  "Example 1 - Single Case Class Mapping" in {
+    testContext.run(`Ex 1 CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1A - Single Case Class Mapping" in {
+    testContext.run(`Ex 1A CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1B - Single Case Class Mapping" in {
+    testContext.run(`Ex 1B CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Single Record Mapped Join" in {
+    testContext.run(`Ex 2 Single-Record Join`) should contain theSameElementsAs `Ex 2 Single-Record Join expected result`
+  }
+
+  "Example 3 - Inline Record as Filter" in {
+    testContext.run(`Ex 3 Inline Record Usage`) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/CaseClassQueryJdbcSpec.scala
@@ -1,0 +1,38 @@
+package io.getquill.context.jdbc.postgres
+
+import io.getquill.context.sql.CaseClassQuerySpec
+import org.scalatest.Matchers._
+
+class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Contact].delete)
+      testContext.run(query[Address].delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+    }
+    ()
+  }
+
+  "Example 1 - Single Case Class Mapping" in {
+    testContext.run(`Ex 1 CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1A - Single Case Class Mapping" in {
+    testContext.run(`Ex 1A CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1B - Single Case Class Mapping" in {
+    testContext.run(`Ex 1B CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Single Record Mapped Join" in {
+    testContext.run(`Ex 2 Single-Record Join`) should contain theSameElementsAs `Ex 2 Single-Record Join expected result`
+  }
+
+  "Example 3 - Inline Record as Filter" in {
+    testContext.run(`Ex 3 Inline Record Usage`) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/CaseClassQueryJdbcSpec.scala
@@ -1,0 +1,38 @@
+package io.getquill.context.jdbc.sqlite
+
+import io.getquill.context.sql.CaseClassQuerySpec
+import org.scalatest.Matchers._
+
+class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Contact].delete)
+      testContext.run(query[Address].delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+    }
+    ()
+  }
+
+  "Example 1 - Single Case Class Mapping" in {
+    testContext.run(`Ex 1 CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1A - Single Case Class Mapping" in {
+    testContext.run(`Ex 1A CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+  "Example 1B - Single Case Class Mapping" in {
+    testContext.run(`Ex 1B CaseClass Record Output`) should contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Single Record Mapped Join" in {
+    testContext.run(`Ex 2 Single-Record Join`) should contain theSameElementsAs `Ex 2 Single-Record Join expected result`
+  }
+
+  "Example 3 - Inline Record as Filter" in {
+    testContext.run(`Ex 3 Inline Record Usage`) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
@@ -241,6 +241,7 @@ trait OrientDBIdiom extends Idiom {
     case Constant(v)         => stmt"${v.toString.token}"
     case NullValue           => stmt"null"
     case Tuple(values)       => stmt"${values.token}"
+    case CaseClass(values)   => stmt"${values.map(_._2).token}"
   }
 
   implicit def infixTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy): Tokenizer[Infix] = Tokenizer[Infix] {

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/CaseClassQueryOrientSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/CaseClassQueryOrientSpec.scala
@@ -1,0 +1,69 @@
+package io.getquill.context.orientdb
+
+import io.getquill.Spec
+
+class CaseClassQueryOrientSpec extends Spec {
+
+  val testSyncDB = orientdb.testSyncDB
+  import testSyncDB._
+
+  case class Contact(id: Int, firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: String)
+  case class Address(id: Int, street: String, zip: Int, otherExtraInfo: String)
+
+  val peopleInsert =
+    quote((p: Contact) => query[Contact].insert(p))
+
+  val peopleEntries = List(
+    Contact(1, "Alex", "Jones", 60, 2, "foo"),
+    Contact(2, "Bert", "James", 55, 3, "bar"),
+    Contact(3, "Cora", "Jasper", 33, 3, "baz")
+  )
+
+  val addressInsert =
+    quote((c: Address) => query[Address].insert(c))
+
+  val addressEntries = List(
+    Address(1, "123 Fake Street", 11234, "something"),
+    Address(2, "456 Old Street", 45678, "something else"),
+    Address(3, "789 New Street", 89010, "another thing")
+  )
+
+  case class ContactSimplified(firstName: String, lastName: String, age: Int)
+  case class AddressableContact(firstName: String, lastName: String, age: Int, street: String, zip: Int)
+
+  val `Ex 1 CaseClass Record Output` = quote {
+    query[Contact].map(p => new ContactSimplified(p.firstName, p.lastName, p.age))
+  }
+
+  val `Ex 1 CaseClass Record Output expected result` = List(
+    ContactSimplified("Alex", "Jones", 60),
+    ContactSimplified("Bert", "James", 55),
+    ContactSimplified("Cora", "Jasper", 33)
+  )
+
+  case class FiltrationObject(idFilter: Int)
+
+  val `Ex 3 Inline Record Usage` = quote {
+    val filtrationObject = new FiltrationObject(1)
+    query[Contact].filter(p => p.id == filtrationObject.idFilter)
+  }
+
+  val `Ex 3 Inline Record Usage exepected result` = List(
+    new Contact(1, "Alex", "Jones", 60, 2, "foo")
+  )
+
+  override def beforeAll = {
+    testSyncDB.run(query[Contact].delete)
+    testSyncDB.run(query[Address].delete)
+    testSyncDB.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+    testSyncDB.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+  }
+
+  "Example 1 - Single Case Class Mapping" in {
+    testSyncDB.run(`Ex 1 CaseClass Record Output`) must contain theSameElementsAs `Ex 1 CaseClass Record Output expected result`
+  }
+
+  "Example 2 - Inline Record as Filter" in {
+    testSyncDB.run(`Ex 3 Inline Record Usage`) must contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
+  }
+}

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
@@ -254,6 +254,14 @@ class OrientDBIdiomSpec extends Spec {
       ctx.run(q).string mustEqual
         "SELECT i, s FROM TestEntity"
     }
+    "caseclass" in {
+      case class IntString(intProp: Int, stringProp: String)
+      val q = quote {
+        qr1.map(t => new IntString(t.i, t.s))
+      }
+      ctx.run(q).string mustEqual
+        "SELECT i, s FROM TestEntity"
+    }
     "null" in {
       val q = quote {
         qr1.filter(t => t.s == null)

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/orientdb.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/orientdb.scala
@@ -39,6 +39,8 @@ object orientdb {
     getOrCreateClass(schema, "Person")
     getOrCreateClass(schema, "OrderTestEntity")
     getOrCreateClass(schema, "SetsEntity")
+    getOrCreateClass(schema, "Contact")
+    getOrCreateClass(schema, "Address")
   }
 
   private def getOrCreateClass(iSchema: OSchemaProxy, iClassName: String): Unit = {

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -305,6 +305,7 @@ trait SqlIdiom extends Idiom {
     case Constant(v)         => stmt"${v.toString.token}"
     case NullValue           => stmt"null"
     case Tuple(values)       => stmt"${values.token}"
+    case CaseClass(values)   => stmt"${values.map(_._2).token}"
   }
 
   implicit def infixTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Infix] = Tokenizer[Infix] {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/CaseClassQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/CaseClassQuerySpec.scala
@@ -1,0 +1,76 @@
+package io.getquill.context.sql
+
+import io.getquill.Spec
+
+trait CaseClassQuerySpec extends Spec {
+
+  val context: SqlContext[_, _]
+
+  import context._
+
+  case class Contact(firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: String)
+  case class Address(id: Int, street: String, zip: Int, otherExtraInfo: String)
+
+  val peopleInsert =
+    quote((p: Contact) => query[Contact].insert(p))
+
+  val peopleEntries = List(
+    Contact("Alex", "Jones", 60, 2, "foo"),
+    Contact("Bert", "James", 55, 3, "bar"),
+    Contact("Cora", "Jasper", 33, 3, "baz")
+  )
+
+  val addressInsert =
+    quote((c: Address) => query[Address].insert(c))
+
+  val addressEntries = List(
+    Address(1, "123 Fake Street", 11234, "something"),
+    Address(2, "456 Old Street", 45678, "something else"),
+    Address(3, "789 New Street", 89010, "another thing")
+  )
+
+  case class ContactSimplified(firstName: String, lastName: String, age: Int)
+  case class AddressableContact(firstName: String, lastName: String, age: Int, street: String, zip: Int)
+
+  val `Ex 1 CaseClass Record Output` = quote {
+    query[Contact].map(p => new ContactSimplified(p.firstName, p.lastName, p.age))
+  }
+
+  val `Ex 1A CaseClass Record Output` = quote {
+    query[Contact].map(p => ContactSimplified(p.firstName, p.lastName, p.age))
+  }
+
+  val `Ex 1B CaseClass Record Output` = quote {
+    query[Contact].map(p => ContactSimplified.apply(p.firstName, p.lastName, p.age))
+  }
+
+  val `Ex 1 CaseClass Record Output expected result` = List(
+    ContactSimplified("Alex", "Jones", 60),
+    ContactSimplified("Bert", "James", 55),
+    ContactSimplified("Cora", "Jasper", 33)
+  )
+
+  val `Ex 2 Single-Record Join` =
+    quote {
+      for {
+        p <- query[Contact]
+        a <- query[Address] if p.addressFk == a.id
+      } yield {
+        new AddressableContact(p.firstName, p.lastName, p.age, a.street, a.zip)
+      }
+    }
+  val `Ex 2 Single-Record Join expected result` = List(
+    AddressableContact("Alex", "Jones", 60, "456 Old Street", 45678),
+    AddressableContact("Bert", "James", 55, "789 New Street", 89010),
+    AddressableContact("Cora", "Jasper", 33, "789 New Street", 89010)
+  )
+
+  val `Ex 3 Inline Record Usage` = quote {
+    val person = new ContactSimplified("Alex", "Jones", 44)
+    query[Contact].filter(p => p.firstName == person.firstName && person.lastName == person.lastName)
+  }
+
+  val `Ex 3 Inline Record Usage exepected result` = List(
+    new Contact("Alex", "Jones", 60, 2, "foo")
+  )
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -70,6 +70,15 @@ class SqlIdiomSpec extends Spec {
             "SELECT DISTINCT i.i, i.l FROM TestEntity i"
         }
 
+        "caseclass" in {
+          case class IntLong(i: Int, l: Long)
+          val q = quote {
+            qr1.map(i => new IntLong(i.i, i.l)).distinct
+          }
+          testContext.run(q).string mustEqual
+            "SELECT x.i, x.l FROM (SELECT DISTINCT i.i, i.l FROM TestEntity i) x"
+        }
+
         "nesting" in {
           val q = quote {
             qr1.map(i => i.i).distinct.map(x => x + 1)
@@ -841,6 +850,14 @@ class SqlIdiomSpec extends Spec {
       "tuple" in {
         val q = quote {
           qr1.map(t => (1, 2))
+        }
+        testContext.run(q).string mustEqual
+          "SELECT 1, 2 FROM TestEntity t"
+      }
+      "caseclass" in {
+        case class TwoInts(one: Int, two: Int)
+        val q = quote {
+          qr1.map(t => new TwoInts(1, 2))
         }
         testContext.run(q).string mustEqual
           "SELECT 1, 2 FROM TestEntity t"

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -6,6 +6,8 @@ import io.getquill.context.sql.testContext
 
 class RenamePropertiesSpec extends Spec {
 
+  case class IntLongCaseClassScope(im: Int, lm: Long)
+
   val e = quote {
     querySchema[TestEntity]("test_entity", _.s -> "field_s", _.i -> "field_i")
   }
@@ -123,6 +125,21 @@ class RenamePropertiesSpec extends Spec {
         case class IntLongCase(im: Int, lm: Long)
         val q = quote {
           e.map(t => new IntLongCase(t.i, t.l))
+        }
+        testContext.run(q).string mustEqual
+          "SELECT t.field_i, t.l FROM test_entity t"
+      }
+      "body with caseclass companion constructed" in {
+        case class IntLongCase(im: Int, lm: Long)
+        val q = quote {
+          e.map(t => IntLongCase(t.i, t.l))
+        }
+        testContext.run(q).string mustEqual
+          "SELECT t.field_i, t.l FROM test_entity t"
+      }
+      "body with caseclass companion in class scope" in {
+        val q = quote {
+          e.map(t => IntLongCaseClassScope(t.i, t.l))
         }
         testContext.run(q).string mustEqual
           "SELECT t.field_i, t.l FROM test_entity t"

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -10,8 +10,30 @@ class RenamePropertiesSpec extends Spec {
     querySchema[TestEntity]("test_entity", _.s -> "field_s", _.i -> "field_i")
   }
 
+  val tup = quote {
+    querySchema[(String, Int)]("test_tuple", _._1 -> "field_s", _._2 -> "field_i")
+  }
+
   val f = quote {
     qr1.filter(t => t.i == 1)
+  }
+
+  "renames properties of a tuple" - {
+    "body" in {
+      val q = quote {
+        tup.map(t => (t._1, t._2))
+      }
+      testContext.run(q).string mustEqual
+        "SELECT t.field_s, t.field_i FROM test_tuple t"
+    }
+    "mapped to caseclass and filtered" in {
+      case class StringInt(strProp: String, intProp: Int)
+      val q = quote {
+        tup.map(t => new StringInt(t._1, t._2)).filter(_.strProp == "foo")
+      }
+      testContext.run(q).string mustEqual
+        "SELECT t.field_s, t.field_i FROM test_tuple t WHERE t.field_s = 'foo'"
+    }
   }
 
   "renames properties according to the entity aliases" - {
@@ -93,6 +115,14 @@ class RenamePropertiesSpec extends Spec {
       "body" in {
         val q = quote {
           e.map(t => (t.i, t.l))
+        }
+        testContext.run(q).string mustEqual
+          "SELECT t.field_i, t.l FROM test_entity t"
+      }
+      "body with caseclass" in {
+        case class IntLongCase(im: Int, lm: Long)
+        val q = quote {
+          e.map(t => new IntLongCase(t.i, t.l))
         }
         testContext.run(q).string mustEqual
           "SELECT t.field_i, t.l FROM test_entity t"

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -105,3 +105,48 @@ CREATE TABLE Product(
     sku BIGINT,
     PRIMARY KEY (id)
 );
+
+CREATE TABLE Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);
+
+CREATE TABLE Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);
+
+CREATE TABLE Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -119,3 +119,18 @@ CREATE TABLE ArrayOps (
   id int,
   numbers int[]
 );
+
+CREATE TABLE Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);

--- a/quill-sql/src/test/sql/sqlserver-schema.sql
+++ b/quill-sql/src/test/sql/sqlserver-schema.sql
@@ -82,3 +82,33 @@ CREATE TABLE Product(
     description VARCHAR(255),
     sku BIGINT
 );
+
+CREATE TABLE Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);
+
+CREATE TABLE Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);


### PR DESCRIPTION
Fixes #494

### Problem

Using arbitrary Case Classes in output used to be impossible, only Case Classes were allowed. This meant that in any situation where one wishes to return a single Case Class based on a Join, a tuple had to be used. For example:
````scala
case class Person(id: Int, name: String, age: Int)
case class Contact(personId: Int, phone: String)
case class ReachablePerson(name: String, phone: String)

val q = quote {
      val idFilter = new IdFilter(999)
      for {
        p <- query[Person] if (p.id == 999)
        c <- query[Contact] if (c.personId == idFilter.id)
      } yield {
        new ReachablePerson(p.name, c.phone)
      }
    }
````
had to be expressed like this:

````scala
val q = quote {
      val idFilter = new IdFilter(999)
      for {
        p <- query[Person] if (p.id == 999)
        c <- query[Contact] if (c.personId == idFilter.id)
      } yield {
       (p.name, c.phone)
      }
    }
````
In certain circumstances, particularly involving dynamic filters this is really annoying. For example say I want a filter downstream that looks like this:
````scala
def customizeableFilter(filtration:FiltrationType) = filtration match {
      case ByPhone => (q:Query[ReachablePerson]) => q.filter(_.phone == "123-456-7890")
      case ByName => (q:Query[ReachablePerson]) => q.filter(_.name == "Someone")
      case None => (q:Query[ReachablePerson]) => q
    }
````
... writing it with tuples is quite unpleasant and causes a loss of information of the domain (i.e. what are _1 and _2 supposed to represent now?).
````scala
def customizeableFilter(filtration:FiltrationType) = filtration match {
      case ByPhone => (q:Query[(String, String)]) => q.filter(_._2 == "123-456-7890")
      case ByName => (q:Query[(String, String)]) => q.filter(_._1 == "Someone")
      case None => (q:Query[(String, String)]) => q
````

Therefore this functionality was added.

### Solution

Allows arbitrary Case Classes to be used as return-types just like Tuples as well as the ability to generally use arbitrary Case Classes inside of quoted blocks. This was achieved by adding a Case Class type to the Quill AST.

### Notes

Note that there are currently two restrictions on the use of these Ad-Hoc Case Classes.
1. They must have one constructor with one parameter list.
2. They must be constructed with the 'new' keyword inside the quotation block. Construction via companion objects is not yet supported.

### Checklist

- [x ] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
