### PR TITLE
Fix removing assignment in returning insert if embedded field has col…

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/NormalizeReturning.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/NormalizeReturning.scala
@@ -19,9 +19,15 @@ object NormalizeReturning {
 
   private def filterReturnedColumn(assignment: Assignment, column: Ast): Option[Assignment] =
     (assignment, column) match {
-      case (Assignment(_, Property(_, p1), _), Property(_, p2)) if (p1 == p2) =>
+      case (Assignment(_, p1: Property, _), p2: Property) if p1.name == p2.name && isSameProperties(p1, p2) =>
         None
       case (assignment, column) =>
         Some(assignment)
     }
+
+  private def isSameProperties(p1: Property, p2: Property): Boolean = (p1.ast, p2.ast) match {
+    case (_: Ident, _: Ident)           => p1.name == p2.name
+    case (pp1: Property, pp2: Property) => isSameProperties(pp1, pp2)
+    case _                              => false
+  }
 }

--- a/quill-core/src/test/scala/io/getquill/norm/NormalizeReturningSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/NormalizeReturningSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.norm
+
+import io.getquill.context.mirror.Row
+import io.getquill.{ Spec, testContext }
+import io.getquill.testContext._
+
+class NormalizeReturningSpec extends Spec {
+
+  "do not remove assignment if embedded has columns with the same name" - {
+
+    case class EmbEntity(id: Int) extends Embedded
+    case class Entity(id: Int, emb: EmbEntity)
+
+    val e = Entity(1, EmbEntity(2))
+    val q = quote {
+      query[Entity].insert(lift(e))
+    }
+
+    "when returning parent col" in {
+      val r = testContext.run(q.returning(p => p.id))
+      r.string mustEqual """querySchema("Entity").insert(v => v.emb.id -> ?).returning((p) => p.id)"""
+      r.prepareRow mustEqual Row(2)
+      r.returningColumn mustEqual "id"
+    }
+
+    "when returning embedded col" in {
+      val r = testContext.run(q.returning(p => p.emb.id))
+      r.string mustEqual """querySchema("Entity").insert(v => v.id -> ?).returning((p) => p.emb.id)"""
+      r.prepareRow mustEqual Row(1)
+      r.returningColumn mustEqual "id"
+    }
+  }
+
+}


### PR DESCRIPTION
…umns with the same name as in parent case class

Fixes #1008

### Problem

`NormalizeReturning#filterReturnedColumn` filters out properties with the same name as in returning

### Solution
Add `NormalizeReturning#isSameProperties` which traverses property tree to determine whereas the properties equality.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
