### PR TITLE
move to scastie

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,7 @@ This template isn't a strict requirement to open issues, but please try to provi
 
 ### Steps to reproduce the behavior
 
-If the issue can be reproduced using a [mirror context](http://getquill.io/#contexts-mirror-context), please provide a scalafiddle that reproduces it. See https://scalafiddle.io/sf/pMg4JvY/1 as an example. Remember to select the correct Quill version in the left menu.
+If the issue can be reproduced using a [mirror context](http://getquill.io/#contexts-mirror-context), please provide a scastie snippet that reproduces it. See https://scastie.scala-lang.org/wFLlOditSvuKghZlJPqXuw as an example. Remember to select the correct Quill version in the left menu.
 
 ### Workaround
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import io.getquill._
 val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
 ```
 
-> ### **Note:** [Scalafiddle](http://scalafiddle.io) is a great tool to try out Quill without having to prepare a local environment. It works with [mirror contexts](#mirror-context), see [this](https://scalafiddle.io/sf/lsmX57J/0) fiddle as an example.
+> ### **Note:** [Scastie](https://scastie.scala-lang.org/) is a great tool to try out Quill without having to prepare a local environment. It works with [mirror contexts](#mirror-context), see [this](https://scastie.scala-lang.org/wFLlOditSvuKghZlJPqXuw) snippet as an example.
 
 The context instance provides all types and methods to deal quotations:
 


### PR DESCRIPTION
Fixes #848 

### Problem

The scalafiddle link doesn't update automatically to the latest Quill version. Also, scalafiddle has limitations since it runs on javascript.

### Solution

Move to scastie, it's stable now.

### Notes

The scastie link points to the latest Quill version automatically using this SBT config:

```
libraryDependencies += "io.getquill" %% "quill-sql" % "2.+"
````

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
