### PR TITLE
Fix concatenation operator for SQL Server

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/SQLServerDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/SQLServerDialect.scala
@@ -1,6 +1,6 @@
 package io.getquill
 
-import io.getquill.ast.Ast
+import io.getquill.ast._
 import io.getquill.context.sql.{ FlattenSqlQuery, SqlQuery }
 import io.getquill.idiom.{ Statement, StringToken, Token }
 import io.getquill.context.sql.idiom.SqlIdiom
@@ -31,6 +31,12 @@ trait SQLServerDialect
       case flatten: FlattenSqlQuery if flatten.orderBy.isEmpty && flatten.offset.nonEmpty =>
         fail(s"SQLServer does not support OFFSET without ORDER BY")
       case other => super.sqlQueryTokenizer.token(other)
+    }
+
+  override implicit def operationTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Operation] =
+    Tokenizer[Operation] {
+      case BinaryOperation(a, StringOperator.`+`, b) => stmt"${scopedTokenizer(a)} + ${scopedTokenizer(b)}"
+      case other                                     => super.operationTokenizer.token(other)
     }
 }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SQLServerDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SQLServerDialectSpec.scala
@@ -12,6 +12,14 @@ class SQLServerDialectSpec extends Spec {
   val ctx = new SqlMirrorContext(SQLServerDialect, Literal) with TestEntities
   import ctx._
 
+  "uses + instead of ||" in {
+    val q = quote {
+      qr1.map(t => t.s + t.s)
+    }
+    ctx.run(q).string mustEqual
+      "SELECT t.s + t.s FROM TestEntity t"
+  }
+
   "top" in {
     val q = quote {
       qr1.take(15).map(t => t.i)


### PR DESCRIPTION
Fixes #1054 

### Problem

SQL Server concatonates strings with `+`, not `||` as is the standard.

### Solution

Overwrite the operation tokenizer with correct concatonation.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
