### PR TITLE
[WIP] Create a streaming module for Monix over JDBC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val modules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
   `quill-core-jvm`, `quill-core-js`, `quill-sql-jvm`, `quill-sql-js`,
   `quill-jdbc`, `quill-finagle-mysql`, `quill-finagle-postgres`, `quill-async`,
   `quill-async-mysql`, `quill-async-postgres`, `quill-cassandra`, `quill-orientdb`,
-  `quill-spark`
+  `quill-spark`, `quill-streaming-cats`, `quill-streaming-monix`
 )
 
 lazy val `quill` =
@@ -180,6 +180,41 @@ lazy val `quill-orientdb` =
         )
       )
       .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
+
+lazy val `quill-streaming-cats` = 
+  (project in file("quill-streaming-cats"))
+    .settings(commonSettings: _*)
+    .settings(mimaSettings: _*)
+    .settings(
+      fork in Test := true,
+      libraryDependencies ++= Seq(
+        "com.zaxxer"    % "HikariCP"     % "3.2.0",
+        "org.typelevel" %% "cats-effect" % "1.1.0"
+      ),
+      scalacOptions ++= Seq(
+        "-language:higherKinds",
+        "-language:existentials",
+        "-Ypartial-unification"
+      )
+    )
+    .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
+
+lazy val `quill-streaming-monix` =
+  (project in file("quill-streaming-monix"))
+    .settings(commonSettings: _*)
+    .settings(mimaSettings: _*)
+    .settings(
+      fork in Test := true,
+      libraryDependencies ++= Seq(
+        "io.monix" %% "monix" % "3.0.0-RC2"
+      ),
+      scalacOptions ++= Seq(
+        "-language:higherKinds",
+        "-language:existentials",
+        "-Ypartial-unification"
+      )
+    )
+    .dependsOn(`quill-streaming-cats` % "compile->compile;test->test")
 
 lazy val `tut-sources` = Seq(
   "CASSANDRA.md",

--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,8 @@ lazy val `quill-streaming-monix` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "io.monix" %% "monix" % "3.0.0-RC2"
+        "io.monix" %% "monix" % "3.0.0-RC2",
+        "org.postgresql" % "postgresql" % "42.2.5" % Test,
       ),
       scalacOptions ++= Seq(
         "-language:higherKinds",
@@ -214,7 +215,7 @@ lazy val `quill-streaming-monix` =
         "-Ypartial-unification"
       )
     )
