### PR TITLE
[WIP] Splice query

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,11 @@ lazy val `quill-core` =
 lazy val `quill-core-jvm` = `quill-core`.jvm
 lazy val `quill-core-js` = `quill-core`.js
 
+lazy val `quill-tests` =
+  (project in file("quill-tests"))
+    .dependsOn(`quill-sql-jvm`)
+    .settings(commonSettings: _*)
+
 lazy val `quill-sql` =
   crossProject(JVMPlatform, JSPlatform).crossType(superPure)
     .settings(commonSettings: _*)

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -33,6 +33,7 @@ class MirrorIdiom extends Idiom {
     case ast: OptionOperation      => ast.token
     case ast: TraversableOperation => ast.token
     case ast: Dynamic              => ast.token
+    case ast: Splice               => ast.token
     case ast: If                   => ast.token
     case ast: Block                => ast.token
     case ast: Val                  => ast.token
@@ -183,6 +184,10 @@ class MirrorIdiom extends Idiom {
     case e => stmt"${e.name.token}"
   }
 
+  implicit val spliceTokenizer: Tokenizer[Splice] = Tokenizer[Splice] {
+    case Splice(tree) => stmt"${tree.toString.token}"
+  }
+
   implicit val excludedTokenizer: Tokenizer[OnConflict.Excluded] = Tokenizer[OnConflict.Excluded] {
     case OnConflict.Excluded(ident) => stmt"${ident.token}"
   }
@@ -232,8 +237,10 @@ class MirrorIdiom extends Idiom {
     case Infix(parts, params) =>
       def tokenParam(ast: Ast) =
         ast match {
-          case ast: Ident => stmt"$$${ast.token}"
-          case other      => stmt"$${${ast.token}}"
+          case ast: Ident            => stmt"$$${ast.token}"
+          case Splice(value: String) => value.token
+          case Splice(tree)          => stmt"#$${${tree.toString.token}}"
+          case other                 => stmt"$${${ast.token}}"
         }
 
       val pt = parts.map(_.token)

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -147,6 +147,8 @@ object OnConflict {
 
 case class Dynamic(tree: Any) extends Ast
 
+case class Splice(tree: Any) extends Ast
+
 case class QuotedReference(tree: Any, ast: Ast) extends Ast
 
 sealed trait Lift extends Ast {

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -34,6 +34,8 @@ trait StatefulTransformer[T] {
 
       case l: Dynamic => (l, this)
 
+      case e: Splice  => (e, this)
+
       case l: Lift    => (l, this)
 
       case QuotedReference(a, b) =>

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -17,6 +17,7 @@ trait StatelessTransformer {
       case e: TraversableOperation => apply(e)
       case If(a, b, c)             => If(apply(a), apply(b), apply(c))
       case e: Dynamic              => e
+      case e: Splice               => e
       case e: Lift                 => e
       case e: QuotedReference      => e
       case Block(statements)       => Block(statements.map(apply))

--- a/quill-core/src/main/scala/io/getquill/quotation/IsDynamic.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/IsDynamic.scala
@@ -1,10 +1,23 @@
 package io.getquill.quotation
 
-import io.getquill.ast.Ast
-import io.getquill.ast.CollectAst
-import io.getquill.ast.Dynamic
+import io.getquill.ast.{ Ast, CollectAst, Dynamic, Splice }
+
+sealed trait IsDynamic
 
 object IsDynamic {
-  def apply(a: Ast) =
-    CollectAst(a) { case d: Dynamic => d }.nonEmpty
+  case object Yes extends IsDynamic
+  case object No extends IsDynamic
+  case object Partially extends IsDynamic
+
+  def apply(a: Ast) = {
+    val set = CollectAst(a) {
+      case _: Dynamic => 1
+      case _: Splice  => 2
+    }.toSet
+
+    if (set.contains(1)) Yes
+    else if (set.contains(2)) Partially
+    else No
+  }
+
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -35,6 +35,7 @@ trait Liftables {
     case QuotedReference(tree: Tree, ast) => q"$ast"
     case OnConflict.Excluded(a) => q"$pack.OnConflict.Excluded($a)"
     case OnConflict.Existing(a) => q"$pack.OnConflict.Existing($a)"
+    case Splice(tree: Tree) => q"$pack.Splice($tree)"
   }
 
   implicit val optionOperationLiftable: Liftable[OptionOperation] = Liftable[OptionOperation] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -46,7 +46,7 @@ trait Quotation extends Liftables with Unliftables with Parsing with ReifyLiftin
         """
       }
 
-    if (IsDynamic(ast)) {
+    if (IsDynamic(ast) == IsDynamic.Yes) {
       q"$quotation: ${c.prefix}.Quoted[$t]"
     } else {
       quotation

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -28,6 +28,7 @@ trait Unliftables {
     case q"$pack.If.apply(${ a: Ast }, ${ b: Ast }, ${ c: Ast })" => If(a, b, c)
     case q"$pack.OnConflict.Excluded.apply(${ a: Ident })" => OnConflict.Excluded(a)
     case q"$pack.OnConflict.Existing.apply(${ a: Ident })" => OnConflict.Existing(a)
+    case q"$pack.Splice.apply($a)" => Splice(a)
     case q"$tree.ast" => Dynamic(tree)
   }
 

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -56,6 +56,7 @@ trait SqlIdiom extends Idiom {
       case a: Lift            => a.token
       case a: Assignment      => a.token
       case a: OptionOperation => a.token
+      case a: Splice          => a.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
         _: Val | _: Ordering | _: QuotedReference | _: TraversableOperation | _: OnConflict.Excluded | _: OnConflict.Existing
@@ -309,6 +310,11 @@ trait SqlIdiom extends Idiom {
 
   implicit def identTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Ident] =
     Tokenizer[Ident](e => strategy.default(e.name).token)
+
+  implicit def spliceTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Splice] = Tokenizer[Splice] {
+    case Splice(value: String) => value.token
+    case Splice(value)         => stmt"#$${${value.toString.token}}"
+  }
 
   implicit def assignmentTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Assignment] = Tokenizer[Assignment] {
     case Assignment(alias, prop, value) =>

--- a/quill-tests/src/main/scala/TestCase.scala
+++ b/quill-tests/src/main/scala/TestCase.scala
@@ -1,0 +1,37 @@
+import io.getquill._
+
+object TestCase {
+  def main(args: Array[String]): Unit = {
+    val ctx = new SqlMirrorContext(PostgresDialect, SnakeCase)
+
+    import ctx._
+
+    case class Person(name: String, age: Int)
+
+    val col = "col"
+    def table = "my_table"
+
+    val q1 = quote {
+      infix"SELECT #$col FROM #$table".as[Query[Int]]
+    }
+    //[info] TestCase.scala:18:20: SELECT x.* FROM (SELECT #${col} FROM #${table}) x
+    //[info]     println(ctx.run(q1).string)
+    //[info] Running TestCase
+    //SELECT x.* FROM (SELECT col FROM my_table) x
+    println(ctx.run(q1).string)
+
+    implicit class Ops[T](q: Query[T]) {
+      def put(v: String) = quote(infix"$q WHERE name = #$v".as[Query[T]])
+      //[error] Could not find proxy for v: String in List(value v, method put, class Ops$2, object TestCase, package <empty>, package <root>) (currentOwner= method ast )
+      //[error] scala.tools.nsc.transform.LambdaLift$LambdaLifter.scala$tools$nsc$transform$LambdaLift$LambdaLifter$$searchIn$1(LambdaLift.scala:326)
+    }
+
+    val name = "some_name"
+    val q2 = quote {
+      query[Person].put(name)
+    }
+    //[info] TestCase.scala:34:20: SELECT x.name, x.age FROM person x WHERE name = #${v}
+    //[info]     println(ctx.run(q2).string)
+    println(ctx.run(q2).string)
+  }
+}


### PR DESCRIPTION
Fixes #223

### Problem

Infix does not accept runtime string literals

### Solution

Add `#$` feature to allow splicing runtime literal values

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
