### PR TITLE
Fix Infix causing ignoring renamings

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -109,6 +109,21 @@ object RenameProperties extends StatelessTransformer {
       case Map(q: Operation, x, p) if x == p =>
         (Map(apply(q), x, p), Tuple(List.empty))
 
+      case Map(Infix(parts, params), x, p) =>
+        val schema = params.collect {
+          case q: Query =>
+            val (_, schema) = applySchema(q)
+            schema
+        } match {
+          case e :: Nil => e
+          case ls       => Tuple(ls)
+        }
+        val replace = replacements(x, schema)
+        val pr = BetaReduction(p, replace: _*)
+        val prr = apply(pr)
+
+        (Map(Infix(parts, params), x, prr), schema)
+
       case q =>
         (q, Tuple(List.empty))
     }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -406,6 +406,19 @@ class RenamePropertiesSpec extends Spec {
           "INSERT INTO A (bC) VALUES (1)"
       }
     }
+
+    "infix" - {
+      "does not break schema" in {
+        case class B(b: Int) extends Embedded
+        case class A(u: Long, v: Int, w: B)
+        val q = quote {
+          infix"${querySchema[A]("C", _.v -> "m", _.w.b -> "n")} LIMIT 10".as[Query[A]]
+        }
+
+        testContext.run(q).string mustEqual
+          "SELECT x.u, x.m, x.n FROM C x LIMIT 10"
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #1138

### Problem

Pattern matching in `RenameProperties` expected `Query` even in cases where an `Ast` could slip trough.

### Solution

Use `Ast` instead of `Query` in partial functions in `RenameProperties.applySchema` and add the `Infix` case there.

### Notes

The tests locally failed with an error regarding some DB connection. Probing?
I hope that PR will trigger CI. I'll check the checklist as soon as I know the tests pass.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers