### PR TITLE
support dynamic strings within infix

### DIFF
--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -777,6 +777,51 @@ class QuotationSpec extends Spec {
         }
         quote(unquote(q)).ast.body mustEqual Infix(List("", " || ", ""), List(Ident("a"), Ident("b")))
       }
+      "with dynamic string" - {
+        "at the end" in {
+          val b = "dyn"
+          val q = quote {
+            (a: String) =>
+              infix"$a || #$b".as[String]
+          }
+          quote(unquote(q)).ast must matchPattern {
+            case Function(_, Infix(List("", " || dyn"), List(Ident("a")))) =>
+          }
+        }
+        "at the beginning" in {
+          val a = "dyn"
+          val q = quote {
+            (b: String) =>
+              infix"#$a || $b".as[String]
+          }
+          quote(unquote(q)).ast must matchPattern {
+            case Function(_, Infix(List("dyn || ", ""), List(Ident("b")))) =>
+          }
+        }
+        "only" in {
+          val a = "dyn1"
+          val q = quote {
+            infix"#$a".as[String]
+          }
+          quote(unquote(q)).ast mustEqual Infix(List("dyn1"), List())
+        }
+        "sequential" in {
+          val a = "dyn1"
+          val b = "dyn2"
+          val q = quote {
+            infix"#$a#$b".as[String]
+          }
+          quote(unquote(q)).ast mustEqual Infix(List("dyn1dyn2"), List())
+        }
+        "non-string value" in {
+          case class Value(a: String)
+          val a = Value("dyn")
+          val q = quote {
+            infix"#$a".as[String]
+          }
+          quote(unquote(q)).ast mustEqual Infix(List("Value(dyn)"), List())
+        }
+      }
     }
     "option operation" - {
       "map" in {


### PR DESCRIPTION
Fixes #223 

### Problem

Quill doesn't allow users to inject runtime strings into their quotations.

### Solution

Introduce a mechanism to splice dynamic strings within infixes.

### Notes

@mentegy I took a simpler approach here than https://github.com/getquill/quill/pull/1020, please check if there's anything missing

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