-    .dependsOn(`quill-streaming-cats` % "compile->compile;test->test")
+    .dependsOn(`quill-sql-jvm` % "compile->compile;test->test", `quill-streaming-cats` % "compile->compile;test->test")
 
 lazy val `tut-sources` = Seq(
   "CASSANDRA.md",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,3 +26,5 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
+
+addSbtPlugin("com.triplequote" % "sbt-hydra" % "2.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,5 +26,3 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
-
-addSbtPlugin("com.triplequote" % "sbt-hydra" % "2.0.0")

--- a/quill-streaming-cats/src/main/scala/io/getquill/StreamingContextConfig.scala
+++ b/quill-streaming-cats/src/main/scala/io/getquill/StreamingContextConfig.scala
@@ -1,0 +1,26 @@
+package io.getquill
+
+import com.typesafe.config.Config
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import java.util.Properties
+import scala.util.control.NonFatal
+
+case class StreamingContextConfig(config: Config) {
+
+  def configProperties = {
+    import scala.collection.JavaConverters._
+    val p = new Properties
+    for (entry <- config.entrySet.asScala)
+      p.setProperty(entry.getKey, entry.getValue.unwrapped.toString)
+    p
+  }
+
+  def dataSource =
+    try
+      new HikariDataSource(new HikariConfig(configProperties))
+    catch {
+      case NonFatal(ex) =>
+        throw new IllegalStateException(s"Failed to load data source for config: '$config'", ex)
+    }
+}

--- a/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/ArrayDecoders.scala
+++ b/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/ArrayDecoders.scala
@@ -1,0 +1,63 @@
+package io.getquill.context.streaming
+
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.util.Date
+import java.sql.{ Date => SqlDate }
+import java.math.{ BigDecimal => JBigDecimal }
+
+import io.getquill.context.sql.encoding.ArrayEncoding
+import io.getquill.util.Messages.fail
+
+import scala.collection.generic.CanBuildFrom
+import scala.reflect.ClassTag
+
+trait ArrayDecoders[F[_]] extends ArrayEncoding { self: StreamingContext[F, _, _] =>
+
+  implicit def arrayStringDecoder[Col <: Seq[String]](implicit bf: CanBuildFrom[Nothing, String, Col]): Decoder[Col] = arrayRawDecoder[String, Col]
+  implicit def arrayBigDecimalDecoder[Col <: Seq[BigDecimal]](implicit bf: CBF[BigDecimal, Col]): Decoder[Col] = arrayDecoder[JBigDecimal, BigDecimal, Col](BigDecimal.apply)
+  implicit def arrayBooleanDecoder[Col <: Seq[Boolean]](implicit bf: CBF[Boolean, Col]): Decoder[Col] = arrayRawDecoder[Boolean, Col]
+  implicit def arrayByteDecoder[Col <: Seq[Byte]](implicit bf: CBF[Byte, Col]): Decoder[Col] = arrayRawDecoder[Byte, Col]
+  implicit def arrayShortDecoder[Col <: Seq[Short]](implicit bf: CBF[Short, Col]): Decoder[Col] = arrayRawDecoder[Short, Col]
+  implicit def arrayIntDecoder[Col <: Seq[Int]](implicit bf: CBF[Int, Col]): Decoder[Col] = arrayRawDecoder[Int, Col]
+  implicit def arrayLongDecoder[Col <: Seq[Long]](implicit bf: CBF[Long, Col]): Decoder[Col] = arrayRawDecoder[Long, Col]
+  implicit def arrayFloatDecoder[Col <: Seq[Float]](implicit bf: CBF[Float, Col]): Decoder[Col] = arrayRawDecoder[Float, Col]
+  implicit def arrayDoubleDecoder[Col <: Seq[Double]](implicit bf: CBF[Double, Col]): Decoder[Col] = arrayRawDecoder[Double, Col]
+  implicit def arrayDateDecoder[Col <: Seq[Date]](implicit bf: CBF[Date, Col]): Decoder[Col] = arrayRawDecoder[Date, Col]
+  implicit def arrayTimestampDecoder[Col <: Seq[Timestamp]](implicit bf: CBF[Timestamp, Col]): Decoder[Col] = arrayRawDecoder[Timestamp, Col]
+  implicit def arrayLocalDateDecoder[Col <: Seq[LocalDate]](implicit bf: CBF[LocalDate, Col]): Decoder[Col] = arrayDecoder[SqlDate, LocalDate, Col](_.toLocalDate)
+
+  /**
+   * Generic encoder for JDBC arrays.
+   *
+   * @param mapper retrieved raw types fro JDBC array may be mapped via this mapper to satisfy encoder type
+   * @param bf builder factory is needed to create instances of decoder's collection
+   * @tparam I raw type retrieved form JDBC array
+   * @tparam O mapped type fulfilled in decoder's collection
+   * @tparam Col seq type
+   * @return JDBC array decoder
+   */
+  def arrayDecoder[I, O, Col <: Seq[O]](mapper: I => O)(implicit bf: CanBuildFrom[Nothing, O, Col], tag: ClassTag[I]): Decoder[Col] = {
+    decoder[Col]((idx: Index, row: ResultRow) => {
+      val arr = row.getArray(idx)
+      if (arr == null) bf().result()
+      else arr.getArray.asInstanceOf[Array[AnyRef]].foldLeft(bf()) {
+        case (b, x: I)                => b += mapper(x)
+        case (b, x: java.lang.Number) => b += mapper(x.asInstanceOf[I])
+        case (_, x) =>
+          fail(s"Retrieved ${x.getClass.getCanonicalName} type from JDBC array, but expected $tag. Re-check your decoder implementation")
+      }.result()
+    })
+  }
+
+  /**
+   * Creates JDBC array decoder for type `T` which is already supported by database as array element.
+   *
+   * @param bf builder factory is needed to create instances of decoder's collection
+   * @tparam T element type
+   * @tparam Col seq type
+   * @return JDBC array decoder
+   */
+  def arrayRawDecoder[T: ClassTag, Col <: Seq[T]](implicit bf: CanBuildFrom[Nothing, T, Col]): Decoder[Col] =
+    arrayDecoder[T, T, Col](identity)
+}

--- a/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/ArrayEncoders.scala
+++ b/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/ArrayEncoders.scala
@@ -1,0 +1,70 @@
+package io.getquill.context.streaming
+
+import java.sql.{ Timestamp, Date => SqlDate }
+import java.sql.Types._
+import java.time.LocalDate
+import java.util.Date
+import scala.collection.generic.CanBuildFrom
+
+trait ArrayEncoders[F[_]] { self: StreamingContext[F, _, _] =>
+
+  implicit def arrayStringEncoder[Col <: Seq[String]]: Encoder[Col] = arrayRawEncoder[String, Col](VARCHAR)
+  implicit def arrayBigDecimalEncoder[Col <: Seq[BigDecimal]]: Encoder[Col] =
+    arrayEncoder[BigDecimal, Col](parseJdbcType(NUMERIC), _.bigDecimal)
+  implicit def arrayBooleanEncoder[Col <: Seq[Boolean]]: Encoder[Col] = arrayRawEncoder[Boolean, Col](BOOLEAN)
+  implicit def arrayByteEncoder[Col <: Seq[Byte]]: Encoder[Col] = arrayRawEncoder[Byte, Col](TINYINT)
+  implicit def arrayShortEncoder[Col <: Seq[Short]]: Encoder[Col] = arrayRawEncoder[Short, Col](SMALLINT)
+  implicit def arrayIntEncoder[Col <: Seq[Int]]: Encoder[Col] = arrayRawEncoder[Int, Col](INTEGER)
+  implicit def arrayLongEncoder[Col <: Seq[Long]]: Encoder[Col] = arrayRawEncoder[Long, Col](BIGINT)
+  implicit def arrayFloatEncoder[Col <: Seq[Float]]: Encoder[Col] = arrayRawEncoder[Float, Col](FLOAT)
+  implicit def arrayDoubleEncoder[Col <: Seq[Double]]: Encoder[Col] = arrayRawEncoder[Double, Col](DOUBLE)
+  implicit def arrayDateEncoder[Col <: Seq[Date]]: Encoder[Col] = arrayRawEncoder[Date, Col](TIMESTAMP)
+  implicit def arrayTimestampEncoder[Col <: Seq[Timestamp]]: Encoder[Col] = arrayRawEncoder[Timestamp, Col](TIMESTAMP)
+  implicit def arrayLocalDateEncoder[Col <: Seq[LocalDate]]: Encoder[Col] =
+    arrayEncoder[LocalDate, Col](parseJdbcType(DATE), SqlDate.valueOf)
+
+  /**
+   * Generic encoder for JDBC arrays.
+   *
+   * @param jdbcType JDBC specific type identification, may be various regarding to JDBC driver
+   * @param mapper jdbc array accepts AnyRef objects hence a mapper is needed.
+   *               If input type of an element of collection is not comfortable with jdbcType
+   *               then use this mapper to transform to appropriate type before casting to AnyRef
+   * @tparam T element type
+   * @tparam Col seq type
+   * @return JDBC array encoder
+   */
+  def arrayEncoder[T, Col <: Seq[T]](jdbcType: String, mapper: T => AnyRef): Encoder[Col] = {
+    encoder[Col](
+      ARRAY,
+      (idx: Index, seq: Col, row: PrepareRow) => {
+        val bf = implicitly[CanBuildFrom[Nothing, AnyRef, Array[AnyRef]]]
+        row.setArray(
+          idx,
+          row.getConnection.createArrayOf(jdbcType, seq.foldLeft(bf())((b, x) => b += mapper(x)).result())
+        )
+      }
+    )
+  }
+
+  /**
+   * Creates JDBC array encoder for type `T` which is already supported by database as array element.
+   *
+   * @param jdbcType JDBC specific type identification, may be various regarding to JDBC driver
+   * @tparam T element type
+   * @tparam Col seq type
+   * @return JDBC array encoder
+   */
+  def arrayRawEncoder[T, Col <: Seq[T]](jdbcType: String): Encoder[Col] =
+    arrayEncoder[T, Col](jdbcType, _.asInstanceOf[AnyRef])
+
+  /**
+   * Transform jdbcType int using `parseJdbcType` and calls overloaded method to create Encoder
+   *
+   * @param jdbcType java.sql.Types
+   * @see arrayRawEncoder(jdbcType: String)
+   * @see JdbcContext#parseJdbcType(jdbcType: String)
+   */
+  def arrayRawEncoder[T, Col <: Seq[T]](jdbcType: Int): Encoder[Col] =
+    arrayRawEncoder[T, Col](parseJdbcType(jdbcType))
+}

--- a/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/Decoders.scala
+++ b/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/Decoders.scala
@@ -1,0 +1,83 @@
+package io.getquill.context.streaming
+
+import java.time.{ LocalDate, LocalDateTime }
+import java.util
+import java.util.Calendar
+import scala.math.BigDecimal.javaBigDecimal2bigDecimal
+
+trait Decoders[F[_]] { self: StreamingContext[F, _, _] =>
+
+  type Decoder[T] = JdbcDecoder[T]
+
+  case class JdbcDecoder[T](decoder: BaseDecoder[T]) extends BaseDecoder[T] {
+    def apply(index: Index, row: ResultRow) =
+      decoder(index + 1, row)
+  }
+
+  def decoder[T](d: BaseDecoder[T]): Decoder[T] =
+    JdbcDecoder(d)
+
+  def decoder[T](f: ResultRow => Index => T): Decoder[T] =
+    decoder((index, row) => f(row)(index))
+
+  implicit def mappedDecoder[I, O](implicit mapped: MappedEncoding[I, O], d: Decoder[I]): Decoder[O] =
+    JdbcDecoder(mappedBaseDecoder(mapped, d.decoder))
+
+  implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] =
+    JdbcDecoder(
+      (index, row) => {
+        try {
+          val res = d.decoder(index, row)
+          if (row.wasNull()) {
+            None
+          } else {
+            Some(res)
+          }
+        } catch {
+          case _: NullPointerException if row.wasNull() => None
+        }
+      }
+    )
+
+  implicit val stringDecoder: Decoder[String] = decoder(_.getString)
+  implicit val bigDecimalDecoder: Decoder[BigDecimal] =
+    decoder((index, row) => {
+      val v = row.getBigDecimal(index)
+      if (v == null)
+        BigDecimal(0)
+      else
+        v
+    })
+  implicit val booleanDecoder: Decoder[Boolean] = decoder(_.getBoolean)
+  implicit val byteDecoder: Decoder[Byte] = decoder(_.getByte)
+  implicit val shortDecoder: Decoder[Short] = decoder(_.getShort)
+  implicit val intDecoder: Decoder[Int] = decoder(_.getInt)
+  implicit val longDecoder: Decoder[Long] = decoder(_.getLong)
+  implicit val floatDecoder: Decoder[Float] = decoder(_.getFloat)
+  implicit val doubleDecoder: Decoder[Double] = decoder(_.getDouble)
+  implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoder(_.getBytes)
+  implicit val dateDecoder: Decoder[util.Date] =
+    decoder((index, row) => {
+      val v = row.getTimestamp(index, Calendar.getInstance(dateTimeZone))
+      if (v == null)
+        new util.Date(0)
+      else
+        new util.Date(v.getTime)
+    })
+  implicit val localDateDecoder: Decoder[LocalDate] =
+    decoder((index, row) => {
+      val v = row.getDate(index, Calendar.getInstance(dateTimeZone))
+      if (v == null)
+        LocalDate.ofEpochDay(0)
+      else
+        v.toLocalDate
+    })
+  implicit val localDateTimeDecoder: Decoder[LocalDateTime] =
+    decoder((index, row) => {
+      val v = row.getTimestamp(index, Calendar.getInstance(dateTimeZone))
+      if (v == null)
+        LocalDate.ofEpochDay(0).atStartOfDay()
+      else
+        v.toLocalDateTime
+    })
+}

--- a/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/Encoders.scala
+++ b/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/Encoders.scala
@@ -1,0 +1,62 @@
+package io.getquill.context.streaming
+import java.{ sql, util }
+import java.sql.{ Date, Timestamp, Types }
+import java.time.{ LocalDate, LocalDateTime }
+import java.util.{ Calendar, TimeZone }
+
+trait Encoders[F[_]] { self: StreamingContext[F, _, _] =>
+  type Encoder[T] = JdbcEncoder[T]
+
+  protected val dateTimeZone = TimeZone.getDefault
+
+  case class JdbcEncoder[T](sqlType: Int, encoder: BaseEncoder[T]) extends BaseEncoder[T] {
+    override def apply(index: Index, value: T, row: PrepareRow): PrepareRow =
+      encoder(index + 1, value, row)
+  }
+
+  def encoder[T](sqlType: Int, f: (Index, T, PrepareRow) => Unit): Encoder[T] =
+    JdbcEncoder(sqlType, (index: Index, value: T, row: PrepareRow) => {
+      f(index, value, row)
+      row
+    })
+
+  def encoder[T](sqlType: Int, f: PrepareRow => (Index, T) => Unit): Encoder[T] =
+    encoder(sqlType, (index: Index, value: T, row: PrepareRow) => f(row)(index, value))
+
+  implicit def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], e: Encoder[O]): Encoder[I] =
+    JdbcEncoder(e.sqlType, mappedBaseEncoder(mapped, e.encoder))
+
+  private[this] val nullEncoder: Encoder[Int] = encoder(Types.INTEGER, _.setNull)
+
+  implicit def optionEncoder[T](implicit d: Encoder[T]): Encoder[Option[T]] =
+    JdbcEncoder(
+      d.sqlType,
+      (index, value, row) =>
+        value match {
+          case Some(v) => d.encoder(index, v, row)
+          case None    => nullEncoder.encoder(index, d.sqlType, row)
+        }
+    )
+
+  implicit val stringEncoder: Encoder[String] = encoder(Types.VARCHAR, _.setString)
+  implicit val bigDecimalEncoder: Encoder[BigDecimal] =
+    encoder(Types.NUMERIC, (index, value, row) => row.setBigDecimal(index, value.bigDecimal))
+  implicit val booleanEncoder: Encoder[Boolean] = encoder(Types.BOOLEAN, _.setBoolean)
+  implicit val byteEncoder: Encoder[Byte] = encoder(Types.TINYINT, _.setByte)
+  implicit val shortEncoder: Encoder[Short] = encoder(Types.SMALLINT, _.setShort)
+  implicit val intEncoder: Encoder[Int] = encoder(Types.INTEGER, _.setInt)
+  implicit val longEncoder: Encoder[Long] = encoder(Types.BIGINT, _.setLong)
+  implicit val floatEncoder: Encoder[Float] = encoder(Types.FLOAT, _.setFloat)
+  implicit val doubleEncoder: Encoder[Double] = encoder(Types.DOUBLE, _.setDouble)
+  implicit val byteArrayEncoder: Encoder[Array[Byte]] = encoder(Types.VARBINARY, _.setBytes)
+  implicit val dateEncoder: Encoder[util.Date] =
+    encoder(Types.TIMESTAMP, (index, value, row) =>
+      row.setTimestamp(index, new sql.Timestamp(value.getTime), Calendar.getInstance(dateTimeZone)))
+  implicit val localDateEncoder: Encoder[LocalDate] =
+    encoder(Types.DATE, (index, value, row) =>
+      row.setDate(index, Date.valueOf(value), Calendar.getInstance(dateTimeZone)))
+  implicit val localDateTimeEncoder: Encoder[LocalDateTime] =
+    encoder(Types.TIMESTAMP, (index, value, row) =>
+      row.setTimestamp(index, Timestamp.valueOf(value), Calendar.getInstance(dateTimeZone)))
+}
+

