### PR TITLE
Fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
 jobs:
   include:
     - stage: release
+      if: branch = master
       env:
         - SCALA_VERSION_2_11=2.11.11
         - SCALA_VERSION_2_12=2.12.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ env:
     - secure: YWJ9ho4mwXjy4GrnbjehDlP5wFA6P8KLZMb+jOCEFNI9wKSiKzUUeIqGNog6Q9KCHE+RMEFz/kqE+7jNhhOgGGv0mRF0RVfHL0SkamhD0NMxiC1vITk3+oqMi/v1sK/V88WbfM4+1sAcFqV7yoptyWw/Db7U/MdLcRZaVe2zMz6s4P811CZjpT2Y/EkwxWcxejTCxptAvAkIfrgIyI28xW9hgA9oWvQJjD42ShKd445AC9qNq8E2cY8ukFIMik/FNHYWQMmdUTYOqX68O6fn2lPcIayPNCl0UuY6L9DB0KS0ZxrItX6/0JQU/CR8iFHWxshACvxLAMLUofPl/0QVkoSVaCGrKCX8WpjQ4K2FV/xiXa6xPXSFcI4RRsGkpXe3S6BHdWdH7whEsLDhvIJN3WQREWYqujXNi2imCO08+N0/GuDxfIcCzkrsEZYk5d1h8HQTk6Ml9ahhbL5EbrgEO6z8C/cLoSwebeYPeO7Wlw8y1f0pT8yIMH0cAI0PrdUzhQOgSgMUZGgntCynHyJymwtlHV7y829qsxvf3M0IpjCwK3VAdQLQKt2evFOT2hIbubpzvR6u26zeflpiMr/U8/uZnu3XYCPFLwkAZEDLb1LNfDiXOZY+cG+aX0R/m3hPDv5G5iH0OCTCwJ/usGSRMxdhwgQqltXrhGLUkvKcy8w=
   matrix:
     - SCALA_VERSION=2.11.11
-    - SCALA_VERSION=2.12.4
+    - SCALA_VERSION=2.12.6
 jobs:
   include:
     - stage: release
       if: branch = master
       env:
         - SCALA_VERSION_2_11=2.11.11
-        - SCALA_VERSION_2_12=2.12.4
+        - SCALA_VERSION_2_12=2.12.6
       script:
         - docker-compose run release

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - ./build/pull_docker_images.sh
 script:
   - travis_retry docker-compose run setup
-  - travis_wait 120 docker-compose run sbt bash -c "./build/build.sh"
+  - docker-compose run sbt bash -c "./build/build.sh"
 after_success:
   - ./build/push_docker_images.sh
   - pip install --user codecov && codecov

--- a/build.sbt
+++ b/build.sbt
@@ -255,7 +255,7 @@ def updateWebsiteTag =
 lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
   organization := "io.getquill",
   scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12","2.12.4"),
+  crossScalaVersions := Seq("2.11.12","2.12.6"),
   libraryDependencies ++= Seq(
     "org.scalamacros" %% "resetallattrs"  % "1.0.0",
     "org.scalatest"   %%% "scalatest"     % "3.0.4"     % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -296,7 +296,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     .setPreference(IndentPackageBlocks, true)
     .setPreference(FormatXml, true)
     .setPreference(PreserveSpaceBeforeArguments, false)
-    .setPreference(DoubleIndentClassDeclaration, false)
+    .setPreference(DoubleIndentConstructorArguments, false)
     .setPreference(RewriteArrowSymbols, false)
     .setPreference(AlignSingleLineCaseStatements, true)
     .setPreference(AlignSingleLineCaseStatements.MaxArrowIndent, 40)

--- a/build.sbt
+++ b/build.sbt
@@ -277,7 +277,8 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard",
-    "-Xfuture"
+    "-Xfuture",
+    "-Ycache-macro-class-loader:last-modified"
   ),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/build.sbt
+++ b/build.sbt
@@ -277,8 +277,7 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard",
-    "-Xfuture",
-    "-Ycache-macro-class-loader:last-modified"
+    "-Xfuture"
   ),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/build/Dockerfile-sbt
+++ b/build/Dockerfile-sbt
@@ -17,9 +17,10 @@ RUN apt-get update; \
     curl -sL https://deb.nodesource.com/setup_8.x | bash -; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs
 
-ENV SBT_VERSION 1.0.4
+ENV SBT_VERSION 1.1.1
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin
+ENV JAVA_OPTS "-Dquill.macro.log=false -Xmx2G -Xms2G"
 
 # Install sbt
 RUN curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local --strip-components=1 && \

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -2,7 +2,7 @@
 
 DB_FILE=quill-jdbc/quill_test.db
 
-rm $DB_FILE
+rm -f $DB_FILE
 
 echo "Waiting for Sqlite"
 until sqlite3 $DB_FILE "SELECT 1" &> /dev/null

--- a/quill-core/src/test/resources/logback.xml
+++ b/quill-core/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
 
 	<!-- <logger name="io.getquill" level="DEBUG" /> -->
 
-	<root level="INFO">
+	<root level="WARN">
 		<appender-ref ref="STDOUT" />
 	</root>
 </configuration>

--- a/quill-core/src/test/resources/logback.xml
+++ b/quill-core/src/test/resources/logback.xml
@@ -6,7 +6,7 @@
 		</encoder>
 	</appender>
 
-	<logger name="io.getquill" level="DEBUG" />
+	<!-- <logger name="io.getquill" level="DEBUG" /> -->
 
 	<root level="INFO">
 		<appender-ref ref="STDOUT" />

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -128,25 +128,3 @@ CREATE TABLE Contact(
     addressFk int,
     extraInfo VARCHAR(255)
 );
-
-CREATE TABLE Address(
-    id int,
-    street VARCHAR(255),
-    zip int,
-    otherExtraInfo VARCHAR(255)
-);
-
-CREATE TABLE Contact(
-    firstName VARCHAR(255),
-    lastName VARCHAR(255),
-    age int,
-    addressFk int,
-    extraInfo VARCHAR(255)
-);
-
-CREATE TABLE Address(
-    id int,
-    street VARCHAR(255),
-    zip int,
-    otherExtraInfo VARCHAR(255)
-);


### PR DESCRIPTION
@getquill/maintainers these changes seem to make travis more stable. Summary:

- Disabled compile and runtime logging of queries since it introduces overhead. It also makes it easier to read the ci logs.
- Upgraded to scala 2.12.6 since it has a new flag that makes macro compilations
- Removed `travis_wait`. The build was failing occasionally with it.
- Updated the sbt docker to pull the sbt version we're using so it doesn't need to download it again
- Fixed some errors warnings that were happening during the build
- Disabled the release stage if the build is not running on master
