### PR TITLE
update finagle-postgres to 0.7.0 (Finagle 18.2.0)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ lazy val `quill-finagle-postgres` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "io.github.finagle" %% "finagle-postgres" % "0.4.3"
+        "io.github.finagle" %% "finagle-postgres" % "0.6.0"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")


### PR DESCRIPTION
### Problem

Quill uses an old version of `finagle-postgres` which uses a very old version of Finagle. That makes very hard to integrate with projects using up to date Finagle libraries.

### Solution

Update finagle-postgres to the latest version that uses finagle version 18.2.0.

@getquill/maintainers
