### PR TITLE
#1204 add explicit `AS` for aliases (except table context)

### DIFF
--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
@@ -40,7 +40,7 @@ class CassandraContextSpec extends Spec {
     testSyncDB.probe("SELECT * FROM TestEntity") mustBe Success(())
   }
 
-  "return failed future on `prepare` error in async context" - {
+1  "return failed future on `prepare` error in async context" - {
     "query" - {
       val f = testAsyncDB.executeQuery("bad cql")
       Try(await(f)).isFailure mustEqual true

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
@@ -40,7 +40,7 @@ class CassandraContextSpec extends Spec {
     testSyncDB.probe("SELECT * FROM TestEntity") mustBe Success(())
   }
 
-1  "return failed future on `prepare` error in async context" - {
+  "return failed future on `prepare` error in async context" - {
     "query" - {
       val f = testAsyncDB.executeQuery("bad cql")
       Try(await(f)).isFailure mustEqual true

--- a/quill-spark/src/main/scala/io/getquill/context/spark/norm/QuestionMarkEscaper.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/norm/QuestionMarkEscaper.scala
@@ -3,9 +3,9 @@ package io.getquill.context.spark.norm
 import java.util.regex.Matcher
 
 object QuestionMarkEscaper {
-  def escape(str:String) = str.replace("?", "\\?")
-  def unescape(str:String) = str.replace("\\?", "?")
+  def escape(str: String) = str.replace("?", "\\?")
+  def unescape(str: String) = str.replace("\\?", "?")
 
-  def pluginValueSafe(str:String, value:String) =
+  def pluginValueSafe(str: String, value: String) =
     str.replaceFirst("(?<!\\\\)\\?", Matcher.quoteReplacement(escape(value)))
 }

--- a/quill-spark/src/test/scala/io/getquill/context/spark/QuestionMarkSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/QuestionMarkSpec.scala
@@ -27,7 +27,7 @@ class QuestionMarkSpec extends Spec {
   }
 
   "simple variable usage must work in the middle of a stirng" in {
-    val newContact = Contact("Moe","Rabbenu", 123, 2, "Something ? Something ? Else")
+    val newContact = Contact("Moe", "Rabbenu", 123, 2, "Something ? Something ? Else")
     val extraPeopleList = peopleList :+ newContact
 
     val q = quote {

--- a/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
@@ -35,7 +35,7 @@ class SparkDialectSpec extends Spec {
     val ast = query[Test].map(t => "test'").ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT 'test\\'' _1 FROM Test t"
+    stmt.toString mustEqual "SELECT 'test\\'' AS _1 FROM Test t"
   }
 
   "nested property" in {
@@ -51,28 +51,28 @@ class SparkDialectSpec extends Spec {
     val ast = query[Test].map(t => ((t.i, t.j), t.i + 1)).ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT (t.i, t.j) _1, t.i + 1 _2 FROM Test t"
+    stmt.toString mustEqual "SELECT (t.i, t.j) AS _1, t.i + 1 AS _2 FROM Test t"
   }
 
   "concatMap" in {
     val ast = query[Test].concatMap(t => t.s.split(" ")).ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT explode(SPLIT(t.s, ' ')) _1 FROM Test t"
+    stmt.toString mustEqual "SELECT explode(SPLIT(t.s, ' ')) AS _1 FROM Test t"
   }
 
   "non-tuple select" in {
     val ast = query[Test].concatMap(t => t.s.split(" ")).filter(s => s == "s").ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT s.* FROM (SELECT explode(SPLIT(t.s, ' ')) _1 FROM Test t) s WHERE s._1 = 's'"
+    stmt.toString mustEqual "SELECT s.* FROM (SELECT explode(SPLIT(t.s, ' ')) AS _1 FROM Test t) AS s WHERE s._1 = 's'"
   }
 
   "concat string" in {
     val ast = query[Test].map(t => t.s + " ").ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT concat(t.s, ' ') _1 FROM Test t"
+    stmt.toString mustEqual "SELECT concat(t.s, ' ') AS _1 FROM Test t"
   }
 
   "groupBy with multiple columns" in {

--- a/quill-spark/src/test/scala/io/getquill/context/spark/norm/QuestionMarkEscaperSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/norm/QuestionMarkEscaperSpec.scala
@@ -6,45 +6,45 @@ import QuestionMarkEscaper._
 class QuestionMarkEscaperSpec extends Spec {
 
   "should escape strings with question marks and even ones with slashes already" in {
-    escape("foo ? bar \\? baz \\\\?") must equal ("foo \\? bar \\\\? baz \\\\\\?")
+    escape("foo ? bar \\? baz \\\\?") must equal("foo \\? bar \\\\? baz \\\\\\?")
   }
 
   "should escape and then unescape going back to original form" in {
     val str = "foo ? bar \\? baz \\\\?"
-    unescape(escape(str)) must equal (str)
+    unescape(escape(str)) must equal(str)
   }
 
-  def plug1(str:String) = pluginValueSafe(str, "<1>")
-  def plug2(str:String) = pluginValueSafe(plug1(str), "<2>")
-  def plug3(str:String) = pluginValueSafe(plug2(str), "<3>")
-  def plug4(str:String) = pluginValueSafe(plug3(str), "<4>")
+  def plug1(str: String) = pluginValueSafe(str, "<1>")
+  def plug2(str: String) = pluginValueSafe(plug1(str), "<2>")
+  def plug3(str: String) = pluginValueSafe(plug2(str), "<3>")
+  def plug4(str: String) = pluginValueSafe(plug3(str), "<4>")
 
-  def plug2Q(str:String) = pluginValueSafe(plug1(str), "<2?>")
-  def plug3QN(str:String) = pluginValueSafe(plug2Q(str), "<3>")
-  def plug4Q(str:String) = pluginValueSafe(plug3QN(str), "<4?>")
+  def plug2Q(str: String) = pluginValueSafe(plug1(str), "<2?>")
+  def plug3QN(str: String) = pluginValueSafe(plug2Q(str), "<3>")
+  def plug4Q(str: String) = pluginValueSafe(plug3QN(str), "<4?>")
 
   "should escape and replace variables correctly" in {
     val str = "foo ? bar ? ?"
-    plug1(str) must equal ("foo <1> bar ? ?")
-    plug2(str) must equal ("foo <1> bar <2> ?")
-    plug3(str) must equal ("foo <1> bar <2> <3>")
+    plug1(str) must equal("foo <1> bar ? ?")
+    plug2(str) must equal("foo <1> bar <2> ?")
+    plug3(str) must equal("foo <1> bar <2> <3>")
   }
 
   "should escape and replace variables correctly with other question marks" in {
     val str = "foo ? bar \\? ? baz ? \\\\? ?"
-    plug1(str) must equal ("foo <1> bar \\? ? baz ? \\\\? ?")
-    plug2(str) must equal ("foo <1> bar \\? <2> baz ? \\\\? ?")
-    plug3(str) must equal ("foo <1> bar \\? <2> baz <3> \\\\? ?")
-    plug4(str) must equal ("foo <1> bar \\? <2> baz <3> \\\\? <4>")
-    unescape(plug4(str)) must equal ("foo <1> bar ? <2> baz <3> \\? <4>")
+    plug1(str) must equal("foo <1> bar \\? ? baz ? \\\\? ?")
+    plug2(str) must equal("foo <1> bar \\? <2> baz ? \\\\? ?")
+    plug3(str) must equal("foo <1> bar \\? <2> baz <3> \\\\? ?")
+    plug4(str) must equal("foo <1> bar \\? <2> baz <3> \\\\? <4>")
+    unescape(plug4(str)) must equal("foo <1> bar ? <2> baz <3> \\? <4>")
   }
 
   "should escape and replace variables correctly even if the variables have question marks" in {
     val str = "foo ? bar \\? ? baz ? \\\\? ?"
-    plug1(str) must equal ("foo <1> bar \\? ? baz ? \\\\? ?")
-    plug2Q(str) must equal ("foo <1> bar \\? <2\\?> baz ? \\\\? ?")
-    plug3QN(str) must equal ("foo <1> bar \\? <2\\?> baz <3> \\\\? ?")
-    plug4Q(str) must equal ("foo <1> bar \\? <2\\?> baz <3> \\\\? <4\\?>")
-    unescape(plug4Q(str)) must equal ("foo <1> bar ? <2?> baz <3> \\? <4?>")
+    plug1(str) must equal("foo <1> bar \\? ? baz ? \\\\? ?")
+    plug2Q(str) must equal("foo <1> bar \\? <2\\?> baz ? \\\\? ?")
+    plug3QN(str) must equal("foo <1> bar \\? <2\\?> baz <3> \\\\? ?")
+    plug4Q(str) must equal("foo <1> bar \\? <2\\?> baz <3> \\\\? <4\\?>")
+    unescape(plug4Q(str)) must equal("foo <1> bar ? <2?> baz <3> \\? <4?>")
   }
 }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -140,8 +140,8 @@ trait SqlIdiom extends Idiom {
 
     def tokenizer(implicit astTokenizer: Tokenizer[Ast]) =
       Tokenizer[SelectValue] {
-        case SelectValue(ast, Some(alias), false) => stmt"${ast.token} ${strategy.column(alias).token}"
-        case SelectValue(ast, Some(alias), true)  => stmt"${concatFunction.token}(${ast.token}) ${strategy.column(alias).token}"
+        case SelectValue(ast, Some(alias), false) => stmt"${ast.token} AS ${strategy.column(alias).token}"
+        case SelectValue(ast, Some(alias), true)  => stmt"${concatFunction.token}(${ast.token}) AS ${strategy.column(alias).token}"
         case selectValue =>
           val value =
             selectValue match {
@@ -211,8 +211,8 @@ trait SqlIdiom extends Idiom {
 
   implicit def sourceTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[FromContext] = Tokenizer[FromContext] {
     case TableContext(name, alias)  => stmt"${name.token} ${strategy.default(alias).token}"
-    case QueryContext(query, alias) => stmt"(${query.token}) ${strategy.default(alias).token}"
-    case InfixContext(infix, alias) => stmt"(${(infix: Ast).token}) ${strategy.default(alias).token}"
+    case QueryContext(query, alias) => stmt"(${query.token}) AS ${strategy.default(alias).token}"
+    case InfixContext(infix, alias) => stmt"(${(infix: Ast).token}) AS ${strategy.default(alias).token}"
     case JoinContext(t, a, b, on)   => stmt"${a.token} ${t.token} ${b.token} ON ${on.token}"
     case FlatJoinContext(t, a, on)  => stmt"${t.token} ${a.token} ON ${on.token}"
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
@@ -70,7 +70,7 @@ class SqlIdiomNamingSpec extends Spec {
       val q = quote {
         query[SomeEntity].distinct
       }
-      db.run(q.dynamic).string mustEqual "SELECT d_x.d_somecolumn FROM (SELECT DISTINCT d_x.* FROM d_someentity d_x) d_x"
+      db.run(q.dynamic).string mustEqual "SELECT d_x.d_somecolumn FROM (SELECT DISTINCT d_x.* FROM d_someentity d_x) AS d_x"
     }
 
     val db = new SqlMirrorContext(MirrorSqlDialect, SnakeCase)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -15,7 +15,7 @@ class ExpandNestedQueriesSpec extends Spec {
     }
 
     testContext.run(q).string mustEqual
-      "SELECT x.s, x.i, x.l, x.o FROM (SELECT x.s, x.i, x.l, x.o FROM TestEntity a, TestEntity2 x) x"
+      "SELECT x.s, x.i, x.l, x.o FROM (SELECT x.s, x.i, x.l, x.o FROM TestEntity a, TestEntity2 x) AS x"
   }
 
   "partial select" in {
@@ -27,7 +27,7 @@ class ExpandNestedQueriesSpec extends Spec {
       } yield (b.i, a.i)).nested
     }
     testContext.run(q).string mustEqual
-      "SELECT x._1, x._2 FROM (SELECT b.i _1, a.i _2 FROM TestEntity a, TestEntity2 b) x"
+      "SELECT x._1, x._2 FROM (SELECT b.i AS _1, a.i AS _2 FROM TestEntity a, TestEntity2 b) AS x"
   }
 
   "tokenize property" in {
@@ -41,7 +41,7 @@ class ExpandNestedQueriesSpec extends Spec {
         .map(e => (e, 1))
         .nested
     ).string mustEqual
-      "SELECT e.camel_case, 1 FROM (SELECT x.camel_case FROM entity x) e"
+      "SELECT e.camel_case, 1 FROM (SELECT x.camel_case FROM entity x) AS e"
   }
 
   "expands nested tuple select" in {
@@ -67,6 +67,6 @@ class ExpandNestedQueriesSpec extends Spec {
       }).distinct
     }
     testContext.run(q).string mustEqual
-      "SELECT x.s, x.i, x.l, x.o, x.s, x.i, x.l, x.o FROM (SELECT DISTINCT x.* FROM (SELECT a.*, b.* FROM TestEntity a, TestEntity2 b) x) x"
+      "SELECT x.s, x.i, x.l, x.o, x.s, x.i, x.l, x.o FROM (SELECT DISTINCT x.* FROM (SELECT a.*, b.* FROM TestEntity a, TestEntity2 b) AS x) AS x"
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinSpec.scala
@@ -40,7 +40,7 @@ class JoinSpec extends Spec {
       }
     }
     testContext.run(q).string mustEqual
-      "SELECT ab.s, ab.i, ab.l, ab.o, ab.s, ab.i, ab.l, ab.o, c.s, c.i, c.l, c.o FROM (SELECT a.s s, a.o o, a.l l, a.i i, b.l l, b.i i, b.o o, b.s s FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.l = 3) ab LEFT JOIN TestEntity3 c ON ab.i = ab.i AND ab.i = c.i"
+      "SELECT ab.s, ab.i, ab.l, ab.o, ab.s, ab.i, ab.l, ab.o, c.s, c.i, c.l, c.o FROM (SELECT a.s AS s, a.o AS o, a.l AS l, a.i AS i, b.l AS l, b.i AS i, b.o AS o, b.s AS s FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.l = 3) AS ab LEFT JOIN TestEntity3 c ON ab.i = ab.i AND ab.i = c.i"
   }
 
   "join + distinct + leftjoin" in {
@@ -53,7 +53,7 @@ class JoinSpec extends Spec {
       }
     }
     testContext.run(q).string mustEqual
-      "SELECT ab.s, ab.i, ab.l, ab.o, ab.s, ab.i, ab.l, ab.o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.*, b.* FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i) ab LEFT JOIN TestEntity3 c ON ab.i = ab.i AND ab.i = c.i"
+      "SELECT ab.s, ab.i, ab.l, ab.o, ab.s, ab.i, ab.l, ab.o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.*, b.* FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i) AS ab LEFT JOIN TestEntity3 c ON ab.i = ab.i AND ab.i = c.i"
   }
 
   "multiple joins + filter + map + distinct" in {
@@ -70,7 +70,7 @@ class JoinSpec extends Spec {
         .distinct
     }
     testContext.run(q).string mustEqual
-      "SELECT DISTINCT a.s, d.l, n.i FROM TestEntity d INNER JOIN TestEntity2 a ON d.i = a.i INNER JOIN (SELECT rp.l, rp.i FROM TestEntity3 rp WHERE rp.s = ?) rp ON d.i = rp.i LEFT JOIN TestEntity4 n ON rp.l = n.i"
+      "SELECT DISTINCT a.s, d.l, n.i FROM TestEntity d INNER JOIN TestEntity2 a ON d.i = a.i INNER JOIN (SELECT rp.l, rp.i FROM TestEntity3 rp WHERE rp.s = ?) AS rp ON d.i = rp.i LEFT JOIN TestEntity4 n ON rp.l = n.i"
   }
 
   "multiple joins + map" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -222,14 +222,14 @@ class RenamePropertiesSpec extends Spec {
           e.distinct
         }
         testContext.run(q).string mustEqual
-          "SELECT x.field_s, x.field_i, x.l, x.o FROM (SELECT DISTINCT x.* FROM test_entity x) x"
+          "SELECT x.field_s, x.field_i, x.l, x.o FROM (SELECT DISTINCT x.* FROM test_entity x) AS x"
       }
       "transitive" in {
         val q = quote {
           e.distinct.map(t => t.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT t.field_s FROM (SELECT DISTINCT x.* FROM test_entity x) t"
+          "SELECT t.field_s FROM (SELECT DISTINCT x.* FROM test_entity x) AS t"
       }
     }
 
@@ -246,21 +246,21 @@ class RenamePropertiesSpec extends Spec {
           e.join(f).on((a, b) => a.s == b.s).map(t => t._1.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT a.field_s FROM test_entity a INNER JOIN (SELECT t.s FROM TestEntity t WHERE t.i = 1) t ON a.field_s = t.s"
+          "SELECT a.field_s FROM test_entity a INNER JOIN (SELECT t.s FROM TestEntity t WHERE t.i = 1) AS t ON a.field_s = t.s"
       }
       "left" in {
         val q = quote {
           e.leftJoin(f).on((a, b) => a.s == b.s).map(t => t._1.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT a.field_s FROM test_entity a LEFT JOIN (SELECT t.s FROM TestEntity t WHERE t.i = 1) t ON a.field_s = t.s"
+          "SELECT a.field_s FROM test_entity a LEFT JOIN (SELECT t.s FROM TestEntity t WHERE t.i = 1) AS t ON a.field_s = t.s"
       }
       "right" in {
         val q = quote {
           f.rightJoin(e).on((a, b) => a.s == b.s).map(t => t._2.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT b.field_s FROM (SELECT t.s FROM TestEntity t WHERE t.i = 1) t RIGHT JOIN test_entity b ON t.s = b.field_s"
+          "SELECT b.field_s FROM (SELECT t.s FROM TestEntity t WHERE t.i = 1) AS t RIGHT JOIN test_entity b ON t.s = b.field_s"
       }
       "flat inner" in {
         val q = quote {


### PR DESCRIPTION
Fixes #1204 

### Problem

Some generated queries are invalid without explicit `AS` keyword. This PR fixes it

### Solution

Explicit `AS` emitted in all cases except table aliases

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers