### PR TITLE
build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ before_script:
   - ./build/pull_docker_images.sh
 script:
   - travis_retry docker-compose run setup
-  - docker-compose run sbt bash -c "./build/build.sh"
+  - travis_retry docker-compose run sbt bash -c "./build/build.sh $TRAVIS_SCALA_VERSION $PROJECT"
+language: scala
+scala:
+  - 2.11.11
+  - 2.12.6
 after_success:
   - ./build/push_docker_images.sh
   - pip install --user codecov && codecov
@@ -28,10 +32,24 @@ env:
     - secure: cq/0b2mHyfkpNtoecmJBhsq37vySkzeaH0TN06jAtW9/zGkm5yaIJkPUCdlJmW0on/xgXLCTvrx17nuRXQJmNpO32KfUOPfn7VIKS054Y8s86z61dKarWthTruNEosIdnmp88lV+V9lsjmAlYZv23u0yMDx4U34FYumPrH14eb27gGd/Xc7+LZpMYf3okxGPRtdxZ5KRO05v9dHcR3IthITixL26M6Z2VUb79fXkMiQ5Z17zh8sh1elS6AnE8SkcLYAefHhdJP18vFx3dmMlYY7m+qwfUmZ3YCZjUUYxA1Z+dnH5/mRNww4Se47TZFmoyHycq+P29znH+P7fSN5TnzTd6B5yPzIjFFTogv7BlPOgpq67J7vKeEyJ7mTYa5br84wnIIw1RJOltzhn2DO3YhXGysPzw8icz1RTlOASW86kUBAGiCzHW9iQGk2wll0ARohHSplahN8Qyb5vtUnF9Qep7fS6DTUHqAFCXiS1g7PEmvTD0ns5j+GNXLUy56LMrotpyV+zO5p8822Vu6315dbDkj7+znh+XTXG5we0AZIEAHK/F3BXy3URWmMdnrowPvlMMB20LLGvxOyaZMQsqBxYypHeKXqDMy9+M16LMJdUQRFCQFFunyGedHLJFyucs3ao6L0sxUdirXKFeoXnuB1QhLHQOphwhENuz1OLWmk=
     - secure: YWJ9ho4mwXjy4GrnbjehDlP5wFA6P8KLZMb+jOCEFNI9wKSiKzUUeIqGNog6Q9KCHE+RMEFz/kqE+7jNhhOgGGv0mRF0RVfHL0SkamhD0NMxiC1vITk3+oqMi/v1sK/V88WbfM4+1sAcFqV7yoptyWw/Db7U/MdLcRZaVe2zMz6s4P811CZjpT2Y/EkwxWcxejTCxptAvAkIfrgIyI28xW9hgA9oWvQJjD42ShKd445AC9qNq8E2cY8ukFIMik/FNHYWQMmdUTYOqX68O6fn2lPcIayPNCl0UuY6L9DB0KS0ZxrItX6/0JQU/CR8iFHWxshACvxLAMLUofPl/0QVkoSVaCGrKCX8WpjQ4K2FV/xiXa6xPXSFcI4RRsGkpXe3S6BHdWdH7whEsLDhvIJN3WQREWYqujXNi2imCO08+N0/GuDxfIcCzkrsEZYk5d1h8HQTk6Ml9ahhbL5EbrgEO6z8C/cLoSwebeYPeO7Wlw8y1f0pT8yIMH0cAI0PrdUzhQOgSgMUZGgntCynHyJymwtlHV7y829qsxvf3M0IpjCwK3VAdQLQKt2evFOT2hIbubpzvR6u26zeflpiMr/U8/uZnu3XYCPFLwkAZEDLb1LNfDiXOZY+cG+aX0R/m3hPDv5G5iH0OCTCwJ/usGSRMxdhwgQqltXrhGLUkvKcy8w=
   matrix:
-    - SCALA_VERSION=2.11.11
-    - SCALA_VERSION=2.12.6
+    - PROJECT="quill-coreJVM"
+    - PROJECT="quill-coreJS"
+    - PROJECT="quill-sqlJVM"
+    - PROJECT="quill-sqlJS"
+    - PROJECT="quill-spark"
+    - PROJECT="quill-async"
+    - PROJECT="quill-async-mysql"
+    - PROJECT="quill-async-postgres"
+    - PROJECT="quill-cassandra"
+    - PROJECT="quill-finagle-mysql"
+    - PROJECT="quill-finagle-postgres"
+    - PROJECT="quill-jdbc"
+    - PROJECT="quill-orientdb"
 jobs:
   include:
