### PR TITLE
Fix IO Re-run

### DIFF
--- a/quill-core/src/main/scala/io/getquill/monad/IOMonad.scala
+++ b/quill-core/src/main/scala/io/getquill/monad/IOMonad.scala
@@ -114,7 +114,7 @@ trait IOMonad {
 
     def recoverWith[U >: T, E2 <: Effect](pf: PartialFunction[Throwable, IO[U, E2]]): IO[U, E with E2] =
       transformWith {
-        case Failure(t)     => pf.applyOrElse(t, (t: Throwable) => IO.failed(t))
+        case Failure(t)     => pf.applyOrElse(t, IO.failed _)
         case s @ Success(_) => IO.fromTry(s)
       }
 

--- a/quill-core/src/test/scala/io/getquill/monad/IOMonadSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/IOMonadSpec.scala
@@ -1,6 +1,9 @@
 package io.getquill.monad
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import io.getquill.Spec
+
 import scala.util.Success
 import scala.util.Try
 import scala.util.Failure
@@ -387,18 +390,17 @@ trait IOMonadSpec extends Spec {
         eval(io) mustEqual 2
       }
       "flatMap and recoverWith" in {
-        var evalCount = 0
+        val evalCount = new AtomicInteger(0)
         val e = new Exception("failure")
         val io = Run(() => {
-          evalCount += 1
-          resultValue[Int](1)
+          resultValue[Int](evalCount.incrementAndGet())
         }).flatMap { _ =>
           IO.failed(e)
         }.recoverWith {
           case _: VirtualMachineError => IO.successful(-1) // won't match the error
         }
         Try(eval(io)) mustEqual Failure(e)
-        evalCount mustEqual 1
+        evalCount.get() mustEqual 1
       }
     }
 

--- a/quill-core/src/test/scala/io/getquill/monad/ScalaFutureIOMonadSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/ScalaFutureIOMonadSpec.scala
@@ -1,5 +1,7 @@
 package io.getquill.monad
 
+import scala.concurrent.Future
+
 class ScalaFutureIOMonadSpec extends IOMonadSpec {
 
   override val ctx = io.getquill.testAsyncContext
@@ -8,4 +10,6 @@ class ScalaFutureIOMonadSpec extends IOMonadSpec {
   override def eval[T](io: IO[T, _]) = {
     ctx.eval(ctx.performIO(io))
   }
+
+  override def resultValue[T](x: T): Result[T] = Future.successful(x)
 }

--- a/quill-core/src/test/scala/io/getquill/monad/SyncIOMonadSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/SyncIOMonadSpec.scala
@@ -8,6 +8,8 @@ class SyncIOMonadSpec extends IOMonadSpec {
   override def eval[T](io: IO[T, _]) =
     performIO[T](io)
 
+  override def resultValue[T](x: T): Result[T] = x
+
   "runIO" - {
     "RunQuerySingleResult" in {
       val q = quote(qr1.map(_.i).max)

--- a/quill-finagle-mysql/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
@@ -5,7 +5,7 @@ import com.twitter.util.{ Await, Future }
 
 class TwitterFutureIOMonadSpec extends IOMonadSpec {
 
-  val ctx = testContext
+  override val ctx = testContext
   import ctx._
 
   override def eval[T](io: IO[T, _]): T = Await.result(performIO(io))

--- a/quill-finagle-mysql/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
@@ -1,13 +1,15 @@
 package io.getquill.monad
 
 import io.getquill.context.finagle.mysql.testContext
-import com.twitter.util.Await
+import com.twitter.util.{ Await, Future }
 
 class TwitterFutureIOMonadSpec extends IOMonadSpec {
 
   val ctx = testContext
   import ctx._
 
-  def eval[T](io: IO[T, _]): T =
-    Await.result(performIO(io))
+  override def eval[T](io: IO[T, _]): T = Await.result(performIO(io))
+
+  override def resultValue[T](x: T): Result[T] = Future.value[T](x)
+
 }

--- a/quill-finagle-postgres/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/monad/TwitterFutureIOMonadSpec.scala
@@ -1,13 +1,16 @@
 package io.getquill.monad
 
 import io.getquill.context.finagle.postgres.testContext
-import com.twitter.util.Await
+import com.twitter.util.{ Await, Future }
 
 class TwitterFutureIOMonadSpec extends IOMonadSpec {
 
-  val ctx = testContext
+  override val ctx = testContext
   import ctx._
 
-  def eval[T](io: IO[T, _]): T =
+  override def eval[T](io: IO[T, _]): T =
     Await.result(performIO(io))
+
+  override def resultValue[T](x: T): Result[T] = Future.value[T](x)
+
 }


### PR DESCRIPTION
### Problem
The IO monad implementation could re-run actions under certain combinations of `TransformWith`. See the below example for a fairly minimal reproducible case:

```scala
runIO(
  quote(query[Person].insert(_.name -> lift(name))) // will execute twice
).flatMap { _ =>
   IO.failed(new Exception("failure"))
}.recoverWith {
  case t: SomeNotMatchedExceptionType => // not matched exception type
    IO.successful(0)
}
```

This was enough to trigger the insert to run twice. Thankfully, in our case we had a unique constraint exception so this didn't actually produce multiple inserts. Other users might not be so lucky.

### Solution

The `flatMap` and `recoverWith` IO transformations should not return `this`, but rather an instance of `FromTry` when the success / failure cases don't actually execute the provided transform function.

I changed a few unrelated IO transformations to re-use scala.util.{Success, Failure} instances instead of re-creating them.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
