### PR TITLE
update finagle to the latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val `quill-finagle-mysql` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "com.twitter" %% "finagle-mysql" % "17.11.0"
+        "com.twitter" %% "finagle-mysql" % "17.12.0"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")


### PR DESCRIPTION
### Problem

The latest version of finagle 17.12.0 has been released, but the previous version is still in use.

### Solution

Update finagle to the latest.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
