### PR TITLE
Add encoding between java.time.ZonedDateTime and java.util.Date

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encodings.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encodings.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.cassandra.encoding
 
-import java.time.{ Instant, LocalDate }
+import java.time.{ Instant, LocalDate, ZonedDateTime, ZoneId }
 import java.util.Date
 
 import com.datastax.driver.core.{ LocalDate => CasLocalDate }
@@ -16,4 +16,9 @@ trait Encodings extends CassandraMapperConversions with CassandraTypes {
 
   implicit val encodeJava8Instant: MappedEncoding[Instant, Date] = MappedEncoding(Date.from)
   implicit val decodeJava8Instant: MappedEncoding[Date, Instant] = MappedEncoding(_.toInstant)
+
+  implicit val encodeJava8ZonedDateTime: MappedEncoding[ZonedDateTime, Date] = MappedEncoding(zdt =>
+    Date.from(zdt.toInstant))
+  implicit val decodeJava8ZonedDateTime: MappedEncoding[Date, ZonedDateTime] = MappedEncoding(d =>
+    ZonedDateTime.ofInstant(d.toInstant, ZoneId.systemDefault))
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encodings.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encodings.scala
@@ -9,6 +9,8 @@ import io.getquill.context.cassandra.CassandraContext
 trait Encodings extends CassandraMapperConversions with CassandraTypes {
   this: CassandraContext[_] =>
 
+  protected val zoneId = ZoneId.systemDefault
+
   implicit val encodeJava8LocalDate: MappedEncoding[LocalDate, CasLocalDate] = MappedEncoding(ld =>
     CasLocalDate.fromYearMonthDay(ld.getYear, ld.getMonthValue, ld.getDayOfMonth))
   implicit val decodeJava8LocalDate: MappedEncoding[CasLocalDate, LocalDate] = MappedEncoding(ld =>
@@ -20,5 +22,5 @@ trait Encodings extends CassandraMapperConversions with CassandraTypes {
   implicit val encodeJava8ZonedDateTime: MappedEncoding[ZonedDateTime, Date] = MappedEncoding(zdt =>
     Date.from(zdt.toInstant))
   implicit val decodeJava8ZonedDateTime: MappedEncoding[Date, ZonedDateTime] = MappedEncoding(d =>
-    ZonedDateTime.ofInstant(d.toInstant, ZoneId.systemDefault))
+    ZonedDateTime.ofInstant(d.toInstant, zoneId))
 }


### PR DESCRIPTION
Fixes #1185 

### Problem

Missing Encoding for `java.time.ZonedDateTime`.

### Solution

Added it!

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
