### PR TITLE
add IO.lift

### DIFF
--- a/quill-core/src/main/scala/io/getquill/monad/IOMonad.scala
+++ b/quill-core/src/main/scala/io/getquill/monad/IOMonad.scala
@@ -38,6 +38,8 @@ trait IOMonad {
 
   object IO {
 
+    def lift[T](result: => Result[T]): IO[T, Effect] = Run(() => result)
+
     def fromTry[T](result: Try[T]): IO[T, Effect] = FromTry(result)
 
     def sequence[A, M[X] <: TraversableOnce[X], E <: Effect](in: M[IO[A, E]])(implicit cbfIOToResult: CanBuildFrom[M[IO[A, E]], Result[A], M[Result[A]]], cbfResultToValue: CanBuildFrom[M[Result[A]], A, M[A]]): IO[M[A], E] =

--- a/quill-core/src/test/scala/io/getquill/monad/IOMonadSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/monad/IOMonadSpec.scala
@@ -22,6 +22,12 @@ trait IOMonadSpec extends Spec {
 
   "IO companion object" - {
 
+    "lift" in {
+      val t = Success(1)
+      val io = IO.lift(resultValue(1))
+      Try(eval(io)) mustEqual t
+    }
+
     "fromTry" - {
       "success" in {
         val t = Success(1)


### PR DESCRIPTION
### Problem

There's no way to lift a `Future` into `IO`.

### Solution

Add `IO.lift` that receives a `Result`, which is a `Future` for async contexts.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
