### PR TITLE
[wip] faster build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,48 @@
-language: generic
+sudo: false
+language: scala
+jdk: oraclejdk8
 services:
   - docker
 branches:
   except:
     - release
     - website
-before_script:
-  - ./build/pull_docker_images.sh
-script:
-  - travis_retry docker-compose run setup
-  - travis_retry docker-compose run sbt bash -c "./build/build.sh $TRAVIS_SCALA_VERSION $PROJECT"
-language: scala
-scala:
-  - 2.11.11
-  - 2.12.6
-after_success:
-  - ./build/push_docker_images.sh
-  - pip install --user codecov && codecov
-before_cache:
-  - ./build/cleanup_cache.sh
 cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.m2
     - $HOME/.sbt
-sudo: false
+    - $HOME/compiled
 env:
   global:
+    - S_2_11=2.11.11
+    - S_2_12=2.12.6
     - secure: Glt43/THOQFt4rX7PyBj3eEFgRssB20H8wzw/Isj3pXP0pmG8d0jetVta6cA8geMGLsTh3t/nGdMOKa2fkP7cDD2pGZzgeMBPbpXsyWAForKYC+9fa7AUTmUlY82rKIzMpnvBeYj+XrVtS17+jqTSxB7t1OxJsX9VZB0YOxn9SJADLyGeXLlXcmJfBgdA+l1riUMYEJrWZwLKgSOKDr3qO32UAFRcCWPKBeJZ4qwV/cd5+nmtbMERlV3TsWWgtb03eH9ps+nBcobmsyRYpnrWVlYvqUV7rTmibSMuALoeczK8HDUZjy9XMRSPe2RDlzCtF+Pp8Q2VepBJtKSKu3k4yJ6NMbltgtb+uOtx8lIsVk+JIu4sVQuyYHwJBjfPzSmz/JI3EDYiJqgX9Q4MAn0BCj7QBTqEQdZmsoVWo9E5R7XWXRmr97wPnoKtjPAWM5FCuBITlEmzbHMOCwF3+RBqV+6KMEeq7RrEfrE85OpESntJndVdFikupk/JoektxQWV4aNxrkxlnxntsKxpShOcBHIyCzGrimKn8cHpViF4C/LiqORv1XLK4/bmCQ548db1Gidj9G9x0WTCyhvqiavTAEaj+R4p6XrWxS3+za404ZYQc4BRLn/VacVuaihWkf8F2Bj6V9X1LjnSyBcAWGRm6DaJVyXq7Oh9LzH4/iLyPQ=
     - secure: GVYDRNMwVypUDJXUQe9SCobwVCezyPODG4T2sMFZdZ3IjBV3vpPQxG0vKj5LL3HjRULb6D8X60Rsso/EQKSVs6cbRhU3h1Am4tgO/KjUswTcf97RJMk9a+pz+KmEFemJXYatpqK5uusYaJcMoKj5D4FeR2Z1FQjgLVV5y6dqAZc+lBzGq2l3QJbBgdwgIb7PLPBszdajpO5LZ3rcxKm+VvvittFqCCNA6V8NINnByByYpxy+BRm2JGrbOiDWzNC41RVbOY/xsRkOAHFKKJofh3sSHf/YAVyavCGi0nwmBevsoGS9Lmt9wGPydvuW7mQ58QODxjlpKoidohQRg81TY/rutl+Ul0a3xVFmTNVwK5dqfBekfwZBI7esBat864LdoWXViH93eQHbkYANUMMb14z5TBWprmAwRdUAUhVXxI201bYFpHTRl8ejBvtT/x0B38CRYd3cM2qjKNkhuOq3G2bCcU1iSW5Kn8U8M+sKI8rXkNtzqSKlQzPXznFhmVybNUh8K6FysIaPDwdtkfnzq9Obw8p1fLcHBts1BeaPxzF28GnTV/nsvTV44VF1sLJJ9kep7YlGzNfNM/eTianlQ1TZozVp+z4sAuytRkYoNgC+NpMnnwdqUk74AvKw2ExRHZbMLtMlKvcliV9etzdiaC0ZbKIFCjS1QFOFB2mpDaI=
     - secure: cq/0b2mHyfkpNtoecmJBhsq37vySkzeaH0TN06jAtW9/zGkm5yaIJkPUCdlJmW0on/xgXLCTvrx17nuRXQJmNpO32KfUOPfn7VIKS054Y8s86z61dKarWthTruNEosIdnmp88lV+V9lsjmAlYZv23u0yMDx4U34FYumPrH14eb27gGd/Xc7+LZpMYf3okxGPRtdxZ5KRO05v9dHcR3IthITixL26M6Z2VUb79fXkMiQ5Z17zh8sh1elS6AnE8SkcLYAefHhdJP18vFx3dmMlYY7m+qwfUmZ3YCZjUUYxA1Z+dnH5/mRNww4Se47TZFmoyHycq+P29znH+P7fSN5TnzTd6B5yPzIjFFTogv7BlPOgpq67J7vKeEyJ7mTYa5br84wnIIw1RJOltzhn2DO3YhXGysPzw8icz1RTlOASW86kUBAGiCzHW9iQGk2wll0ARohHSplahN8Qyb5vtUnF9Qep7fS6DTUHqAFCXiS1g7PEmvTD0ns5j+GNXLUy56LMrotpyV+zO5p8822Vu6315dbDkj7+znh+XTXG5we0AZIEAHK/F3BXy3URWmMdnrowPvlMMB20LLGvxOyaZMQsqBxYypHeKXqDMy9+M16LMJdUQRFCQFFunyGedHLJFyucs3ao6L0sxUdirXKFeoXnuB1QhLHQOphwhENuz1OLWmk=
     - secure: YWJ9ho4mwXjy4GrnbjehDlP5wFA6P8KLZMb+jOCEFNI9wKSiKzUUeIqGNog6Q9KCHE+RMEFz/kqE+7jNhhOgGGv0mRF0RVfHL0SkamhD0NMxiC1vITk3+oqMi/v1sK/V88WbfM4+1sAcFqV7yoptyWw/Db7U/MdLcRZaVe2zMz6s4P811CZjpT2Y/EkwxWcxejTCxptAvAkIfrgIyI28xW9hgA9oWvQJjD42ShKd445AC9qNq8E2cY8ukFIMik/FNHYWQMmdUTYOqX68O6fn2lPcIayPNCl0UuY6L9DB0KS0ZxrItX6/0JQU/CR8iFHWxshACvxLAMLUofPl/0QVkoSVaCGrKCX8WpjQ4K2FV/xiXa6xPXSFcI4RRsGkpXe3S6BHdWdH7whEsLDhvIJN3WQREWYqujXNi2imCO08+N0/GuDxfIcCzkrsEZYk5d1h8HQTk6Ml9ahhbL5EbrgEO6z8C/cLoSwebeYPeO7Wlw8y1f0pT8yIMH0cAI0PrdUzhQOgSgMUZGgntCynHyJymwtlHV7y829qsxvf3M0IpjCwK3VAdQLQKt2evFOT2hIbubpzvR6u26zeflpiMr/U8/uZnu3XYCPFLwkAZEDLb1LNfDiXOZY+cG+aX0R/m3hPDv5G5iH0OCTCwJ/usGSRMxdhwgQqltXrhGLUkvKcy8w=
