### PR TITLE
Fix renaming fields with schema/query meta for queries where unary/binary operation produces nested query

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -16,12 +16,6 @@ object RenameProperties extends StatelessTransformer {
     e match {
       case UnaryOperation(o, c: Query) =>
         UnaryOperation(o, applySchemaOnly(apply(c)))
-      case BinaryOperation(a, b, c) =>
-        def applyIfQuery(a: Ast) = a match {
-          case q: Query => applySchemaOnly(apply(q))
-          case _        => a
-        }
-        BinaryOperation(applyIfQuery(a), b, applyIfQuery(c))
       case _ => super.apply(e)
     }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -319,7 +319,7 @@ class RenamePropertiesSpec extends Spec {
           e.filter(a => e.filter(b => b.i > 0).isEmpty && a.s == "test").map(_.i)
         }
         testContext.run(q).string mustEqual
-          "SELECT a.field_i FROM test_entity a WHERE NOT EXISTS (SELECT b.* FROM test_entity b WHERE b.i > 0) AND a.field_s = 'test'"
+          "SELECT a.field_i FROM test_entity a WHERE NOT EXISTS (SELECT b.* FROM test_entity b WHERE b.field_i > 0) AND a.field_s = 'test'"
       }
       "query body" in {
         val q = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -305,6 +305,30 @@ class RenamePropertiesSpec extends Spec {
           "SELECT a.field_s, SUM(a.field_i) FROM test_entity a GROUP BY a.field_s"
       }
     }
+
+    "operation" - {
+      "unary" in {
+        val q = quote {
+          e.filter(a => e.filter(b => b.i > 0).isEmpty).map(_.i)
+        }
+        testContext.run(q).string mustEqual
+          "SELECT a.field_i FROM test_entity a WHERE NOT EXISTS (SELECT b.* FROM test_entity b WHERE b.field_i > 0)"
+      }
+      "binary" in {
+        val q = quote {
+          e.filter(a => e.filter(b => b.i > 0).isEmpty && a.s == "test").map(_.i)
+        }
+        testContext.run(q).string mustEqual
+          "SELECT a.field_i FROM test_entity a WHERE NOT EXISTS (SELECT b.* FROM test_entity b WHERE b.i > 0) AND a.field_s = 'test'"
+      }
+      "query body" in {
+        val q = quote {
+          e.filter(a => a.i > 0).isEmpty
+        }
+        testContext.run(q).string mustEqual
+          "SELECT NOT EXISTS (SELECT a.* FROM test_entity a WHERE a.field_i > 0)"
+      }
+    }
   }
 
   "respects the schema definition for embeddeds" - {


### PR DESCRIPTION
Fixes #1132

THis PR addresses to issues with `RenameProperties` one from the #1132 and another found while debugging.

### Problem

1. #1132 case of `Map(q: Operation, x, p)` is ignored by renaming
2. `Query(ast, i1, body: Operation)` - the query in `body` will have different ident to `i1`, hence beta reduction won't rename the nested query.

### Solution

1. Add such case in `RenameProperties`.
2. Override transformer of `Operation` in `RenameProperties` to apply custom logic.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