--- a/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/StreamingContext.scala
+++ b/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/StreamingContext.scala
@@ -1,0 +1,131 @@
+package io.getquill.context.streaming
+
+import java.sql.{ Connection, JDBCType, PreparedStatement, ResultSet }
+import scala.annotation.tailrec
+import cats.syntax.functor._
+import cats.effect.Sync
+import io.getquill.NamingStrategy
+import io.getquill.context.sql.idiom.SqlIdiom
+import io.getquill.context.sql.SqlContext
+import io.getquill.context.Context
+import io.getquill.util.ContextLogger
+
+abstract class StreamingContext[F[_], Dialect <: SqlIdiom, Naming <: NamingStrategy](implicit F: Sync[F])
+  extends Context[Dialect, Naming]
+  with SqlContext[Dialect, Naming]
+  with Encoders[F]
+  with Decoders[F] {
+
+  protected val logger = ContextLogger(getClass)
+
+  override type PrepareRow = PreparedStatement
+  override type ResultRow = ResultSet
+
+  override type Result[T] = F[T]
+  override type RunQueryResult[T] = List[T]
+  override type RunQuerySingleResult[T] = T
+  override type RunActionResult = Long
+  override type RunActionReturningResult[T] = T
+  override type RunBatchActionResult = List[Long]
+  override type RunBatchActionReturningResult[T] = List[T]
+
+  def transaction[A](f: F[A]): F[A]
+
+  protected def withConnection[T](f: Connection => F[T]): F[T]
+
+  def executeQuery[T](
+    sql:       String,
+    prepare:   Prepare      = identityPrepare,
+    extractor: Extractor[T] = identityExtractor
+  ): F[List[T]] = withConnection { connection =>
+    F.delay {
+      val (params, ps) = prepare(connection.prepareStatement(sql))
+      logger.logQuery(sql, params)
+      val rs = ps.executeQuery()
+      extractResult(rs, extractor)
+    }
+  }
+
+  def executeQuerySingle[T](
+    sql:       String,
+    prepare:   Prepare      = identityPrepare,
+    extractor: Extractor[T] = identityExtractor
+  ): F[T] =
+    executeQuery(sql, prepare, extractor).map(handleSingleResult)
+
+  def executeAction[T](sql: String, prepare: Prepare = identityPrepare): F[Long] = withConnection { connection =>
+    F.delay {
+      val (params, ps) = prepare(connection.prepareStatement(sql))
+      logger.logQuery(sql, params)
+      ps.executeUpdate().toLong
+    }
+  }
+
+  def executeActionReturning[O](
+    sql:             String,
+    prepare:         Prepare      = identityPrepare,
+    extractor:       Extractor[O],
+    returningColumn: String
+  ): F[O] = withConnection { connection =>
+    F.delay {
+      val (params, ps) = prepare(connection.prepareStatement(sql, Array(returningColumn)))
+      logger.logQuery(sql, params)
+      ps.executeUpdate()
+      handleSingleResult(extractResult(ps.getGeneratedKeys, extractor))
+    }
+  }
+
+  def executeBatchAction(groups: List[BatchGroup]): F[List[Long]] = withConnection { connection =>
+    F.delay {
+      groups.flatMap {
+        case BatchGroup(sql, prepare) =>
+          val ps = connection.prepareStatement(sql)
+          logger.underlying.debug("Batch: {}", sql)
+          prepare.foreach { f =>
+            val (params, _) = f(ps)
+            logger.logBatchItem(sql, params)
+            ps.addBatch()
+          }
+          ps.executeBatch().map(_.toLong)
+      }
+    }
+  }
+
+  def executeBatchActionReturning[T](
+    groups:    List[BatchGroupReturning],
+    extractor: Extractor[T]              = identityExtractor
+  ): F[List[T]] = withConnection {
+    connection =>
+      F.delay {
+        groups.flatMap {
+          case BatchGroupReturning(sql, column, prepare) =>
+            val ps = connection.prepareStatement(sql, Array(column))
+            logger.underlying.debug("Batch: {}", sql)
+            prepare.foreach { f =>
+              val (params, _) = f(ps)
+              logger.logBatchItem(sql, params)
+              ps.addBatch()
+            }
+            ps.executeBatch()
+            extractResult(ps.getGeneratedKeys, extractor)
+        }
+      }
+  }
+
+  /**
+   * Parses instances of java.sql.Types to string form so it can be used in creation of sql arrays.
+   * Some databases does not support each of generic types, hence it's welcome to override this method
+   * and provide alternatives to non-existent types.
+   *
+   * @param intType one of java.sql.Types
+   * @return JDBC type in string form
+   */
+  def parseJdbcType(intType: Int): String = JDBCType.valueOf(intType).getName
+
+  @tailrec
+  private def extractResult[T](rs: ResultSet, extractor: Extractor[T], acc: List[T] = List()): List[T] =
+    if (rs.next)
+      extractResult(rs, extractor, extractor(rs) :: acc)
+    else
+      acc.reverse
+}

