### PR TITLE
fix property renaming for nested queries within infixes

### DIFF
--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/norm/RenamePropertiesSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/norm/RenamePropertiesSpec.scala
@@ -16,6 +16,15 @@ class RenamePropertiesSpec extends Spec {
   }
 
   "renames properties according to the entity aliases" - {
+
+    "allowFiltering" in {
+      val q = quote {
+        e.filter(_.i == 1).allowFiltering
+      }
+      mirrorContext.run(q).string mustEqual
+        "SELECT field_s, field_i, l, o FROM test_entity WHERE field_i = 1 ALLOW FILTERING"
+    }
+
     "action" - {
       "insert" in {
         val q = quote {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -408,15 +408,23 @@ class RenamePropertiesSpec extends Spec {
     }
 
     "infix" - {
+      case class B(b: Int) extends Embedded
+      case class A(u: Long, v: Int, w: B)
       "does not break schema" in {
-        case class B(b: Int) extends Embedded
-        case class A(u: Long, v: Int, w: B)
         val q = quote {
           infix"${querySchema[A]("C", _.v -> "m", _.w.b -> "n")} LIMIT 10".as[Query[A]]
         }
 
         testContext.run(q).string mustEqual
           "SELECT x.u, x.m, x.n FROM C x LIMIT 10"
+      }
+      "with filter" in {
+        val q = quote {
+          infix"${querySchema[A]("C", _.v -> "m", _.w.b -> "n").filter(x => x.v == 1)} LIMIT 10".as[Query[A]]
+        }
+
+        testContext.run(q).string mustEqual
+          "SELECT x.u, x.m, x.n FROM C x WHERE x.m = 1 LIMIT 10"
       }
     }
   }


### PR DESCRIPTION
Fixes #1047 

### Problem

`RenameProperties` calls `applySchema` for nested queries within infixes but discards the transformed query.

### Solution

Fix it!

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