+    - stage: tut
+      script:
+        - docker-compose run sbt sbt tut
     - stage: release
       if: branch = master
       env:

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,6 @@ lazy val `quill-jdbc` =
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(
-      fork in Test := true,
       libraryDependencies ++= Seq(
         "com.zaxxer"              % "HikariCP"             % "2.7.4",
         "mysql"                   % "mysql-connector-java" % "5.1.42"             % Test,
@@ -86,7 +85,6 @@ lazy val `quill-spark` =
     .settings(mimaSettings: _*)
     .settings(
       crossScalaVersions := Seq("2.11.12"),
-      fork in Test := true,
       libraryDependencies ++= Seq(
         "org.apache.spark" %% "spark-sql" % "2.2.0"
       )
@@ -98,7 +96,6 @@ lazy val `quill-finagle-mysql` =
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(
-      fork in Test := true,
       libraryDependencies ++= Seq(
         "com.twitter" %% "finagle-mysql" % "18.2.0"
       )
@@ -110,7 +107,6 @@ lazy val `quill-finagle-postgres` =
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(
-      fork in Test := true,
       libraryDependencies ++= Seq(
         "io.github.finagle" %% "finagle-postgres" % "0.7.0"
       )
@@ -122,7 +118,6 @@ lazy val `quill-async` =
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(
-      fork in Test := true,
       libraryDependencies ++= Seq(
         "com.github.mauricio" %% "db-async-common"  % "0.2.21"
       )
@@ -134,7 +129,6 @@ lazy val `quill-async-mysql` =
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(
-      fork in Test := true,
       libraryDependencies ++= Seq(
         "com.github.mauricio" %% "mysql-async"      % "0.2.21"
       )
@@ -146,7 +140,6 @@ lazy val `quill-async-postgres` =
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(
-      fork in Test := true,
       libraryDependencies ++= Seq(
         "com.github.mauricio" %% "postgresql-async" % "0.2.21"
       )
@@ -158,7 +151,6 @@ lazy val `quill-cassandra` =
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(
-      fork in Test := true,
       libraryDependencies ++= Seq(
         "com.datastax.cassandra" %  "cassandra-driver-core" % "3.4.0",
         "io.monix"               %% "monix"                 % "2.3.3"
@@ -171,7 +163,6 @@ lazy val `quill-orientdb` =
       .settings(commonSettings: _*)
       .settings(mimaSettings: _*)
       .settings(
-        fork in Test := true,
         libraryDependencies ++= Seq(
           "com.orientechnologies" % "orientdb-graphdb" % "2.2.30"
         )

--- a/build/Dockerfile-sbt
+++ b/build/Dockerfile-sbt
@@ -20,7 +20,7 @@ RUN apt-get update; \
 ENV SBT_VERSION 1.1.1
 ENV SBT_HOME /usr/local/sbt
 ENV PATH ${PATH}:${SBT_HOME}/bin
-ENV JAVA_OPTS "-Dquill.macro.log=false -Xmx2G"
+ENV JAVA_OPTS "-Dquill.macro.log=false -Xmx3G"
 
 # Install sbt
 RUN curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local --strip-components=1 && \

--- a/build/build.sh
+++ b/build/build.sh
@@ -4,21 +4,32 @@ set -e # Any subsequent(*) commands which fail will cause the shell script to ex
 chown root ~/.ssh/config
 chmod 644 ~/.ssh/config
 
-SBT_CMD="sbt -DscalaVersion=$SCALA_VERSION ++$SCALA_VERSION clean"
+SCALA_VERSION=$1
+PROJECT=$2
+
+if [[ $SCALA_VERSION == 2.12* && $PROJECT == "quill-spark" ]]
+then
+    echo "Spark doesn't support Scala 2.12"
+    exit 0
+fi
+
+SBT_CMD="sbt -DscalaVersion=$SCALA_VERSION ++$SCALA_VERSION $PROJECT/clean"
 
 if [[ $SCALA_VERSION == 2.11* ]]
 then
-    SBT_CMD+=" coverage test tut coverageReport coverageAggregate checkUnformattedFiles"
+    SBT_CMD+=" coverage $PROJECT/test checkUnformattedFiles $PROJECT/coverageReport $PROJECT/coverageAggregate"
 elif [[ $SCALA_VERSION == 2.12* ]]
 then
-    SBT_CMD+=" test"
+    SBT_CMD+=" $PROJECT/test"
 else
     exit 1
 fi
 
 if [[ $TRAVIS_PULL_REQUEST == "false" ]]
 then
-    SBT_CMD+=" coverageOff publish"
+    SBT_CMD+=" coverageOff $PROJECT/publish"
+    echo $SBT_CMD
+
     openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/secring.gpg.enc -out local.secring.gpg -d
     openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/pubring.gpg.enc -out local.pubring.gpg -d
     openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/credentials.sbt.enc -out local.credentials.sbt -d
@@ -36,5 +47,6 @@ then
         $SBT_CMD
     fi
 else
+    echo $SBT_CMD
     $SBT_CMD
 fi

--- a/build/credentials.sbt.enc
+++ b/build/credentials.sbt.enc
@@ -1,3 +1,2 @@
-Salted__‰r5xÐ‘ÈæÛÞ>ÌˆÎ±úÛ*Âè+}:¬ôo_Šðÿ•Ÿvýâ.32n²Ië=!2ªÝã\¡¡BÍ;åo[Stä¤ïãcÄ bRøwYÇÀ@¥)(·É
-¨“ß_ZÞ¬¡8Â-nKFùÔð°=/®;ËCV[#°é­ˆPE'¦‡RüÌ(šìÇƒp.Õ-xP	î
-^ãp¡€8Z$ØŽŠªõ*YT	0¨	=¤j‡T)°ËVúw»Õr»ö½‘ŽŽ\öÛ²vpÌ¯äl]nâD¶£SdÄ-]ÀÉ÷ìÙ’"O?–Ÿ:fúµæ5ä¼©QÀ‰{ëÅ$]‰´mÇ®ªQ)?
+Salted__y…ÅR”Äx¯.ÆeUÞAüf»2–x¥io¹iªé¶×Ù8äk[*6ú+„ž*f£ÃjyU†ÌgÜ2nbÎë‰¨Ûˆ0v‡\+/s·&¥M‡¿YH"ÓÎj°ý’Ý~ÈsðT{ä)=³CU—)iáá„u9ìåž­?,—WÑ/öÐ¹Dœy\¢H`äÐßqÒÚk
+Àèe¨à@S˜º²+,\7ÃCI½¹uBþF°¯ÚáÈRWAÂ¡žöYÕVô¤%ÑÙ¯ž´é±2b‘àCU—óˆÑTAá³È¡#Eþ€pždñh÷†ðÏtLø/ýìÏûÔ-ês5tE?‡Ð¥ñûÅï`¦jÌX¾‘\‚ØNYÖßš|

--- a/quill-jdbc/src/test/resources/application.conf
+++ b/quill-jdbc/src/test/resources/application.conf
@@ -17,7 +17,7 @@ testH2DB.dataSource.url="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 
 testH2DB.dataSource.user=sa
 
 testSqliteDB.driverClassName=org.sqlite.JDBC
-testSqliteDB.jdbcUrl="jdbc:sqlite:quill_test.db"
+testSqliteDB.jdbcUrl="jdbc:sqlite:quill-jdbc/quill_test.db"
 
 testSqlServerDB.dataSourceClassName=com.microsoft.sqlserver.jdbc.SQLServerDataSource
 testSqlServerDB.dataSource.user=sa

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -120,11 +120,3 @@ CREATE TABLE Address(
     zip int,
     otherExtraInfo VARCHAR(255)
 );
-
-CREATE TABLE Contact(
-    firstName VARCHAR(255),
-    lastName VARCHAR(255),
-    age int,
-    addressFk int,
-    extraInfo VARCHAR(255)
-);


### PR DESCRIPTION
### Problem

The build is still unstable. The two main issues are the scalajs and spark tests failing occasionally.

### Solution

Use a CI matrix to build modules individually. This approach allows us to use `travis_retry` on individual modules and doesn't require forking of tests since only one module is tested (we can allocate more memory for the VM this way).

### Notes

- The build is still around 1h
- We could reduce the build time by having custom docker containers with only what the specific module needs. We can work on this later.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
