### PR TITLE
fix column name conflict

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandNestedQueries.scala
@@ -21,10 +21,7 @@ object ExpandNestedQueries {
   def apply(q: SqlQuery, references: collection.Set[Property]): SqlQuery =
     q match {
       case q: FlattenSqlQuery =>
-        q.distinct match {
-          case false => expandNested(q.copy(select = expandSelect(q.select, references)))
-          case true  => expandNested(q.copy(select = expandSelect(q.select, Set.empty)))
-        }
+        expandNested(q.copy(select = expandSelect(q.select, references)))
       case SetOperationSqlQuery(a, op, b) =>
         SetOperationSqlQuery(apply(a, references), op, apply(b, references))
       case UnaryOperationSqlQuery(op, q) =>
@@ -75,8 +72,8 @@ object ExpandNestedQueries {
           }
         case Property(ast: Property, name) =>
           expandReference(ast) match {
-            case SelectValue(ast, _, c) =>
-              SelectValue(Property(ast, name), Some(name), c)
+            case SelectValue(ast, nested, c) =>
+              SelectValue(Property(ast, name), Some(s"${nested.getOrElse("")}$name"), c)
           }
         case Property(_, TupleIndex(idx)) =>
           select(idx) match {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -57,7 +57,7 @@ class SqlQuerySpec extends Spec {
         }
       }
       testContext.run(q).string mustEqual
-        "SELECT x02.s, x02.i, x02.l, x02.o, x02.s, x02.i, x02.l, x02.o, x12.s, x12.i, x12.l, x12.o FROM (SELECT x01.s AS s, x01.l AS l, x01.o AS o, x01.i AS i, x11.i AS i, x11.o AS o, x11.l AS l, x11.s AS s FROM TestEntity x01 LEFT JOIN TestEntity2 x11 ON x01.i = x11.i WHERE x11.l = 3) AS x02 LEFT JOIN TestEntity3 x12 ON x02.i = x02.i AND x02.i = x12.i"
+        "SELECT x02._1s, x02._1i, x02._1l, x02._1o, x02._2s, x02._2i, x02._2l, x02._2o, x12.s, x12.i, x12.l, x12.o FROM (SELECT x01.s AS _1s, x01.l AS _1l, x01.o AS _1o, x01.i AS _1i, x11.i AS _2i, x11.o AS _2o, x11.l AS _2l, x11.s AS _2s FROM TestEntity x01 LEFT JOIN TestEntity2 x11 ON x01.i = x11.i WHERE x11.l = 3) AS x02 LEFT JOIN TestEntity3 x12 ON x02._2i = x02._1i AND x02._2i = x12.i"
     }
 
     "flat outer join" in {
@@ -295,7 +295,7 @@ class SqlQuerySpec extends Spec {
               }
           }
           testContext.run(q).string mustEqual
-            "SELECT t.i, SUM(t.i) FROM (SELECT a.i AS i, b.i AS i FROM TestEntity a INNER JOIN TestEntity2 b ON a.s = b.s) AS t GROUP BY t.i"
+            "SELECT t._2i, SUM(t._1i) FROM (SELECT a.i AS _1i, b.i AS _2i FROM TestEntity a INNER JOIN TestEntity2 b ON a.s = b.s) AS t GROUP BY t._2i"
         }
       }
     }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomNamingSpec.scala
@@ -70,7 +70,7 @@ class SqlIdiomNamingSpec extends Spec {
       val q = quote {
         query[SomeEntity].distinct
       }
-      db.run(q.dynamic).string mustEqual "SELECT d_x.d_somecolumn FROM (SELECT DISTINCT d_x.* FROM d_someentity d_x) AS d_x"
+      db.run(q.dynamic).string mustEqual "SELECT d_x.d_somecolumn FROM (SELECT DISTINCT d_x.d_somecolumn FROM d_someentity d_x) AS d_x"
     }
 
     val db = new SqlMirrorContext(MirrorSqlDialect, SnakeCase)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -101,7 +101,7 @@ class SqlIdiomSpec extends Spec {
             qr1.distinct
           }
           testContext.run(q).string mustEqual
-            "SELECT x.s, x.i, x.l, x.o FROM (SELECT DISTINCT x.* FROM TestEntity x) AS x"
+            "SELECT x.s, x.i, x.l, x.o FROM (SELECT DISTINCT x.s, x.i, x.l, x.o FROM TestEntity x) AS x"
         }
 
         "single" in {
@@ -126,7 +126,7 @@ class SqlIdiomSpec extends Spec {
             qr1.map(i => new IntLong(i.i, i.l)).distinct
           }
           testContext.run(q).string mustEqual
-            "SELECT i.i, i.l FROM (SELECT DISTINCT i.i, i.l FROM TestEntity i) AS i"
+            "SELECT i.i, i.l FROM (SELECT DISTINCT i.i AS i, i.l AS l FROM TestEntity i) AS i"
         }
         "caseclass companion constructor" in {
           case class IntLong(i: Int, l: Long)
@@ -134,7 +134,7 @@ class SqlIdiomSpec extends Spec {
             qr1.map(i => IntLong(i.i, i.l)).distinct
           }
           testContext.run(q).string mustEqual
-            "SELECT i.i, i.l FROM (SELECT DISTINCT i.i, i.l FROM TestEntity i) AS i"
+            "SELECT i.i, i.l FROM (SELECT DISTINCT i.i AS i, i.l AS l FROM TestEntity i) AS i"
         }
 
         "nesting" in {
@@ -142,7 +142,7 @@ class SqlIdiomSpec extends Spec {
             qr1.map(i => i.i).distinct.map(x => x + 1)
           }
           testContext.run(q).string mustEqual
-            "SELECT i.i + 1 FROM (SELECT DISTINCT i.i FROM TestEntity i) AS i"
+            "SELECT i.i + 1 FROM (SELECT DISTINCT i AS i FROM TestEntity i) AS i"
         }
 
         "with join + filter" in {
@@ -153,7 +153,7 @@ class SqlIdiomSpec extends Spec {
             } yield (v1, v2)
           }
           testContext.run(q).string mustEqual
