### PR TITLE
sqlite dialect - translate boolean literals into 1/0

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/SqliteDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/SqliteDialect.scala
@@ -1,17 +1,11 @@
 package io.getquill
 
 import io.getquill.idiom.StatementInterpolator._
-import io.getquill.ast.{ Ast, OnConflict }
 import io.getquill.context.sql.idiom._
 import io.getquill.idiom.StatementInterpolator.Tokenizer
 import io.getquill.idiom.{ StringToken, Token }
-import io.getquill.ast.AscNullsLast
-import io.getquill.ast.DescNullsLast
-import io.getquill.ast.Desc
+import io.getquill.ast._
 import io.getquill.context.sql.OrderByCriteria
-import io.getquill.ast.Asc
-import io.getquill.ast.DescNullsFirst
-import io.getquill.ast.AscNullsFirst
 
 trait SqliteDialect
   extends SqlIdiom
@@ -46,6 +40,12 @@ trait SqliteDialect
       stmt"${scopedTokenizer(ast)} ASC $omittedNullsLast"
     case OrderByCriteria(ast, DescNullsLast) =>
       stmt"${scopedTokenizer(ast)} DESC $omittedNullsLast"
+  }
+
+  override implicit def valueTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Value] = Tokenizer[Value] {
+    case Constant(v: Boolean) if v  => stmt"1"
+    case Constant(v: Boolean) if !v => stmt"0"
+    case value                      => super.valueTokenizer.token(value)
   }
 }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqliteDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqliteDialectSpec.scala
@@ -29,6 +29,11 @@ class SqliteDialectSpec extends OnConflictSpec {
     }
   }
 
+  "transforms boolean literals into 0/1" in {
+    ctx.run(qr1.map(t => (true, false))).string mustEqual
+      "SELECT 1, 0 FROM TestEntity t"
+  }
+
   "OnConflict" - {
     "no target - ignore" in {
       ctx.run(`no target - ignore`).string mustEqual


### PR DESCRIPTION
Fixes #1136 

### Problem

Sqlite doesn't support boolean literals.

### Solution

Use 1 and 0 as recommended by the Sqlite docs

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
