### PR TITLE
Use Option.getOrElse(boolean) to generate ... OR IS [NOT] NULL queries

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
@@ -7,10 +7,15 @@ object FlattenOptionOperation extends StatelessTransformer {
   private def isNotEmpty(ast: Ast) =
     BinaryOperation(ast, EqualityOperator.`!=`, NullValue)
 
+  private def emptyOrNot(b: Boolean, ast: Ast) =
+    if (b) OptionIsEmpty(ast) else OptionNonEmpty(ast)
+
   override def apply(ast: Ast): Ast =
     ast match {
       case OptionFlatten(ast) =>
         apply(ast)
+      case OptionGetOrElse(OptionMap(ast, alias, body), Constant(b: Boolean)) =>
+        apply(BinaryOperation(BetaReduction(body, alias -> ast), BooleanOperator.`||`, emptyOrNot(b, ast)): Ast)
       case OptionGetOrElse(ast, body) =>
         apply(If(isNotEmpty(ast), ast, body))
       case OptionFlatMap(ast, alias, body) =>

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -36,6 +36,28 @@ class FlattenOptionOperationSpec extends Spec {
       FlattenOptionOperation(q.ast.body: Ast) mustEqual
         BinaryOperation(Ident("o"), NumericOperator.`+`, Constant(1))
     }
+    "map + getOrElse(true)" in {
+      val q = quote {
+        (o: Option[Int]) => o.map(_ < 1).getOrElse(true)
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        BinaryOperation(
+          BinaryOperation(Ident("o"), NumericOperator.`<`, Constant(1)),
+          BooleanOperator.`||`,
+          OptionIsEmpty(Ident("o"))
+        )
+    }
+    "map + getOrElse(false)" in {
+      val q = quote {
+        (o: Option[Int]) => o.map(_ < 1).getOrElse(false)
+      }
+      FlattenOptionOperation(q.ast.body: Ast) mustEqual
+        BinaryOperation(
+          BinaryOperation(Ident("o"), NumericOperator.`<`, Constant(1)),
+          BooleanOperator.`||`,
+          OptionNonEmpty(Ident("o"))
+        )
+    }
     "forall" in {
       val q = quote {
         (o: Option[Int]) => o.forall(i => i != 1)

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -775,6 +775,16 @@ class QuotationSpec extends Spec {
         }
         quote(unquote(q)).ast.body mustEqual OptionGetOrElse(Ident("o"), Constant(11))
       }
+      "map + getOrElse" in {
+        val q = quote {
+          (o: Option[Int]) => o.map(i => i < 10).getOrElse(true)
+        }
+        quote(unquote(q)).ast.body mustEqual
+          OptionGetOrElse(
+            OptionMap(Ident("o"), Ident("i"), BinaryOperation(Ident("i"), NumericOperator.`<`, Constant(10))),
+            Constant(true)
+          )
+      }
       "flatten" in {
         val q = quote {
           (o: Option[Option[Int]]) => o.flatten

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -1019,6 +1019,22 @@ class SqlIdiomSpec extends Spec {
             "DELETE FROM TestEntity WHERE o IS NOT NULL"
         }
       }
+      "getOrElse" - {
+        "is null" in {
+          val q = quote {
+            qr1.filter { t => t.o.map(_ < 10).getOrElse(true) }.map(t => t.i)
+          }
+          testContext.run(q).string mustEqual
+            "SELECT t.i FROM TestEntity t WHERE t.o < 10 OR t.o IS NULL"
+        }
+        "is not null" in {
+          val q = quote {
+            qr1.filter { t => t.o.map(_ < 10).getOrElse(false) }.map(t => t.i)
+          }
+          testContext.run(q).string mustEqual
+            "SELECT t.i FROM TestEntity t WHERE t.o < 10 OR t.o IS NOT NULL"
+        }
+      }
     }
     "infix" - {
       "part of the query" in {


### PR DESCRIPTION
Fixes #490 

### Problem

Implements the use of `Option.getOrElse(true)` to generate `... OR IS NULL` query and `Option.getOrElse(false)` to generate `... OR IS NOT NULL` query.

### Solution

Flattens `OptionGetOrElse` in a different way in `FlattenOptionOperation` class.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