-            "SELECT i.i, x1.s, x1.i, x1.l, x1.o FROM (SELECT DISTINCT i.i FROM TestEntity i) AS i, TestEntity2 x1 WHERE x1.i = i.i"
+            "SELECT i.i, x1.s, x1.i, x1.l, x1.o FROM (SELECT DISTINCT i AS i FROM TestEntity i) AS i, TestEntity2 x1 WHERE x1.i = i.i"
         }
 
         "with two joins" in {
@@ -164,7 +164,7 @@ class SqlIdiomSpec extends Spec {
             } yield (v1, v2)
           }
           testContext.run(q).string mustEqual
-            "SELECT i.i, x2.s, x2.i, x2.l, x2.o FROM (SELECT DISTINCT i.i FROM TestEntity i) AS i INNER JOIN (SELECT x2.s, x2.i, x2.l, x2.o FROM TestEntity2 x2 ORDER BY x2.l ASC NULLS FIRST) AS x2 ON x2.i = i.i"
+            "SELECT i.i, x2.s, x2.i, x2.l, x2.o FROM (SELECT DISTINCT i AS i FROM TestEntity i) AS i INNER JOIN (SELECT x2.s, x2.i, x2.l, x2.o FROM TestEntity2 x2 ORDER BY x2.l ASC NULLS FIRST) AS x2 ON x2.i = i.i"
         }
 
         "followed by aggregation" in {
@@ -435,7 +435,7 @@ class SqlIdiomSpec extends Spec {
             j.union(j).map(u => (u._1.s, u._2.i))
           }
           testContext.run(q).string mustEqual
-            "SELECT u.s, u.i FROM ((SELECT a.s AS s, b.i AS i FROM TestEntity a, TestEntity2 b) UNION (SELECT a1.s AS s, b1.i AS i FROM TestEntity a1, TestEntity2 b1)) AS u"
+            "SELECT u._1s, u._2i FROM ((SELECT a.s AS _1s, b.i AS _2i FROM TestEntity a, TestEntity2 b) UNION (SELECT a1.s AS _1s, b1.i AS _2i FROM TestEntity a1, TestEntity2 b1)) AS u"
         }
       }
       "unionAll" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/JoinSpec.scala
@@ -40,7 +40,7 @@ class JoinSpec extends Spec {
       }
     }
     testContext.run(q).string mustEqual
-      "SELECT ab.s, ab.i, ab.l, ab.o, ab.s, ab.i, ab.l, ab.o, c.s, c.i, c.l, c.o FROM (SELECT a.s AS s, a.o AS o, a.l AS l, a.i AS i, b.l AS l, b.i AS i, b.o AS o, b.s AS s FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.l = 3) AS ab LEFT JOIN TestEntity3 c ON ab.i = ab.i AND ab.i = c.i"
+      "SELECT ab._1s, ab._1i, ab._1l, ab._1o, ab._2s, ab._2i, ab._2l, ab._2o, c.s, c.i, c.l, c.o FROM (SELECT a.s AS _1s, a.o AS _1o, a.l AS _1l, a.i AS _1i, b.l AS _2l, b.i AS _2i, b.o AS _2o, b.s AS _2s FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i WHERE b.l = 3) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
   }
 
   "join + distinct + leftjoin" in {
@@ -53,7 +53,7 @@ class JoinSpec extends Spec {
       }
     }
     testContext.run(q).string mustEqual
-      "SELECT ab.s, ab.i, ab.l, ab.o, ab.s, ab.i, ab.l, ab.o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.*, b.* FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i) AS ab LEFT JOIN TestEntity3 c ON ab.i = ab.i AND ab.i = c.i"
+      "SELECT ab._1s, ab._1i, ab._1l, ab._1o, ab._2s, ab._2i, ab._2l, ab._2o, c.s, c.i, c.l, c.o FROM (SELECT DISTINCT a.s AS _1s, a.o AS _1o, a.l AS _1l, a.i AS _1i, b.l AS _2l, b.i AS _2i, b.o AS _2o, b.s AS _2s FROM TestEntity a LEFT JOIN TestEntity2 b ON a.i = b.i) AS ab LEFT JOIN TestEntity3 c ON ab._2i = ab._1i AND ab._2i = c.i"
   }
 
   "multiple joins + filter + map + distinct" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesSpec.scala
@@ -222,14 +222,14 @@ class RenamePropertiesSpec extends Spec {
           e.distinct
         }
         testContext.run(q).string mustEqual
-          "SELECT x.field_s, x.field_i, x.l, x.o FROM (SELECT DISTINCT x.* FROM test_entity x) AS x"
+          "SELECT x.field_s, x.field_i, x.l, x.o FROM (SELECT DISTINCT x.field_s, x.field_i, x.l, x.o FROM test_entity x) AS x"
       }
       "transitive" in {
         val q = quote {
           e.distinct.map(t => t.s)
         }
         testContext.run(q).string mustEqual
-          "SELECT t.field_s FROM (SELECT DISTINCT x.* FROM test_entity x) AS t"
+          "SELECT t.field_s FROM (SELECT DISTINCT x.field_s FROM test_entity x) AS t"
       }
     }
 


### PR DESCRIPTION
Fixes #1021 

### Problem

Quill expands nested queries but it doesn't handle column name conflicts correctly.

### Solution

Use column aliases to avoid the conflicts.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
