### PR TITLE
expand map.distinct

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandDistinct.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandDistinct.scala
@@ -1,0 +1,19 @@
+package io.getquill.context.sql.norm
+
+import io.getquill.ast._
+
+object ExpandDistinct {
+
+  def apply(q: Ast): Ast =
+    q match {
+      case Distinct(q) =>
+        Distinct(apply(q))
+      case q =>
+        Transform(q) {
+          case Aggregation(op, Distinct(q)) =>
+            Aggregation(op, Distinct(apply(q)))
+          case Distinct(Map(q, x, p)) =>
+            Map(Distinct(Map(q, x, p)), x, p)
+        }
+    }
+}

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
@@ -17,6 +17,8 @@ object SqlNormalize {
       .andThen(trace("Normalize"))
       .andThen(RenameProperties.apply _)
       .andThen(trace("RenameProperties"))
+      .andThen(ExpandDistinct.apply _)
+      .andThen(trace("ExpandDistinct"))
       .andThen(ExpandJoin.apply _)
       .andThen(trace("ExpandJoin"))
       .andThen(ExpandMappedInfix.apply _)


### PR DESCRIPTION
Fixes #1032 

### Problem

Quill doesn't expand the `map` transformations that come before a `distinct`.

### Solution

Introduce a normalization phase to expand map.distinct

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
