### PR TITLE
Adding flatMap, flatten, getOrElse, and Option.apply

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - ./build/pull_docker_images.sh
 script:
   - travis_retry docker-compose run setup
-  - docker-compose run sbt bash -c "./build/build.sh"
+  - travis_wait 120 docker-compose run sbt bash -c "./build/build.sh"
 after_success:
   - ./build/push_docker_images.sh
   - pip install --user codecov && codecov

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -123,13 +123,16 @@ class MirrorIdiom extends Idiom {
   }
 
   implicit def optionOperationTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[OptionOperation] = Tokenizer[OptionOperation] {
-    case OptionMap(ast, alias, body)    => stmt"${ast.token}.map((${alias.token}) => ${body.token})"
-    case OptionForall(ast, alias, body) => stmt"${ast.token}.forall((${alias.token}) => ${body.token})"
-    case OptionExists(ast, alias, body) => stmt"${ast.token}.exists((${alias.token}) => ${body.token})"
-    case OptionContains(ast, body)      => stmt"${ast.token}.contains(${body.token})"
-    case OptionIsEmpty(ast)             => stmt"${ast.token}.isEmpty"
-    case OptionNonEmpty(ast)            => stmt"${ast.token}.nonEmpty"
-    case OptionIsDefined(ast)           => stmt"${ast.token}.isDefined"
+    case OptionFlatten(ast)              => stmt"${ast.token}.flatten"
+    case OptionGetOrElse(ast, body)      => stmt"${ast.token}.getOrElse(${body.token})"
+    case OptionFlatMap(ast, alias, body) => stmt"${ast.token}.flatMap((${alias.token}) => ${body.token})"
+    case OptionMap(ast, alias, body)     => stmt"${ast.token}.map((${alias.token}) => ${body.token})"
+    case OptionForall(ast, alias, body)  => stmt"${ast.token}.forall((${alias.token}) => ${body.token})"
+    case OptionExists(ast, alias, body)  => stmt"${ast.token}.exists((${alias.token}) => ${body.token})"
+    case OptionContains(ast, body)       => stmt"${ast.token}.contains(${body.token})"
+    case OptionIsEmpty(ast)              => stmt"${ast.token}.isEmpty"
+    case OptionNonEmpty(ast)             => stmt"${ast.token}.nonEmpty"
+    case OptionIsDefined(ast)            => stmt"${ast.token}.isDefined"
   }
 
   implicit def traversableOperationTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[TraversableOperation] = Tokenizer[TraversableOperation] {

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -72,6 +72,9 @@ case class Ident(name: String) extends Ast
 case class Property(ast: Ast, name: String) extends Ast
 
 sealed trait OptionOperation extends Ast
+case class OptionFlatten(ast: Ast) extends OptionOperation
+case class OptionGetOrElse(ast: Ast, body: Ast) extends OptionOperation
+case class OptionFlatMap(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
 case class OptionMap(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
 case class OptionForall(ast: Ast, alias: Ident, body: Ast) extends OptionOperation
 case class OptionExists(ast: Ast, alias: Ident, body: Ast) extends OptionOperation

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -54,6 +54,17 @@ trait StatefulTransformer[T] {
 
   def apply(o: OptionOperation): (OptionOperation, StatefulTransformer[T]) =
     o match {
+      case OptionFlatten(a) =>
+        val (at, att) = apply(a)
+        (OptionFlatten(at), att)
+      case OptionGetOrElse(a, c) =>
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
+        (OptionGetOrElse(at, ct), ctt)
+      case OptionFlatMap(a, b, c) =>
+        val (at, att) = apply(a)
+        val (ct, ctt) = att.apply(c)
+        (OptionFlatMap(at, b, ct), ctt)
       case OptionMap(a, b, c) =>
         val (at, att) = apply(a)
         val (ct, ctt) = att.apply(c)

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -26,13 +26,16 @@ trait StatelessTransformer {
 
   def apply(o: OptionOperation): OptionOperation =
     o match {
-      case OptionMap(a, b, c)    => OptionMap(apply(a), b, apply(c))
-      case OptionForall(a, b, c) => OptionForall(apply(a), b, apply(c))
-      case OptionExists(a, b, c) => OptionExists(apply(a), b, apply(c))
-      case OptionContains(a, b)  => OptionContains(apply(a), apply(b))
-      case OptionIsEmpty(a)      => OptionIsEmpty(apply(a))
-      case OptionNonEmpty(a)     => OptionNonEmpty(apply(a))
-      case OptionIsDefined(a)    => OptionIsDefined(apply(a))
+      case OptionFlatten(a)       => OptionFlatten(apply(a))
+      case OptionGetOrElse(a, b)  => OptionGetOrElse(apply(a), apply(b))
+      case OptionFlatMap(a, b, c) => OptionFlatMap(apply(a), b, apply(c))
+      case OptionMap(a, b, c)     => OptionMap(apply(a), b, apply(c))
+      case OptionForall(a, b, c)  => OptionForall(apply(a), b, apply(c))
+      case OptionExists(a, b, c)  => OptionExists(apply(a), b, apply(c))
+      case OptionContains(a, b)   => OptionContains(apply(a), apply(b))
+      case OptionIsEmpty(a)       => OptionIsEmpty(apply(a))
+      case OptionNonEmpty(a)      => OptionNonEmpty(apply(a))
+      case OptionIsDefined(a)     => OptionIsDefined(apply(a))
     }
 
   def apply(o: TraversableOperation): TraversableOperation =

--- a/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
@@ -212,7 +212,9 @@ class MetaDslMacro(val c: MacroContext) {
                 nest(tpe, term)
             }
 
-          if (is[Option[Any]](tpe)) {
+          if (isNone(tpe)) {
+            c.fail("Cannot handle untyped `None` objects. Use a cast e.g. `None:Option[String]` or `Option.empty`.")
+          } else if (is[Option[Any]](tpe)) {
             value(tpe.typeArgs.head).copy(optional = true)
           } else {
             value(tpe)
@@ -250,6 +252,9 @@ class MetaDslMacro(val c: MacroContext) {
 
     filterExcludes(apply(tpe, term = None, nested = false))
   }
+
+  private def isNone(tpe: Type) =
+    tpe.typeSymbol.name.toString == "None"
 
   private def isTuple(tpe: Type) =
     tpe.typeSymbol.name.toString.startsWith("Tuple")

--- a/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -69,6 +69,8 @@ case class BetaReduction(map: collection.Map[Ast, Ast])
 
   override def apply(o: OptionOperation) =
     o match {
+      case other @ OptionFlatMap(a, b, c) =>
+        OptionFlatMap(apply(a), b, BetaReduction(map - b)(c))
       case OptionMap(a, b, c) =>
         OptionMap(apply(a), b, BetaReduction(map - b)(c))
       case OptionForall(a, b, c) =>

--- a/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
@@ -4,8 +4,17 @@ import io.getquill.ast._
 
 object FlattenOptionOperation extends StatelessTransformer {
 
-  override def apply(ast: Ast) =
+  private def isNotEmpty(ast: Ast) =
+    BinaryOperation(ast, EqualityOperator.`!=`, NullValue)
+
+  override def apply(ast: Ast): Ast =
     ast match {
+      case OptionFlatten(ast) =>
+        apply(ast)
+      case OptionGetOrElse(ast, body) =>
+        apply(If(isNotEmpty(ast), ast, body))
+      case OptionFlatMap(ast, alias, body) =>
+        apply(BetaReduction(body, alias -> ast))
       case OptionMap(ast, alias, body) =>
         apply(BetaReduction(body, alias -> ast))
       case OptionForall(ast, alias, body) =>

--- a/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/FreeVariables.scala
@@ -22,6 +22,8 @@ case class FreeVariables(state: State)
 
   override def apply(o: OptionOperation): (OptionOperation, StatefulTransformer[State]) =
     o match {
+      case q @ OptionFlatMap(a, b, c) =>
+        (q, free(a, b, c))
       case q @ OptionMap(a, b, c) =>
         (q, free(a, b, c))
       case q @ OptionForall(a, b, c) =>

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -36,13 +36,16 @@ trait Liftables {
   }
 
   implicit val optionOperationLiftable: Liftable[OptionOperation] = Liftable[OptionOperation] {
-    case OptionMap(a, b, c)    => q"$pack.OptionMap($a,$b,$c)"
-    case OptionForall(a, b, c) => q"$pack.OptionForall($a,$b,$c)"
-    case OptionExists(a, b, c) => q"$pack.OptionExists($a,$b,$c)"
-    case OptionContains(a, b)  => q"$pack.OptionContains($a,$b)"
-    case OptionIsEmpty(a)      => q"$pack.OptionIsEmpty($a)"
-    case OptionNonEmpty(a)     => q"$pack.OptionNonEmpty($a)"
-    case OptionIsDefined(a)    => q"$pack.OptionIsDefined($a)"
+    case OptionFlatten(a)       => q"$pack.OptionFlatten($a)"
+    case OptionGetOrElse(a, b)  => q"$pack.OptionGetOrElse($a,$b)"
+    case OptionFlatMap(a, b, c) => q"$pack.OptionFlatMap($a,$b,$c)"
+    case OptionMap(a, b, c)     => q"$pack.OptionMap($a,$b,$c)"
+    case OptionForall(a, b, c)  => q"$pack.OptionForall($a,$b,$c)"
+    case OptionExists(a, b, c)  => q"$pack.OptionExists($a,$b,$c)"
+    case OptionContains(a, b)   => q"$pack.OptionContains($a,$b)"
+    case OptionIsEmpty(a)       => q"$pack.OptionIsEmpty($a)"
+    case OptionNonEmpty(a)      => q"$pack.OptionNonEmpty($a)"
+    case OptionIsDefined(a)     => q"$pack.OptionIsDefined($a)"
   }
 
   implicit val traversableOperationLiftable: Liftable[TraversableOperation] = Liftable[TraversableOperation] {

--- a/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
@@ -61,6 +61,12 @@ trait ReifyLiftings {
         case ast: Lift =>
           (ast, ReifyLiftings(state + (encode(ast.name) -> reify(ast))))
 
+        case p: OptionFlatMap =>
+          super.apply(p) match {
+            case (p2 @ OptionFlatMap(_: CaseClassValueLift, _, _), _) => apply(lift(unparse(p2)))
+            case other => other
+          }
+
         case p: OptionMap =>
           super.apply(p) match {
             case (p2 @ OptionMap(_: CaseClassValueLift, _, _), _) => apply(lift(unparse(p2)))

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -30,13 +30,16 @@ trait Unliftables {
   }
 
   implicit val optionOperationUnliftable: Unliftable[OptionOperation] = Unliftable[OptionOperation] {
-    case q"$pack.OptionMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"    => OptionMap(a, b, c)
-    case q"$pack.OptionForall.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionForall(a, b, c)
-    case q"$pack.OptionExists.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionExists(a, b, c)
-    case q"$pack.OptionContains.apply(${ a: Ast }, ${ b: Ast })"              => OptionContains(a, b)
-    case q"$pack.OptionIsEmpty.apply(${ a: Ast })"                            => OptionIsEmpty(a)
-    case q"$pack.OptionNonEmpty.apply(${ a: Ast })"                           => OptionNonEmpty(a)
-    case q"$pack.OptionIsDefined.apply(${ a: Ast })"                          => OptionIsDefined(a)
+    case q"$pack.OptionFlatten.apply(${ a: Ast })"                             => OptionFlatten(a)
+    case q"$pack.OptionGetOrElse.apply(${ a: Ast }, ${ b: Ast })"              => OptionGetOrElse(a, b)
+    case q"$pack.OptionFlatMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })" => OptionFlatMap(a, b, c)
+    case q"$pack.OptionMap.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"     => OptionMap(a, b, c)
+    case q"$pack.OptionForall.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"  => OptionForall(a, b, c)
+    case q"$pack.OptionExists.apply(${ a: Ast }, ${ b: Ident }, ${ c: Ast })"  => OptionExists(a, b, c)
+    case q"$pack.OptionContains.apply(${ a: Ast }, ${ b: Ast })"               => OptionContains(a, b)
+    case q"$pack.OptionIsEmpty.apply(${ a: Ast })"                             => OptionIsEmpty(a)
+    case q"$pack.OptionNonEmpty.apply(${ a: Ast })"                            => OptionNonEmpty(a)
+    case q"$pack.OptionIsDefined.apply(${ a: Ast })"                           => OptionIsDefined(a)
   }
 
   implicit val traversableOperationUnliftable: Unliftable[TraversableOperation] = Unliftable[TraversableOperation] {

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -264,6 +264,30 @@ class StatefulTransformerSpec extends Spec {
     }
 
     "option operation" - {
+      "flatten" in {
+        val ast: Ast = OptionFlatten(Ident("a"))
+        Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionFlatten(Ident("a'"))
+            att.state mustEqual List(Ident("a"))
+        }
+      }
+      "getOrElse" in {
+        val ast: Ast = OptionGetOrElse(Ident("a"), Ident("b"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionGetOrElse(Ident("a'"), Ident("b'"))
+            att.state mustEqual List(Ident("a"), Ident("b"))
+        }
+      }
+      "flatMap" in {
+        val ast: Ast = OptionFlatMap(Ident("a"), Ident("b"), Ident("c"))
+        Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {
+          case (at, att) =>
+            at mustEqual OptionFlatMap(Ident("a'"), Ident("b"), Ident("c'"))
+            att.state mustEqual List(Ident("a"), Ident("c"))
+        }
+      }
       "map" in {
         val ast: Ast = OptionMap(Ident("a"), Ident("b"), Ident("c"))
         Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) match {

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -175,6 +175,21 @@ class StatelessTransformerSpec extends Spec {
     }
 
     "option operation" - {
+      "flatten" in {
+        val ast: Ast = OptionFlatten(Ident("a"))
+        Subject(Ident("a") -> Ident("a'"))(ast) mustEqual
+          OptionFlatten(Ident("a'"))
+      }
+      "getOrElse" in {
+        val ast: Ast = OptionGetOrElse(Ident("a"), Ident("b"))
+        Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) mustEqual
+          OptionGetOrElse(Ident("a'"), Ident("b'"))
+      }
+      "flatMap" in {
+        val ast: Ast = OptionFlatMap(Ident("a"), Ident("b"), Ident("c"))
+        Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual
+          OptionFlatMap(Ident("a'"), Ident("b"), Ident("c'"))
+      }
       "map" in {
         val ast: Ast = OptionMap(Ident("a"), Ident("b"), Ident("c"))
         Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(ast) mustEqual

--- a/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/mirror/MirrorIdiomSpec.scala
@@ -486,6 +486,27 @@ class MirrorIdiomSpec extends Spec {
   }
 
   "shows option operations" - {
+    "getOrElse" in {
+      val q = quote {
+        (o: Option[Int]) => o.getOrElse(1)
+      }
+      stmt"${(q.ast: Ast).token}" mustEqual
+        stmt"(o) => o.getOrElse(1)"
+    }
+    "flatten" in {
+      val q = quote {
+        (o: Option[Option[Int]]) => o.flatten
+      }
+      stmt"${(q.ast: Ast).token}" mustEqual
+        stmt"(o) => o.flatten"
+    }
+    "flatMap" in {
+      val q = quote {
+        (o: Option[Option[Int]]) => o.flatMap(v => v)
+      }
+      stmt"${(q.ast: Ast).token}" mustEqual
+        stmt"(o) => o.flatMap((v) => v)"
+    }
     "map" in {
       val q = quote {
         (o: Option[Int]) => o.map(v => v)

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -101,6 +101,10 @@ class BetaReductionSpec extends Spec {
         BetaReduction(ast, Ident("c") -> Ident("c'"), Ident("d") -> Ident("d'")) mustEqual ast
       }
       "option operation" - {
+        "flatMap" in {
+          val ast: Ast = OptionFlatMap(Ident("a"), Ident("b"), Ident("b"))
+          BetaReduction(ast, Ident("b") -> Ident("b'")) mustEqual ast
+        }
         "map" in {
           val ast: Ast = OptionMap(Ident("a"), Ident("b"), Ident("b"))
           BetaReduction(ast, Ident("b") -> Ident("b'")) mustEqual ast

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -8,6 +8,27 @@ import io.getquill.ast.NumericOperator
 class FlattenOptionOperationSpec extends Spec {
 
   "transforms option operations into simple properties" - {
+    "getOrElse" in {
+      val q = quote {
+        (o: Option[Int]) => o.getOrElse(1)
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        If(BinaryOperation(Ident("o"), EqualityOperator.`!=`, NullValue), Ident("o"), Constant(1))
+    }
+    "flatten" in {
+      val q = quote {
+        (o: Option[Option[Int]]) => o.flatten.map(i => i + 1)
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        BinaryOperation(Ident("o"), NumericOperator.`+`, Constant(1))
+    }
+    "flatMap" in {
+      val q = quote {
+        (o: Option[Option[Int]]) => o.flatMap(i => i.map(j => j + 1))
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        BinaryOperation(Ident("o"), NumericOperator.`+`, Constant(1))
+    }
     "map" in {
       val q = quote {
         (o: Option[Int]) => o.map(i => i + 1)

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -396,6 +396,22 @@ class QuotationSpec extends Spec {
         val q = quote("s" != null)
         quote(unquote(q)).ast.b mustEqual NullValue
       }
+      "None" in {
+        val q = quote(None)
+        quote(unquote(q)).ast mustEqual NullValue
+      }
+      "Option.empty" in {
+        val q = quote(Option.empty[String])
+        quote(unquote(q)).ast mustEqual NullValue
+      }
+      "Option.apply" in {
+        val q = quote(Option.apply("a"))
+        quote(unquote(q)).ast mustEqual Constant("a")
+      }
+      "Some" in {
+        val q = quote(Some("a"))
+        quote(unquote(q)).ast mustEqual Constant("a")
+      }
       "constant" in {
         val q = quote(11L)
         quote(unquote(q)).ast mustEqual Constant(11L)
@@ -746,6 +762,24 @@ class QuotationSpec extends Spec {
           (o: Option[Int]) => o.map(v => v)
         }
         quote(unquote(q)).ast.body mustEqual OptionMap(Ident("o"), Ident("v"), Ident("v"))
+      }
+      "flatMap" in {
+        val q = quote {
+          (o: Option[Int]) => o.flatMap(v => Option(v))
+        }
+        quote(unquote(q)).ast.body mustEqual OptionFlatMap(Ident("o"), Ident("v"), Ident("v"))
+      }
+      "getOrElse" in {
+        val q = quote {
+          (o: Option[Int]) => o.getOrElse(11)
+        }
+        quote(unquote(q)).ast.body mustEqual OptionGetOrElse(Ident("o"), Constant(11))
+      }
+      "flatten" in {
+        val q = quote {
+          (o: Option[Option[Int]]) => o.flatten
+        }
+        quote(unquote(q)).ast.body mustEqual OptionFlatten(Ident("o"))
       }
       "forall" - {
         "simple" in {

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/OptionJdbcSpec.scala
@@ -1,0 +1,48 @@
+package io.getquill.context.jdbc.h2
+
+import io.getquill.context.sql.OptionQuerySpec
+import org.scalatest.Matchers._
+
+class OptionJdbcSpec extends OptionQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Contact].delete)
+      testContext.run(query[Address].delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+    }
+    ()
+  }
+
+  "Example 1 - Simple Map with Condition" in {
+    testContext.run(`Simple Map with Condition`) should contain theSameElementsAs `Simple Map with Condition Result`
+  }
+
+  "Example 1.1 - Simple Map with Condition and GetOrElse" in {
+    testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
+  }
+
+  "Example 2 - Simple GetOrElse" in {
+    testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 3 - LeftJoin with FlatMap" in {
+    testContext.run(`LeftJoin with FlatMap`) should contain theSameElementsAs `LeftJoin with FlatMap Result`
+  }
+
+  "Example 4 - LeftJoin with Flatten" in {
+    testContext.run(`LeftJoin with Flatten`) should contain theSameElementsAs `LeftJoin with Flatten Result`
+  }
+
+  "Example 5 - Map+getOrElse Join" in {
+    testContext.run(`Map+getOrElse LeftJoin`) should contain theSameElementsAs `Map+getOrElse LeftJoin Result`
+  }
+
+  "Example 6 - Map+Option+Flatten+getOrElse Join" in {
+    testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/OptionJdbcSpec.scala
@@ -1,0 +1,48 @@
+package io.getquill.context.jdbc.mysql
+
+import io.getquill.context.sql.OptionQuerySpec
+import org.scalatest.Matchers._
+
+class OptionJdbcSpec extends OptionQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Contact].delete)
+      testContext.run(query[Address].delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+    }
+    ()
+  }
+
+  "Example 1 - Simple Map with Condition" in {
+    testContext.run(`Simple Map with Condition`) should contain theSameElementsAs `Simple Map with Condition Result`
+  }
+
+  "Example 1.1 - Simple Map with Condition and GetOrElse" in {
+    testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
+  }
+
+  "Example 2 - Simple GetOrElse" in {
+    testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 3 - LeftJoin with FlatMap" in {
+    testContext.run(`LeftJoin with FlatMap`) should contain theSameElementsAs `LeftJoin with FlatMap Result`
+  }
+
+  "Example 4 - LeftJoin with Flatten" in {
+    testContext.run(`LeftJoin with Flatten`) should contain theSameElementsAs `LeftJoin with Flatten Result`
+  }
+
+  "Example 5 - Map+getOrElse Join" in {
+    testContext.run(`Map+getOrElse LeftJoin`) should contain theSameElementsAs `Map+getOrElse LeftJoin Result`
+  }
+
+  "Example 6 - Map+Option+Flatten+getOrElse Join" in {
+    testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OptionJdbcSpec.scala
@@ -1,0 +1,48 @@
+package io.getquill.context.jdbc.postgres
+
+import io.getquill.context.sql.OptionQuerySpec
+import org.scalatest.Matchers._
+
+class OptionJdbcSpec extends OptionQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Contact].delete)
+      testContext.run(query[Address].delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+    }
+    ()
+  }
+
+  "Example 1 - Simple Map with Condition" in {
+    testContext.run(`Simple Map with Condition`) should contain theSameElementsAs `Simple Map with Condition Result`
+  }
+
+  "Example 1.1 - Simple Map with Condition and GetOrElse" in {
+    testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
+  }
+
+  "Example 2 - Simple GetOrElse" in {
+    testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 3 - LeftJoin with FlatMap" in {
+    testContext.run(`LeftJoin with FlatMap`) should contain theSameElementsAs `LeftJoin with FlatMap Result`
+  }
+
+  "Example 4 - LeftJoin with Flatten" in {
+    testContext.run(`LeftJoin with Flatten`) should contain theSameElementsAs `LeftJoin with Flatten Result`
+  }
+
+  "Example 5 - Map+getOrElse Join" in {
+    testContext.run(`Map+getOrElse LeftJoin`) should contain theSameElementsAs `Map+getOrElse LeftJoin Result`
+  }
+
+  "Example 6 - Map+Option+Flatten+getOrElse Join" in {
+    testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
@@ -1,0 +1,44 @@
+package io.getquill.context.jdbc.sqlite
+
+import io.getquill.context.sql.OptionQuerySpec
+import org.scalatest.Matchers._
+
+class OptionJdbcSpec extends OptionQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Contact].delete)
+      testContext.run(query[Address].delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+    }
+    ()
+  }
+
+  "Example 1 - Simple Map with Condition" in {
+    testContext.run(`Simple Map with Condition`) should contain theSameElementsAs `Simple Map with Condition Result`
+  }
+
+  "Example 1.1 - Simple Map with Condition and GetOrElse" in {
+    testContext.run(`Simple Map with Condition and GetOrElse`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
+  }
+
+  "Example 2 - Simple GetOrElse" in {
+    testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 3 - LeftJoin with FlatMap" in {
+    testContext.run(`LeftJoin with FlatMap`) should contain theSameElementsAs `LeftJoin with FlatMap Result`
+  }
+
+  "Example 4 - LeftJoin with Flatten" in {
+    testContext.run(`LeftJoin with Flatten`) should contain theSameElementsAs `LeftJoin with Flatten Result`
+  }
+
+  "Example 5 - Map+getOrElse Join" in {
+    testContext.run(`Map+getOrElse LeftJoin`) should contain theSameElementsAs `Map+getOrElse LeftJoin Result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/OptionJdbcSpec.scala
@@ -1,0 +1,55 @@
+package io.getquill.context.jdbc.sqlserver
+
+import io.getquill.context.sql.OptionQuerySpec
+import org.scalatest.Matchers._
+
+class OptionJdbcSpec extends OptionQuerySpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Contact].delete)
+      testContext.run(query[Address].delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(addressEntries).foreach(p => addressInsert(p)))
+    }
+    ()
+  }
+
+  // Hack because Quill does not have correct SQL Server infix concatenation. See issue #1054 for more info.
+  val `Simple Map with Condition and GetOrElse Infix` = quote {
+    query[Address].map(
+      a => (a.street, a.otherExtraInfo.map(info => infix"${info} + ' suffix'".as[String]).getOrElse("baz"))
+    )
+  }
+
+  "Example 1 - Simple Map with Condition" in {
+    testContext.run(`Simple Map with Condition`) should contain theSameElementsAs `Simple Map with Condition Result`
+  }
+
+  "Example 1.1 - Simple Map with Condition and GetOrElse" in {
+    testContext.run(`Simple Map with Condition and GetOrElse Infix`) should contain theSameElementsAs `Simple Map with Condition and GetOrElse Result`
+  }
+
+  "Example 2 - Simple GetOrElse" in {
+    testContext.run(`Simple GetOrElse`) should contain theSameElementsAs `Simple GetOrElse Result`
+  }
+
+  "Example 3 - LeftJoin with FlatMap" in {
+    testContext.run(`LeftJoin with FlatMap`) should contain theSameElementsAs `LeftJoin with FlatMap Result`
+  }
+
+  "Example 4 - LeftJoin with Flatten" in {
+    testContext.run(`LeftJoin with Flatten`) should contain theSameElementsAs `LeftJoin with Flatten Result`
+  }
+
+  "Example 5 - Map+getOrElse Join" in {
+    testContext.run(`Map+getOrElse LeftJoin`) should contain theSameElementsAs `Map+getOrElse LeftJoin Result`
+  }
+
+  "Example 6 - Map+Option+Flatten+getOrElse Join" in {
+    testContext.run(`Option+Some+None Normalize`) should contain theSameElementsAs `Option+Some+None Normalize Result`
+  }
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/OptionQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/OptionQuerySpec.scala
@@ -1,0 +1,130 @@
+package io.getquill.context.sql
+
+import io.getquill.Spec
+
+trait OptionQuerySpec extends Spec {
+
+  val context: SqlContext[_, _]
+
+  import context._
+
+  case class NoAddressContact(firstName: String, lastName: String, age: Int)
+  case class HasAddressContact(firstName: String, lastName: String, age: Int, addressFk: Int)
+  case class Contact(firstName: String, lastName: String, age: Int, addressFk: Option[Int], extraInfo: String)
+  case class Address(id: Int, street: String, zip: Int, otherExtraInfo: Option[String])
+
+  val peopleInsert =
+    quote((p: Contact) => query[Contact].insert(p))
+
+  val peopleEntries = List(
+    Contact("Alex", "Jones", 60, Option(1), "foo"),
+    Contact("Bert", "James", 55, Option(2), "bar"),
+    Contact("Cora", "Jasper", 33, None, "baz")
+  )
+
+  val addressInsert =
+    quote((c: Address) => query[Address].insert(c))
+
+  val addressEntries = List(
+    Address(1, "123 Fake Street", 11234, Some("something")),
+    Address(2, "456 Old Street", 45678, Some("something else")),
+    Address(3, "789 New Street", 89010, None),
+    Address(111, "111 Default Address", 12345, None)
+  )
+
+  val `Simple Map with Condition` = quote {
+    query[Address].map(a => (a.street, a.otherExtraInfo.map(info => if (info == "something") "one" else "two")))
+  }
+  val `Simple Map with Condition Result` = List(
+    ("123 Fake Street", Some("one")),
+    ("456 Old Street", Some("two")),
+    // Technically the below tuples' second member should be None according to functor laws
+    // but due to issue #1053 they are not properly null checked in the SQL output.
+    ("789 New Street", Some("two")),
+    ("111 Default Address", Some("two"))
+  )
+
+  val `Simple Map with Condition and GetOrElse` = quote {
+    query[Address].map(
+      a => (a.street, a.otherExtraInfo.map(info => info + " suffix").getOrElse("baz"))
+    )
+  }
+  val `Simple Map with Condition and GetOrElse Result` = List(
+    ("123 Fake Street", "something suffix"),
+    ("456 Old Street", "something else suffix"),
+    ("789 New Street", "baz"),
+    ("111 Default Address", "baz")
+  )
+
+  val `Simple GetOrElse` = quote {
+    query[Address].map(a => (a.street, a.otherExtraInfo.getOrElse("yet something else")))
+  }
+  val `Simple GetOrElse Result` = List(
+    ("123 Fake Street", "something"),
+    ("456 Old Street", "something else"),
+    ("789 New Street", "yet something else"),
+    ("111 Default Address", "yet something else")
+  )
+
+  val `LeftJoin with FlatMap` = quote {
+    query[Contact].leftJoin(query[Address]).on((c, a) => c.addressFk.exists(_ == a.id))
+      .map({ case (c, a) => (a.map(_.id), a.flatMap(_.otherExtraInfo)) })
+  }
+  val `LeftJoin with FlatMap Result` = List(
+    (Some(1), Some("something")),
+    (Some(2), Some("something else")),
+    (None, None)
+  )
+
+  val `LeftJoin with Flatten` = quote {
+    query[Contact].leftJoin(query[Address]).on((c, a) => c.addressFk.exists(_ == a.id))
+      .map({ case (c, a) => (a.map(_.id), a.map(_.otherExtraInfo).flatten) })
+  }
+  val `LeftJoin with Flatten Result` = List(
+    (Some(1), Some("something")),
+    (Some(2), Some("something else")),
+    (None, None)
+  )
+
+  val `Map+getOrElse LeftJoin` = quote {
+    query[Contact].leftJoin(query[Address]).on((c, a) => c.addressFk.getOrElse(-1) == a.id)
+      .map({ case (c, a) => (a.map(_.id), a.flatMap(_.otherExtraInfo)) })
+  }
+  val `Map+getOrElse LeftJoin Result` = List(
+    (Some(1), Some("something")),
+    (Some(2), Some("something else")),
+    (None, None)
+  )
+
+  case class NormalizedContact(name: String, addressFk: Option[Int])
+
+  def normalizeAddress = quote {
+    (addressFk: Option[Int]) => addressFk.getOrElse(111)
+  }
+
+  val `Option+Some+None Normalize` = quote {
+    val c1 = querySchema[NoAddressContact]("Contact").map(c => (c.firstName, None: Option[Int]))
+    val c2 = querySchema[HasAddressContact]("Contact").map(c => (c.firstName, Some(c.addressFk)))
+    val c3 = query[Contact].map(c => (c.firstName, c.addressFk))
+
+    val normalized = (c1 ++ c2 ++ c3).map({ case (name, address) => (name, normalizeAddress(address)) })
+
+    for {
+      (name, addressFk) <- normalized
+      address <- query[Address] if address.id == addressFk
+    } yield (name, address.street)
+  }
+
+  val `Option+Some+None Normalize Result` = List(
+    ("Alex", "111 Default Address"),
+    ("Bert", "111 Default Address"),
+    ("Cora", "111 Default Address"),
+    ("Alex", "123 Fake Street"),
+    ("Bert", "456 Old Street"),
+    ("Cora", "111 Default Address"),
+    ("Alex", "123 Fake Street"),
+    ("Bert", "456 Old Street"),
+    ("Cora", "111 Default Address")
+  )
+
+}


### PR DESCRIPTION
Fixes #924 (please have a look at the issue for my comments)

### Problem

No support for Option[T] operations flatMap, flatten, getOrElse, or apply inside of quoted blocks.

### Solution

New AST types OptionFlatMap, OptionGetOrElse, OptionFlatten, introduced parsing for Option, Some, None, and Option.empty. container which works similarly to Tuple/CaseClass. Additional conditionals for Optional field processing in FlattenOptionOperation as well as an additional normalization step to simplify nested null checking.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

Edit. Updating description.