### PR TITLE
[WIP] Add support of dynamic table names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,12 @@ lazy val `quill-sql` =
 lazy val `quill-sql-jvm` = `quill-sql`.jvm
 lazy val `quill-sql-js` = `quill-sql`.js
 
+lazy val `quill-test` =
+  (project in file("quill-test"))
+    .settings(commonSettings: _*)
+    .settings(mimaSettings: _*)
+    .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
+
 lazy val `quill-jdbc` =
   (project in file("quill-jdbc"))
     .settings(commonSettings: _*)

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -60,11 +60,17 @@ class MirrorIdiom extends Idiom {
 
   implicit def queryTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Query] = Tokenizer[Query] {
 
-    case Entity(name, Nil) => stmt"querySchema(${s""""$name"""".token})"
+    case Entity(name, Nil) => name match {
+      case StaticName(n)  => stmt"querySchema(${s""""$n"""".token})"
+      case DynamicName(t) => stmt"querySchemaDynamicName(${t.toString.token})"
+    }
 
     case Entity(name, prop) =>
       val properties = prop.map(p => stmt"""_.${p.path.mkStmt(".")} -> "${p.alias.token}"""")
-      stmt"querySchema(${s""""$name"""".token}, ${properties.token})"
+      name match {
+        case StaticName(n)  => stmt"querySchema(${s""""$n"""".token}, ${properties.token})"
+        case DynamicName(t) => stmt"querySchemaDynamicName(${t.toString.token}, ${properties.token})"
+      }
 
     case Filter(source, alias, body) =>
       stmt"${source.token}.filter(${alias.token} => ${body.token})"

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -16,7 +16,11 @@ sealed trait Ast {
 
 sealed trait Query extends Ast
 
-case class Entity(name: String, properties: List[PropertyAlias]) extends Query
+trait EntityName
+case class DynamicName(name: Any) extends EntityName
+case class StaticName(name: String) extends EntityName
+
+case class Entity(name: EntityName, properties: List[PropertyAlias]) extends Query
 
 case class PropertyAlias(path: List[String], alias: String)
 

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -13,6 +13,9 @@ private[dsl] trait QueryDsl {
   @compileTimeOnly(NonQuotedException.message)
   def querySchema[T](entity: String, columns: (T => (Any, String))*): EntityQuery[T] = NonQuotedException()
 
+  @compileTimeOnly(NonQuotedException.message)
+  def querySchemaDynamicName[T](entity: String, columns: (T => (Any, String))*): EntityQuery[T] = NonQuotedException()
+
   sealed trait Query[+T] {
 
     def map[R](f: T => R): Query[R]

--- a/quill-core/src/main/scala/io/getquill/quotation/IsDynamic.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/IsDynamic.scala
@@ -1,10 +1,24 @@
 package io.getquill.quotation
 
-import io.getquill.ast.Ast
-import io.getquill.ast.CollectAst
-import io.getquill.ast.Dynamic
+import io.getquill.ast
+import io.getquill.ast.{ CollectAst, DynamicName, Entity }
 
 object IsDynamic {
-  def apply(a: Ast) =
-    CollectAst(a) { case d: Dynamic => d }.nonEmpty
+  def apply(a: ast.Ast) =
+    ast.CollectAst(a) { case d: Dynamic => d }.nonEmpty
+
+  def typed(a: ast.Ast): DynamicType = {
+    val list = CollectAst(a) {
+      case d: Dynamic                    => d
+      case e @ Entity(_: DynamicName, _) => e
+    }
+    if (list.isEmpty) None
+    else if (list.exists(_.isInstanceOf[Dynamic])) Ast
+    else Name
+  }
+
+  trait DynamicType
+  case object None extends DynamicType
+  case object Name extends DynamicType
+  case object Ast extends DynamicType
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -109,6 +109,12 @@ trait Liftables {
     case Nested(a)              => q"$pack.Nested($a)"
   }
 
+  implicit val entityNameLiftable: Liftable[EntityName] = Liftable[EntityName] {
+    case StaticName(a)        => q"$pack.StaticName($a)"
+    //case DynamicName(a: String) => q"$pack.StaticName($a)"
+    case DynamicName(a: Tree) => q"$pack.DynamicName($a)"
+  }
+
   implicit val propertyAliasLiftable: Liftable[PropertyAlias] = Liftable[PropertyAlias] {
     case PropertyAlias(a, b) => q"$pack.PropertyAlias($a, $b)"
   }

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -162,10 +162,13 @@ trait Parsing {
 
     case q"$pack.query[$t]" =>
       // Unused, it's here only to make eclipse's presentation compiler happy
-      Entity("unused", Nil)
+      Entity(StaticName("unused"), Nil)
 
     case q"$pack.querySchema[$t](${ name: String }, ..$properties)" =>
-      Entity(name, properties.map(propertyAliasParser(_)))
+      Entity(StaticName(name), properties.map(propertyAliasParser(_)))
+
+    case q"$pack.querySchemaDynamicName[$t]($name, ..$properties)" if is[String](name) =>
+      Entity(DynamicName(name), properties.map(propertyAliasParser(_)))
 
     case q"$source.filter(($alias) => $body)" if (is[CoreDsl#Query[Any]](source)) =>
       Filter(astParser(source), identParser(alias), astParser(body))

--- a/quill-core/src/main/scala/io/getquill/quotation/ReplaceDynamicName.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/ReplaceDynamicName.scala
@@ -1,0 +1,9 @@
+package io.getquill.quotation
+
+import io.getquill.ast._
+
+object ReplaceDynamicName {
+  def apply(ast: Ast) = Transform(ast) {
+    case Entity(DynamicName(name: String), props) => Entity(StaticName(name), props)
+  }
+}

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -90,7 +90,7 @@ trait Unliftables {
   }
 
   implicit val queryUnliftable: Unliftable[Query] = Unliftable[Query] {
-    case q"$pack.Entity.apply(${ a: String }, ${ b: List[PropertyAlias] })"          => Entity(a, b)
+    case q"$pack.Entity.apply(${ a: EntityName }, ${ b: List[PropertyAlias] })"      => Entity(a, b)
     case q"$pack.Filter.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"              => Filter(a, b, c)
     case q"$pack.Map.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"                 => Map(a, b, c)
     case q"$pack.FlatMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"             => FlatMap(a, b, c)
@@ -107,6 +107,11 @@ trait Unliftables {
       FlatJoin(t, a, iA, on)
     case q"$pack.Distinct.apply(${ a: Ast })" => Distinct(a)
     case q"$pack.Nested.apply(${ a: Ast })"   => Nested(a)
+  }
+
+  implicit val entityNameUnliftable: Unliftable[EntityName] = Unliftable[EntityName] {
+    case q"$pack.StaticName.apply(${ a: String })" => StaticName(a)
+    case q"$pack.DynamicName.apply(${ a: Tree })"  => DynamicName(a)
   }
 
   implicit val orderingUnliftable: Unliftable[Ordering] = Unliftable[Ordering] {

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -368,7 +368,8 @@ trait SqlIdiom extends Idiom {
   }
 
   implicit def entityTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Entity] = Tokenizer[Entity] {
-    case Entity(name, _) => strategy.table(name).token
+    case Entity(StaticName(n), _)  => strategy.table(n).token
+    case Entity(DynamicName(n), _) => stmt"$${{${n.toString.token}}}"
   }
 
   protected def scopedTokenizer(ast: Ast)(implicit tokenizer: Tokenizer[Ast]) =

--- a/quill-test/src/main/scala/hey/hey/Hey.scala
+++ b/quill-test/src/main/scala/hey/hey/Hey.scala
@@ -1,0 +1,21 @@
+package hey.hey
+
+import io.getquill.{ PostgresDialect, SnakeCase, SqlMirrorContext }
+
+object Hey {
+  val ctx = new SqlMirrorContext(PostgresDialect, SnakeCase)
+  import ctx._
+
+  case class MyTable(id: Int)
+
+  def main(args: Array[String]): Unit = {
+
+    def runWith(tableName: String) = {
+      run {
+        querySchemaDynamicName[MyTable](tableName)
+      }
+    }
+    println(runWith("table1").string)
+    println(runWith("table2").string)
+  }
+}


### PR DESCRIPTION
Fixes #373 

### Problem

Currently table name should be known at compile time, even if query is designed to be dynamic by default. There's no way to define runtime table name.

### Solution
Introduce `StaticName` and `DynamicName`. 
At compile time Ast is normalized and generated query is printed to output (`DynamicName` is parsed as wildcard (tree.toString) within curly braces e.g. `.. FROM ${tableName} ..`)
Then it fallbacks to dynamic expanding (so we can replace DynamicName with StaticName here).
Since such approach requires twice call of `idiom.translate` I've decided to introduce `querySchemaDynamicName` (maybe better name?). Hence dynamic table name approach will be applied only if users explicitly required this.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers 
