### PR TITLE
Not auto wrap an infix query with map

### DIFF
--- a/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
@@ -21,7 +21,11 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
     }
 
   private def expandQueryWithDecoder(quoted: Tree, method: String, decoder: Tree) = {
-    val ast = Map(extractAst(quoted), Ident("x"), Ident("x"))
+    val extracted = extractAst(quoted)
+    val ast = extracted match {
+      case i: Infix => i
+      case _        => Map(extracted, Ident("x"), Ident("x"))
+    }
     c.untypecheck {
       q"""
         ..${EnableReflectiveCalls(c)}

--- a/quill-core/src/test/scala/io/getquill/context/ContextMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/ContextMacroSpec.scala
@@ -144,7 +144,7 @@ class ContextMacroSpec extends Spec {
           infix"SELECT ${lift("a")}".as[Query[String]]
         }
         val r = testContext.run(q)
-        r.string mustEqual s"""infix"SELECT $${?}".map(x => x)"""
+        r.string mustEqual s"""infix"SELECT $${?}""""
         r.prepareRow mustEqual Row("a")
       }
       "dynamic" in {

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
@@ -170,7 +170,7 @@ trait OrientDBIdiom extends Idiom {
   implicit def sourceTokenizer(implicit strategy: NamingStrategy): Tokenizer[FromContext] = Tokenizer[FromContext] {
     case TableContext(name, alias)  => stmt"${name.token}"
     case QueryContext(query, alias) => stmt"(${query.token})"
-    case InfixContext(infix, alias) => stmt"(${(infix: Ast).token})"
+    case InfixContext(infix, alias) => stmt"(${(infix: Ast).token}) ${alias.token}"
     case _                          => fail("OrientDB sql doesn't support joins")
   }
 

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/OrientDBIdiomSpec.scala
@@ -327,7 +327,12 @@ class OrientDBIdiomSpec extends Spec {
           infix"SELECT MODE(i) FROM TestEntity".as[Query[Int]]
         }
         ctx.run(q).string mustEqual
-          "SELECT * FROM (SELECT MODE(i) FROM TestEntity)"
+          "SELECT MODE(i) FROM TestEntity"
+      }
+      "as select context" in {
+        val es = quote(infix"SELECT 1 FROM Test_Entity".as[Query[Int]])
+        val q = quote(es.map(i => i + 1))
+        ctx.run(q).string must equal("SELECT i + 1 FROM (SELECT 1 FROM Test_Entity) i")
       }
     }
     "action" - {

--- a/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
+++ b/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
@@ -38,7 +38,7 @@ trait QuillSparkContext
 
   def liftQuery[T](ds: Dataset[T]) =
     quote {
-      infix"${lift(ds)}".as[Query[T]]
+      infix"SELECT * FROM (${lift(ds)})".as[Query[T]]
     }
 
   // Helper class for the perculateNullArrays method

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -99,7 +99,7 @@ class SqlQuerySpec extends Spec {
           infix"""SELECT t.i FROM TestEntity t""".as[Query[Int]]
         }
         testContext.run(q).string mustEqual
-          """SELECT x.* FROM (SELECT t.i FROM TestEntity t) x"""
+          """SELECT t.i FROM TestEntity t"""
       }
     }
 


### PR DESCRIPTION

### Problem

Auto wrap infix with map sometimes make invalid sql
And get ride of `xxxClass.newInstance` to make java 9/10 happy

@getquill/maintainers
