### PR TITLE
spark 2.4.0 with scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,15 +7,12 @@ import sbtcrossproject.crossProject
 
 enablePlugins(TutPlugin)
 
-lazy val sparkIncludeProp = Option(System.getProperty("spark.include"))
-
 lazy val modules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
   `quill-core-jvm`, `quill-core-js`, `quill-sql-jvm`, `quill-sql-js`,
   `quill-jdbc`, `quill-finagle-mysql`, `quill-finagle-postgres`, `quill-async`,
-  `quill-async-mysql`, `quill-async-postgres`, `quill-cassandra`, `quill-orientdb`
-) ++ 
-  Seq[sbt.ClasspathDep[sbt.ProjectReference]](`quill-spark`)
-    .filter(_ => sparkIncludeProp.contains("true"))
+  `quill-async-mysql`, `quill-async-postgres`, `quill-cassandra`, `quill-orientdb`,
+  `quill-spark`
+)
 
 lazy val `quill` =
   (project in file("."))
@@ -92,10 +89,9 @@ lazy val `quill-spark` =
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(
-      crossScalaVersions := Seq("2.11.12"),
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "org.apache.spark" %% "spark-sql" % "2.3.2"
+        "org.apache.spark" %% "spark-sql" % "2.4.0"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
@@ -262,7 +258,7 @@ def updateWebsiteTag =
 lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
   organization := "io.getquill",
   scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12","2.12.6"),
+  crossScalaVersions := Seq("2.11.12","2.12.7"),
   libraryDependencies ++= Seq(
     "org.scalamacros" %% "resetallattrs"  % "1.0.0",
     "org.scalatest"   %%% "scalatest"     % "3.0.5"     % Test,
@@ -293,7 +289,8 @@ lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ Seq(
       case Some((2, 12)) => 
         Seq("-Xlint:-unused,_", 
             "-Ywarn-unused:imports", 
-            "-Ycache-macro-class-loader:last-modified")
+            "-Ycache-macro-class-loader:last-modified"
+        )
       case _ => Seq()
     }
   },

--- a/build/release.sh
+++ b/build/release.sh
@@ -2,7 +2,7 @@
 set -e # Any subsequent(*) commands which fail will cause the shell script to exit immediately
 
 SBT_2_12="sbt ++2.12.6"
-SBT_2_11="sbt -Dspark.include=true ++2.11.12"
+SBT_2_11="sbt ++2.11.12"
 
 echo $SBT_CMD
 if [[ $TRAVIS_PULL_REQUEST == "false" ]]

--- a/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
+++ b/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
@@ -3,7 +3,7 @@ package io.getquill
 import scala.util.Success
 import scala.util.Try
 import org.apache.spark.sql.{ Column, Dataset, Row, SQLContext, Encoder => SparkEncoder }
-import org.apache.spark.sql.functions.{ udf, struct, col }
+import org.apache.spark.sql.functions.{ struct, col }
 import io.getquill.context.Context
 import io.getquill.context.spark.Encoders
 import io.getquill.context.spark.Decoders
@@ -13,6 +13,7 @@ import io.getquill.context.spark.DatasetBinding
 import io.getquill.context.spark.ValueBinding
 import org.apache.spark.sql.types.{ StructField, StructType }
 import io.getquill.context.spark.norm.QuestionMarkEscaper._
+import org.apache.spark.sql.TypedUDF
 
 object QuillSparkContext extends QuillSparkContext
 
