### PR TITLE
scala-js 0.6.24

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,4 +23,6 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")


### PR DESCRIPTION
### Problem

latest scala-js version is 0.6.24.
We should update scala-js version if support latest scala 2.11.x, 2.12.x versions and scala 2.13 milestone version.

### Solution

update scala-js version, use sbt-crossproject and fix some warnings in build.sbt 
- https://github.com/portable-scala/sbt-crossproject#migration-from-scalajs-default-crossproject
- https://www.scala-js.org/news/2018/05/22/announcing-scalajs-0.6.23/

### Notes


### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
