### PR TITLE
Fix typo in setup_mysql of setup_db_scripts.sh

### DIFF
--- a/build/setup_db_scripts.sh
+++ b/build/setup_db_scripts.sh
@@ -27,7 +27,7 @@ function setup_sqlite() {
 function setup_mysql() {
     connection=$2
     if [[ "$2" == "mysql" ]]; then
-       conn="mysql -proot"
+       connection="mysql -proot"
        hacks="mysql -h mysql -u root -proot -e \"ALTER USER 'root'@'%' IDENTIFIED BY ''\""
     fi
 


### PR DESCRIPTION
Fixes #1114

### Problem

typo in setup_db_scripts.sh caused hanging of local build

### Solution

fix typo

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
