### PR TITLE
Adds master-slave capability to FinagleMysqlContext

### DIFF
--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
@@ -1,10 +1,10 @@
 package io.getquill.context.finagle.mysql
 
 import java.util.TimeZone
-
 import com.twitter.finagle.mysql
 import com.twitter.finagle.mysql.{ EmptyValue, Error }
 import com.twitter.util._
+import io.getquill.context.sql.{ TestDecoders, TestEncoders }
 import io.getquill.{ FinagleMysqlContext, _ }
 
 class FinagleMysqlContextSpec extends Spec {
@@ -44,6 +44,38 @@ class FinagleMysqlContextSpec extends Spec {
   "different constructors" in {
     new FinagleMysqlContext(Literal, "testDB", TimeZone.getDefault).close
     new FinagleMysqlContext(Literal, "testDB", TimeZone.getDefault, TimeZone.getDefault).close
+  }
+
+  def masterSlaveContext(
+    master: mysql.Client with mysql.Transactions,
+    slave:  mysql.Client with mysql.Transactions
+  ): FinagleMysqlContext[Literal] = {
+    new FinagleMysqlContext[Literal](Literal, master, slave, TimeZone.getDefault)
+      with TestEntities with TestEncoders with TestDecoders
+  }
+
+  "master & slave client writes to master" in {
+    val master = new OkTestClient
+    val slave = new OkTestClient
+    val context = masterSlaveContext(master, slave)
+
+    import context._
+    await(context.run(qr4.insert(TestEntity4(0))))
+
+    master.methodCount.get() mustBe 1
+    slave.methodCount.get() mustBe 0
+  }
+
+  "master & slave client reads from slave" in {
+    val master = new OkTestClient
+    val slave = new OkTestClient
+    val context = masterSlaveContext(master, slave)
+
+    import context._
+    await(context.run(qr4))
+
+    master.methodCount.get() mustBe 0
+    slave.methodCount.get() mustBe 1
   }
 
   "fail in toOk" in {

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
@@ -50,8 +50,7 @@ class FinagleMysqlContextSpec extends Spec {
     master: mysql.Client with mysql.Transactions,
     slave:  mysql.Client with mysql.Transactions
   ): FinagleMysqlContext[Literal] = {
-    new FinagleMysqlContext[Literal](Literal, master, slave, TimeZone.getDefault)
-      with TestEntities with TestEncoders with TestDecoders
+    new FinagleMysqlContext[Literal](Literal, master, slave, TimeZone.getDefault) with TestEntities with TestEncoders with TestDecoders
   }
 
   "master & slave client writes to master" in {
@@ -60,7 +59,7 @@ class FinagleMysqlContextSpec extends Spec {
     val context = masterSlaveContext(master, slave)
 
     import context._
-    await(context.run(qr4.insert(TestEntity4(0))))
+    await(context.run(query[TestEntity4].insert(TestEntity4(0))))
 
     master.methodCount.get() mustBe 1
     slave.methodCount.get() mustBe 0
@@ -72,7 +71,7 @@ class FinagleMysqlContextSpec extends Spec {
     val context = masterSlaveContext(master, slave)
 
     import context._
-    await(context.run(qr4))
+    await(context.run(query[TestEntity4]))
 
     master.methodCount.get() mustBe 0
     slave.methodCount.get() mustBe 1

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/OkTestClient.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/OkTestClient.scala
@@ -1,0 +1,53 @@
+package io.getquill.context.finagle.mysql
+
+import com.twitter.concurrent.AsyncStream
+import com.twitter.finagle.mysql
+import com.twitter.util.{ Future, Time }
+import java.util.concurrent.atomic.AtomicInteger
+
+class OkTestClient extends mysql.Client with mysql.Transactions {
+  val methodCount = new AtomicInteger
+
+  val ok = mysql.OK(0, 0, 0, 0, "")
+
+  override def query(sql: String): Future[mysql.Result] = {
+    methodCount.incrementAndGet()
+    Future(ok)
+  }
+
+  override def select[T](sql: String)(f: mysql.Row => T): Future[Seq[T]] = {
+    methodCount.incrementAndGet()
+    Future(Seq.empty)
+  }
+  override def prepare(sql: String): mysql.PreparedStatement = {
+    methodCount.incrementAndGet()
+    new mysql.PreparedStatement {
+      override def apply(params: mysql.Parameter*): Future[mysql.Result] = Future(ok)
+    }
+  }
+  override def cursor(sql: String): mysql.CursoredStatement = {
+    methodCount.incrementAndGet()
+    new mysql.CursoredStatement {
+      override def apply[T](rowsPerFetch: Int, params: mysql.Parameter*)(f: mysql.Row => T): Future[mysql.CursorResult[T]] = Future {
+        new mysql.CursorResult[T] {
+          override def stream: AsyncStream[T] = AsyncStream.empty
+          override def close(deadline: Time): Future[Unit] = Future.Unit
+        }
+      }
+    }
+  }
+
+  override def ping(): Future[mysql.Result] = {
+    methodCount.incrementAndGet()
+    Future(ok)
+  }
+
+  override def transaction[T](f: mysql.Client => Future[T]): Future[T] = {
+    f(this)
+  }
+  override def transactionWithIsolation[T](isolationLevel: mysql.IsolationLevel)(f: mysql.Client => Future[T]): Future[T] = {
+    f(this)
+  }
+
+  override def close(deadline: Time): Future[Unit] = Future.Unit
+}


### PR DESCRIPTION
### Problem

Deferring reads to a MySQL slave is not supported in `finagle-mysql`

### Solution

Provide master & slave constructor arguments and perform all queries on slave.


Not sure whether we want to go the extra mile and add unit tests. I was thinking we could create 2 databases in the MySQL docker service and verify that writes were only reflected in the master and reads were only taking place from the slave. Would probably need to add a `.sql` file in the container's `/docker-entrypoint-initdb.d` (according to https://hub.docker.com/_/mysql/) to create a second database.

@getquill/maintainers