### PR TITLE
fix orientdb image to old sha

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - HEAP_NEWSIZE=64m
 
   orientdb:
-    image: orientdb:latest
+    image: orientdb@sha256:4e5305d089aa1a1c2c9934f4110a6ded38b26ba89c75975e75043e2b88594aee
     ports:
       - "12424:2424"
     environment:


### PR DESCRIPTION
### Problem

The build is failing on mater because the orientdb docker image is pointing to `latest`, which was updated recently and doesn't work with quill.

### Solution

Fix the orientdb to a specific sha pointing to the working version.

### Notes

I'll merge this as a hotfix

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
