### PR TITLE
Add question mark escaping for Spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1447,6 +1447,21 @@ def filter(myDataset: Dataset[Person], name: String): Dataset[Int] =
 
 Note that the `run` method returns a `Dataset` transformed by the Quill query using the SQL engine.
 
+Additionally, note that the queries printed from `run(myQuery)` during compile time escape question marks via a backslash them in order to
+be able to substitute liftings properly. They are then returned back to their original form before running.
+```scala
+import org.apache.spark.sql.Dataset
+
+run {
+  liftQuery(myDataset).filter(_.field == "?").map(_.anotherField)
+}
+// This is generated during compile time:
+// SELECT x1.anotherField _1 FROM (?) x1 WHERE x1.field = '\?'
+// It is reverted upon run-time:
+// SELECT x1.anotherField _1 FROM (ds1) x1 WHERE x1.field = '?'
+```
+
+
 **Important**: Spark doesn't support transformations of inner classes. Use top-level classes.
 
 ## SQL Contexts

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -11,7 +11,7 @@ import io.getquill.ast.StringOperator
 import io.getquill.ast.Tuple
 import io.getquill.ast.Value
 import io.getquill.ast.CaseClass
-import io.getquill.context.spark.norm.ExpandEntityIds
+import io.getquill.context.spark.norm.{EscapeQuestionMarks, ExpandEntityIds}
 import io.getquill.context.sql.SqlQuery
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.norm.SqlNormalize
@@ -30,7 +30,7 @@ class SparkDialect extends SqlIdiom {
   override def prepareForProbing(string: String) = string
 
   override def translate(ast: Ast)(implicit naming: NamingStrategy) = {
-    val normalizedAst = SqlNormalize(ast)
+    val normalizedAst = EscapeQuestionMarks(SqlNormalize(ast))
 
     implicit val tokernizer = defaultTokenizer
 

--- a/quill-spark/src/main/scala/io/getquill/context/spark/norm/EscapeQuestionMarks.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/norm/EscapeQuestionMarks.scala
@@ -1,0 +1,17 @@
+package io.getquill.context.spark.norm
+
+import io.getquill.ast._
+import QuestionMarkEscaper._
+
+object EscapeQuestionMarks extends StatelessTransformer {
+
+  override def apply(ast: Ast): Ast =
+    ast match {
+      case Constant(value) =>
+        Constant(if (value.isInstanceOf[String]) escape(value.asInstanceOf[String]) else value)
+      case Infix(parts, params) =>
+        Infix(parts.map(escape(_)), params)
+      case other =>
+        super.apply(other)
+    }
+}

--- a/quill-spark/src/main/scala/io/getquill/context/spark/norm/QuestionMarkEscaper.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/norm/QuestionMarkEscaper.scala
@@ -1,0 +1,11 @@
+package io.getquill.context.spark.norm
+
+import java.util.regex.Matcher
+
+object QuestionMarkEscaper {
+  def escape(str:String) = str.replace("?", "\\?")
+  def unescape(str:String) = str.replace("\\?", "?")
+
+  def pluginValueSafe(str:String, value:String) =
+    str.replaceFirst("(?<!\\\\)\\?", Matcher.quoteReplacement(escape(value)))
+}

--- a/quill-spark/src/test/scala/io/getquill/context/spark/QuestionMarkSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/QuestionMarkSpec.scala
@@ -1,0 +1,68 @@
+package io.getquill.context.spark
+
+import io.getquill.Spec
+import org.scalatest.Matchers._
+
+class QuestionMarkSpec extends Spec {
+  val context = io.getquill.context.sql.testContext
+  import testContext._
+  import sqlContext.implicits._
+
+  val peopleList = Seq(
+    Contact("Alex", "Jones", 60, 2, "?"),
+    Contact("Bert", "James", 55, 3, "bar")
+  )
+
+  val addressList = Seq(
+    Address(1, "123 Fake Street", 11234, "?")
+  )
+
+  "simple variable usage must work" in {
+    val q = quote {
+      for {
+        p <- liftQuery(peopleList.toDS()) if p.extraInfo == "?" && p.firstName == lift("Alex")
+      } yield p
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(peopleList(0))
+  }
+
+  "simple variable usage must work in the middle of a stirng" in {
+    val newContact = Contact("Moe","Rabbenu", 123, 2, "Something ? Something ? Else")
+    val extraPeopleList = peopleList :+ newContact
+
+    val q = quote {
+      for {
+        p <- liftQuery(extraPeopleList.toDS()) if p.extraInfo == "Something ? Something ? Else" && p.firstName == lift("Moe")
+      } yield p
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(newContact)
+  }
+
+  "lift usage" in {
+    val q = quote {
+      for {
+        p <- liftQuery(peopleList.toDS()) if p.extraInfo == lift("?") && p.firstName == lift("Alex")
+      } yield p
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(peopleList(0))
+  }
+
+  "infix usage must work" in {
+    val q = quote {
+      for {
+        p <- liftQuery(peopleList.toDS()) if p.extraInfo == infix"'?'".as[String] && p.firstName == lift("Alex")
+      } yield p
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq(peopleList(0))
+  }
+
+  "simple join on question mark" in {
+    val q = quote {
+      for {
+        p <- liftQuery(peopleList.toDS()) if p.extraInfo == "?" && p.firstName == lift("Alex")
+        a <- liftQuery(addressList.toDS()) if p.extraInfo == a.otherExtraInfo
+      } yield (p, a)
+    }
+    testContext.run(q).collect() should contain theSameElementsAs Seq((peopleList(0), addressList(0)))
+  }
+}

--- a/quill-spark/src/test/scala/io/getquill/context/spark/norm/QuestionMarkEscaperSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/norm/QuestionMarkEscaperSpec.scala
@@ -1,0 +1,50 @@
+package io.getquill.context.spark.norm
+
+import io.getquill.Spec
+import QuestionMarkEscaper._
+
+class QuestionMarkEscaperSpec extends Spec {
+
+  "should escape strings with question marks and even ones with slashes already" in {
+    escape("foo ? bar \\? baz \\\\?") must equal ("foo \\? bar \\\\? baz \\\\\\?")
+  }
+
+  "should escape and then unescape going back to original form" in {
+    val str = "foo ? bar \\? baz \\\\?"
+    unescape(escape(str)) must equal (str)
+  }
+
+  def plug1(str:String) = pluginValueSafe(str, "<1>")
+  def plug2(str:String) = pluginValueSafe(plug1(str), "<2>")
+  def plug3(str:String) = pluginValueSafe(plug2(str), "<3>")
+  def plug4(str:String) = pluginValueSafe(plug3(str), "<4>")
+
+  def plug2Q(str:String) = pluginValueSafe(plug1(str), "<2?>")
+  def plug3QN(str:String) = pluginValueSafe(plug2Q(str), "<3>")
+  def plug4Q(str:String) = pluginValueSafe(plug3QN(str), "<4?>")
+
+  "should escape and replace variables correctly" in {
+    val str = "foo ? bar ? ?"
+    plug1(str) must equal ("foo <1> bar ? ?")
+    plug2(str) must equal ("foo <1> bar <2> ?")
+    plug3(str) must equal ("foo <1> bar <2> <3>")
+  }
+
+  "should escape and replace variables correctly with other question marks" in {
+    val str = "foo ? bar \\? ? baz ? \\\\? ?"
+    plug1(str) must equal ("foo <1> bar \\? ? baz ? \\\\? ?")
+    plug2(str) must equal ("foo <1> bar \\? <2> baz ? \\\\? ?")
+    plug3(str) must equal ("foo <1> bar \\? <2> baz <3> \\\\? ?")
+    plug4(str) must equal ("foo <1> bar \\? <2> baz <3> \\\\? <4>")
+    unescape(plug4(str)) must equal ("foo <1> bar ? <2> baz <3> \\? <4>")
+  }
+
+  "should escape and replace variables correctly even if the variables have question marks" in {
+    val str = "foo ? bar \\? ? baz ? \\\\? ?"
+    plug1(str) must equal ("foo <1> bar \\? ? baz ? \\\\? ?")
+    plug2Q(str) must equal ("foo <1> bar \\? <2\\?> baz ? \\\\? ?")
+    plug3QN(str) must equal ("foo <1> bar \\? <2\\?> baz <3> \\\\? ?")
+    plug4Q(str) must equal ("foo <1> bar \\? <2\\?> baz <3> \\\\? <4\\?>")
+    unescape(plug4Q(str)) must equal ("foo <1> bar ? <2?> baz <3> \\? <4?>")
+  }
+}


### PR DESCRIPTION
Fixes #1111 

### Problem
Question marks in string constants, lifted values, or infixes cause variable substition to break.

### Solution
Escape all question marks during compile time in string constants and infixes, and during runtime in liftings. Escaping for string constants and infixes is done by adding a new stateless transformer called `EscapeQuestionMarks`. Escaping for liftings is done when infix values are substituted into the `prepareString` method of the `QuillSparkDialect`. The actual escaping simple converts all single question marks into double question marks and uses a regex to translated them back into single question marks after all variables are successfuly substituted.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
