### PR TITLE
Allow mapping MySQL `TIMESTAMP` and `DATETIME` to Joda `DateTime` type.

### DIFF
--- a/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncEncodingSpec.scala
+++ b/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/MysqlAsyncEncodingSpec.scala
@@ -3,7 +3,7 @@ package io.getquill.context.async.mysql
 import java.time.{ LocalDate, LocalDateTime }
 
 import io.getquill.context.sql.EncodingSpec
-import org.joda.time.{ LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
+import org.joda.time.{ DateTime => JodaDateTime, LocalDate => JodaLocalDate, LocalDateTime => JodaLocalDateTime }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
@@ -84,6 +84,17 @@ class MysqlAsyncEncodingSpec extends EncodingSpec {
     } yield result
     Await.result(r, Duration.Inf)
     ()
+  }
+
+  "decode joda DateTime and Date types" in {
+    case class DateEncodingTestEntity(v1: LocalDate, v2: JodaDateTime, v3: JodaDateTime)
+    val entity = DateEncodingTestEntity(LocalDate.now, JodaDateTime.now, JodaDateTime.now)
+    val r = for {
+      _ <- testContext.run(query[DateEncodingTestEntity].delete)
+      _ <- testContext.run(query[DateEncodingTestEntity].insert(lift(entity)))
+      result <- testContext.run(query[DateEncodingTestEntity])
+    } yield result
+    Await.result(r, Duration.Inf) must contain(entity)
   }
 
   "decode joda LocalDate and LocalDateTime types" in {

--- a/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
@@ -124,7 +124,8 @@ trait Decoders {
   implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoder[Array[Byte]](PartialFunction.empty, SqlTypes.TINYINT)
 
   implicit val jodaDateTimeDecoder: Decoder[JodaDateTime] = decoder[JodaDateTime]({
-    case dateTime: JodaDateTime => dateTime
+    case dateTime: JodaDateTime           => dateTime
+    case localDateTime: JodaLocalDateTime => localDateTime.toDateTime
   }, SqlTypes.TIMESTAMP)
 
   implicit val jodaLocalDateDecoder: Decoder[JodaLocalDate] = decoder[JodaLocalDate]({

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncodingSpec.scala
@@ -120,8 +120,8 @@ class FinagleMysqlEncodingSpec extends EncodingSpec {
 
     def verify(result: DateEncodingTestEntity) = {
       round(result.v1.getTime, 24.hours) mustEqual round(entity.v1.getTime, 24.hours)
-      result.v2.getTime mustEqual round(entity.v2.getTime, 1.second)
-      result.v3.getTime mustEqual round(entity.v3.getTime, 1.second)
+      result.v2.getTime mustEqual entity.v2.getTime
+      result.v3.getTime mustEqual entity.v3.getTime
     }
 
     "default timezone" in {

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -56,8 +56,8 @@ CREATE TABLE EncodingTestEntity(
 
 Create TABLE DateEncodingTestEntity(
     v1 date,
-    v2 datetime,
-    v3 timestamp
+    v2 datetime(6),
+    v3 timestamp(6)
 );
 
 Create TABLE LocalDateTimeEncodingTestEntity(


### PR DESCRIPTION
Changed `Decoder[JodaDateTime]` to be able to handle `JodaLocalDateTime` fields for MySQL
Added test case for `DateTime` conversion.
Changed testing MySQL schema, so that it can test if fractional second part is correct.

### Problem

It could not map `TIMESTAMP` or `DATETIME` type of MySQL to Joda `DateTime` because the Quill decoder didn't handle matching type.

### Solution

Added partial function which handles `JodaLocalDateTime` which is return type of `mysql-async` module.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
