### PR TITLE
Fix for Nested Objects with Spark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,10 @@ local.*
 quill_test.db
 Bug.scala
 *.gz
-
+quill-jdbc/io/
+quill-sql/io/
+MyTest.scala
+MySparkTest.scala
+MyTestJdbc.scala
+quill-core/src/main/resources/logback.xml
+quill-jdbc/src/main/resources/logback.xml

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -11,6 +11,7 @@ import io.getquill.ast.StringOperator
 import io.getquill.ast.Tuple
 import io.getquill.ast.Value
 import io.getquill.ast.CaseClass
+import io.getquill.context.spark.norm.ExpandEntityIds
 import io.getquill.context.sql.SqlQuery
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.norm.SqlNormalize
@@ -38,7 +39,9 @@ class SparkDialect extends SqlIdiom {
         case q: Query =>
           val sql = SqlQuery(q)
           trace("sql")(sql)
-          sql.token
+          val expanded = ExpandEntityIds(sql)
+          trace("expanded sql")(expanded)
+          expanded.token
         case other =>
           other.token
       }

--- a/quill-spark/src/main/scala/io/getquill/context/spark/norm/ExpandEntityIds.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/norm/ExpandEntityIds.scala
@@ -1,0 +1,231 @@
+package io.getquill.context.spark.norm
+
+import io.getquill.ast.Ast
+import io.getquill.ast.Ident
+import io.getquill.ast._
+import io.getquill.context.sql.FlattenSqlQuery
+import io.getquill.context.sql.FromContext
+import io.getquill.context.sql.InfixContext
+import io.getquill.context.sql.JoinContext
+import io.getquill.context.sql.QueryContext
+import io.getquill.context.sql.SelectValue
+import io.getquill.context.sql.SetOperationSqlQuery
+import io.getquill.context.sql.SqlQuery
+import io.getquill.context.sql.TableContext
+import io.getquill.context.sql.UnaryOperationSqlQuery
+import io.getquill.context.sql.FlatJoinContext
+
+/**
+ * Spark requires nested objects to be expanded in tupled form in order to be properly encoded.
+ * In order to do this, we have to find the needed Entity by looking up the field identity
+ * and then expand it's fields. When a Spark Dataset is encoded via "liftDataset",
+ * we attempt to do the same thing by pulling out the case class (and it's fields)
+ * from the ScalarValueLift.
+ */
+object ExpandEntityIds {
+
+  private def replaceSelect(v: SelectValue, searchState: SearchState, idx: Int, isNested: Boolean): SelectValue = {
+    val newAst = diveReplaceAst(v.ast, searchState)
+
+    def newAlias = Some(v.alias.getOrElse((s"_${idx}")))
+    // Make sure if what was returned was a tuple or case class, that tuple or case class actually has fields
+    // otherwise fall back to the original entity.
+    newAst match {
+      case Tuple(props) if (props.size > 0) => v.copy(ast = newAst, alias = newAlias)
+      case CaseClass(props) if (props.size > 0) => v.copy(ast = newAst, alias = newAlias)
+      case other if (!other.isInstanceOf[Tuple] && !other.isInstanceOf[CaseClass]) => v.copy(ast = newAst)
+      case _ => v
+    }
+  }
+
+  private def diveReplaceAst(a: Ast, searchState: SearchState): Ast = {
+    def diveReplaceRecurse(a: Ast): Ast =
+      a match {
+        case Tuple(values)     => Tuple(values.map(diveReplaceRecurse))
+        case CaseClass(values) => CaseClass(values.map({ case (k, v) => (k, diveReplaceRecurse(v)) }))
+        case id @ Ident(name) =>
+          if (searchState.contains(name))
+            Tuple(searchState(name).fields)
+          else
+            id
+        case other => other
+      }
+
+    diveReplaceRecurse(a)
+  }
+
+  private def gatherSubstates(s: SqlQuery): (SqlQuery, SearchState) =
+    s match {
+      case q: FlattenSqlQuery => {
+        val contextsAndStates = q.from.map(processSingleFromContext)
+        (
+          q.copy(from = contextsAndStates.map({ case (newFrom, _) => newFrom })),
+          contextsAndStates.map({ case (_, state) => state }).fold(NotFound)(_ merge _)
+        )
+      }
+      case so @ SetOperationSqlQuery(a, _, b) => {
+        val (queryA, stateA) = processQuerySelects(a)
+        val (queryB, stateB) = processQuerySelects(b)
+        (so.copy(a = queryA, b = queryB), stateA merge stateB)
+      }
+      case uo @ UnaryOperationSqlQuery(_, q) => {
+        val (query, state) = processQuerySelects(q)
+        (uo.copy(q = query), state)
+      }
+    }
+
+  private def processSingleFromContext(s: FromContext): (FromContext, SearchState) =
+    s match {
+      case qc @ QueryContext(q, queryAlias) => {
+        val (newQuery, state) = processQuerySelects(q, true)
+        val newState =
+          newQuery match {
+            case fq: FlattenSqlQuery =>
+              FoundEntityIds(queryAlias, fq.select.collect({
+                case SelectValue(_, Some(alias), _) => alias
+              }))
+            case _ => state
+          }
+        (qc.copy(query = newQuery), newState)
+      }
+      case j @ JoinContext(_, a, b, _) => {
+        val (contextA, stateA) = processSingleFromContext(a)
+        val (contextB, stateB) = processSingleFromContext(b)
+        (j.copy(a = contextA, b = contextB), stateA merge stateB)
+      }
+      case f @ FlatJoinContext(_, a, _) => {
+        val (context, state) = processSingleFromContext(a)
+        (f.copy(a = context), state)
+      }
+      // Star-selection expansion for spark is not selected for entity query
+      // the proper way to use spark is via liftQuery
+      case t @ TableContext(e, alias) => (t, NotFound)
+      case inf @ InfixContext(i, alias) => {
+        (inf, searchInfix(i, alias))
+      }
+    }
+
+  // Search infixes for a dataframe definition. This is a best-effort process.
+  def searchInfix(i: Infix, id: String): SearchState = InfixExtractor(i, id)
+
+  private def processQuerySelects(q: SqlQuery, nested: Boolean = false): (SqlQuery, SearchState) = {
+    val output = gatherSubstates(q)
+    output match {
+      case (f: FlattenSqlQuery, searchState: FoundEntityIds) => {
+        val newQuery = f.copy(select =
+          f.select.zipWithIndex.map({
+            case (sv, idx) => replaceSelect(sv, searchState, idx, nested)
+          }))
+        (retuplize(newQuery), searchState)
+      }
+      case (s: SetOperationSqlQuery, searchState: FoundEntityIds) => (s, searchState)
+      case (u: UnaryOperationSqlQuery, searchState: FoundEntityIds) => (u, searchState)
+      case _ => (q, NotFound)
+    }
+  }
+
+  /**
+   * Spark expects nested case classes to be expressed in a <code>((fields...) var, (fields...) var) var</code>
+   * form. In particular, one case class cannot be within another case classes's ast or the format will be invalid,
+   * we have to wrap the inner one in a tuple beforehand.
+   * This function does exactly that:
+   *
+   * <pre>
+   * SELECT (a.i, a.j) ta, (a.i, a.j) tb tha, foo FROM ... ->  // Invalid format for Spark
+   * SELECT ((a.i, a.j) ta), ((a.i, a.j) tb) tha, FROM ...   // Valid format for Spark
+   * </pre>
+   */
+  private def surroundCaseClassesWithTuple(sv: SelectValue) = {
+    def surroundCaseClassesWithTupleInternal(cc: Ast): Ast = {
+      cc match {
+        case cc @ CaseClass(_) => Tuple(List(CaseClass(cc.values.map({ case (k, v) => (k, surroundCaseClassesWithTupleInternal(v)) }))))
+        case Tuple(props)      => Tuple(props.map(surroundCaseClassesWithTupleInternal))
+        case other             => other
+      }
+    }
+    sv.copy(ast = surroundCaseClassesWithTupleInternal(sv.ast))
+  }
+
+  /**
+   * This function does two things. The first is to expand a tuple/caseclass which is the only argument
+   * in the selects since spark does not support this kind of construction:
+   *
+   * <pre>
+   * SELECT ((fooa, foob) foobar) FROM ... -> // This becomes SELECT ((fooa, foob) foobar) _1 FROM ... which in invalid
+   * SELECT (fooa, foob) foobar FROM ...
+   * </pre>
+   *
+   * In cases where they are multiple arguments however since these steps typically run recursively, you
+   * start with an object that has already been detupleized so it needs to be retuplized correctly now.
+   *
+   * <pre>
+   *
+   * // In previous steps they went "SELECT ((fooa, foob) foo) FROM ..." to "SELECT (fooa, foob) foo FROM ..."
+   * // which is a typical result of using Ad-Hoc case classes.
+   * SELECT ((fooa, foob) foo) fo, ((baza, bazb) baz) ba foba, ... FROM ... -> // which is invalid
+   *
+   * // So now you need to surround the case classes with tuples so that Spark decodes them correctly:
+   * SELECT (((fooa, foob) foo) fo), (((baza, bazb) baz) ba) foba, ... FROM ...
+   *
+   * By performing both off these steps (recursively if any subqueries are involved), the output
+   * of the <code>SelectValue</code>s will be specified correctly for spark decoding to work.
+   * </pre>
+   */
+  def retuplize(q: SqlQuery): SqlQuery =
+    q match {
+      case f: FlattenSqlQuery => {
+        val detupleized = detupleize(f)
+        detupleized.copy(select = detupleized.select.map(surroundCaseClassesWithTuple))
+      }
+      case SetOperationSqlQuery(a, op, b) => SetOperationSqlQuery(retuplize(a), op, retuplize(b))
+      case UnaryOperationSqlQuery(op, q)  => UnaryOperationSqlQuery(op, retuplize(q))
+    }
+
+  /**
+   * If a query has a single select-value which is a tuple, 'unwrap' that into a set of
+   * select-values representing the individual fields.
+   *
+   * <pre>
+   * SELECT (foo, bar) FROM ... ->  // Which later becomes SELECT (foo, bar) _1 FROM ... which is invalid
+   * SELECT foo, bar FROM ...
+   * </pre>
+   *
+   * When the selection criteria has nested tuples that need to be reformatted, also do that.
+   * <pre>
+   * SELECT ((a, b) foo, bar) FROM ... ->  // Which later becomes SELECT ((a, b), bar) _1 FROM ... which is invalid
+   * SELECT (a, b) foo, bar FROM ...
+   * </pre>
+   *
+   * For three levels of nesting, it looks like this:
+   * <pre>
+   * SELECT (((x, y), b) foo, bar) FROM ... ->  // Which later becomes SELECT (((x, y), b), bar) _1 FROM ... which is invalid
+   * SELECT ((x, y) a, b) foo, bar FROM ...
+   * </pre>
+   */
+  private def detupleize(q: FlattenSqlQuery): FlattenSqlQuery = {
+    def expandSelectValue(selectValue: SelectValue): List[SelectValue] =
+      selectValue match {
+        case SelectValue(cc @ CaseClass(_), _, concat) =>
+          cc.values
+            .map({ case (k, v) => SelectValue(v, Some(k), concat) })
+
+        case SelectValue(Tuple(props), _, _) => props.map({
+          // if the select is a property that is selecting, add the property's name for the alias
+          case Property(ast, name) => SelectValue(Property(ast, name), Some(name), false)
+          // this case shouldn't happen but fallback to just returning the property if it does
+          case other               => SelectValue(other, None, false)
+        })
+
+        case other => List(other)
+      }
+
+    q.select match {
+      case selectValue :: Nil => q.copy(select = expandSelectValue(selectValue))
+      case _                  => q
+    }
+  }
+
+  def apply(q: SqlQuery): SqlQuery = processQuerySelects(q) match {
+    case (q, _) => retuplize(q)
+  }
+}

