### PR TITLE
quill-spark: fix groupby with multiple columns

### DIFF
--- a/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
@@ -41,7 +41,7 @@ object StatementInterpolator {
   implicit def stringTokenTokenizer: Tokenizer[StringToken] = Tokenizer[StringToken](identity)
   implicit def liftingTokenTokenizer: Tokenizer[ScalarLiftToken] = Tokenizer[ScalarLiftToken](identity)
 
-  implicit class TokenList[T](list: List[T])(implicit tokenize: Tokenizer[T]) {
+  implicit class TokenList[T](list: List[T]) {
     def mkStmt(sep: String = ", ")(implicit tokenize: Tokenizer[T]) = {
       val l1 = list.map(_.token)
       val l2 = List.fill(l1.size - 1)(StringToken(sep))

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -11,15 +11,11 @@ import io.getquill.ast.StringOperator
 import io.getquill.ast.Tuple
 import io.getquill.ast.Value
 import io.getquill.ast.CaseClass
-import io.getquill.context.spark.norm.{EscapeQuestionMarks, ExpandEntityIds}
+import io.getquill.context.spark.norm.{ EscapeQuestionMarks, ExpandEntityIds }
 import io.getquill.context.sql.SqlQuery
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.norm.SqlNormalize
-import io.getquill.idiom.StatementInterpolator.Impl
-import io.getquill.idiom.StatementInterpolator.TokenImplicit
-import io.getquill.idiom.StatementInterpolator.Tokenizer
-import io.getquill.idiom.StatementInterpolator.stringTokenizer
-import io.getquill.idiom.StatementInterpolator.tokenTokenizer
+import io.getquill.idiom.StatementInterpolator._
 import io.getquill.idiom.Token
 import io.getquill.util.Messages.trace
 
@@ -83,6 +79,12 @@ class SparkDialect extends SqlIdiom {
     case CaseClass(values) => stmt"${values.map({ case (prop, value) => stmt"${value.token} ${prop.token}".token }).token}"
     case other             => super.valueTokenizer.token(other)
   }
+
+  override protected def tokenizeGroupBy(values: Ast)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Token =
+    values match {
+      case Tuple(items) => items.mkStmt()
+      case values       => values.token
+    }
 }
 
 object SparkDialect extends SparkDialect

--- a/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
@@ -67,4 +67,11 @@ class SparkDialectSpec extends Spec {
     norm mustEqual ast
     stmt.toString mustEqual "SELECT concat(t.s, ' ') _1 FROM Test t"
   }
+
+  "groupBy with multiple columns" in {
+    val ast = query[Test].groupBy(t => (t.i, t.j)).map(t => t._2).ast
+    val (norm, stmt) = SparkDialect.translate(ast)(Literal)
+    norm mustEqual ast
+    stmt.toString mustEqual "SELECT t.* FROM Test t GROUP BY t.i, t.j"
+  }
 }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -10,6 +10,7 @@ import io.getquill.idiom.StatementInterpolator._
 import io.getquill.NamingStrategy
 import io.getquill.util.Interleave
 import io.getquill.util.Messages.{ fail, trace }
+import io.getquill.idiom.Token
 
 trait SqlIdiom extends Idiom {
 
@@ -84,6 +85,9 @@ trait SqlIdiom extends Idiom {
 
   def concatFunction: String
 
+  protected def tokenizeGroupBy(values: Ast)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Token =
+    values.token
+
   implicit def sqlQueryTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[SqlQuery] = Tokenizer[SqlQuery] {
     case FlattenSqlQuery(from, where, groupBy, orderBy, limit, offset, select, distinct) =>
 
@@ -117,7 +121,7 @@ trait SqlIdiom extends Idiom {
       val withGroupBy =
         groupBy match {
           case None          => withWhere
-          case Some(groupBy) => stmt"$withWhere GROUP BY ${groupBy.token}"
+          case Some(groupBy) => stmt"$withWhere GROUP BY ${tokenizeGroupBy(groupBy)}"
         }
       val withOrderBy =
         orderBy match {


### PR DESCRIPTION
Fixes #1023 

### Problem

Spark doesn't expect parentheses when a group by uses multiple columns.

### Solution

Change the dialect to avoid parentheses for group by columns.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