-  matrix:
-    - PROJECT="quill-coreJVM"
-    - PROJECT="quill-coreJS"
-    - PROJECT="quill-sqlJVM"
-    - PROJECT="quill-sqlJS"
-    - PROJECT="quill-spark"
-    - PROJECT="quill-async"
-    - PROJECT="quill-async-mysql"
-    - PROJECT="quill-async-postgres"
-    - PROJECT="quill-cassandra"
-    - PROJECT="quill-finagle-mysql"
-    - PROJECT="quill-finagle-postgres"
-    - PROJECT="quill-jdbc"
-    - PROJECT="quill-orientdb"
 jobs:
   include:
-    - stage: tut
-      script:
-        - docker-compose run sbt sbt tut
+#    - stage: compile
+#      env: SCALA_VERSION=$S_2_11
+#      script: ./build/compile.sh
+
+    - stage: compile
+      env: SCALA_VERSION=$S_2_12
+      script: ./build/compile.sh
+
+    - stage: test 2
+      env: SCALA_VERSION=$S_2_12
+      script: docker-compose run sbt bash -c "./build/test.sh"
+
+#    - stage: test 1
+#      env: SCALA_VERSION=$S_2_11
+#      before_script:
+#        - docker-compose pull
+#        - docker-compose build
+#      script: docker-compose run sbt bash -c "./build/test.sh"
+#      after_success: pip install --user codecov && codecov
+
     - stage: release
