### PR TITLE
Add connectTimeout option into FinagleMysqlContextConfig

### DIFF
--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContextConfig.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContextConfig.scala
@@ -21,12 +21,15 @@ case class FinagleMysqlContextConfig(config: Config) {
   def bufferSize = Try(config.getInt("pool.bufferSize")).getOrElse(0)
   def maxWaiters = Try(config.getInt("pool.maxWaiters")).getOrElse(Int.MaxValue)
   def maxPrepareStatements = Try(config.getInt("maxPrepareStatements")).getOrElse(20)
+  def connectTimeout = Try(config.getInt("connectTimeout")).getOrElse(1)
 
   def client =
     Mysql.client
       .withCredentials(user, password)
       .withDatabase(database)
       .withMaxConcurrentPrepareStatements(maxPrepareStatements)
+      .withTransport
+      .connectTimeout(connectTimeout.second)
       .configured(DefaultPool.Param(
         low = lowWatermark, high = highWatermark,
         idleTime = idleTime.seconds,


### PR DESCRIPTION
### Problem

`FinagleMysqlContextConfig` doesn't have `connectTimeout` option. default is 1sec. Sometimes this value is too short.

https://github.com/twitter/finagle/blob/d87c0fe4347bf35a1bbad25defd2b4c4f3131dd3/finagle-core/src/main/scala/com/twitter/finagle/param/ClientTransportParams.scala#L26-L33

### Solution

Add `connectTimeout` option into FinagleMysqlContextConfig

### Notes

N/A

### Checklist

- [ ] ~Unit test all changes~
- [ ] ~Update `README.md` if applicable~
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
