### PR TITLE
fix invalid alias with distinct

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -162,7 +162,7 @@ trait SqlIdiom extends Idiom {
           val value =
             selectValue match {
               case SelectValue(Ident("?"), _, _)  => "?".token
-              case SelectValue(Ident(name), _, _) => stmt"${name.token}.*"
+              case SelectValue(Ident(name), _, _) => stmt"${strategy.default(name).token}.*"
               case SelectValue(ast, _, _)         => ast.token
             }
           selectValue.concat match {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
@@ -19,6 +19,11 @@ trait CustomColumnStrategy extends SnakeCase {
 }
 object CustomColumnStrategy extends CustomColumnStrategy
 
+trait CustomDefaultStrategy extends SnakeCase {
+  override def default(s: String) = s"d_$s".toLowerCase
+}
+object CustomDefaultStrategy extends CustomDefaultStrategy
+
 class SqlIdiomNamingSpec extends Spec {
 
   "uses the naming strategy" - {
@@ -58,6 +63,14 @@ class SqlIdiomNamingSpec extends Spec {
 
       db.run(q.dynamic).string mustEqual
         "SELECT t.c_somecolumn FROM some_entity t"
+    }
+    "apply strategy to select indent" in {
+      val db = new SqlMirrorContext(MirrorSqlDialect, CustomDefaultStrategy)
+      import db._
+      val q = quote {
+        query[SomeEntity].distinct
+      }
+      db.run(q.dynamic).string mustEqual "SELECT d_x.d_somecolumn FROM (SELECT DISTINCT d_x.* FROM d_someentity d_x) d_x"
     }
 
     val db = new SqlMirrorContext(MirrorSqlDialect, SnakeCase)


### PR DESCRIPTION
### Problem

```scala
case SelectValue(Ident(name), _, _) => stmt"${name.token}.*"
```

Default naming strategy is not applied here.

Will generate invalid sql like 

```sql
SELECT d_x.d_somecolumn FROM (SELECT DISTINCT x.* FROM d_someentity d_x) d_x
```


@getquill/maintainers
