### PR TITLE
Fix postgres probing

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
@@ -27,8 +27,14 @@ trait PostgresDialect
 
   private[getquill] val preparedStatementId = new AtomicInteger
 
-  override def prepareForProbing(string: String) =
-    s"PREPARE p${preparedStatementId.incrementAndGet.toString.token} AS $string"
+  override def prepareForProbing(string: String) = {
+    var i = 0
+    val query = string.flatMap(x => if (x != '?') s"$x" else {
+      i += 1
+      s"$$$i"
+    })
+    s"PREPARE p${preparedStatementId.incrementAndGet.toString.token} AS $query"
+  }
 }
 
 object PostgresDialect extends PostgresDialect

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/PostgresDialectSpec.scala
@@ -33,4 +33,15 @@ class PostgresDialectSpec extends Spec {
         "SELECT x1.id, x1.numbers FROM ArrayOps x1 WHERE 10 = ANY(x1.numbers)"
     }
   }
+
+  "prepareForProbing" in {
+    import PostgresDialect._
+    val id = preparedStatementId.get()
+
+    prepareForProbing("SELECT t.x1, t.x2 FROM tb t WHERE (t.x1 = ?) AND (t.x2 = ?)") mustEqual
+      s"PREPARE p${id + 1} AS SELECT t.x1, t.x2 FROM tb t WHERE (t.x1 = $$1) AND (t.x2 = $$2)"
+
+    prepareForProbing("INSERT INTO tb (x1,x2,x3) VALUES (?,?,?)") mustEqual
+      s"PREPARE p${id + 2} AS INSERT INTO tb (x1,x2,x3) VALUES ($$1,$$2,$$3)"
+  }
 }


### PR DESCRIPTION
Fixes #978

### Problem

Postgres `PREPARE <name> as <query>` expects postional wildcards (`$1`, `$2`) instead of question marks (`?`), see https://www.postgresql.org/docs/current/static/sql-prepare.html

### Solution

Replace wildcards in `PostgresDialect.prepareForProbing`

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [xd] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