--- a/quill-spark/src/main/scala/io/getquill/context/spark/norm/InfixExtractor.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/norm/InfixExtractor.scala
@@ -1,0 +1,68 @@
+package io.getquill.context.spark.norm
+
+import io.getquill.ast.{ Infix, ScalarValueLift }
+
+class InfixExtractor(i: Infix, id: String) {
+  val universe: scala.reflect.runtime.universe.type = scala.reflect.runtime.universe
+  import universe._
+
+  import scala.util.{ Failure => MFailure, Success => MSuccess, Try => MTry }
+
+  protected def firstConstructorParamList(tpe: Type): Option[List[String]] = {
+    val paramLists = tpe.decls.collect {
+      case m: MethodSymbol if m.isConstructor => m.paramLists.map(_.map(_.name))
+    }
+    for {
+      paramList <- paramLists.toList.headOption
+      firstParamList <- paramList.headOption
+    } yield (firstParamList.map(_.toString))
+  }
+
+  protected def firstTypeArgInMethodSymbol(sym: Symbol): Option[Type] =
+    (for {
+      method <- MTry(sym.asInstanceOf[MethodSymbol])
+      tpe <- MTry(method.returnType.asInstanceOf[TypeRef])
+      firstArg <- MTry(tpe.typeArgs(0))
+    } yield (firstArg)) match {
+      case MSuccess(value) => Some(value)
+      case MFailure(_)     => None
+    }
+
+  protected def extractLiftValue(value: Any) = value match {
+    case q"$v.value" => Some(v)
+    case _           => None
+  }
+
+  protected def isDataset(tpe: Type) =
+    tpe.typeSymbol.fullName == weakTypeOf[org.apache.spark.sql.Dataset[_]].typeSymbol.fullName
+
+  protected def extractDatasetParameter(tpe: Type) =
+    if (isDataset(tpe)) Some(tpe.typeArgs(0)) else None
+
+  protected def findTypeArgsFromDataset =
+    for {
+      scalarValue <- i.params.headOption.collect({ case ScalarValueLift(_, value, _) => value })
+      liftValue <- extractLiftValue(scalarValue)
+      firstTypeArg <- firstTypeArgInMethodSymbol(liftValue.symbol)
+      datasetClass <- extractDatasetParameter(firstTypeArg)
+      typeArgs <- firstConstructorParamList(datasetClass)
+    } yield (typeArgs)
+
+  def extract: SearchState = {
+    // Last resort, catch any possible exception that could have happened from the retrieval
+    val outputState =
+      MTry(findTypeArgsFromDataset) match {
+        case MSuccess(value) => value.map(propertyList => FoundEntityIds(id, propertyList))
+        case MFailure(_)     => None
+      }
+
+    outputState match {
+      case Some(value) => value
+      case None        => NotFound
+    }
+  }
+}
+
+object InfixExtractor {
+  def apply(i: Infix, id: String) = new InfixExtractor(i, id).extract
+}

