### PR TITLE
remove double table-creation in sqlserver-schema

### DIFF
--- a/quill-sql/src/test/sql/sqlserver-schema.sql
+++ b/quill-sql/src/test/sql/sqlserver-schema.sql
@@ -97,18 +97,3 @@ CREATE TABLE Address(
     zip int,
     otherExtraInfo VARCHAR(255)
 );
-
-CREATE TABLE Contact(
-    firstName VARCHAR(255),
-    lastName VARCHAR(255),
-    age int,
-    addressFk int,
-    extraInfo VARCHAR(255)
-);
-
-CREATE TABLE Address(
-    id int,
-    street VARCHAR(255),
-    zip int,
-    otherExtraInfo VARCHAR(255)
-);


### PR DESCRIPTION
### Problem

Tables `Contact` and `Address` are created twice in the `sqlserver-schema.sql`. This causes builds to break since they exit the build, travis doesn't understand that, and then thinks it's a stuck-build:
````
Waiting for Sql Server

Sql Server ready
Msg 2714, Level 16, State 6, Server 2376ab1b146e, Line 101
There is already an object named 'Contact' in the database.


The command "travis_retry docker-compose run setup" exited with 0.
$ travis_wait 120 docker-compose run sbt bash -c "./build/build.sh"


Still running (23 of 120): docker-compose run sbt bash -c ./build/build.sh

The job exceeded the maximum time limit for jobs, and has been terminated.
````

### Solution

Remove the extra table-creation statements.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