@@ -68,7 +69,8 @@ trait QuillSparkContext
    * As a result of these two steps, arrays whose values are all null should be recursively translated to single null objects.
    */
   private def perculateNullArrays[T: SparkEncoder](ds: Dataset[T]) = {
-    def nullifyNullArray(schema: StructType) = udf(
+
+    def nullifyNullArray(schema: StructType) = TypedUDF(
       (row: Row) => if ((0 until row.length).forall(row.isNullAt)) null else row,
       schema
     )

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -11,7 +11,7 @@ import io.getquill.ast.StringOperator
 import io.getquill.ast.Tuple
 import io.getquill.ast.Value
 import io.getquill.ast.CaseClass
-import io.getquill.context.spark.norm.{EscapeQuestionMarks, ExpandEntityIds}
+import io.getquill.context.spark.norm.{ EscapeQuestionMarks, ExpandEntityIds }
 import io.getquill.context.sql.SqlQuery
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.norm.SqlNormalize

--- a/quill-spark/src/main/scala/io/getquill/context/spark/norm/QuestionMarkEscaper.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/norm/QuestionMarkEscaper.scala
@@ -3,9 +3,9 @@ package io.getquill.context.spark.norm
 import java.util.regex.Matcher
 
 object QuestionMarkEscaper {
-  def escape(str:String) = str.replace("?", "\\?")
-  def unescape(str:String) = str.replace("\\?", "?")
+  def escape(str: String) = str.replace("?", "\\?")
+  def unescape(str: String) = str.replace("\\?", "?")
 
-  def pluginValueSafe(str:String, value:String) =
+  def pluginValueSafe(str: String, value: String) =
     str.replaceFirst("(?<!\\\\)\\?", Matcher.quoteReplacement(escape(value)))
 }

--- a/quill-spark/src/main/scala/org/apache/spark/sql/TypedUDF.scala
+++ b/quill-spark/src/main/scala/org/apache/spark/sql/TypedUDF.scala
@@ -1,0 +1,15 @@
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.ScalaReflection
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import scala.reflect.runtime.universe.{ TypeTag, typeTag }
+import scala.util.Try
+import org.apache.spark.sql.expressions.SparkUserDefinedFunction
+import org.apache.spark.sql.types.StructType
+
+object TypedUDF {
+  def apply[RT, A1: TypeTag](f: Function1[A1, RT], dataType: StructType): UserDefinedFunction = {
+    val inputSchemas = Try(ScalaReflection.schemaFor(typeTag[A1])).toOption :: Nil
+    SparkUserDefinedFunction.create(f, dataType, inputSchemas).asNonNullable()
+  }
+}

--- a/quill-spark/src/test/scala/io/getquill/context/spark/QuestionMarkSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/QuestionMarkSpec.scala
@@ -27,7 +27,7 @@ class QuestionMarkSpec extends Spec {
   }
 
   "simple variable usage must work in the middle of a stirng" in {
-    val newContact = Contact("Moe","Rabbenu", 123, 2, "Something ? Something ? Else")
+    val newContact = Contact("Moe", "Rabbenu", 123, 2, "Something ? Something ? Else")
     val extraPeopleList = peopleList :+ newContact
 
     val q = quote {

--- a/quill-spark/src/test/scala/io/getquill/context/spark/norm/QuestionMarkEscaperSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/norm/QuestionMarkEscaperSpec.scala
@@ -6,45 +6,45 @@ import QuestionMarkEscaper._
 class QuestionMarkEscaperSpec extends Spec {
 
   "should escape strings with question marks and even ones with slashes already" in {
-    escape("foo ? bar \\? baz \\\\?") must equal ("foo \\? bar \\\\? baz \\\\\\?")
+    escape("foo ? bar \\? baz \\\\?") must equal("foo \\? bar \\\\? baz \\\\\\?")
   }
 
   "should escape and then unescape going back to original form" in {
     val str = "foo ? bar \\? baz \\\\?"
-    unescape(escape(str)) must equal (str)
+    unescape(escape(str)) must equal(str)
   }
 
-  def plug1(str:String) = pluginValueSafe(str, "<1>")
-  def plug2(str:String) = pluginValueSafe(plug1(str), "<2>")
-  def plug3(str:String) = pluginValueSafe(plug2(str), "<3>")
-  def plug4(str:String) = pluginValueSafe(plug3(str), "<4>")
+  def plug1(str: String) = pluginValueSafe(str, "<1>")
+  def plug2(str: String) = pluginValueSafe(plug1(str), "<2>")
+  def plug3(str: String) = pluginValueSafe(plug2(str), "<3>")
+  def plug4(str: String) = pluginValueSafe(plug3(str), "<4>")
 
-  def plug2Q(str:String) = pluginValueSafe(plug1(str), "<2?>")
-  def plug3QN(str:String) = pluginValueSafe(plug2Q(str), "<3>")
-  def plug4Q(str:String) = pluginValueSafe(plug3QN(str), "<4?>")
+  def plug2Q(str: String) = pluginValueSafe(plug1(str), "<2?>")
+  def plug3QN(str: String) = pluginValueSafe(plug2Q(str), "<3>")
+  def plug4Q(str: String) = pluginValueSafe(plug3QN(str), "<4?>")
 
   "should escape and replace variables correctly" in {
     val str = "foo ? bar ? ?"
-    plug1(str) must equal ("foo <1> bar ? ?")
-    plug2(str) must equal ("foo <1> bar <2> ?")
-    plug3(str) must equal ("foo <1> bar <2> <3>")
+    plug1(str) must equal("foo <1> bar ? ?")
+    plug2(str) must equal("foo <1> bar <2> ?")
+    plug3(str) must equal("foo <1> bar <2> <3>")
   }
 
   "should escape and replace variables correctly with other question marks" in {
     val str = "foo ? bar \\? ? baz ? \\\\? ?"
-    plug1(str) must equal ("foo <1> bar \\? ? baz ? \\\\? ?")
-    plug2(str) must equal ("foo <1> bar \\? <2> baz ? \\\\? ?")
-    plug3(str) must equal ("foo <1> bar \\? <2> baz <3> \\\\? ?")
-    plug4(str) must equal ("foo <1> bar \\? <2> baz <3> \\\\? <4>")
-    unescape(plug4(str)) must equal ("foo <1> bar ? <2> baz <3> \\? <4>")
+    plug1(str) must equal("foo <1> bar \\? ? baz ? \\\\? ?")
+    plug2(str) must equal("foo <1> bar \\? <2> baz ? \\\\? ?")
+    plug3(str) must equal("foo <1> bar \\? <2> baz <3> \\\\? ?")
+    plug4(str) must equal("foo <1> bar \\? <2> baz <3> \\\\? <4>")
+    unescape(plug4(str)) must equal("foo <1> bar ? <2> baz <3> \\? <4>")
   }
 
   "should escape and replace variables correctly even if the variables have question marks" in {
     val str = "foo ? bar \\? ? baz ? \\\\? ?"
-    plug1(str) must equal ("foo <1> bar \\? ? baz ? \\\\? ?")
-    plug2Q(str) must equal ("foo <1> bar \\? <2\\?> baz ? \\\\? ?")
-    plug3QN(str) must equal ("foo <1> bar \\? <2\\?> baz <3> \\\\? ?")
-    plug4Q(str) must equal ("foo <1> bar \\? <2\\?> baz <3> \\\\? <4\\?>")
-    unescape(plug4Q(str)) must equal ("foo <1> bar ? <2?> baz <3> \\? <4?>")
+    plug1(str) must equal("foo <1> bar \\? ? baz ? \\\\? ?")
+    plug2Q(str) must equal("foo <1> bar \\? <2\\?> baz ? \\\\? ?")
+    plug3QN(str) must equal("foo <1> bar \\? <2\\?> baz <3> \\\\? ?")
+    plug4Q(str) must equal("foo <1> bar \\? <2\\?> baz <3> \\\\? <4\\?>")
+    unescape(plug4Q(str)) must equal("foo <1> bar ? <2?> baz <3> \\? <4?>")
   }
 }


### PR DESCRIPTION
Fixes #issue_number

### Problem

There's a new release of spark that supports Scala 2.12.

### Solution

Upgrade to the new version and configure the build to publish 2.12 artifacts for `quill-spark`

### Notes

There are three NPEs that I don't know how to fix yet. Maybe @deusaquilus can help here?

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
