### PR TITLE
Fix for spark optional nested objects

### DIFF
--- a/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
+++ b/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
@@ -2,9 +2,8 @@ package io.getquill
 
 import scala.util.Success
 import scala.util.Try
-import org.apache.spark.sql.Dataset
-import org.apache.spark.sql.{ Encoder => SparkEncoder }
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{ Column, Dataset, Row, SQLContext, Encoder => SparkEncoder }
+import org.apache.spark.sql.functions.{ udf, struct, col }
 import io.getquill.context.Context
 import io.getquill.context.spark.Encoders
 import io.getquill.context.spark.Decoders
@@ -12,6 +11,7 @@ import io.getquill.context.spark.SparkDialect
 import io.getquill.context.spark.Binding
 import io.getquill.context.spark.DatasetBinding
 import io.getquill.context.spark.ValueBinding
+import org.apache.spark.sql.types.{ StructField, StructType }
 
 object QuillSparkContext extends QuillSparkContext
 
@@ -40,11 +40,59 @@ trait QuillSparkContext
       infix"${lift(ds)}".as[Query[T]]
     }
 
+  // Helper class for the perculateNullArrays method
+  case class StructElement(column: Column, structField: StructField) {
+    def children: Array[StructElement] = structField.dataType match {
+      case StructType(fields) => fields.map(f => StructElement(column.getField(f.name), f))
+      case _                  => Array()
+    }
+  }
+
+  /**
+   * As a result of converting product objects from <code>value.*</code> selects in <code>ExpandEntityIds</code>,
+   * when expressing empty options (e.g. as a result of left joins), we will get a array of null values instead of
+   * a single null value like the Spark decode expects. See the issue #123 for more details.
+   *
+   * In order to fix this, we have to convert the array of nulls resulting from the selection of the
+   * <code>o.bar</code>, and <code>o.baz</code> fields. We do this in two steps.
+   * <ol>
+   *   <li> We recursively traverse through <code>o</code>'s selected fields to see if they in turn have sub fields inside.
+   *   For example, the selection could be <code>(o.bar, (o.waz, o.kaz) oo)</code>
+   *   </li>
+   *   <li> Then at every level of the recursion, we introduce a UDF that will nullify the entire row if all
+   *   of the elements of that row are null.
+   *   </li>
+   * </ol>
+   *
+   * As a result of these two steps, arrays whose values are all null should be recursively translated to single null objects.
+   */
+  private def perculateNullArrays[T: SparkEncoder](ds: Dataset[T]) = {
+    def nullifyNullArray(schema: StructType) = udf(
+      (row: Row) => if ((0 until row.length).map(row.isNullAt(_)).forall(n => n)) null else row,
+      schema
+    )
+
+    def perculateNullArraysRecursive(node: StructElement): Column =
+      node.structField.dataType match {
+        case st: StructType =>
+          // Recursively convert all parent array columns to single null values if all their children are null
+          val preculatedColumn = struct(node.children.map(perculateNullArraysRecursive(_)): _*)
+          // Then express that column back out the schema
+          nullifyNullArray(st)(preculatedColumn).as(node.structField.name)
+        case _ =>
+          node.column.as(node.structField.name)
+      }
+
+    ds.select(
+      ds.schema.fields.map(f => perculateNullArraysRecursive(StructElement(col(f.name), f))): _*
+    ).as[T]
+  }
+
   def executeQuery[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit enc: SparkEncoder[T], spark: SQLContext) =
-    spark.sql(prepareString(string, prepare)).as[T]
+    perculateNullArrays(spark.sql(prepareString(string, prepare)).as[T])
 
   def executeQuerySingle[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit enc: SparkEncoder[T], spark: SQLContext) =
-    spark.sql(prepareString(string, prepare)).as[T]
+    perculateNullArrays(spark.sql(prepareString(string, prepare)).as[T])
 
   private def prepareString(string: String, prepare: Prepare)(implicit spark: SQLContext) = {
     var dsId = 0


### PR DESCRIPTION
Fixes #1096 

### Problem

When using nested objects with quill-spark which are null, an array of null values is returned instead of a single null value.

 As a result of converting product objects from `value.*` selects in `ExpandEntityIds`,
 when expressing empty options (e.g. as a result of left joins), we will get a array of null values instead of
 a single null value like the Spark decode expects. See the issue #123 for more details. 
 
 For example,
 Say we have a Quill query like this:
 
 ````scala
   case class SomeTable(id:Int)
   case class SomeOtherTable(fk:Int, bar:String, baz:String)

   quote {
     for {
       t <- liftQuery(someDataSet)
       o <- liftQuery(someOtherDataSet).leftJoin(_.fk == i.id)
     } yield (t, o)
   }
````

 This creates a SQL query like this:
 
 ````sql
   select t.foo, (o.bar, o.baz) from ? t left join ? o on t.id = o.fk
 ````

 This will result in Spark returning the following in the dataframe when `o` the table
 cannot be found does not match a entry as a result of the left join.

 TODO Scastie example sketch

 When re-encoding this object however, Spark expects this row to be an instance of SomeOtherTable
 but whose fields are all nullable i.e. defined as SomeOtherTable(fk:Option[Int], bar:Option[String], baz:Option[String])
 whose actual values are SomeOtherTable(fk:None, bar:None, baz:None).

 In order to fix this, we have to convert the array of nulls resulting from the selection of the
 `o.bar`, and `o.baz` fields. We do this in two steps.
 
 1. We recursively traverse through `o`'s selected fields to see if they in turn have sub fields inside. For example, the selection could be `(o.bar, (o.waz, o.kaz) oo)`

 2. Then at every level of the recursion, we introduce a UDF `perculateNullArrays` that will nullify the entire row if all of the elements of that row are null. In the above example it would be: `perculateNullArrays((o.bar, perculateNullArrays((o.waz, o.kaz)) oo))`

 As a result of these two steps, arrays whose values are all null should be recursively translated to single null objects.

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
