### PR TITLE
Use PreparedStatement.getConnection for JDBC Array Encoders

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayEncoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayEncoders.scala
@@ -41,10 +41,10 @@ trait ArrayEncoders extends ArrayEncoding {
       val bf = implicitly[CanBuildFrom[Nothing, AnyRef, Array[AnyRef]]]
       row.setArray(
         idx,
-        withConnection(_.createArrayOf(
+        row.getConnection.createArrayOf(
           jdbcType,
           seq.foldLeft(bf())((b, x) => b += mapper(x)).result()
-        ))
+        )
       )
     })
   }


### PR DESCRIPTION
Skips calling `Context#withConnection` when encoding JDBC array types since prepared statements contain a reference to the existing connection. 

### Problem

I'm not 100% sure this was the underlying problem, but in load tests we observed what appeared to be a deadlock getting connections from the connection pool when the number of DB threadpool threads was the same as the number of connections. The stack trace pointed to that line as the potential cause:

```
java.sql.SQLTransientConnectionException: hikaricp-default - Connection is not available, request timed out after 6002ms.
	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:676)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:190)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:155)
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:100)
	at io.getquill.context.jdbc.JdbcContext.$anonfun$withConnection$1(JdbcContext.scala:43)
	at scala.Option.getOrElse(Option.scala:121)
	at io.getquill.context.jdbc.JdbcContext.withConnection(JdbcContext.scala:42)
	at io.getquill.context.jdbc.ArrayEncoders.$anonfun$arrayEncoder$1(ArrayEncoders.scala:44)
	at io.getquill.context.jdbc.ArrayEncoders.$anonfun$arrayEncoder$1$adapted(ArrayEncoders.scala:40)
	at io.getquill.context.jdbc.Encoders.$anonfun$encoder$1(Encoders.scala:22)
```

### Solution

The `PrepareRow` aka `PreparedStatement` instance already has a backing connection, and calling `row.getConnection` seems more appropriate.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
