### PR TITLE
Add upsert support for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,9 +705,9 @@ ctx.run(a)
 
 ### insert or update (upsert, conflict)
 
-Upsert is only supported by Postgres and MySQL
+Upsert is supported by Postgres, SQLite and MySQL
 
-#### Postgres
+#### Postgres and SQLite
 Ignore conflict
 ```scala
 val a = quote {

--- a/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
+++ b/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
 
 CREATE TABLE IF NOT EXISTS TestEntity(
     s VARCHAR(255),
-    i INTEGER,
+    i INTEGER primary key,
     l BIGINT,
     o INTEGER
 );

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OnConflictJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OnConflictJdbcSpec.scala
@@ -1,0 +1,35 @@
+package io.getquill.context.jdbc.sqlite
+
+import io.getquill.context.sql.OnConflictSpec
+
+class OnConflictJdbcSpec extends OnConflictSpec {
+  val ctx = testContext
+  import ctx._
+
+  override protected def beforeAll(): Unit = {
+    ctx.run(qr1.delete)
+    ()
+  }
+
+  "ON CONFLICT DO NOTHING" in {
+    import `onConflictIgnore`._
+    ctx.run(testQuery1) mustEqual res1
+    ctx.run(testQuery2) mustEqual res2
+    ctx.run(testQuery3) mustEqual res3
+  }
+
+  "ON CONFLICT (i) DO NOTHING" in {
+    import `onConflictIgnore(_.i)`._
+    ctx.run(testQuery1) mustEqual res1
+    ctx.run(testQuery2) mustEqual res2
+    ctx.run(testQuery3) mustEqual res3
+  }
+
+  "ON CONFLICT (i) DO UPDATE ..." in {
+    import `onConflictUpdate(_.i)((t, e) => ...)`._
+    ctx.run(testQuery(e1)) mustEqual res1
+    ctx.run(testQuery(e2)) mustEqual res2
+    ctx.run(testQuery(e3)) mustEqual res3
+    ctx.run(testQuery4) mustEqual res4
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/PostgresDialect.scala
@@ -3,15 +3,14 @@ package io.getquill
 import java.util.concurrent.atomic.AtomicInteger
 
 import io.getquill.ast._
-import io.getquill.context.sql.idiom.{ ConcatSupport, QuestionMarkBindVariables, SqlIdiom }
+import io.getquill.context.sql.idiom._
 import io.getquill.idiom.StatementInterpolator._
-import io.getquill.idiom.Token
-import io.getquill.util.Messages.fail
 
 trait PostgresDialect
   extends SqlIdiom
   with QuestionMarkBindVariables
-  with ConcatSupport {
+  with ConcatSupport
+  with OnConflictSupport {
 
   override def astTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Ast] =
     Tokenizer[Ast] {
@@ -19,48 +18,6 @@ trait PostgresDialect
       case c: OnConflict           => conflictTokenizer.token(c)
       case ast                     => super.astTokenizer.token(ast)
     }
-
-  implicit def conflictTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[OnConflict] = {
-
-    val customEntityTokenizer = Tokenizer[Entity] {
-      case Entity(name, _) => stmt"INTO ${strategy.table(name).token} AS t"
-    }
-
-    val customAstTokenizer =
-      Tokenizer.withFallback[Ast](PostgresDialect.this.astTokenizer(_, strategy)) {
-        case _: OnConflict.Excluded => stmt"EXCLUDED"
-        case OnConflict.Existing(a) => stmt"${a.token}"
-        case a: Action              => super.actionTokenizer(customEntityTokenizer)(actionAstTokenizer, strategy).token(a)
-      }
-
-    import OnConflict._
-
-    def doUpdateStmt(i: Token, t: Token, u: Update) = {
-      val assignments = u.assignments
-        .map(a => stmt"${actionAstTokenizer.token(a.property)} = ${scopedTokenizer(a.value)(customAstTokenizer)}")
-        .mkStmt()
-
-      stmt"$i ON CONFLICT $t DO UPDATE SET $assignments"
-    }
-
-    def doNothingStmt(i: Ast, t: Token) = stmt"${i.token} ON CONFLICT $t DO NOTHING"
-
-    implicit val conflictTargetPropsTokenizer =
-      Tokenizer[Properties] {
-        case OnConflict.Properties(props) => stmt"(${props.map(n => strategy.column(n.name)).mkStmt(",")})"
-      }
-
-    def tokenizer(implicit astTokenizer: Tokenizer[Ast]) =
-      Tokenizer[OnConflict] {
-        case OnConflict(_, NoTarget, _: Update)      => fail("'DO UPDATE' statement requires explicit conflict target")
-        case OnConflict(i, p: Properties, u: Update) => doUpdateStmt(i.token, p.token, u)
-
-        case OnConflict(i, NoTarget, Ignore)         => stmt"${astTokenizer.token(i)} ON CONFLICT DO NOTHING"
-        case OnConflict(i, p: Properties, Ignore)    => doNothingStmt(i, p.token)
-      }
-
-    tokenizer(customAstTokenizer)
-  }
 
   override implicit def operationTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Operation] =
     Tokenizer[Operation] {

--- a/quill-sql/src/main/scala/io/getquill/SqliteDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/SqliteDialect.scala
@@ -1,9 +1,10 @@
 package io.getquill
 
-import io.getquill.idiom.{ Token, StringToken }
-import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.sql.idiom.QuestionMarkBindVariables
-import io.getquill.context.sql.idiom.NoConcatSupport
+import io.getquill.ast._
+import io.getquill.context.sql.idiom.{ NoConcatSupport, QuestionMarkBindVariables, SqlIdiom }
+import io.getquill.idiom.StatementInterpolator._
+import io.getquill.idiom.{ StringToken, Token }
+import io.getquill.util.Messages.fail
 
 trait SqliteDialect
   extends SqlIdiom
@@ -13,6 +14,54 @@ trait SqliteDialect
   override def emptySetContainsToken(field: Token) = StringToken("0")
 
   override def prepareForProbing(string: String) = s"sqlite3_prepare_v2($string)"
+
+  override def astTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Ast] =
+    Tokenizer[Ast] {
+      case c: OnConflict => conflictTokenizer.token(c)
+      case ast           => super.astTokenizer.token(ast)
+    }
+
+  implicit def conflictTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[OnConflict] = {
+
+    val customEntityTokenizer = Tokenizer[Entity] {
+      case Entity(name, _) => stmt"INTO ${strategy.table(name).token} AS t"
+    }
+
+    val customAstTokenizer =
+      Tokenizer.withFallback[Ast](SqliteDialect.this.astTokenizer(_, strategy)) {
+        case _: OnConflict.Excluded => stmt"EXCLUDED"
+        case OnConflict.Existing(a) => stmt"${a.token}"
+        case a: Action              => super.actionTokenizer(customEntityTokenizer)(actionAstTokenizer, strategy).token(a)
+      }
+
+    import OnConflict._
+
+    def doUpdateStmt(i: Token, t: Token, u: Update) = {
+      val assignments = u.assignments
+        .map(a => stmt"${actionAstTokenizer.token(a.property)} = ${scopedTokenizer(a.value)(customAstTokenizer)}")
+        .mkStmt()
+
+      stmt"$i ON CONFLICT $t DO UPDATE SET $assignments"
+    }
+
+    def doNothingStmt(i: Ast, t: Token) = stmt"${i.token} ON CONFLICT $t DO NOTHING"
+
+    implicit val conflictTargetPropsTokenizer =
+      Tokenizer[Properties] {
+        case OnConflict.Properties(props) => stmt"(${props.map(n => strategy.column(n.name)).mkStmt(",")})"
+      }
+
+    def tokenizer(implicit astTokenizer: Tokenizer[Ast]) =
+      Tokenizer[OnConflict] {
+        case OnConflict(_, NoTarget, _: Update)      => fail("'DO UPDATE' statement requires explicit conflict target")
+        case OnConflict(i, p: Properties, u: Update) => doUpdateStmt(i.token, p.token, u)
+
+        case OnConflict(i, NoTarget, Ignore)         => stmt"${astTokenizer.token(i)} ON CONFLICT DO NOTHING"
+        case OnConflict(i, p: Properties, Ignore)    => doNothingStmt(i, p.token)
+      }
+
+    tokenizer(customAstTokenizer)
+  }
 }
 
 object SqliteDialect extends SqliteDialect

--- a/quill-sql/src/main/scala/io/getquill/SqliteDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/SqliteDialect.scala
@@ -1,15 +1,15 @@
 package io.getquill
 
-import io.getquill.ast._
-import io.getquill.context.sql.idiom.{ NoConcatSupport, QuestionMarkBindVariables, SqlIdiom }
-import io.getquill.idiom.StatementInterpolator._
+import io.getquill.ast.{ Ast, OnConflict }
+import io.getquill.context.sql.idiom._
+import io.getquill.idiom.StatementInterpolator.Tokenizer
 import io.getquill.idiom.{ StringToken, Token }
-import io.getquill.util.Messages.fail
 
 trait SqliteDialect
   extends SqlIdiom
   with QuestionMarkBindVariables
-  with NoConcatSupport {
+  with NoConcatSupport
+  with OnConflictSupport {
 
   override def emptySetContainsToken(field: Token) = StringToken("0")
 
@@ -20,48 +20,6 @@ trait SqliteDialect
       case c: OnConflict => conflictTokenizer.token(c)
       case ast           => super.astTokenizer.token(ast)
     }
-
-  implicit def conflictTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[OnConflict] = {
-
-    val customEntityTokenizer = Tokenizer[Entity] {
-      case Entity(name, _) => stmt"INTO ${strategy.table(name).token} AS t"
-    }
-
-    val customAstTokenizer =
-      Tokenizer.withFallback[Ast](SqliteDialect.this.astTokenizer(_, strategy)) {
-        case _: OnConflict.Excluded => stmt"EXCLUDED"
-        case OnConflict.Existing(a) => stmt"${a.token}"
-        case a: Action              => super.actionTokenizer(customEntityTokenizer)(actionAstTokenizer, strategy).token(a)
-      }
-
-    import OnConflict._
-
-    def doUpdateStmt(i: Token, t: Token, u: Update) = {
-      val assignments = u.assignments
-        .map(a => stmt"${actionAstTokenizer.token(a.property)} = ${scopedTokenizer(a.value)(customAstTokenizer)}")
-        .mkStmt()
-
-      stmt"$i ON CONFLICT $t DO UPDATE SET $assignments"
-    }
-
-    def doNothingStmt(i: Ast, t: Token) = stmt"${i.token} ON CONFLICT $t DO NOTHING"
-
-    implicit val conflictTargetPropsTokenizer =
-      Tokenizer[Properties] {
-        case OnConflict.Properties(props) => stmt"(${props.map(n => strategy.column(n.name)).mkStmt(",")})"
-      }
-
-    def tokenizer(implicit astTokenizer: Tokenizer[Ast]) =
-      Tokenizer[OnConflict] {
-        case OnConflict(_, NoTarget, _: Update)      => fail("'DO UPDATE' statement requires explicit conflict target")
-        case OnConflict(i, p: Properties, u: Update) => doUpdateStmt(i.token, p.token, u)
-
-        case OnConflict(i, NoTarget, Ignore)         => stmt"${astTokenizer.token(i)} ON CONFLICT DO NOTHING"
-        case OnConflict(i, p: Properties, Ignore)    => doNothingStmt(i, p.token)
-      }
-
-    tokenizer(customAstTokenizer)
-  }
 }
 
 object SqliteDialect extends SqliteDialect

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/OnConflictSupport.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/OnConflictSupport.scala
@@ -1,0 +1,53 @@
+package io.getquill.context.sql.idiom
+
+import io.getquill.ast._
+import io.getquill.idiom.StatementInterpolator._
+import io.getquill.idiom.Token
+import io.getquill.NamingStrategy
+import io.getquill.util.Messages.fail
+
+trait OnConflictSupport {
+  self: SqlIdiom =>
+
+  implicit def conflictTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[OnConflict] = {
+
+    val customEntityTokenizer = Tokenizer[Entity] {
+      case Entity(name, _) => stmt"INTO ${strategy.table(name).token} AS t"
+    }
+
+    val customAstTokenizer =
+      Tokenizer.withFallback[Ast](self.astTokenizer(_, strategy)) {
+        case _: OnConflict.Excluded => stmt"EXCLUDED"
+        case OnConflict.Existing(a) => stmt"${a.token}"
+        case a: Action              => self.actionTokenizer(customEntityTokenizer)(actionAstTokenizer, strategy).token(a)
+      }
+
+    import OnConflict._
+
+    def doUpdateStmt(i: Token, t: Token, u: Update) = {
+      val assignments = u.assignments
+        .map(a => stmt"${actionAstTokenizer.token(a.property)} = ${scopedTokenizer(a.value)(customAstTokenizer)}")
+        .mkStmt()
+
+      stmt"$i ON CONFLICT $t DO UPDATE SET $assignments"
+    }
+
+    def doNothingStmt(i: Ast, t: Token) = stmt"${i.token} ON CONFLICT $t DO NOTHING"
+
+    implicit val conflictTargetPropsTokenizer =
+      Tokenizer[Properties] {
+        case OnConflict.Properties(props) => stmt"(${props.map(n => strategy.column(n.name)).mkStmt(",")})"
+      }
+
+    def tokenizer(implicit astTokenizer: Tokenizer[Ast]) =
+      Tokenizer[OnConflict] {
+        case OnConflict(_, NoTarget, _: Update)      => fail("'DO UPDATE' statement requires explicit conflict target")
+        case OnConflict(i, p: Properties, u: Update) => doUpdateStmt(i.token, p.token, u)
+
+        case OnConflict(i, NoTarget, Ignore)         => stmt"${astTokenizer.token(i)} ON CONFLICT DO NOTHING"
+        case OnConflict(i, p: Properties, Ignore)    => doNothingStmt(i, p.token)
+      }
+
+    tokenizer(customAstTokenizer)
+  }
+}


### PR DESCRIPTION
Fixes #1150 

### Problem

SQLite 3.24.0 supports upsert, atm quill doesn't.

### Solution

Add upsert support for SQLite

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
