### PR TITLE
Fix renaming aggregated properties in groupBy with custom querySchema

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/Normalize.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/Normalize.scala
@@ -27,6 +27,7 @@ object Normalize extends StatelessTransformer {
       case SymbolicReduction(query)         => norm(query)
       case AdHocReduction(query)            => norm(query)
       case OrderTerms(query)                => norm(query)
+      case NormalizeAggregationIdent(query) => norm(query)
       case other                            => other
     }
 }

--- a/quill-core/src/main/scala/io/getquill/norm/NormalizeAggregationIdent.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/NormalizeAggregationIdent.scala
@@ -1,0 +1,17 @@
+package io.getquill.norm
+
+import io.getquill.ast._
+
+object NormalizeAggregationIdent {
+
+  def unapply(q: Query) =
+    q match {
+
+      // a => a.b.map(x => x.c).agg =>
+      //   a => a.b.map(a => a.c).agg
+      case Aggregation(op, Map(p @ Property(i: Ident, _), mi, Property(_: Ident, n))) if i != mi =>
+        Some(Aggregation(op, Map(p, i, Property(i, n))))
+
+      case _ => None
+    }
+}

--- a/quill-core/src/test/scala/io/getquill/norm/NormalizeAggregationIdentSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/NormalizeAggregationIdentSpec.scala
@@ -1,0 +1,21 @@
+package io.getquill.norm
+
+import io.getquill.Spec
+import io.getquill.testContext._
+
+class NormalizeAggregationIdentSpec extends Spec {
+
+  "multiple select" in {
+    val q = quote {
+      qr1.groupBy(p => p.i).map {
+        case (i, qrs) => i -> qrs.map(_.l).sum
+      }
+    }
+    val n = quote {
+      qr1.groupBy(p => p.i).map {
+        p => p._1 -> p._2.map(p => p.l).sum
+      }
+    }
+    Normalize(q.ast) mustEqual n.ast
+  }
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -293,6 +293,18 @@ class RenamePropertiesSpec extends Spec {
           "SELECT b.field_i, b.field_s FROM TestEntity2 a RIGHT JOIN test_entity b ON a.s = b.field_s"
       }
     }
+
+    "aggregation" - {
+      "groupBy" in {
+        val q = quote {
+          e.groupBy(a => a.s).map {
+            case (s, eq) => s -> eq.map(_.i).sum
+          }
+        }
+        testContext.run(q).string mustEqual
+          "SELECT a.field_s, SUM(a.field_i) FROM test_entity a GROUP BY a.field_s"
+      }
+    }
   }
 
   "respects the schema definition for embeddeds" - {


### PR DESCRIPTION
Fixes #1035

### Problem
Check issue description for more details

`RenameProperties` is not able to rename property since `map` on grouped query (created by `groupBy`) creates different ident to the one used in group by. 

### Solution

Add normalization step `NormalizeAggregationIdent` which substitute the correct ident so later it could be renamed.

The fix is not related to group by directly however this is only one known situation so far.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