--- a/quill-spark/src/main/scala/io/getquill/context/spark/norm/SearchState.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/norm/SearchState.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.spark.norm
+
+import io.getquill.ast.{ Entity, Ident, Property }
+
+sealed trait SearchState {
+  def aliases: Seq[EntityId] = Seq()
+
+  def merge(other: SearchState): SearchState = {
+    (this, other) match {
+      case (NotFound, NotFound)                   => NotFound
+      case (NotFound, b: FoundEntityIds)          => b
+      case (a: FoundEntityIds, NotFound)          => a
+      case (a: FoundEntityIds, b: FoundEntityIds) => FoundEntityIds(a.aliases ++ b.aliases)
+    }
+  }
+
+  def contains(id: String): Boolean = aliases.map(a => (a.id, a)).toMap.contains(id)
+  def apply(id: String): EntityId = aliases.map(a => (a.id, a)).toMap.apply(id)
+}
+
+object NotFound extends SearchState
+case class EntityId(id: String, fields: List[Property])
+case class FoundEntityIds(override val aliases: Seq[EntityId]) extends SearchState
+
+object FoundEntityIds {
+  def apply(id: String, e: Entity) =
+    new FoundEntityIds(Seq(EntityId(id, e)))
+
+  def apply(id: String, propertyList: List[String]) =
+    new FoundEntityIds(Seq(EntityId(id, propertyList.map(p => Property(Ident(id), p)))))
+}
+object EntityId {
+  def apply(id: String, e: Entity) = new EntityId(id, e.properties.map(pa => Property(Ident(id), pa.path.mkString("."))))
+}

