### PR TITLE
[WIP] Update finagle to 17.11.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val `quill-finagle-mysql` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "com.twitter" %% "finagle-mysql" % "17.10.0"
+        "com.twitter" %% "finagle-mysql" % "17.11.0"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")


### PR DESCRIPTION
Fixes #issue_number

### Problem
Finagle 17.11.0 was released, but we use the old version of it.

### Solution
Update finagle mysql

### Notes

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