--- a/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/UUIDObjectEncoding.scala
+++ b/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/UUIDObjectEncoding.scala
@@ -1,0 +1,8 @@
+package io.getquill.context.streaming
+import java.sql.Types
+import java.util.UUID
+
+trait UUIDObjectEncoding[F[_]] { self: StreamingContext[F, _, _] =>
+  implicit val uuidEncoder: Encoder[UUID] = encoder(Types.OTHER, (index, value, row) => row.setObject(index, value, Types.OTHER))
+  implicit val uuidDecoder: Decoder[UUID] = decoder((index, row) => UUID.fromString(row.getObject(index).toString))
+}

--- a/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/UUIDStringEncoding.scala
+++ b/quill-streaming-cats/src/main/scala/io/getquill/context/streaming/UUIDStringEncoding.scala
@@ -1,0 +1,9 @@
+package io.getquill.context.streaming
+
+import java.sql.Types
+import java.util.UUID
+
+trait UUIDStringEncoding[F[_]] { self: StreamingContext[F, _, _] =>
+  implicit val uuidEncoder: Encoder[UUID] = encoder(Types.VARCHAR, (index, value, row) => row.setString(index, value.toString))
+  implicit val uuidDecoder: Decoder[UUID] = decoder((index, row) => UUID.fromString(row.getString(index)))
+}

