### PR TITLE
fail is property is not a case acessor

### DIFF
--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -457,6 +457,28 @@ class QuotationSpec extends Spec {
           }
         """ mustNot compile
       }
+      "fails if not case class property" - {
+        "val" in {
+          case class T(s: String) {
+            val boom = 1
+          }
+          """
+          quote {
+            (o: T) => o.boom
+          }
+          """ mustNot compile
+        }
+        "def" in {
+          case class T(s: String) {
+            def boom = 1
+          }
+          """
+          quote {
+            (o: T) => o.boom
+          }
+          """ mustNot compile
+        }
+      }
     }
     "property anonymous" in {
       val q = quote {


### PR DESCRIPTION
Fixes #822 

### Problem

Quill generates invalid queries when users mistakenly use a method or value that is not part of the case class product.

### Solution

Fail during parsing.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
