### PR TITLE
fix regression: allow table references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2.3.0
+
+- [Ad-Hoc Tuple Support in Quotations](https://github.com/getquill/quill/pull/957)
+- [fix regression: allow table references](https://github.com/getquill/quill/pull/968)
+
+# 2.2.0
+
+- [Fix StackOverflowError in select distinct with aggregation](https://github.com/getquill/quill/pull/954)
+- [Add support of java.time.Instant/java.time.LocalDate for quill-casandra](https://github.com/getquill/quill/pull/953)
+- [Fix select query for unlimited optional embedded case classes](https://github.com/getquill/quill/pull/955)
+- [`concatMap`, `startsWith`, and `split` support](https://github.com/getquill/quill/pull/956)
+- [Upgrade finagle to 17.10.0](https://github.com/getquill/quill/pull/959)
+
 # 2.1.0
 
 - [Spark SQL support](https://github.com/getquill/quill/pull/941)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/VerifySqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/VerifySqlQuerySpec.scala
@@ -4,6 +4,7 @@ import io.getquill.Spec
 import io.getquill.context.sql.testContext._
 import io.getquill.context.sql.SqlQuery
 import scala.util.Try
+import io.getquill.context.sql.norm.SqlNormalize
 
 class VerifySqlQuerySpec extends Spec {
 
@@ -24,14 +25,13 @@ class VerifySqlQuerySpec extends Spec {
         "Some(The monad composition can't be expressed using applicative joins. Faulty expression: 'b.s == a.s'. Free variables: 'List(a)'.)"
     }
 
-    "invalid table reference" in {
+    "accepts table reference" in {
       val q = quote {
         qr1.leftJoin(qr2).on((a, b) => a.i == b.i).filter {
           case (a, b) => b.isDefined
         }
       }
-      VerifySqlQuery(SqlQuery(q.ast)).toString mustEqual
-        "Some(The monad composition can't be expressed using applicative joins. Faulty expression: 'x01._2.isDefined'. Free variables: 'List(x01)'.)"
+      VerifySqlQuery(SqlQuery(SqlNormalize(q.ast))) mustEqual None
     }
 
     "invalid flatJoin on" in {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.1-SNAPSHOT"
+version in ThisBuild := "2.3.0"


### PR DESCRIPTION
Fixes #942

### Problem

The change introduced by https://github.com/getquill/quill/pull/906 is wrong. The error reported by https://github.com/getquill/quill/issues/702 was actually due to another bug that is also fixed.

### Solution

Revert the table reference check.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
