### PR TITLE
Cassandra async improvements

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -37,7 +37,7 @@ class CassandraAsyncContext[N <: NamingStrategy](
   }
 
   def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[List[T]] =
-    Future(prepare(this.prepare(cql))).flatMap {
+    this.prepareAsync(cql).map(prepare).flatMap {
       case (params, bs) =>
         logger.logQuery(cql, params)
         session.executeAsync(bs)
@@ -48,7 +48,7 @@ class CassandraAsyncContext[N <: NamingStrategy](
     executeQuery(cql, prepare, extractor).map(handleSingleResult)
 
   def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Unit] = {
-    Future(prepare(this.prepare(cql))).flatMap {
+    this.prepareAsync(cql).map(prepare).flatMap {
       case (params, bs) =>
         logger.logQuery(cql, params)
         session.executeAsync(bs).map(_ => ())

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
@@ -76,12 +76,12 @@ class CassandraStreamContext[N <: NamingStrategy](
 
 
   private def prepareRowAndLog(cql: String, prepare: Prepare = identityPrepare): Task[PrepareRow] = {
-    Task.async[PrepareRow] {(scheduler, callback) =>
+    Task.async[PrepareRow] { (scheduler, callback) =>
       implicit val executor: Scheduler = scheduler
 
       super.prepareAsync(cql)
         .map(prepare)
-        .onComplete{
+        .onComplete {
           case Success((params, bs)) =>
             logger.logQuery(cql, params)
             callback.onSuccess(bs)

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
@@ -8,12 +8,12 @@ import scala.collection.JavaConverters._
 import io.getquill.context.cassandra.CassandraSessionContext
 import io.getquill.context.cassandra.util.FutureConversions.toScalaFuture
 import monix.reactive.Observable
-import io.getquill.util.{ContextLogger, LoadConfig}
+import io.getquill.util.{ ContextLogger, LoadConfig }
 import com.datastax.driver.core.Cluster
 import monix.eval.Task
-import monix.execution.{Cancelable, Scheduler}
+import monix.execution.{ Cancelable, Scheduler }
 
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 class CassandraStreamContext[N <: NamingStrategy](
   naming:                     N,
@@ -73,7 +73,6 @@ class CassandraStreamContext[N <: NamingStrategy](
           .flatMap(executeAction(cql, _))
           .map(_ => ())
     }
-
 
   private def prepareRowAndLog(cql: String, prepare: Prepare = identityPrepare): Task[PrepareRow] = {
     Task.async[PrepareRow] { (scheduler, callback) =>

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraStreamContext.scala
@@ -8,9 +8,12 @@ import scala.collection.JavaConverters._
 import io.getquill.context.cassandra.CassandraSessionContext
 import io.getquill.context.cassandra.util.FutureConversions.toScalaFuture
 import monix.reactive.Observable
-import io.getquill.util.{ ContextLogger, LoadConfig }
+import io.getquill.util.{ContextLogger, LoadConfig}
 import com.datastax.driver.core.Cluster
 import monix.eval.Task
+import monix.execution.{Cancelable, Scheduler}
+
+import scala.util.{Failure, Success}
 
 class CassandraStreamContext[N <: NamingStrategy](
   naming:                     N,
@@ -43,10 +46,10 @@ class CassandraStreamContext[N <: NamingStrategy](
   }
 
   def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Observable[T] = {
-    val (params, bs) = prepare(super.prepare(cql))
-    logger.logQuery(cql, params)
+
     Observable
-      .fromFuture(session.executeAsync(bs))
+      .fromTask(prepareRowAndLog(cql, prepare))
+      .mapFuture(session.executeAsync(_))
       .flatMap(Observable.fromAsyncStateAction((rs: ResultSet) => page(rs).map((_, rs)))(_))
       .takeWhile(_.nonEmpty)
       .flatMap(Observable.fromIterable)
@@ -57,9 +60,10 @@ class CassandraStreamContext[N <: NamingStrategy](
     executeQuery(cql, prepare, extractor)
 
   def executeAction[T](cql: String, prepare: Prepare = identityPrepare): Observable[Unit] = {
-    val (params, bs) = prepare(super.prepare(cql))
-    logger.logQuery(cql, params)
-    Observable.fromFuture(session.executeAsync(bs)).map(_ => ())
+    Observable
+      .fromTask(prepareRowAndLog(cql, prepare))
+      .mapFuture(session.executeAsync(_))
+      .map(_ => ())
   }
 
   def executeBatchAction(groups: List[BatchGroup]): Observable[Unit] =
@@ -69,4 +73,23 @@ class CassandraStreamContext[N <: NamingStrategy](
           .flatMap(executeAction(cql, _))
           .map(_ => ())
     }
+
+
+  private def prepareRowAndLog(cql: String, prepare: Prepare = identityPrepare): Task[PrepareRow] = {
+    Task.async[PrepareRow] {(scheduler, callback) =>
+      implicit val executor: Scheduler = scheduler
+
+      super.prepareAsync(cql)
+        .map(prepare)
+        .onComplete{
+          case Success((params, bs)) =>
+            logger.logQuery(cql, params)
+            callback.onSuccess(bs)
+          case Failure(ex) =>
+            callback.onError(ex)
+        }
+
+      Cancelable.empty
+    }
+  }
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
@@ -1,13 +1,13 @@
 package io.getquill.context.cassandra
 
-import com.datastax.driver.core.{Cluster, _}
+import com.datastax.driver.core.{ Cluster, _ }
 import io.getquill.NamingStrategy
 import io.getquill.context.Context
-import io.getquill.context.cassandra.encoding.{CassandraTypes, Decoders, Encoders, UdtEncoding}
+import io.getquill.context.cassandra.encoding.{ CassandraTypes, Decoders, Encoders, UdtEncoding }
 import io.getquill.util.Messages.fail
 import io.getquill.context.cassandra.util.FutureConversions._
 import scala.collection.JavaConverters._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
 abstract class CassandraSessionContext[N <: NamingStrategy](
@@ -55,8 +55,7 @@ abstract class CassandraSessionContext[N <: NamingStrategy](
   protected def prepare(cql: String): BoundStatement =
     preparedStatementCache(cql)(session.prepare)
 
-  protected def prepareAsync(cql: String)
-                            (implicit executionContext: ExecutionContext): Future[BoundStatement] =
+  protected def prepareAsync(cql: String)(implicit executionContext: ExecutionContext): Future[BoundStatement] =
     preparedStatementCache.async(cql)(session.prepareAsync(_))
 
   def close() = {

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
@@ -1,12 +1,13 @@
 package io.getquill.context.cassandra
 
-import com.datastax.driver.core.{ Cluster, _ }
+import com.datastax.driver.core.{Cluster, _}
 import io.getquill.NamingStrategy
 import io.getquill.context.Context
-import io.getquill.context.cassandra.encoding.{ CassandraTypes, Decoders, Encoders, UdtEncoding }
+import io.getquill.context.cassandra.encoding.{CassandraTypes, Decoders, Encoders, UdtEncoding}
 import io.getquill.util.Messages.fail
-
+import io.getquill.context.cassandra.util.FutureConversions._
 import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 abstract class CassandraSessionContext[N <: NamingStrategy](
@@ -53,6 +54,10 @@ abstract class CassandraSessionContext[N <: NamingStrategy](
 
   protected def prepare(cql: String): BoundStatement =
     preparedStatementCache(cql)(session.prepare)
+
+  protected def prepareAsync(cql: String)
+                            (implicit executionContext: ExecutionContext): Future[BoundStatement] =
+    preparedStatementCache.async(cql)(session.prepareAsync(_))
 
   def close() = {
     session.close

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/PrepareStatementCache.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/PrepareStatementCache.scala
@@ -2,12 +2,12 @@ package io.getquill.context.cassandra
 
 import java.util.concurrent.Callable
 
-import com.datastax.driver.core.{BoundStatement, PreparedStatement}
+import com.datastax.driver.core.{ BoundStatement, PreparedStatement }
 import com.google.common.base.Charsets
 import com.google.common.cache.CacheBuilder
 import com.google.common.hash.Hashing
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Success
 
 class PrepareStatementCache(size: Long) {
@@ -28,9 +28,7 @@ class PrepareStatementCache(size: Long) {
       }
     ).bind
 
-  def async(stmt: String)
-           (prepare: String => Future[PreparedStatement])
-           (implicit context: ExecutionContext): Future[BoundStatement] = {
+  def async(stmt: String)(prepare: String => Future[PreparedStatement])(implicit context: ExecutionContext): Future[BoundStatement] = {
     val key = hash(stmt)
     val found = cache.getIfPresent(key)
 
@@ -39,7 +37,6 @@ class PrepareStatementCache(size: Long) {
       case Success(s) => cache.put(key, s)
     }.map(_.bind())
   }
-
 
   private def hash(string: String): java.lang.Long = {
     hasher

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/PrepareStatementCache.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/PrepareStatementCache.scala
@@ -1,8 +1,14 @@
 package io.getquill.context.cassandra
 
 import java.util.concurrent.Callable
-import com.datastax.driver.core.PreparedStatement
+
+import com.datastax.driver.core.{BoundStatement, PreparedStatement}
+import com.google.common.base.Charsets
 import com.google.common.cache.CacheBuilder
+import com.google.common.hash.Hashing
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
 
 class PrepareStatementCache(size: Long) {
 
@@ -12,11 +18,33 @@ class PrepareStatementCache(size: Long) {
       .maximumSize(size)
       .build[java.lang.Long, PreparedStatement]
 
-  def apply(stmt: String)(prepare: String => PreparedStatement) =
+  private val hasher = Hashing.goodFastHash(128)
+
+  def apply(stmt: String)(prepare: String => PreparedStatement): BoundStatement =
     cache.get(
-      stmt.hashCode,
+      hash(stmt),
       new Callable[PreparedStatement] {
         override def call = prepare(stmt)
       }
     ).bind
+
+  def async(stmt: String)
+           (prepare: String => Future[PreparedStatement])
+           (implicit context: ExecutionContext): Future[BoundStatement] = {
+    val key = hash(stmt)
+    val found = cache.getIfPresent(key)
+
+    if (found != null) Future.successful(found.bind)
+    else prepare(stmt).andThen {
+      case Success(s) => cache.put(key, s)
+    }.map(_.bind())
+  }
+
+
+  private def hash(string: String): java.lang.Long = {
+    hasher
+      .hashString(string, Charsets.UTF_8)
+      .asLong()
+  }
+
 }


### PR DESCRIPTION
### Problems

* cassandra async and sreamings libs are not fully async. Prepare statements receiving is blocking
* prepare statements cache uses `hashCode`, (simple tests produce collision with rate about 0.012%)

### Solution

* modified PrepareStatementCache for work with async statements
* added async vesion of statement receiving
* updated async/streaming contexts
* replaced `hashCode` with more precise `Hashing.goodFastHash` from Guava


