### PR TITLE
Fixing unions with Ad-Hoc tuples

### DIFF
--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/CaseClassQueryJdbcSpec.scala
@@ -35,4 +35,24 @@ class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
   "Example 3 - Inline Record as Filter" in {
     testContext.run(`Ex 3 Inline Record Usage`) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
   }
+
+  "Example 4 - Ex 4 Mapped Union of Nicknames" in {
+    testContext.run(`Ex 4 Mapped Union of Nicknames`) should contain theSameElementsAs `Ex 4 Mapped Union of Nicknames expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames Filtered" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames Filtered`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames Filtered expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames Same Field" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames Same Field`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames Same Field expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames Same Field Filtered" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames Same Field Filtered`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames Same Field Filtered expected result`
+  }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/CaseClassQueryJdbcSpec.scala
@@ -35,4 +35,24 @@ class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
   "Example 3 - Inline Record as Filter" in {
     testContext.run(`Ex 3 Inline Record Usage`) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
   }
+
+  "Example 4 - Ex 4 Mapped Union of Nicknames" in {
+    testContext.run(`Ex 4 Mapped Union of Nicknames`) should contain theSameElementsAs `Ex 4 Mapped Union of Nicknames expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames Filtered" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames Filtered`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames Filtered expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames Same Field" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames Same Field`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames Same Field expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames Same Field Filtered" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames Same Field Filtered`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames Same Field Filtered expected result`
+  }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/CaseClassQueryJdbcSpec.scala
@@ -35,4 +35,24 @@ class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
   "Example 3 - Inline Record as Filter" in {
     testContext.run(`Ex 3 Inline Record Usage`) should contain theSameElementsAs `Ex 3 Inline Record Usage exepected result`
   }
+
+  "Example 4 - Ex 4 Mapped Union of Nicknames" in {
+    testContext.run(`Ex 4 Mapped Union of Nicknames`) should contain theSameElementsAs `Ex 4 Mapped Union of Nicknames expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames Filtered" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames Filtered`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames Filtered expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames Same Field" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames Same Field`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames Same Field expected result`
+  }
+
+  "Example 4 - Ex 4 Mapped Union All of Nicknames Same Field Filtered" in {
+    testContext.run(`Ex 4 Mapped Union All of Nicknames Same Field Filtered`) should contain theSameElementsAs `Ex 4 Mapped Union All of Nicknames Same Field Filtered expected result`
+  }
 }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
@@ -85,6 +85,8 @@ object ExpandNestedQueries {
           }
         case Property(_, name) =>
           select match {
+            case List(SelectValue(cc: CaseClass, alias, c)) =>
+              SelectValue(cc.values.toMap.apply(name), Some(name), c)
             case List(SelectValue(i: Ident, _, c)) =>
               SelectValue(Property(i, name), None, c)
             case other =>

--- a/quill-sql/src/test/scala/io/getquill/context/sql/CaseClassQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/CaseClassQuerySpec.scala
@@ -10,6 +10,8 @@ trait CaseClassQuerySpec extends Spec {
 
   case class Contact(firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: String)
   case class Address(id: Int, street: String, zip: Int, otherExtraInfo: String)
+  case class Nickname(nickname: String)
+  case class NicknameSameField(firstName: String)
 
   val peopleInsert =
     quote((p: Contact) => query[Contact].insert(p))
@@ -73,4 +75,52 @@ trait CaseClassQuerySpec extends Spec {
   val `Ex 3 Inline Record Usage exepected result` = List(
     new Contact("Alex", "Jones", 60, 2, "foo")
   )
+
+  val `Ex 4 Mapped Union of Nicknames` = quote {
+    query[Contact].map(c => Nickname(c.firstName)) union query[Contact].map(c => Nickname(c.firstName))
+  }
+
+  val `Ex 4 Mapped Union All of Nicknames` = quote {
+    query[Contact].map(c => Nickname(c.firstName)) ++ query[Contact].map(c => Nickname(c.firstName))
+  }
+
+  val `Ex 4 Mapped Union All of Nicknames Filtered` = quote {
+    `Ex 4 Mapped Union All of Nicknames`.filter(_.nickname == "Alex")
+  }
+
+  val `Ex 4 Mapped Union All of Nicknames Same Field` = quote {
+    query[Contact].map(c => NicknameSameField(c.firstName)) ++ query[Contact].map(c => NicknameSameField(c.firstName))
+  }
+
+  val `Ex 4 Mapped Union All of Nicknames Same Field Filtered` = quote {
+    `Ex 4 Mapped Union All of Nicknames Same Field`.filter(_.firstName == "Alex")
+  }
+
+  val `Ex 4 Mapped Union of Nicknames expected result` =
+    List(Nickname("Alex"), Nickname("Bert"), Nickname("Cora"))
+
+  val `Ex 4 Mapped Union All of Nicknames expected result` =
+    List(Nickname("Alex"), Nickname("Bert"), Nickname("Cora"), Nickname("Alex"), Nickname("Bert"), Nickname("Cora"))
+
+  val `Ex 4 Mapped Union All of Nicknames Same Field expected result` =
+    List(
+      NicknameSameField("Alex"),
+      NicknameSameField("Bert"),
+      NicknameSameField("Cora"),
+      NicknameSameField("Alex"),
+      NicknameSameField("Bert"),
+      NicknameSameField("Cora")
+    )
+
+  val `Ex 4 Mapped Union All of Nicknames Filtered expected result` =
+    List(
+      Nickname("Alex"),
+      Nickname("Alex")
+    )
+
+  val `Ex 4 Mapped Union All of Nicknames Same Field Filtered expected result` =
+    List(
+      NicknameSameField("Alex"),
+      NicknameSameField("Alex")
+    )
 }


### PR DESCRIPTION
Fixes #1025

### Problem

Union with two queries both mapping to Ad-Hoc tuples do not produces incorrect sql in which both the alias and the SQL column have the same name.

### Solution

Changes to ExpandNestedQueries to correctly handle CaseClass AST elements in unions.

### Checklist

- [X] Unit test all changes
- [ ] Update `README.md` if applicable (N/A)
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
