### PR TITLE
use Scala 2.11.12 in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: scala
 scala:
-  - 2.11.11
+  - 2.11.12
   - 2.12.6
 jdk: oraclejdk8
 services:

--- a/build/release.sh
+++ b/build/release.sh
@@ -25,7 +25,7 @@ then
         git push --delete origin website || true
 
         $SBT_CMD ++2.12.6 'release with-defaults'
-        $SBT_CMD -Dspark.include=true ++2.11.11 'release with-defaults'
+        $SBT_CMD -Dspark.include=true ++2.11.12 'release with-defaults'
 
     elif [[ $TRAVIS_BRANCH == "master" ]]
     then


### PR DESCRIPTION
Fixes #issue_number

### Problem

use correct version of Scala in Travis build

### Solution

Scala 2.11.12 in .travis.yml

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