--- a/quill-streaming-cats/src/test/scala/io/getquill/context/streaming/StreamingContextConfigSpec.scala
+++ b/quill-streaming-cats/src/test/scala/io/getquill/context/streaming/StreamingContextConfigSpec.scala
@@ -1,0 +1,12 @@
+package io.getquill.context.streaming
+
+import com.typesafe.config.ConfigFactory
+import io.getquill.{ StreamingContextConfig, Spec }
+
+class StreamingContextConfigSpec extends Spec {
+  "fail if cannot load dataSource" in {
+    intercept[IllegalStateException] {
+      StreamingContextConfig(ConfigFactory.empty()).dataSource
+    }
+  }
+}

--- a/quill-streaming-monix/src/main/scala/io/getquill/TaskStreamingContext.scala
+++ b/quill-streaming-monix/src/main/scala/io/getquill/TaskStreamingContext.scala
@@ -1,0 +1,73 @@
+package io.getquill
+import java.io.Closeable
+import java.sql.Connection
+import scala.util.Try
+import io.getquill.context.sql.idiom.SqlIdiom
+import io.getquill.context.streaming.StreamingContext
+import javax.sql.DataSource
+import monix.eval.Task
+import monix.execution.misc.Local
+import monix.execution.Scheduler
+
+abstract class TaskStreamingContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](
+  dataSource: DataSource with Closeable,
+  val idiom:  Dialect,
+  val naming: Naming
+)(implicit transactionScheduler: Scheduler)
+  extends StreamingContext[Task, Dialect, Naming] {
+
+  private val currentConnection: Local[Option[Connection]] = Local(None)
+
+  override def close(): Unit = dataSource.close()
+
+  override protected def withConnection[T](f: Connection => Task[T]): Task[T] =
+    currentConnection.get
+      .map(connection => f(connection))
+      .getOrElse {
+        Task(dataSource.getConnection).bracket(f)(conn => Task(conn.close())).executeOn(transactionScheduler)
+      }
+
+  override def transaction[A](f: Task[A]): Task[A] = {
+    val dbEffects = for {
+      result <- currentConnection.get match {
+        case Some(_) => f // Already in a transaction
+        case None =>
+          Task {
+            val connection = dataSource.getConnection
+            val wasAutoCommit = connection.getAutoCommit
+            connection.setAutoCommit(false)
+            (connection, wasAutoCommit)
+          }.bracket {
+            case (connection, _) =>
+              Task(connection).flatMap { connection =>
+                currentConnection.update(Some(connection))
+                f.onCancelRaiseError(new IllegalStateException()) // TODO Change this to another error
+                  .doOnFinish {
+                    case Some(error) =>
+                      connection.rollback()
+                      Task.raiseError(error)
+                    case None =>
+                      Task(connection.commit())
+                  }
+              }
+          } {
+            case (connection, wasAutoCommit) =>
+              Task {
+                currentConnection.update(None)
+                connection.setAutoCommit(wasAutoCommit)
+                connection.close()
+              }
+          }
+      }
+    } yield result
+
+    dbEffects
+      .executeOn(transactionScheduler)
+      .executeWithOptions(_.enableLocalContextPropagation)
+      .asyncBoundary
+  }
+
+  override def probe(statement: String): Try[_] = Try {
+    withConnection(conn => Task(conn.createStatement.execute(statement))).runSyncUnsafe()
+  }
+}