--- a/quill-spark/src/test/scala/io/getquill/context/spark/CaseClassQuerySpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/CaseClassQuerySpec.scala
@@ -11,6 +11,9 @@ case class AddressableContact(firstName: String, lastName: String, age: Int, str
 case class ContactSimplified(firstName: String, lastNameRenamed: String, firstReverse: String)
 case class ContactSimplifiedMapped(firstNameMapped: String, lastNameMapped: String, firstReverseMapped: String)
 
+case class ContactAndAddress(c: Contact, a: Address)
+case class Note(owner: String, content: String)
+
 class CaseClassQuerySpec extends Spec {
 
   val context = io.getquill.context.sql.testContext
@@ -24,21 +27,27 @@ class CaseClassQuerySpec extends Spec {
   import testContext._
   import sqlContext.implicits._
 
-  val peopleEntries = liftQuery {
-    Seq(
-      Contact("Alex", "Jones", 60, 2, "foo"),
-      Contact("Bert", "James", 55, 3, "bar"),
-      Contact("Cora", "Jasper", 33, 3, "baz")
-    ).toDS()
-  }
+  val peopleList = Seq(
+    Contact("Alex", "Jones", 60, 2, "foo"),
+    Contact("Bert", "James", 55, 3, "bar"),
+    Contact("Cora", "Jasper", 33, 3, "baz")
+  )
+  val peopleEntries = liftQuery(peopleList.toDS())
 
-  val addressEntries = liftQuery {
-    Seq(
-      Address(1, "123 Fake Street", 11234, "something"),
-      Address(2, "456 Old Street", 45678, "something else"),
-      Address(3, "789 New Street", 89010, "another thing")
-    ).toDS()
-  }
+  val addressList = Seq(
+    Address(1, "123 Fake Street", 11234, "something"),
+    Address(2, "456 Old Street", 45678, "something else"),
+    Address(3, "789 New Street", 89010, "another thing")
+  )
+  val addressEntries = liftQuery(addressList.toDS())
+
+  val noteList = Seq(
+    Note("Alex", "Foo"),
+    Note("Alex", "Bar"),
+    Note("Bert", "Baz"),
+    Note("Bert", "Taz")
+  )
+  val noteEntries = liftQuery(noteList.toDS())
 
   val reverse = quote {
     (str: String) => infix"reverse(${str})".as[String]
@@ -61,6 +70,163 @@ class CaseClassQuerySpec extends Spec {
     )
   }
 
+  "Simple Join, Ad-Hoc Case Class, Filtered Union" in {
+    val q = quote {
+      for {
+        p <- (peopleEntries.filter(_.age >= 60)) ++ (peopleEntries.filter(_.age < 60))
+        a <- addressEntries if p.addressFk == a.id
+      } yield {
+        new AddressableContact(p.firstName, p.lastName, p.age, a.street, a.zip)
+      }
+    }
+
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      AddressableContact("Alex", "Jones", 60, "456 Old Street", 45678),
+      AddressableContact("Bert", "James", 55, "789 New Street", 89010),
+      AddressableContact("Cora", "Jasper", 33, "789 New Street", 89010)
+    )
+  }
+
+  "Simple Join, Ad-Hoc Case Class, Filtered Union Distinct" in {
+    val q = quote {
+      (for {
+        // returns a duplicate record that should be deduped
+        p <- (peopleEntries.filter(_.age >= 60)) ++ (peopleEntries.filter(_.age <= 60))
+        a <- addressEntries if p.addressFk == a.id
+      } yield {
+        new AddressableContact(p.firstName, p.lastName, p.age, a.street, a.zip)
+      }).distinct
+    }
+
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      AddressableContact("Alex", "Jones", 60, "456 Old Street", 45678),
+      AddressableContact("Bert", "James", 55, "789 New Street", 89010),
+      AddressableContact("Cora", "Jasper", 33, "789 New Street", 89010)
+    )
+  }
+
+  "Simple Join Nested Objects Explicit and Ad-Hoc Case Class" in {
+    val q = quote {
+      for {
+        p <- peopleEntries
+        a <- addressEntries if p.addressFk == a.id
+      } yield (p, a, AddressableContact(p.firstName, p.lastName, p.age, a.street, a.zip))
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      (Contact("Alex", "Jones", 60, 2, "foo"), Address(2, "456 Old Street", 45678, "something else"), AddressableContact("Alex", "Jones", 60, "456 Old Street", 45678)),
+      (Contact("Bert", "James", 55, 3, "bar"), Address(3, "789 New Street", 89010, "another thing"), AddressableContact("Bert", "James", 55, "789 New Street", 89010)),
+      (Contact("Cora", "Jasper", 33, 3, "baz"), Address(3, "789 New Street", 89010, "another thing"), AddressableContact("Cora", "Jasper", 33, "789 New Street", 89010))
+    )
+  }
+
+  "Simple Join Nested Objects" in {
+    val q = quote {
+      peopleEntries.join(addressEntries).on(_.addressFk == _.id)
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      (Contact("Alex", "Jones", 60, 2, "foo"), Address(2, "456 Old Street", 45678, "something else")),
+      (Contact("Bert", "James", 55, 3, "bar"), Address(3, "789 New Street", 89010, "another thing")),
+      (Contact("Cora", "Jasper", 33, 3, "baz"), Address(3, "789 New Street", 89010, "another thing"))
+    )
+  }
+
+  "Simple Join Nested Object" in {
+    val q = quote {
+      for {
+        p <- peopleEntries
+        a <- addressEntries if p.addressFk == a.id
+      } yield (p, a)
+    }
+  }
+
+  "Simple Join Nested Objects Explicit Distinct" in {
+    val q = quote {
+      (for {
+        p <- peopleEntries
+        a <- addressEntries if p.addressFk == a.id
+      } yield (p, a)).distinct
+    }
+    testContext.run(q).show()
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      (Contact("Alex", "Jones", 60, 2, "foo"), Address(2, "456 Old Street", 45678, "something else")),
+      (Contact("Bert", "James", 55, 3, "bar"), Address(3, "789 New Street", 89010, "another thing")),
+      (Contact("Cora", "Jasper", 33, 3, "baz"), Address(3, "789 New Street", 89010, "another thing"))
+    )
+  }
+
+  "Simple Join Nested Objects Explicit Union Distinct" in {
+    val q = quote {
+      (for {
+        p <- (peopleEntries ++ peopleEntries)
+        a <- addressEntries if p.addressFk == a.id
+      } yield (p, a)).distinct
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      (Contact("Alex", "Jones", 60, 2, "foo"), Address(2, "456 Old Street", 45678, "something else")),
+      (Contact("Bert", "James", 55, 3, "bar"), Address(3, "789 New Street", 89010, "another thing")),
+      (Contact("Cora", "Jasper", 33, 3, "baz"), Address(3, "789 New Street", 89010, "another thing"))
+    )
+  }
+
+  "Simple Join Nested Objects Explicit Union Distinct with Filters" in {
+    val q = quote {
+      (for {
+        p <- (peopleEntries.filter(_.age == 55) ++ peopleEntries.filter(_.age == 33) ++ peopleEntries.filter(_.age <= 33))
+        a <- addressEntries if p.addressFk == a.id
+      } yield (p, a)).distinct
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      (Contact("Bert", "James", 55, 3, "bar"), Address(3, "789 New Street", 89010, "another thing")),
+      (Contact("Cora", "Jasper", 33, 3, "baz"), Address(3, "789 New Street", 89010, "another thing"))
+    )
+  }
+
+  "Three Level Join with Two Nested Distincts and Nested Objects" in {
+    val peopleAndIds = quote {
+      for {
+        id <- noteEntries
+        person <- peopleEntries if person.firstName == id.owner
+      } yield (person)
+    }
+
+    val q = quote {
+      (for {
+        p <- peopleAndIds.distinct
+        a <- addressEntries if p.addressFk == a.id
+      } yield (p, a)).distinct
+    }
+
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      (Contact("Bert", "James", 55, 3, "bar"), Address(3, "789 New Street", 89010, "another thing")),
+      (Contact("Alex", "Jones", 60, 2, "foo"), Address(2, "456 Old Street", 45678, "something else"))
+    )
+  }
+
+  "Simple Join Nested Objects Case Class" in {
+    val q = quote {
+      for {
+        p <- peopleEntries
+        a <- addressEntries if p.addressFk == a.id
+      } yield ContactAndAddress(p, a)
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      ContactAndAddress(Contact("Alex", "Jones", 60, 2, "foo"), Address(2, "456 Old Street", 45678, "something else")),
+      ContactAndAddress(Contact("Bert", "James", 55, 3, "bar"), Address(3, "789 New Street", 89010, "another thing")),
+      ContactAndAddress(Contact("Cora", "Jasper", 33, 3, "baz"), Address(3, "789 New Street", 89010, "another thing"))
+    )
+  }
+
+  "Simple Left Join Optional Objects" in {
+    val q = quote {
+      peopleEntries.leftJoin(addressEntries).on(_.addressFk == _.id)
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(
+      (Contact("Alex", "Jones", 60, 2, "foo"), Some(Address(2, "456 Old Street", 45678, "something else"))),
+      (Contact("Bert", "James", 55, 3, "bar"), Some(Address(3, "789 New Street", 89010, "another thing"))),
+      (Contact("Cora", "Jasper", 33, 3, "baz"), Some(Address(3, "789 New Street", 89010, "another thing")))
+    )
+  }
+
   "Simple Join - External Map" in {
     val q = quote {
       for {
@@ -75,7 +241,6 @@ class CaseClassQuerySpec extends Spec {
     val mapped = dataset.map(ac => ContactSimplified(ac.firstName, ac.lastName, ac.firstName.reverse))
 
     mapped.collect() should contain theSameElementsAs expectedData
-
   }
 
   "Simple Select" in {
@@ -165,4 +330,15 @@ class CaseClassQuerySpec extends Spec {
     )
   }
 
+  "Nested Class Right Join" in {
+    val q = quote {
+      for {
+        a <- addressEntries
+        p <- peopleEntries if p.addressFk == a.id
+      } yield (a, p)
+    }
+
+    val expected = addressList.flatMap(a => peopleList.filter(_.addressFk == a.id).map(p => (a, p)))
+    testContext.run(q).collect() should contain theSameElementsAs expected
+  }
 }

--- a/quill-spark/src/test/scala/io/getquill/context/spark/norm/ExpandEntityIdsSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/norm/ExpandEntityIdsSpec.scala
@@ -1,0 +1,179 @@
+package io.getquill.context.spark.norm
+
+import io.getquill.Spec
+import io.getquill.context.spark.{ sqlContext, testContext }
+
+case class Test(i: Int, j: Int, s: String)
+case class TestHolder(ta: Test, tb: Test)
+case class TestHolderHolder(tha: TestHolder, thb: TestHolder)
+case class TestHolderHolderOneSide(tha: TestHolder, tbb: Test)
+case class TupleHolderTest(tup: (Int, Int), otherData: String)
+case class NestedTupleHolderTest(tup: (Int, Test), otherData: String)
+case class ParentNestedTupleHolderTest(tup: NestedTupleHolderTest, otherData: String)
+case class SuperParentNestedTupleHolderTest(tup: (NestedTupleHolderTest, Test), otherData: String)
+
+class ExpandEntityIdsSpec extends Spec {
+
+  import testContext._
+  import sqlContext.implicits._
+
+  val entities = Seq(Test(1, 2, "3"))
+
+  val qr1 = liftQuery(entities.toDS)
+  val qr2 = liftQuery(entities.toDS)
+  val qr3 = liftQuery(entities.toDS)
+  val qr4 = liftQuery(entities.toDS)
+
+  "allows nested returns" - {
+    "entities inside tuples" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+        } yield (a, b)
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => (e, e))
+    }
+    "entities inside multiple levels of tuples" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+          c <- qr3 if (a.i + 1) == c.j && (b.i + 1) == c.j
+        } yield (a, (b, c))
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => (e, (e, e)))
+    }
+    "entities inside ad-hoc case classes" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+        } yield TestHolder(a, b)
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => TestHolder(e, e))
+    }
+    "regular entities and entities inside ad-hoc case classes" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+        } yield (a, b, TestHolder(a, b))
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => (e, e, TestHolder(e, e)))
+    }
+    "entities inside ad-hoc case classes multiple levels" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+          c <- qr3 if (a.i + 1) == c.j
+          d <- qr4 if (c.i + 1) == d.j
+        } yield TestHolderHolder(TestHolder(a, b), TestHolder(a, b))
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => TestHolderHolder(TestHolder(e, e), TestHolder(e, e)))
+    }
+    "entities inside ad-hoc case classes multiple levels different levels" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+          c <- qr3 if (a.i + 1) == c.j
+          d <- qr4 if (c.i + 1) == d.j
+        } yield TestHolderHolderOneSide(TestHolder(a, b), a)
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => TestHolderHolderOneSide(TestHolder(e, e), e))
+    }
+    "entities inside ad-hoc case classes multiple levels mixed with tuples" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+          c <- qr3 if (a.i + 1) == c.j
+          d <- qr4 if (c.i + 1) == d.j
+        } yield (TestHolderHolder(TestHolder(a, b), TestHolder(a, b)), TestHolder(a, b))
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => (TestHolderHolder(TestHolder(e, e), TestHolder(e, e)), TestHolder(e, e)))
+    }
+    "entities inside tuples - with distinct" in {
+      val q = quote {
+        (for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+        } yield (a, b)).distinct
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => (e, e))
+    }
+    "entities inside ad-hoc case classes - with distinct" in {
+      val q = quote {
+        (for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+        } yield TestHolder(a, b)).distinct
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => TestHolder(e, e))
+    }
+    "entities inside tuples with unions" in {
+      val q = quote {
+        qr1.map(r => (r, r)) ++ (qr2.filter(q => (q.i + 1) == q.j).map(r => (r, r)))
+      }
+      testContext.run(q).collect.toList mustEqual (entities.map(e => (e, e)) union entities.map(e => (e, e)))
+    }
+    "entities inside tuples with sub-unions" in {
+      val q = quote {
+        for {
+          a <- (qr1 ++ qr2)
+          b <- qr2 if (a.i + 1) == b.j
+        } yield (a, b)
+      }
+      testContext.run(q).collect.toList mustEqual (entities.map(e => (e, e)) union entities.map(e => (e, e)))
+    }
+  }
+
+  "advanced tuple nesting cases" - {
+    "test tuple holder" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+          c <- qr3 if (a.i + 1) == c.j
+          d <- qr4 if (c.i + 1) == d.j
+        } yield TupleHolderTest((a.i, b.j), c.s)
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => TupleHolderTest((e.i, e.j), e.s))
+    }
+    "test nested tuple holder" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+          c <- qr3 if (a.i + 1) == c.j
+          d <- qr4 if (c.i + 1) == d.j
+        } yield NestedTupleHolderTest((a.i, b), c.s)
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => NestedTupleHolderTest((e.i, e), e.s))
+    }
+    "test nested tuple holder inside parent" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+          c <- qr3 if (a.i + 1) == c.j
+          d <- qr4 if (c.i + 1) == d.j
+        } yield ParentNestedTupleHolderTest(NestedTupleHolderTest((a.i, b), c.s), c.s)
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => ParentNestedTupleHolderTest(NestedTupleHolderTest((e.i, e), e.s), e.s))
+    }
+    "test nested tuple holder inside parent inside super tuple" in {
+      val q = quote {
+        for {
+          a <- qr1
+          b <- qr2 if (a.i + 1) == b.j
+          c <- qr3 if (a.i + 1) == c.j
+          d <- qr4 if (c.i + 1) == d.j
+        } yield SuperParentNestedTupleHolderTest((NestedTupleHolderTest((a.i, b), c.s), c), c.s)
+      }
+      testContext.run(q).collect.toList mustEqual entities.map(e => SuperParentNestedTupleHolderTest((NestedTupleHolderTest((e.i, e), e.s), e), e.s))
+    }
+  }
+}

