### PR TITLE
disable bindings logging by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1931,9 +1931,9 @@ sbt -Dquill.macro.log=false
 
 Quill uses SLF4J for logging. Each context logs queries which are currently executed.
 It also logs the list of parameters which are bound into prepared statement if any.
-To disable that use `quill.binds.log` option:
+To enable that use `quill.binds.log` option:
 ```
-java -Dquill.binds.log=false -jar myapp.jar
+java -Dquill.binds.log=true -jar myapp.jar
 ```
 
 # Additional resources

--- a/quill-core/src/main/scala/io/getquill/util/ContextLogger.scala
+++ b/quill-core/src/main/scala/io/getquill/util/ContextLogger.scala
@@ -8,18 +8,18 @@ import scala.annotation.tailrec
 class ContextLogger(name: String) {
   val underlying = Logger(LoggerFactory.getLogger(name))
 
-  private val bindsDisabled = sys.props.get("quill.binds.log").contains("false")
+  private val bindsEnabled = sys.props.get("quill.binds.log").contains("true")
   private val nullToken = "null"
 
   def logQuery(query: String, params: Seq[Any]): Unit = {
-    if (bindsDisabled || params.isEmpty) underlying.debug(query)
+    if (!bindsEnabled || params.isEmpty) underlying.debug(query)
     else {
       underlying.debug("{} - binds: {}", query, prepareParams(params))
     }
   }
 
   def logBatchItem(query: String, params: Seq[Any]): Unit = {
-    if (!bindsDisabled) {
+    if (bindsEnabled) {
       underlying.debug("{} - batch item: {}", query, prepareParams(params))
     }
   }


### PR DESCRIPTION
### Problem

Logging binding values by default is a security liability.

### Solution

Disable it by default.


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
