### PR TITLE
trigger 2.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.3.1
+
+- [Fix Ad-Hoc Case Classes for Spark](https://github.com/getquill/quill/pull/981)
+- [Make the error reporting of comparing `Option` to `null` to point actual position](https://github.com/getquill/quill/pull/982)
+- [Fix postgres query probing failing for queries with wildcards](https://github.com/getquill/quill/pull/983)
+- [Dependency updates](https://github.com/getquill/quill/pull/977)
+- [Update finagle to 17.11.0](https://github.com/getquill/quill/pull/976)
+
 # 2.3.0
 
 - [Ad-Hoc Tuple Support in Quotations](https://github.com/getquill/quill/pull/957)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.3.1-SNAPSHOT"
+version in ThisBuild := "2.3.1"


### PR DESCRIPTION
Releasing 2.3.1 per user request, see https://gitter.im/getquill/quill?at=5a1d540c232e79134de07c94
@getquill/maintainers