--- a/quill-spark/src/test/scala/io/getquill/context/spark/package.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/package.scala
@@ -8,6 +8,7 @@ package object spark {
   val sparkSession =
     SparkSession
       .builder()
+      .config("spark.sql.shuffle.partitions", 2) // Default shuffle partitions is 200, too much for tests
       .master("local")
       .appName("spark test")
       .getOrCreate()

--- a/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ObservationMirrorSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/mirror/ObservationMirrorSpec.scala
@@ -10,33 +10,34 @@ class ObservationMirrorSpec extends Spec {
 
   case class LatLon(lat: Int, lon: Int) extends Embedded
   case class ScalarData(value: Long, position: Option[LatLon]) extends Embedded
-  case class Observation(data: Option[ScalarData], foo: Option[String])
+  case class Observation(data: Option[ScalarData], foo: Option[String], bar: Option[String])
 
   val obs = quote {
     querySchema[Observation](
       "observation",
       _.data.map(_.value) -> "obs_value",
       _.data.map(_.position.map(_.lat)) -> "obs_lat",
-      _.data.map(_.position.map(_.lon)) -> "obs_lon"
+      _.data.map(_.position.map(_.lon)) -> "obs_lon",
+      _.bar -> "baz"
     )
   }
 
-  val obsEntry = Observation(Some(ScalarData(123, Some(LatLon(2, 3)))), None)
+  val obsEntry = Observation(Some(ScalarData(123, Some(LatLon(2, 3)))), None, Some("abc"))
 
   "select query" in {
     ctx.run(obs).string mustEqual
-      "SELECT x.obs_value, x.obs_lat, x.obs_lon, x.foo FROM observation x"
+      "SELECT x.obs_value, x.obs_lat, x.obs_lon, x.foo, x.baz FROM observation x"
   }
 
   "insert query" in {
     val r = ctx.run(obs.insert(lift(obsEntry)))
-    r.string mustEqual "INSERT INTO observation (obs_value,obs_lat,obs_lon,foo) VALUES (?, ?, ?, ?)"
-    r.prepareRow mustEqual Row(Some(123), Some(Some(2)), Some(Some(3)), None)
+    r.string mustEqual "INSERT INTO observation (obs_value,obs_lat,obs_lon,foo,baz) VALUES (?, ?, ?, ?, ?)"
+    r.prepareRow mustEqual Row(Some(123), Some(Some(2)), Some(Some(3)), None, Some("abc"))
   }
 
   "update query" in {
     val r = ctx.run(obs.update(lift(obsEntry)))
-    r.string mustEqual "UPDATE observation SET obs_value = ?, obs_lat = ?, obs_lon = ?, foo = ?"
-    r.prepareRow mustEqual Row(Some(123), Some(Some(2)), Some(Some(3)), None)
+    r.string mustEqual "UPDATE observation SET obs_value = ?, obs_lat = ?, obs_lon = ?, foo = ?, baz = ?"
+    r.prepareRow mustEqual Row(Some(123), Some(Some(2)), Some(Some(3)), None, Some("abc"))
   }
 }


### PR DESCRIPTION
Fixes #1073 
Fixes #1076 

### Problem

Spark requires top-level nested entities to be inside SQL-tuples in order to be serialized properly. For instance. Something like this:
````sql
SELECT foo.*, (bar.id, bar.barVal) _2 FROM (ds1) foo, (ds2) bar WHERE foo.barFk = bar.id
````
Actually has to look like this:
````
SELECT (foo.id, foo.fooVal, foo.barFk) _1, (bar.id, bar.barVal) _2 FROM (ds1) foo, (ds2) bar WHERE foo.barFk = bar.id
````
This is because SQL tuples are translated into Spark array objects on the Dataframe from which deserialization is done:
````
+-----------+------------+
|         _1|          _2|
+-----------+------------+
|  [1,one,1]|    [1,blah]|
|  [2,two,2]|[2,blahblah]|
|[3,three,1]|    [1,blah]|
+-----------+------------+
````

### Solution

Wrote the ExpandEntityIds transformer which adds back the needed fields into the Spark-idiom sql.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
