### PR TITLE
call prepare using this and not super 

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -37,7 +37,7 @@ class CassandraAsyncContext[N <: NamingStrategy](
   }
 
   def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[List[T]] =
-    Future(prepare(super.prepare(cql))).flatMap {
+    Future(prepare(this.prepare(cql))).flatMap {
       case (params, bs) =>
         logger.logQuery(cql, params)
         session.executeAsync(bs)
@@ -48,7 +48,7 @@ class CassandraAsyncContext[N <: NamingStrategy](
     executeQuery(cql, prepare, extractor).map(handleSingleResult)
 
   def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Unit] = {
-    Future(prepare(super.prepare(cql))).flatMap {
+    Future(prepare(this.prepare(cql))).flatMap {
       case (params, bs) =>
         logger.logQuery(cql, params)
         session.executeAsync(bs).map(_ => ())

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
@@ -34,7 +34,7 @@ class CassandraSyncContext[N <: NamingStrategy](
   }
 
   def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): List[T] = {
-    val (params, bs) = prepare(super.prepare(cql))
+    val (params, bs) = prepare(this.prepare(cql))
     logger.logQuery(cql, params)
     session.execute(bs)
       .all.asScala.toList.map(extractor)
@@ -44,7 +44,7 @@ class CassandraSyncContext[N <: NamingStrategy](
     handleSingleResult(executeQuery(cql, prepare, extractor))
 
   def executeAction[T](cql: String, prepare: Prepare = identityPrepare): Unit = {
-    val (params, bs) = prepare(super.prepare(cql))
+    val (params, bs) = prepare(this.prepare(cql))
     logger.logQuery(cql, params)
     session.execute(bs)
     ()


### PR DESCRIPTION


### Problem

executeQuery and executeAction in CassandraAsyncContext and CassandraSessionContext classes are calling super.prepare. This will not allow any overriden implementation of prepare to be called.

### Solution
Call prepare method  using this and not using super

@getquill/maintainers
