### PR TITLE
Fix unnecessary nesting of infix queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.6.0-SNAPSHOT
+
+- [Fix unnecessary nesting of infix queries](https://github.com/getquill/quill/pull/1131)
+
+### Migration notes
+
+- When the infix starts with a query, the resulting sql query won't be nested
+
 # 2.5.4
 
 - [Adds master-slave capability to FinagleMysqlContext](https://github.com/getquill/quill/pull/1079)

--- a/README.md
+++ b/README.md
@@ -1154,6 +1154,22 @@ ctx.run(a)
 
 The `forUpdate` quotation can be reused for multiple queries.
 
+### Raw SQL queries
+
+You can also use infix to port raw SQL queries to Quill and map it to regular scala tuples.
+
+```scala
+val rawQuery = quote {
+  (id: Int) => infix"""SELECT id, name FROM my_entity WHERE id = $id""".as[Query[(Int, String)]]
+}
+ctx.run(rawQuery(1))
+//SELECT x._1, x._2 FROM (SELECT id AS "_1", name AS "_2" FROM my_entity WHERE id = 1) x
+```
+
+Note that in this case the result query is nested.
+It's required since quill is not aware of a query tree and cannot safely unnest it.
+This is different to the example above because infix starts with the query `infix"$q...` where its tree is already compiled
+
 ### Database functions
 
 A custom database function can also be used through infix:
@@ -1169,18 +1185,6 @@ val q = quote {
 
 ctx.run(q)
 // SELECT MY_FUNCTION(p.age) FROM Person p
-```
-
-### Raw SQL queries
-
-You can also use infix to port raw SQL queries to Quill and map it to regular scala tuples.
- 
-```scala
-val rawQuery = quote {
-  (id: Int) => infix"""SELECT id AS "_1", name AS "_2" FROM my_entity WHERE id = $id""".as[Query[(Int, String)]]
-}
-ctx.run(rawQuery(1))
-//SELECT id AS "_1", name AS "_2" FROM my_entity WHERE id = 1
 ```
 
 ### Comparison operators

--- a/README.md
+++ b/README.md
@@ -1149,7 +1149,7 @@ val a = quote {
 }
 
 ctx.run(a)
-// SELECT p.id, p.name, p.age FROM (SELECT * FROM Person p WHERE p.age < 18 FOR UPDATE) p
+// SELECT p.name, p.age FROM person p WHERE p.age < 18 FOR UPDATE
 ```
 
 The `forUpdate` quotation can be reused for multiple queries.

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandMappedInfix.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandMappedInfix.scala
@@ -1,0 +1,12 @@
+package io.getquill.context.sql.norm
+
+import io.getquill.ast._
+
+object ExpandMappedInfix {
+  def apply(q: Ast): Ast = {
+    Transform(q) {
+      case Map(Infix("" :: parts, (q: Query) :: params), x, p) =>
+        Infix("" :: parts, Map(q, x, p) :: params)
+    }
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
@@ -19,6 +19,8 @@ object SqlNormalize {
       .andThen(trace("RenameProperties"))
       .andThen(ExpandJoin.apply _)
       .andThen(trace("ExpandJoin"))
+      .andThen(ExpandMappedInfix.apply _)
+      .andThen(trace("ExpandMappedInfix"))
       .andThen(Normalize.apply _)
       .andThen(trace("Normalize"))
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -1044,6 +1044,15 @@ class SqlIdiomSpec extends Spec {
         testContext.run(infix"DELETE FROM TestEntity".as[Action[TestEntity]]).string mustEqual
           "DELETE FROM TestEntity"
       }
+      "do not nest query if infix starts with input query" in {
+        case class Entity(i: Int)
+        val forUpdate = quote {
+          q: Query[Entity] => infix"$q FOR UPDATE".as[Query[Entity]].map(a => a.i)
+        }
+        testContext.run(forUpdate(query[Entity])).string mustEqual
+          "SELECT a.i FROM Entity a FOR UPDATE"
+      }
+
     }
     "if" - {
       "simple" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandMappedInfixSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandMappedInfixSpec.scala
@@ -1,0 +1,31 @@
+package io.getquill.context.sql.norm
+
+import io.getquill.Spec
+import io.getquill.context.sql.testContext._
+
+class ExpandMappedInfixSpec extends Spec {
+  "expand infix out of map body if first part is empty" in {
+    val forUpdate = quote {
+      q: Query[TestEntity] => infix"$q FOR UPDATE".as[Query[TestEntity]]
+    }
+    val q = quote {
+      forUpdate(qr1).map(x => x)
+    }
+    q.ast.toString mustEqual
+      s"""infix"$${querySchema("TestEntity")} FOR UPDATE".map(x => x)"""
+
+    ExpandMappedInfix(q.ast).toString mustEqual
+      s"""infix"$${querySchema("TestEntity").map(x => x)} FOR UPDATE""""
+  }
+
+  "do not expand other cases" in {
+    val forUpdate = quote {
+      q: Query[TestEntity] => infix"SELECT $q FOR UPDATE".as[Query[TestEntity]]
+    }
+    val q = quote {
+      forUpdate(qr1).map(x => x)
+    }
+    ExpandMappedInfix(q.ast) mustEqual q.ast
+  }
+
+}


### PR DESCRIPTION
Fixes #1058

### Problem

`InfixContext` of `SqlQuery` always produces a nested query, sometimes this is unnecessary, see issue example. 

### Solution

Unnest queries.

```scala 
implicit class ForUpdate[T](q: Query[T]) {
  def forUpdate = quote(infix"$q FOR UPDATE".as[Query[T]])
}
run(query[Person].forUpdate)

// before
// SELECT p.id, p.name, p.age FROM (SELECT * FROM Person p WHERE p.age < 18 FOR UPDATE) p	

// after
// SELECT p.name, p.age FROM person p WHERE p.age < 18 FOR UPDATE
```

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
