### PR TITLE
Fix for Ad-Hoc Case Class producing Dynamic Queries

### DIFF
--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -151,6 +151,7 @@ trait Unliftables {
     case q"$pack.NullValue" => NullValue
     case q"$pack.Constant.apply(${ Literal(c.universe.Constant(a)) })" => Constant(a)
     case q"$pack.Tuple.apply(${ a: List[Ast] })" => Tuple(a)
+    case q"$pack.CaseClass.apply(${ values: List[(String, Ast)] })" => CaseClass(values)
   }
   implicit val identUnliftable: Unliftable[Ident] = Unliftable[Ident] {
     case q"$pack.Ident.apply(${ a: String })" => Ident(a)

--- a/quill-core/src/test/scala/io/getquill/TestEntities.scala
+++ b/quill-core/src/test/scala/io/getquill/TestEntities.scala
@@ -9,6 +9,7 @@ trait TestEntities {
   case class TestEntity2(s: String, i: Int, l: Long, o: Option[Int])
   case class TestEntity3(s: String, i: Int, l: Long, o: Option[Int])
   case class TestEntity4(i: Long)
+  case class TestEntity5(s: String, i: Long)
 
   val qr1 = quote {
     query[TestEntity]
@@ -21,5 +22,10 @@ trait TestEntities {
   }
   val qr4 = quote {
     query[TestEntity4]
+  }
+  val qr5 = quote {
+    for {
+      a <- query[TestEntity]
+    } yield TestEntity5(a.s, a.l)
   }
 }

--- a/quill-core/src/test/scala/io/getquill/quotation/IsDynamicSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/IsDynamicSpec.scala
@@ -4,6 +4,7 @@ import io.getquill.Spec
 import io.getquill.ast.Dynamic
 import io.getquill.ast.Property
 import io.getquill.testContext.qr1
+import io.getquill.testContext.qr5
 
 class IsDynamicSpec extends Spec {
 
@@ -18,6 +19,9 @@ class IsDynamicSpec extends Spec {
     }
     "false" in {
       IsDynamic(qr1.ast) mustEqual false
+    }
+    "false when using CaseClass" in {
+      IsDynamic(qr5.ast) mustEqual false
     }
   }
 }


### PR DESCRIPTION
Fixes #992

### Problem

Whenever Ad-Hoc case classes are used, AST produces a Dynamic Query which should not be the case.

### Solution

Add case for Ad-Hoc Case Class in Unliftables.

### Notes

Please note that I also added a test to IsDynamicSpec which is supposed to test this functionality but the IsDynamic method will produce a 'false' (i.e. it thinks it's not dynamic) even when line 154 in Unliftables in commented out. I think IsDynamic doesn't work properly but not sure what to do about it.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