--- a/quill-streaming-monix/src/test/resources/application.conf
+++ b/quill-streaming-monix/src/test/resources/application.conf
@@ -1,0 +1,27 @@
+testMysqlDB.dataSourceClassName=com.mysql.jdbc.jdbc2.optional.MysqlDataSource
+testMysqlDB.dataSource.url="jdbc:mysql://"${?MYSQL_HOST}":"${?MYSQL_PORT}"/quill_test"
+testMysqlDB.dataSource.user=root
+testMysqlDB.dataSource.cachePrepStmts=true
+testMysqlDB.dataSource.prepStmtCacheSize=250
+testMysqlDB.dataSource.prepStmtCacheSqlLimit=2048
+testMysqlDB.maximumPoolSize=1
+
+testPostgresDB.dataSourceClassName=org.postgresql.ds.PGSimpleDataSource
+testPostgresDB.dataSource.user=postgres
+testPostgresDB.dataSource.databaseName=quill_test
+testPostgresDB.dataSource.portNumber=${?POSTGRES_PORT}
+testPostgresDB.dataSource.serverName=${?POSTGRES_HOST}
+
+testH2DB.dataSourceClassName=org.h2.jdbcx.JdbcDataSource
+testH2DB.dataSource.url="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:sql/h2-schema.sql'"
+testH2DB.dataSource.user=sa
+
+testSqliteDB.driverClassName=org.sqlite.JDBC
+testSqliteDB.jdbcUrl="jdbc:sqlite:quill_test.db"
+
+testSqlServerDB.dataSourceClassName=com.microsoft.sqlserver.jdbc.SQLServerDataSource
+testSqlServerDB.dataSource.user=sa
+testSqlServerDB.dataSource.password="QuillRocks!"
+testSqlServerDB.dataSource.databaseName=quill_test
+testSqlServerDB.dataSource.portNumber=${?SQL_SERVER_PORT}
+testSqlServerDB.dataSource.serverName=${?SQL_SERVER_HOST}

