### PR TITLE
quill-spark: escape strings

### DIFF
--- a/quill-spark/src/main/scala/io/getquill/context/spark/Encoders.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/Encoders.scala
@@ -14,8 +14,6 @@ trait Encoders {
 
   private def toStringEncoder[T]: Encoder[T] = encoder((v: T) => s"$v")
 
-  private def quotedToStringEncoder[T]: Encoder[T] = encoder(v => s""""$v"""")
-
   implicit def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], e: Encoder[O]): Encoder[I] =
     mappedBaseEncoder(mapped, e)
 
@@ -26,7 +24,7 @@ trait Encoders {
         case Some(v) => d(index, v, row)
       }
 
-  implicit val stringEncoder: Encoder[String] = quotedToStringEncoder
+  implicit val stringEncoder: Encoder[String] = encoder(v => s"'${v.replaceAll("""[\\']""", """\\$0""")}'")
   implicit val bigDecimalEncoder: Encoder[BigDecimal] = toStringEncoder
   implicit val booleanEncoder: Encoder[Boolean] = toStringEncoder
   implicit val byteEncoder: Encoder[Byte] = toStringEncoder

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -11,7 +11,7 @@ import io.getquill.ast.StringOperator
 import io.getquill.ast.Tuple
 import io.getquill.ast.Value
 import io.getquill.ast.CaseClass
-import io.getquill.context.spark.norm.{EscapeQuestionMarks, ExpandEntityIds}
+import io.getquill.context.spark.norm.{ EscapeQuestionMarks, ExpandEntityIds }
 import io.getquill.context.sql.SqlQuery
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.norm.SqlNormalize
@@ -22,6 +22,7 @@ import io.getquill.idiom.StatementInterpolator.stringTokenizer
 import io.getquill.idiom.StatementInterpolator.tokenTokenizer
 import io.getquill.idiom.Token
 import io.getquill.util.Messages.trace
+import io.getquill.ast.Constant
 
 class SparkDialect extends SqlIdiom {
 
@@ -79,9 +80,10 @@ class SparkDialect extends SqlIdiom {
   }
 
   override implicit def valueTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Value] = Tokenizer[Value] {
-    case Tuple(values)     => stmt"(${values.token})"
-    case CaseClass(values) => stmt"${values.map({ case (prop, value) => stmt"${value.token} ${prop.token}".token }).token}"
-    case other             => super.valueTokenizer.token(other)
+    case Constant(v: String) => stmt"'${v.replaceAll("""[\\']""", """\\$0""").token}'"
+    case Tuple(values)       => stmt"(${values.token})"
+    case CaseClass(values)   => stmt"${values.map({ case (prop, value) => stmt"${value.token} ${prop.token}".token }).token}"
+    case other               => super.valueTokenizer.token(other)
   }
 }
 

--- a/quill-spark/src/test/scala/io/getquill/context/spark/EncodingSparkSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/EncodingSparkSpec.scala
@@ -42,6 +42,38 @@ class EncodingSparkSpec extends Spec {
     testContext.run(q).collect.toList mustEqual List(v)
   }
 
+  "string with ' " in {
+    val v = "will'break"
+
+    val entities = liftQuery(Seq(
+      EncodingTestEntity(
+        v,
+        BigDecimal(1.1),
+        true,
+        11.toByte,
+        23.toShort,
+        33,
+        431L,
+        42d,
+        Array(1.toByte, 2.toByte),
+        Some("s"),
+        Some(BigDecimal(1.1)),
+        Some(true),
+        Some(11.toByte),
+        Some(23.toShort),
+        Some(33),
+        Some(431L),
+        Some(42d),
+        Some(Array(1.toByte, 2.toByte))
+      )
+    ).toDS)
+
+    val q = quote {
+      entities.filter(_.v1 == lift(v)).map(_.v1)
+    }
+    testContext.run(q).collect.toList mustEqual List(v)
+  }
+
   "bigDecimal" in {
     val v = BigDecimal(1.1)
     val q = quote {

--- a/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
@@ -31,6 +31,13 @@ class SparkDialectSpec extends Spec {
     }
   }
 
+  "escapes ' " in {
+    val ast = query[Test].map(t => "test'").ast
+    val (norm, stmt) = SparkDialect.translate(ast)(Literal)
+    norm mustEqual ast
+    stmt.toString mustEqual "SELECT 'test\\'' _1 FROM Test t"
+  }
+
   "nested property" in {
     case class Inner(i: Int)
     case class Outer(inner: Inner)


### PR DESCRIPTION
Fixes #1019 

### Problem

`quill-spark` doesn't escape strings properly. `'` breaks the SQL.

### Solution

Escape strings.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