-      if: branch = master
-      env:
-        - SCALA_VERSION_2_11=2.11.11
-        - SCALA_VERSION_2_12=2.12.6
-      script:
-        - docker-compose run release
+      if: type != pull_request
+      script: echo Hello!

--- a/build/compile.sh
+++ b/build/compile.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+SBT_CMD="sbt -DscalaVersion=$SCALA_VERSION ++$SCALA_VERSION clean"
+ARCHIVE_PATH="$HOME/compiled/codebase"
+
+if [[ $SCALA_VERSION == $S_2_11 ]]
+then
+    SBT_CMD+=" coverage quill-coreJVM/test:compile"
+    ARCHIVE_PATH+="_2_11.tar.gz"
+elif [[ $SCALA_VERSION == $S_2_12 ]]
+then
+    SBT_CMD+=" quill-coreJVM/test:compile"
+    ARCHIVE_PATH+="_2_12.tar.gz"
+else
+    echo unknown scala version $SCALA_VERSION
+    exit 1
+fi
+echo Working dir is $PWD
+
+$SBT_CMD
+
+BASE=$(basename $PWD)
+cd ..
+echo "Achieving..."
+tar --posix --atime-preserve -zpcf $ARCHIVE_PATH $BASE
+cd $BASE

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASE=$(basename $PWD)
+cd ..
+echo "Extracting..."
+tar --posix --atime-preserve -zxf /compiled/codebase_2_1*.tar.gz
+cd $BASE
+
+SBT_CMD="sbt -DscalaVersion=$SCALA_VERSION ++$SCALA_VERSION quill-coreJVM/test"
+
+if [[ $SCALA_VERSION == $S_2_11 ]]
+then
+    SBT_CMD+=" "
+elif [[ $SCALA_VERSION == $S_2_12 ]]
+then
+    echo ""
+else
+    echo unknown scala version $SCALA_VERSION
+    exit 1
+fi
+
+echo "Compile / skip in ThisBuild := true" >> build.sbt
+echo $SBT_CMD
+$SBT_CMD
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,10 +80,13 @@ services:
       - ~/.m2:/root/.m2
       - ~/.sbt:/root/.sbt
       - ~/.ssh:/root/.ssh
+      - $HOME/compiled:/compiled
     environment:
       - TRAVIS_PULL_REQUEST
       - TRAVIS_BRANCH
       - SCALA_VERSION
+      - S_2_11
+      - S_2_12
       - ENCRYPTION_PASSWORD
       - SBT_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Dfile.encoding=UTF-8 -Xms512m -Xmx1536m -Xss2m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC
       - POSTGRES_HOST=postgres


### PR DESCRIPTION
introduce 3 travis stages:
1. Compile stage. 2 parallel jobs for 2.11/2.12 which compile codebase with `test:compile` and then archive it and put into cache.
2. Test stage. Single job which prepares databases. unpack 2.11/2.12 caches and run tests against databases
3. Release. Single job which release artifacts if needed

@getquill/maintainers