--- a/quill-streaming-monix/src/test/resources/sql/h2-schema.sql
+++ b/quill-streaming-monix/src/test/resources/sql/h2-schema.sql
@@ -1,0 +1,114 @@
+CREATE TABLE IF NOT EXISTS Person(
+    name VARCHAR(255),
+    age int
+);
+
+CREATE TABLE IF NOT EXISTS Couple(
+    her VARCHAR(255),
+    him VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Department(
+    dpt VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Employee(
+    emp VARCHAR(255),
+    dpt VARCHAR(255),
+    salary int
+);
+
+CREATE TABLE IF NOT EXISTS Task(
+    emp VARCHAR(255),
+    tsk VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS EncodingTestEntity(
+    v1 VARCHAR(255),
+    v2 DECIMAL(5,2),
+    v3 BOOLEAN,
+    v4 SMALLINT,
+    v5 SMALLINT,
+    v6 INTEGER,
+    v7 BIGINT,
+    v8 FLOAT,
+    v9 DOUBLE PRECISIOn,
+    v10 BYTEA,
+    v11 TIMESTAMP,
+    v12 VARCHAR(255),
+    v13 DATE,
+    v14 UUID,
+    o1 VARCHAR(255),
+    o2 DECIMAL(5,2),
+    o3 BOOLEAN,
+    o4 SMALLINT,
+    o5 SMALLINT,
+    o6 INTEGER,
+    o7 BIGINT,
+    o8 FLOAT,
+    o9 DOUBLE PRECISIOn,
+    o10 BYTEA,
+    o11 TIMESTAMP,
+    o12 VARCHAR(255),
+    o13 DATE,
+    o14 UUID
+);
+
+CREATE TABLE IF NOT EXISTS TestEntity(
+    s VARCHAR(255),
+    i INTEGER,
+    l BIGINT,
+    o INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS TestEntity2(
+    s VARCHAR(255),
+    i INTEGER,
+    l BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS TestEntity3(
+    s VARCHAR(255),
+    i INTEGER,
+    l BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS TestEntity4(
+    i identity
+);
+
+CREATE TABLE IF NOT EXISTS Product(
+    description VARCHAR(255),
+    id identity,
+    sku BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);

--- a/quill-streaming-monix/src/test/resources/sql/sqlite-schema.sql
+++ b/quill-streaming-monix/src/test/resources/sql/sqlite-schema.sql
@@ -1,0 +1,114 @@
+CREATE TABLE IF NOT EXISTS Person(
+    name VARCHAR(255),
+    age int
+);
+
+CREATE TABLE IF NOT EXISTS Couple(
+    her VARCHAR(255),
+    him VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Department(
+    dpt VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Employee(
+    emp VARCHAR(255),
+    dpt VARCHAR(255),
+    salary int
+);
+
+CREATE TABLE IF NOT EXISTS Task(
+    emp VARCHAR(255),
+    tsk VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS EncodingTestEntity(
+    v1 VARCHAR(255),
+    v2 DECIMAL(5,2),
+    v3 BOOLEAN,
+    v4 SMALLINT,
+    v5 SMALLINT,
+    v6 INTEGER,
+    v7 BIGINT,
+    v8 FLOAT,
+    v9 DOUBLE PRECISIOn,
+    v10 BLOB,
+    v11 BIGINT,
+    v12 VARCHAR(255),
+    v13 BIGINT,
+    v14 VARCHAR(36),
+    o1 VARCHAR(255),
+    o2 DECIMAL(5,2),
+    o3 BOOLEAN,
+    o4 SMALLINT,
+    o5 SMALLINT,
+    o6 INTEGER,
+    o7 BIGINT,
+    o8 FLOAT,
+    o9 DOUBLE PRECISIOn,
+    o10 BLOB,
+    o11 BIGINT,
+    o12 VARCHAR(255),
+    o13 BIGINT,
+    o14 VARCHAR(36)
+);
+
+CREATE TABLE IF NOT EXISTS TestEntity(
+    s VARCHAR(255),
+    i INTEGER primary key,
+    l BIGINT,
+    o INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS TestEntity2(
+    s VARCHAR(255),
+    i INTEGER,
+    l BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS TestEntity3(
+    s VARCHAR(255),
+    i INTEGER,
+    l BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS TestEntity4(
+    i INTEGER PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS Product(
+	id INTEGER PRIMARY KEY,
+    description VARCHAR(255),
+    sku BIGINT
+);
+
+CREATE TABLE IF NOT EXISTS Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Contact(
+    firstName VARCHAR(255),
+    lastName VARCHAR(255),
+    age int,
+    addressFk int,
+    extraInfo VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS Address(
+    id int,
+    street VARCHAR(255),
+    zip int,
+    otherExtraInfo VARCHAR(255)
+);

--- a/quill-streaming-monix/src/test/scala/io/getquill/context/streaming/postgres/PeopleStreamingSpec.scala
+++ b/quill-streaming-monix/src/test/scala/io/getquill/context/streaming/postgres/PeopleStreamingSpec.scala
@@ -1,0 +1,63 @@
+package io.getquill.context.streaming.postgres
+
+import io.getquill.context.sql.PeopleSpec
+import monix.execution.Scheduler
+
+class PeopleStreamingSpec extends PeopleSpec {
+
+  implicit val scheduler = Scheduler.global
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      for {
+        _ <- testContext.run(query[Couple].delete)
+        _ <- testContext.run(query[Person].filter(_.age > 0).delete)
+        _ <- testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+        _ <- testContext.run(liftQuery(couplesEntries).foreach(p => couplesInsert(p)))
+      } yield ()
+    }.runSyncUnsafe()
+  }
+
+  "Example 1 - differences" in {
+    testContext.run(`Ex 1 differences`).runSyncUnsafe() mustEqual `Ex 1 expected result`
+  }
+
+  "Example 2 - range simple" in {
+    testContext.run(`Ex 2 rangeSimple`(lift(`Ex 2 param 1`), lift(`Ex 2 param 2`))).runSyncUnsafe() mustEqual `Ex 2 expected result`
+  }
+
+  "Example 3 - satisfies" in {
+    testContext.run(`Ex 3 satisfies`).runSyncUnsafe() mustEqual `Ex 3 expected result`
+  }
+
+  "Example 4 - satisfies" in {
+    testContext.run(`Ex 4 satisfies`).runSyncUnsafe() mustEqual `Ex 4 expected result`
+  }
+
+  "Example 5 - compose" in {
+    testContext.run(`Ex 5 compose`(lift(`Ex 5 param 1`), lift(`Ex 5 param 2`))).runSyncUnsafe() mustEqual `Ex 5 expected result`
+  }
+
+  "Example 6 - predicate 0" in {
+    testContext.run(satisfies(eval(`Ex 6 predicate`))).runSyncUnsafe() mustEqual `Ex 6 expected result`
+  }
+
+  "Example 7 - predicate 1" in {
+    testContext.run(satisfies(eval(`Ex 7 predicate`))).runSyncUnsafe() mustEqual `Ex 7 expected result`
+  }
+
+  "Example 8 - contains empty" in {
+    testContext.run(`Ex 8 and 9 contains`(liftQuery(`Ex 8 param`))).runSyncUnsafe() mustEqual `Ex 8 expected result`
+  }
+
+  "Example 9 - contains non empty" in {
+    testContext.run(`Ex 8 and 9 contains`(liftQuery(`Ex 9 param`))).runSyncUnsafe() mustEqual `Ex 9 expected result`
+  }
+
+  "Example 10 - pagination" in {
+    testContext.run(`Ex 10 page 1 query`).runSyncUnsafe() mustEqual `Ex 10 page 1 expected`
+    testContext.run(`Ex 10 page 2 query`).runSyncUnsafe() mustEqual `Ex 10 page 2 expected`
+  }
+}

--- a/quill-streaming-monix/src/test/scala/io/getquill/context/streaming/postgres/package.scala
+++ b/quill-streaming-monix/src/test/scala/io/getquill/context/streaming/postgres/package.scala
@@ -1,0 +1,17 @@
+package io.getquill.context.streaming
+
+import io.getquill._
+import io.getquill.context.sql.{ TestDecoders, TestEncoders }
+import io.getquill.util.LoadConfig
+import monix.eval.Task
+import monix.execution.Scheduler
+
+package object postgres {
+
+  private implicit val scheduler = Scheduler.global
+  private val config = StreamingContextConfig(LoadConfig("testPostgresDB"))
+  object testContext extends TaskStreamingContext(config.dataSource, PostgresDialect, Literal)
+    with TestEntities with TestEncoders with TestDecoders
+    with UUIDObjectEncoding[Task]
+
+}


### PR DESCRIPTION
Fixes #1228 

### Problem

Quill currently doesn't offer support for streaming APIs, and the only way of using an IO monad is through its own implementation. This change aims to provide support for effect monads from Monix (Task).

### Solution

Created a context class (`TaskStreamingContext`) that abstracts JDBC over Monix. Also, it is provided a module (`quill-streaming-cats`) that provides abstractions over the effect monad, i.e., allows the integration of other implementations supporting cats-effect type classes.

### Notes

This change is based on the code of `quill-jdbc`. Since the streaming concept is orthogonal to the underlying implementation, I'm not sure whether fixing the API under JDBC is the best approach to take here. Despite being deprecated, `postgresql-async` is still pretty popular, and other modules, such as `quill-cassandra`, `quill-spark` and `quill-orientdb` could definitely benefit from a streaming module.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers