### PR TITLE
First-class support for dynamic queries

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/CoreDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/CoreDsl.scala
@@ -7,3 +7,4 @@ private[getquill] trait CoreDsl
   with QuotationDsl
   with EncodingDsl
   with MetaDsl
+  with DynamicQueryDsl

--- a/quill-core/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
@@ -1,0 +1,376 @@
+package io.getquill.dsl
+
+import scala.language.implicitConversions
+import scala.language.experimental.macros
+import io.getquill.ast._
+import scala.reflect.macros.whitebox.{ Context => MacroContext }
+import io.getquill.util.Messages._
+import scala.annotation.tailrec
+import scala.util.DynamicVariable
+import scala.reflect.ClassTag
+
+class DynamicQueryDslMacro(val c: MacroContext) {
+  import c.universe._
+
+  def dynamicUnquote(d: Tree): Tree =
+    q"${c.prefix}.unquote($d.q)"
+
+  def insertValue(value: Tree): Tree =
+    q"""
+      DynamicInsert(${c.prefix}.q.insert(lift($value)))
+    """
+
+  def updateValue(value: Tree): Tree =
+    q"""
+      DynamicUpdate(${c.prefix}.q.update(lift($value)))
+    """
+}
+
+trait DynamicQueryDsl {
+  dsl: CoreDsl =>
+
+  implicit class ToDynamicQuery[T](q: Quoted[Query[T]]) {
+    def dynamic: DynamicQuery[T] = DynamicQuery(q)
+  }
+
+  implicit class ToDynamicEntityQuery[T](q: Quoted[EntityQuery[T]]) {
+    def dynamic: DynamicEntityQuery[T] = DynamicEntityQuery(q)
+  }
+
+  implicit class ToDynamicAction[T](q: Quoted[Action[T]]) {
+    def dynamic: DynamicAction[Action[T]] = DynamicAction(q)
+  }
+
+  implicit class ToDynamicInsert[T](q: Quoted[Insert[T]]) {
+    def dynamic: DynamicInsert[T] = DynamicInsert(q)
+  }
+
+  implicit class ToDynamicUpdate[T](q: Quoted[Update[T]]) {
+    def dynamic: DynamicUpdate[T] = DynamicUpdate(q)
+  }
+
+  implicit class ToDynamicActionReturning[T, U](q: Quoted[ActionReturning[T, U]]) {
+    def dynamic: DynamicActionReturning[T, U] = DynamicActionReturning(q)
+  }
+
+  implicit def dynamicUnquote[T](d: DynamicQuery[T]): Query[T] = macro DynamicQueryDslMacro.dynamicUnquote
+
+  implicit def toQuoted[T](q: DynamicQuery[T]): Quoted[Query[T]] = q.q
+  implicit def toQuoted[T](q: DynamicEntityQuery[T]): Quoted[EntityQuery[T]] = q.q
+  implicit def toQuoted[T <: Action[_]](q: DynamicAction[T]): Quoted[T] = q.q
+
+  def dynamicQuery[T](implicit t: ClassTag[T]): DynamicEntityQuery[T] =
+    dynamicQuerySchema(t.runtimeClass.getName.split('.').last.split('$').last)
+
+  case class DynamicAlias[T](property: Quoted[T] => Quoted[Any], name: String)
+
+  def alias[T](property: Quoted[T] => Quoted[Any], name: String): DynamicAlias[T] = DynamicAlias(property, name)
+
+  sealed trait DynamicSet[T, U]
+
+  case class DynamicSetValue[T, U](property: Quoted[T] => Quoted[U], value: Quoted[U]) extends DynamicSet[T, U]
+  case class DynamicSetEmpty[T, U]() extends DynamicSet[T, U]
+
+  def set[T, U](property: Quoted[T] => Quoted[U], value: Quoted[U]): DynamicSet[T, U] =
+    DynamicSetValue(property, value)
+
+  def setValue[T, U](property: Quoted[T] => Quoted[U], value: U)(implicit enc: Encoder[U]): DynamicSet[T, U] =
+    set[T, U](property, spliceLift(value))
+
+  def setOpt[T, U](property: Quoted[T] => Quoted[U], value: Option[U])(implicit enc: Encoder[U]): DynamicSet[T, U] =
+    value match {
+      case Some(v) => setValue(property, v)
+      case None    => DynamicSetEmpty()
+    }
+
+  def set[T, U](property: String, value: Quoted[U]): DynamicSet[T, U] =
+    set((f: Quoted[T]) => splice(Constant(property)), value)
+
+  def setValue[T, U](property: String, value: U)(implicit enc: Encoder[U]): DynamicSet[T, U] =
+    set(property, spliceLift(value))
+
+  def dynamicQuerySchema[T](entity: String, columns: DynamicAlias[T]*): DynamicEntityQuery[T] = {
+    val aliases =
+      columns.map { alias =>
+
+        @tailrec def path(ast: Ast, acc: List[String] = Nil): List[String] =
+          ast match {
+            case Property(a, name) =>
+              path(a, name :: acc)
+            case _ =>
+              acc
+          }
+
+        PropertyAlias(path(alias.property(splice[T](Ident("v"))).ast), alias.name)
+      }
+    DynamicEntityQuery(splice[EntityQuery[T]](Entity(entity, aliases.toList)))
+  }
+
+  private[this] val nextIdentId = new DynamicVariable(0)
+
+  private[this] def withFreshIdent[R](f: Ident => R): R = {
+    val idx = nextIdentId.value
+    nextIdentId.withValue(idx + 1) {
+      f(Ident(s"v$idx"))
+    }
+  }
+
+  private def dyn[T](ast: Ast): DynamicQuery[T] =
+    DynamicQuery[T](splice[Query[T]](ast))
+
+  private def splice[T](a: Ast) =
+    new Quoted[T] {
+      override def ast = a
+    }
+
+  protected def spliceLift[O](o: O)(implicit enc: Encoder[O]) =
+    splice[O](ScalarValueLift("o", o, enc))
+
+  object DynamicQuery {
+    def apply[T](p: Quoted[Query[T]]) =
+      new DynamicQuery[T] {
+        override def q = p
+      }
+  }
+
+  sealed trait DynamicQuery[+T] {
+
+    protected[getquill] def q: Quoted[Query[T]]
+
+    protected[this] def transform[U, V, R](f: Quoted[U] => Quoted[V], t: (Ast, Ident, Ast) => Ast, r: Ast => R = dyn _) =
+      withFreshIdent { v =>
+        r(t(q.ast, v, f(splice(v)).ast))
+      }
+
+    protected[this] def transformOpt[O, R, D <: DynamicQuery[T]](opt: Option[O], f: (Quoted[T], Quoted[O]) => Quoted[R], t: (Quoted[T] => Quoted[R]) => D, thiz: D)(implicit enc: Encoder[O]) =
+      opt match {
+        case Some(o) =>
+          t(v => f(v, spliceLift(o)))
+        case None =>
+          thiz
+      }
+
+    def map[R](f: Quoted[T] => Quoted[R]): DynamicQuery[R] =
+      transform(f, Map)
+
+    def flatMap[R](f: Quoted[T] => Quoted[Query[R]]): DynamicQuery[R] =
+      transform(f, FlatMap)
+
+    def filter(f: Quoted[T] => Quoted[Boolean]): DynamicQuery[T] =
+      transform(f, Filter)
+
+    def withFilter(f: Quoted[T] => Quoted[Boolean]): DynamicQuery[T] =
+      filter(f)
+
+    def filterOpt[O](opt: Option[O])(f: (Quoted[T], Quoted[O]) => Quoted[Boolean])(implicit enc: Encoder[O]): DynamicQuery[T] =
+      transformOpt(opt, f, filter, this)
+
+    def concatMap[R, U](f: Quoted[T] => Quoted[U])(implicit ev: U => Traversable[R]): DynamicQuery[R] =
+      transform(f, ConcatMap)
+
+    def sortBy[R](f: Quoted[T] => Quoted[R])(implicit ord: OrdDsl#Ord[R]): DynamicQuery[T] =
+      transform(f, SortBy(_, _, _, ord.ord))
+
+    def take(n: Quoted[Int]): DynamicQuery[T] =
+      dyn(Take(q.ast, n.ast))
+
+    def take(n: Int)(implicit enc: Encoder[Int]): DynamicQuery[T] =
+      take(spliceLift(n))
+
+    def takeOpt(opt: Option[Int])(implicit enc: Encoder[Int]): DynamicQuery[T] =
+      opt match {
+        case Some(o) => take(o)
+        case None    => this
+      }
+
+    def drop(n: Quoted[Int]): DynamicQuery[T] =
+      dyn(Drop(q.ast, n.ast))
+
+    def drop(n: Int)(implicit enc: Encoder[Int]): DynamicQuery[T] =
+      drop(spliceLift(n))
+
+    def dropOpt(opt: Option[Int])(implicit enc: Encoder[Int]): DynamicQuery[T] =
+      opt match {
+        case Some(o) => drop(o)
+        case None    => this
+      }
+
+    def ++[U >: T](q2: Quoted[Query[U]]): DynamicQuery[U] =
+      dyn(UnionAll(q.ast, q2.ast))
+
+    def unionAll[U >: T](q2: Quoted[Query[U]]): DynamicQuery[U] =
+      dyn(UnionAll(q.ast, q2.ast))
+
+    def union[U >: T](q2: Quoted[Query[U]]): DynamicQuery[U] =
+      dyn(Union(q.ast, q2.ast))
+
+    def groupBy[R](f: Quoted[T] => Quoted[R]): DynamicQuery[(R, Query[T])] =
+      transform(f, GroupBy)
+
+    private def aggregate(op: AggregationOperator) =
+      splice(Aggregation(op, q.ast))
+
+    def min[U >: T]: Quoted[Option[T]] =
+      aggregate(AggregationOperator.min)
+
+    def max[U >: T]: Quoted[Option[T]] =
+      aggregate(AggregationOperator.max)
+
+    def avg[U >: T](implicit n: Numeric[U]): Quoted[Option[T]] =
+      aggregate(AggregationOperator.avg)
+
+    def sum[U >: T](implicit n: Numeric[U]): Quoted[Option[T]] =
+      aggregate(AggregationOperator.sum)
+
+    def size: Quoted[Long] =
+      aggregate(AggregationOperator.size)
+
+    def join[A >: T, B](q2: Quoted[Query[B]]): DynamicJoinQuery[A, B, (A, B)] =
+      DynamicJoinQuery(InnerJoin, q, q2)
+
+    def leftJoin[A >: T, B](q2: Quoted[Query[B]]): DynamicJoinQuery[A, B, (A, Option[B])] =
+      DynamicJoinQuery(LeftJoin, q, q2)
+
+    def rightJoin[A >: T, B](q2: Quoted[Query[B]]): DynamicJoinQuery[A, B, (Option[A], B)] =
+      DynamicJoinQuery(RightJoin, q, q2)
+
+    def fullJoin[A >: T, B](q2: Quoted[Query[B]]): DynamicJoinQuery[A, B, (Option[A], Option[B])] =
+      DynamicJoinQuery(FullJoin, q, q2)
+
+    private[this] def flatJoin[R](tpe: JoinType, on: Quoted[T] => Quoted[Boolean]): DynamicQuery[R] =
+      withFreshIdent { v =>
+        dyn(FlatJoin(tpe, q.ast, v, on(splice(v)).ast))
+      }
+
+    def join[A >: T](on: Quoted[A] => Quoted[Boolean]): DynamicQuery[A] =
+      flatJoin(InnerJoin, on)
+
+    def leftJoin[A >: T](on: Quoted[A] => Quoted[Boolean]): DynamicQuery[Option[A]] =
+      flatJoin(LeftJoin, on)
+
+    def rightJoin[A >: T](on: Quoted[A] => Quoted[Boolean]): DynamicQuery[Option[A]] =
+      flatJoin(RightJoin, on)
+
+    def nonEmpty: Quoted[Boolean] =
+      splice(UnaryOperation(SetOperator.nonEmpty, q.ast))
+
+    def isEmpty: Quoted[Boolean] =
+      splice(UnaryOperation(SetOperator.isEmpty, q.ast))
+
+    def contains[B >: T](value: B)(implicit enc: Encoder[B]): Quoted[Boolean] =
+      contains(spliceLift(value))
+
+    def contains[B >: T](value: Quoted[B]): Quoted[Boolean] =
+      splice(BinaryOperation(q.ast, SetOperator.contains, value.ast))
+
+    def distinct: DynamicQuery[T] =
+      dyn(Distinct(q.ast))
+
+    def nested: DynamicQuery[T] =
+      dyn(Nested(q.ast))
+
+    override def toString = q.toString
+  }
+
+  case class DynamicJoinQuery[A, B, R](tpe: JoinType, q1: Quoted[Query[A]], q2: Quoted[Query[B]]) {
+    def on(f: (Quoted[A], Quoted[B]) => Quoted[Boolean]): DynamicQuery[R] = {
+      withFreshIdent { iA =>
+        withFreshIdent { iB =>
+          dyn(Join(tpe, q1.ast, q2.ast, iA, iB, f(splice(iA), splice(iB)).ast))
+        }
+      }
+    }
+  }
+
+  case class DynamicEntityQuery[T](q: Quoted[EntityQuery[T]])
+    extends DynamicQuery[T] {
+
+    private[this] def dyn[R](ast: Ast) =
+      DynamicEntityQuery(splice[EntityQuery[R]](ast))
+
+    override def filter(f: Quoted[T] => Quoted[Boolean]): DynamicEntityQuery[T] =
+      transform(f, Filter, dyn)
+
+    override def withFilter(f: Quoted[T] => Quoted[Boolean]): DynamicEntityQuery[T] =
+      filter(f)
+
+    override def filterOpt[O](opt: Option[O])(f: (Quoted[T], Quoted[O]) => Quoted[Boolean])(implicit enc: Encoder[O]): DynamicEntityQuery[T] =
+      transformOpt(opt, f, filter, this)
+
+    override def map[R](f: Quoted[T] => Quoted[R]): DynamicEntityQuery[R] =
+      transform(f, Map, dyn)
+
+    def insertValue(value: T): DynamicInsert[T] = macro DynamicQueryDslMacro.insertValue
+
+    type DynamicAssignment[U] = ((Quoted[T] => Quoted[U]), U)
+
+    private[this] def assignemnts[S](l: List[DynamicSet[S, _]]): List[Assignment] =
+      l.collect {
+        case s: DynamicSetValue[_, _] =>
+          val v = Ident("v")
+          Assignment(v, s.property(splice(v)).ast, s.value.ast)
+      }
+
+    def insert(l: DynamicSet[T, _]*): DynamicInsert[T] =
+      DynamicInsert(splice(Insert(DynamicEntityQuery.this.q.ast, assignemnts(l.toList))))
+
+    def updateValue(value: T): DynamicUpdate[T] = macro DynamicQueryDslMacro.updateValue
+
+    def update(sets: DynamicSet[T, _]*): DynamicUpdate[T] =
+      DynamicUpdate(splice[Update[T]](Update(DynamicEntityQuery.this.q.ast, assignemnts(sets.toList))))
+
+    def delete: DynamicDelete[T] =
+      DynamicDelete(splice[Delete[T]](Delete(DynamicEntityQuery.this.q.ast)))
+  }
+
+  object DynamicAction {
+    def apply[A <: Action[_]](p: Quoted[A]) =
+      new DynamicAction[A] {
+        override val q = p
+      }
+  }
+
+  sealed trait DynamicAction[A <: Action[_]] {
+    protected[getquill] def q: Quoted[A]
+
+    override def toString = q.toString
+  }
+
+  object DynamicInsert {
+    def apply[E](p: Quoted[Insert[E]]) =
+      new DynamicInsert[E] {
+        override val q = p
+      }
+  }
+
+  trait DynamicInsert[E] extends DynamicAction[Insert[E]] {
+
+    private[this] def dyn[R](ast: Ast) =
+      DynamicInsert[R](splice(ast))
+
+    def returning[R](f: Quoted[E] => Quoted[R]): DynamicActionReturning[E, R] =
+      withFreshIdent { v =>
+        DynamicActionReturning(splice(Returning(q.ast, v, f(splice(v)).ast)))
+      }
+
+    def onConflictIgnore: DynamicInsert[E] =
+      dyn(OnConflict(DynamicInsert.this.q.ast, OnConflict.NoTarget, OnConflict.Ignore))
+
+    def onConflictIgnore(targets: (Quoted[E] => Quoted[Any])*): DynamicInsert[E] = {
+      val v = splice[E](Ident("v"))
+      val properties =
+        targets.toList.map { f =>
+          f(v).ast match {
+            case p: Property => p
+            case p =>
+              fail(s"Invalid ignore column: $p")
+          }
+        }
+      dyn(OnConflict(DynamicInsert.this.q.ast, OnConflict.Properties(properties), OnConflict.Ignore))
+    }
+  }
+
+  case class DynamicActionReturning[E, Output](q: Quoted[ActionReturning[E, Output]]) extends DynamicAction[ActionReturning[E, Output]]
+  case class DynamicUpdate[E](q: Quoted[Update[E]]) extends DynamicAction[Update[E]]
+  case class DynamicDelete[E](q: Quoted[Delete[E]]) extends DynamicAction[Delete[E]]
+}

--- a/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/MetaDslMacro.scala
@@ -70,6 +70,8 @@ class MetaDslMacro(val c: MacroContext) {
 
   private def expandQuery[T](value: Value)(implicit t: WeakTypeTag[T]) = {
     val elements = flatten(q"x", value)
+    if (elements.size == 0)
+      c.fail("Case class has no values")
     q"${c.prefix}.quote((q: ${c.prefix}.Query[$t]) => q.map(x => io.getquill.dsl.UnlimitedTuple(..$elements)))"
   }
 

--- a/quill-core/src/main/scala/io/getquill/dsl/OrdDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/OrdDsl.scala
@@ -1,60 +1,52 @@
 package io.getquill.dsl
 
-import io.getquill.quotation.NonQuotedException
-import scala.annotation.compileTimeOnly
+import io.getquill.ast._
 
 private[dsl] trait OrdDsl {
 
-  trait Ord[T]
+  case class Ord[T](ord: Ordering)
 
-  @compileTimeOnly(NonQuotedException.message)
-  implicit def implicitOrd[T]: Ord[T] = NonQuotedException()
+  implicit def implicitOrd[T]: Ord[T] = Ord.ascNullsFirst
 
   object Ord {
 
-    @compileTimeOnly(NonQuotedException.message)
-    def asc[T]: Ord[T] = NonQuotedException()
+    def asc[T]: Ord[T] = Ord(Asc)
 
-    @compileTimeOnly(NonQuotedException.message)
-    def desc[T]: Ord[T] = NonQuotedException()
+    def desc[T]: Ord[T] = Ord(Desc)
 
-    @compileTimeOnly(NonQuotedException.message)
-    def ascNullsFirst[T]: Ord[T] = NonQuotedException()
+    def ascNullsFirst[T]: Ord[T] = Ord(AscNullsFirst)
 
-    @compileTimeOnly(NonQuotedException.message)
-    def descNullsFirst[T]: Ord[T] = NonQuotedException()
+    def descNullsFirst[T]: Ord[T] = Ord(DescNullsFirst)
 
-    @compileTimeOnly(NonQuotedException.message)
-    def ascNullsLast[T]: Ord[T] = NonQuotedException()
+    def ascNullsLast[T]: Ord[T] = Ord(AscNullsLast)
 
-    @compileTimeOnly(NonQuotedException.message)
-    def descNullsLast[T]: Ord[T] = NonQuotedException()
+    def descNullsLast[T]: Ord[T] = Ord(DescNullsLast)
 
-    @compileTimeOnly(NonQuotedException.message)
-    def apply[T1, T2](o1: Ord[T1], o2: Ord[T2]): Ord[(T1, T2)] = NonQuotedException()
+    def apply[T1, T2](o1: Ord[T1], o2: Ord[T2]): Ord[(T1, T2)] =
+      Ord(TupleOrdering(List(o1.ord, o2.ord)))
 
-    @compileTimeOnly(NonQuotedException.message)
-    def apply[T1, T2, T3](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3]): Ord[(T1, T2, T3)] = NonQuotedException()
+    def apply[T1, T2, T3](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3]): Ord[(T1, T2, T3)] =
+      Ord(TupleOrdering(List(o1.ord, o2.ord, o3.ord)))
 
-    @compileTimeOnly(NonQuotedException.message)
-    def apply[T1, T2, T3, T4](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4]): Ord[(T1, T2, T3, T4)] = NonQuotedException()
+    def apply[T1, T2, T3, T4](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4]): Ord[(T1, T2, T3, T4)] =
+      Ord(TupleOrdering(List(o1.ord, o2.ord, o3.ord, o4.ord)))
 
-    @compileTimeOnly(NonQuotedException.message)
-    def apply[T1, T2, T3, T4, T5](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5]): Ord[(T1, T2, T3, T4, T5)] = NonQuotedException()
+    def apply[T1, T2, T3, T4, T5](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5]): Ord[(T1, T2, T3, T4, T5)] =
+      Ord(TupleOrdering(List(o1.ord, o2.ord, o3.ord, o4.ord, o5.ord)))
 
-    @compileTimeOnly(NonQuotedException.message)
-    def apply[T1, T2, T3, T4, T5, T6](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6]): Ord[(T1, T2, T3, T4, T5, T6)] = NonQuotedException()
+    def apply[T1, T2, T3, T4, T5, T6](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6]): Ord[(T1, T2, T3, T4, T5, T6)] =
+      Ord(TupleOrdering(List(o1.ord, o2.ord, o3.ord, o4.ord, o5.ord, o6.ord)))
 
-    @compileTimeOnly(NonQuotedException.message)
-    def apply[T1, T2, T3, T4, T5, T6, T7](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7]): Ord[(T1, T2, T3, T4, T5, T6, T7)] = NonQuotedException()
+    def apply[T1, T2, T3, T4, T5, T6, T7](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7]): Ord[(T1, T2, T3, T4, T5, T6, T7)] =
+      Ord(TupleOrdering(List(o1.ord, o2.ord, o3.ord, o4.ord, o5.ord, o6.ord, o7.ord)))
 
-    @compileTimeOnly(NonQuotedException.message)
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7], o8: Ord[T8]): Ord[(T1, T2, T3, T4, T5, T6, T7, T8)] = NonQuotedException()
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7], o8: Ord[T8]): Ord[(T1, T2, T3, T4, T5, T6, T7, T8)] =
+      Ord(TupleOrdering(List(o1.ord, o2.ord, o3.ord, o4.ord, o5.ord, o6.ord, o7.ord, o8.ord)))
 
-    @compileTimeOnly(NonQuotedException.message)
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7], o8: Ord[T8], o9: Ord[T9]): Ord[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] = NonQuotedException()
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7], o8: Ord[T8], o9: Ord[T9]): Ord[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] =
+      Ord(TupleOrdering(List(o1.ord, o2.ord, o3.ord, o4.ord, o5.ord, o6.ord, o7.ord, o8.ord, o9.ord)))
 
-    @compileTimeOnly(NonQuotedException.message)
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7], o8: Ord[T8], o9: Ord[T9], o10: Ord[T10]): Ord[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)] = NonQuotedException()
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](o1: Ord[T1], o2: Ord[T2], o3: Ord[T3], o4: Ord[T4], o5: Ord[T5], o6: Ord[T6], o7: Ord[T7], o8: Ord[T8], o9: Ord[T9], o10: Ord[T10]): Ord[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)] =
+      Ord(TupleOrdering(List(o1.ord, o2.ord, o3.ord, o4.ord, o5.ord, o6.ord, o7.ord, o8.ord, o9.ord, o10.ord)))
   }
 }

--- a/quill-core/src/main/scala/io/getquill/dsl/QuotationDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QuotationDsl.scala
@@ -10,10 +10,11 @@ import io.getquill.quotation.Quotation
 import scala.annotation.compileTimeOnly
 
 private[dsl] trait QuotationDsl {
+  this: CoreDsl =>
 
   trait Quoted[+T] {
     def ast: Ast
-    def dynamic: Quoted[T] = this
+    override def toString = ast.toString
   }
 
   def quote[T](body: Quoted[T]): Quoted[T] = macro QuotationMacro.doubleQuote[T]

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -639,7 +639,7 @@ trait Parsing {
     try c.typecheck(
       q"""
         def apply[$t](lhs: $t)(rhs: $t) = ()
-        apply(${unquoted(lhs)})($rhs)
+        apply(${unquoted(lhs)})(${unquoted(rhs)})
       """,
       c.TYPEmode
     ) catch {

--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -36,8 +36,6 @@ trait Quotation extends Liftables with Unliftables with Parsing with ReifyLiftin
             def $quoted = ast
     
             override def ast = $reifiedAst
-            override def toString = ast.toString
-
     
             def $id() = ()
             

--- a/quill-core/src/test/scala/io/getquill/quotation/DynamicQuerySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/DynamicQuerySpec.scala
@@ -1,0 +1,589 @@
+package io.getquill.quotation
+
+import io.getquill._
+
+class DynamicQuerySpec extends Spec {
+
+  //  object testContext extends MirrorContext(MirrorIdiom, Literal) with TestEntities with DynamicQueryDsl
+  import testContext._
+
+  "implicit classes" - {
+    "query" in {
+      val q: Quoted[Query[TestEntity]] = qr1
+      val d = {
+        val d = q.dynamic
+        (d: DynamicQuery[TestEntity])
+      }
+      d.q mustEqual q
+    }
+    "entity query" in {
+      val q: Quoted[EntityQuery[TestEntity]] = qr1
+      val d = {
+        val d = q.dynamic
+        (d: DynamicEntityQuery[TestEntity])
+      }
+      d.q mustEqual q
+    }
+    "action" in {
+      val q: Quoted[Action[TestEntity]] = qr1.insert(_.i -> 1)
+      val d = {
+        val d = q.dynamic
+        (d: DynamicAction[Action[TestEntity]])
+      }
+      d.q mustEqual q
+    }
+    "insert" in {
+      val q: Quoted[Insert[TestEntity]] = qr1.insert(_.i -> 1)
+      val d = {
+        val d = q.dynamic
+        (d: DynamicInsert[TestEntity])
+      }
+      d.q mustEqual q
+    }
+    "update" in {
+      val q: Quoted[Update[TestEntity]] = qr1.update(_.i -> 1)
+      val d = {
+        val d = q.dynamic
+        (d: DynamicUpdate[TestEntity])
+      }
+      d.q mustEqual q
+    }
+    "action returning" in {
+      val q: Quoted[ActionReturning[TestEntity, Int]] = qr1.insert(_.i -> 1).returning(_.i)
+      val d = {
+        val d = q.dynamic
+        (d: DynamicActionReturning[TestEntity, Int])
+      }
+      d.q mustEqual q
+    }
+  }
+
+  "query" - {
+
+    def test[T: QueryMeta](d: Quoted[Query[T]], s: Quoted[Query[T]]) =
+      testContext.run(d).string mustEqual testContext.run(s).string
+
+    "dynamicQuery" in {
+      test(
+        dynamicQuery[TestEntity],
+        query[TestEntity]
+      )
+    }
+
+    "dynamicQuerySchema" - {
+      "no aliases" in {
+        test(
+          dynamicQuerySchema[TestEntity]("test"),
+          querySchema[TestEntity]("test")
+        )
+      }
+      "one alias" in {
+        test(
+          dynamicQuerySchema[TestEntity]("test", alias(_.i, "ii")),
+          querySchema[TestEntity]("test", _.i -> "ii")
+        )
+      }
+      "multiple aliases" in {
+        test(
+          dynamicQuerySchema[TestEntity]("test", alias(_.i, "ii"), alias(_.s, "ss")),
+          querySchema[TestEntity]("test", _.i -> "ii", _.s -> "ss")
+        )
+      }
+      "dynamic alias list" in {
+        val aliases = List[DynamicAlias[TestEntity]](alias(_.i, "ii"), alias(_.s, "ss"))
+        test(
+          dynamicQuerySchema[TestEntity]("test", aliases: _*),
+          querySchema[TestEntity]("test", _.i -> "ii", _.s -> "ss")
+        )
+      }
+      "path property" in {
+        case class S(v: String) extends Embedded
+        case class E(s: S)
+        test(
+          dynamicQuerySchema[E]("e", alias(_.s.v, "sv")),
+          querySchema[E]("e", _.s.v -> "sv")
+        )
+      }
+    }
+
+    "map" - {
+      "simple" in {
+        test(
+          dynamicQuery[TestEntity].map(v0 => quote(v0.i)),
+          query[TestEntity].map(v0 => v0.i)
+        )
+      }
+      "dynamic" in {
+        var cond = true
+        test(
+          dynamicQuery[TestEntity].map(v0 => if (cond) quote(v0.i) else quote(1)),
+          query[TestEntity].map(v0 => v0.i)
+        )
+
+        cond = false
+        test(
+          dynamicQuery[TestEntity].map(v0 => if (cond) quote(v0.i) else quote(1)),
+          query[TestEntity].map(v0 => 1)
+        )
+      }
+    }
+
+    "flatMap" - {
+      "simple" in {
+        test(
+          dynamicQuery[TestEntity].flatMap(v0 => dynamicQuery[TestEntity]),
+          query[TestEntity].flatMap(v0 => query[TestEntity])
+        )
+      }
+      "mixed with static" in {
+        test(
+          dynamicQuery[TestEntity].flatMap(v0 => query[TestEntity]),
+          query[TestEntity].flatMap(v0 => query[TestEntity])
+        )
+
+        test(
+          query[TestEntity].flatMap(v0 => dynamicQuery[TestEntity]),
+          query[TestEntity].flatMap(v0 => query[TestEntity])
+        )
+      }
+      "with map" in {
+        test(
+          dynamicQuery[TestEntity].flatMap(v0 => dynamicQuery[TestEntity].map(v1 => quote((unquote(v0), unquote(v1))))),
+          query[TestEntity].flatMap(v0 => query[TestEntity].map(v1 => (v0, v1)))
+        )
+      }
+      "for comprehension" in {
+        test(
+          for {
+            v0 <- dynamicQuery[TestEntity]
+            v1 <- dynamicQuery[TestEntity]
+          } yield (unquote(v0), unquote(v1)),
+          for {
+            v0 <- query[TestEntity]
+            v1 <- query[TestEntity]
+          } yield (v0, v1)
+        )
+      }
+    }
+
+    "filter" in {
+      test(
+        dynamicQuery[TestEntity].filter(v0 => quote(v0.i == 1)),
+        query[TestEntity].filter(v0 => v0.i == 1)
+      )
+    }
+
+    "withFilter" in {
+      test(
+        dynamicQuery[TestEntity].withFilter(v0 => quote(v0.i == 1)),
+        query[TestEntity].withFilter(v0 => v0.i == 1)
+      )
+    }
+
+    "filterOpt" - {
+      "defined" in {
+        val o = Some(1)
+        test(
+          dynamicQuery[TestEntity].filterOpt(o)((v0, i) => quote(v0.i == i)),
+          query[TestEntity].filter(v0 => v0.i == lift(1))
+        )
+      }
+      "empty" in {
+        val o: Option[Int] = None
+        test(
+          dynamicQuery[TestEntity].filterOpt(o)((v0, i) => quote(v0.i == i)),
+          query[TestEntity]
+        )
+      }
+    }
+
+    "concatMap" in {
+      test(
+        dynamicQuery[TestEntity].concatMap[String, Array[String]](v0 => quote(v0.s.split(" "))),
+        query[TestEntity].concatMap[String, Array[String]](v0 => v0.s.split(" "))
+      )
+    }
+
+    "sortBy" in {
+      val o = Ord.desc[Int]
+      test(
+        dynamicQuery[TestEntity].sortBy(v0 => quote(v0.i))(o),
+        query[TestEntity].sortBy(v0 => v0.i)(Ord.desc)
+      )
+    }
+
+    "take" - {
+      "quoted" in {
+        test(
+          dynamicQuery[TestEntity].take(quote(1)),
+          query[TestEntity].take(1)
+        )
+      }
+
+      "int" in {
+        test(
+          dynamicQuery[TestEntity].take(1),
+          query[TestEntity].take(lift(1))
+        )
+      }
+
+      "opt" - {
+        "defined" in {
+          test(
+            dynamicQuery[TestEntity].takeOpt(Some(1)),
+            query[TestEntity].take(lift(1))
+          )
+        }
+        "empty" in {
+          test(
+            dynamicQuery[TestEntity].takeOpt(None),
+            query[TestEntity]
+          )
+        }
+      }
+    }
+
+    "drop" - {
+      "quoted" in {
+        test(
+          dynamicQuery[TestEntity].drop(quote(1)),
+          query[TestEntity].drop(1)
+        )
+      }
+
+      "int" in {
+        test(
+          dynamicQuery[TestEntity].drop(1),
+          query[TestEntity].drop(lift(1))
+        )
+      }
+
+      "opt" - {
+        "defined" in {
+          test(
+            dynamicQuery[TestEntity].dropOpt(Some(1)),
+            query[TestEntity].drop(lift(1))
+          )
+        }
+        "empty" in {
+          test(
+            dynamicQuery[TestEntity].dropOpt(None),
+            query[TestEntity]
+          )
+        }
+      }
+    }
+
+    "++" in {
+      test(
+        dynamicQuery[TestEntity] ++ dynamicQuery[TestEntity].filter(v0 => v0.i == 1),
+        query[TestEntity] ++ query[TestEntity].filter(v0 => v0.i == 1)
+      )
+    }
+
+    "unionAll" in {
+      test(
+        dynamicQuery[TestEntity].unionAll(dynamicQuery[TestEntity].filter(v0 => v0.i == 1)),
+        query[TestEntity].unionAll(query[TestEntity].filter(v0 => v0.i == 1))
+      )
+    }
+
+    "union" in {
+      test(
+        dynamicQuery[TestEntity].union(dynamicQuery[TestEntity].filter(v0 => v0.i == 1)),
+        query[TestEntity].union(query[TestEntity].filter(v0 => v0.i == 1))
+      )
+    }
+
+    "groupBy" in {
+      test(
+        dynamicQuery[TestEntity].groupBy(v0 => v0.i).map(v1 => v1._1),
+        query[TestEntity].groupBy(v0 => v0.i).map(v1 => v1._1)
+      )
+    }
+
+    "min" in {
+      test(
+        dynamicQuery[TestEntity].map(v0 => dynamicQuery[TestEntity].map(v1 => v1.i).min.contains(v0.i)),
+        query[TestEntity].map(v0 => query[TestEntity].map(v1 => v1.i).min.contains(v0.i))
+      )
+    }
+
+    "max" in {
+      test(
+        dynamicQuery[TestEntity].map(v0 => dynamicQuery[TestEntity].map(v1 => v1.i).max.contains(v0.i)),
+        query[TestEntity].map(v0 => query[TestEntity].map(v1 => v1.i).max.contains(v0.i))
+      )
+    }
+
+    "avg" in {
+      test(
+        dynamicQuery[TestEntity].map(v0 => dynamicQuery[TestEntity].map(v1 => v1.i).avg.contains(v0.i)),
+        query[TestEntity].map(v0 => query[TestEntity].map(v1 => v1.i).avg.contains(v0.i))
+      )
+    }
+
+    "sum" in {
+      test(
+        dynamicQuery[TestEntity].map(v0 => dynamicQuery[TestEntity].map(v1 => v1.i).sum.contains(v0.i)),
+        query[TestEntity].map(v0 => query[TestEntity].map(v1 => v1.i).sum.contains(v0.i))
+      )
+    }
+
+    "size" in {
+      test(
+        dynamicQuery[TestEntity].map(v0 => dynamicQuery[TestEntity].size),
+        query[TestEntity].map(v0 => query[TestEntity].size)
+      )
+    }
+
+    "regular joins" - {
+
+      "join" in {
+        test(
+          dynamicQuery[TestEntity].join(dynamicQuery[TestEntity]).on((v0, v1) => v0.i == v1.i),
+          query[TestEntity].join(query[TestEntity]).on((v0, v1) => v0.i == v1.i)
+        )
+      }
+
+      "leftJoin" in {
+        test(
+          dynamicQuery[TestEntity].leftJoin(dynamicQuery[TestEntity2]).on((v0, v1) => v0.i == v1.i),
+          query[TestEntity].leftJoin(query[TestEntity2]).on((v0, v1) => v0.i == v1.i)
+        )
+      }
+
+      "rightJoin" in {
+        test(
+          dynamicQuery[TestEntity].rightJoin(dynamicQuery[TestEntity2]).on((v0, v1) => v0.i == v1.i),
+          query[TestEntity].rightJoin(query[TestEntity2]).on((v0, v1) => v0.i == v1.i)
+        )
+      }
+
+      "fullJoin" in {
+        test(
+          dynamicQuery[TestEntity].fullJoin(dynamicQuery[TestEntity2]).on((v0, v1) => v0.i == v1.i),
+          query[TestEntity].fullJoin(query[TestEntity2]).on((v0, v1) => v0.i == v1.i)
+        )
+      }
+
+    }
+
+    "flat joins" - {
+      "join" in {
+        test(
+          for {
+            v0 <- dynamicQuery[TestEntity]
+            v1 <- dynamicQuery[TestEntity2].join(v1 => v0.i == v1.i)
+          } yield (unquote(v0), unquote(v1)),
+          for {
+            v0 <- query[TestEntity]
+            v1 <- query[TestEntity2].join(v1 => v0.i == v1.i)
+          } yield (unquote(v0), unquote(v1))
+        )
+      }
+
+      "leftJoin" in {
+        test(
+          for {
+            v0 <- dynamicQuery[TestEntity]
+            v1 <- dynamicQuery[TestEntity2].leftJoin(v1 => v0.i == v1.i)
+          } yield (unquote(v0), unquote(v1)),
+          for {
+            v0 <- query[TestEntity]
+            v1 <- query[TestEntity2].leftJoin(v1 => v0.i == v1.i)
+          } yield (unquote(v0), unquote(v1))
+        )
+      }
+
+      "rightJoin" in {
+        test(
+          for {
+            v0 <- dynamicQuery[TestEntity]
+            v1 <- dynamicQuery[TestEntity2].rightJoin(v1 => v0.i == v1.i)
+          } yield (unquote(v0), unquote(v1)),
+          for {
+            v0 <- query[TestEntity]
+            v1 <- query[TestEntity2].rightJoin(v1 => v0.i == v1.i)
+          } yield (unquote(v0), unquote(v1))
+        )
+      }
+    }
+
+    "nonEmpty" in {
+      test(
+        dynamicQuery[TestEntity].map(v0 => dynamicQuery[TestEntity].nonEmpty),
+        query[TestEntity].map(v0 => query[TestEntity].nonEmpty)
+      )
+    }
+
+    "isEmpty" in {
+      test(
+        dynamicQuery[TestEntity].map(v0 => dynamicQuery[TestEntity].isEmpty),
+        query[TestEntity].map(v0 => query[TestEntity].isEmpty)
+      )
+    }
+
+    "contains" - {
+      "quoted" in {
+        test(
+          dynamicQuery[TestEntity].map(v0 => dynamicQuery[TestEntity].map(v1 => v1.i).contains(quote(v0.i))),
+          query[TestEntity].map(v0 => query[TestEntity].map(v1 => v1.i).contains(v0.i))
+        )
+      }
+      "value" in {
+        test(
+          dynamicQuery[TestEntity].map(v0 => dynamicQuery[TestEntity].map(v1 => v1.i).contains(1)),
+          query[TestEntity].map(v0 => query[TestEntity].map(v1 => v1.i).contains(lift(1)))
+        )
+      }
+    }
+
+    "distinct" in {
+      test(
+        dynamicQuery[TestEntity].distinct,
+        query[TestEntity].distinct
+      )
+    }
+
+    "nested" in {
+      test(
+        dynamicQuery[TestEntity].nested.map(v0 => v0.i),
+        query[TestEntity].nested.map(v0 => v0.i)
+      )
+    }
+  }
+
+  "entityQuery" - {
+    def test[T: QueryMeta](d: Quoted[EntityQuery[T]], s: Quoted[EntityQuery[T]]) =
+      testContext.run(d).string mustEqual testContext.run(s).string
+
+    "filter" in {
+      test(
+        dynamicQuery[TestEntity].filter(v0 => v0.i == 1),
+        query[TestEntity].filter(v0 => v0.i == 1)
+      )
+    }
+    "withFilter" in {
+      test(
+        dynamicQuery[TestEntity].withFilter(v0 => v0.i == 1),
+        query[TestEntity].withFilter(v0 => v0.i == 1)
+      )
+    }
+    "filterOpt" - {
+      "defined" in {
+        val o = Some(1)
+        test(
+          dynamicQuery[TestEntity].filterOpt(o)((v0, i) => v0.i == i),
+          query[TestEntity].filter(v0 => v0.i == lift(1))
+        )
+      }
+      "empty" in {
+        val o: Option[Int] = None
+        test(
+          dynamicQuery[TestEntity].filterOpt(o)((v0, i) => v0.i == i),
+          query[TestEntity]
+        )
+      }
+    }
+    "map" in {
+      test(
+        dynamicQuery[TestEntity].map(v0 => v0.i),
+        query[TestEntity].map(v0 => v0.i)
+      )
+    }
+  }
+
+  "actions" - {
+    def test[T](d: Quoted[Action[T]], s: Quoted[Action[T]]) =
+      testContext.run(d).string mustEqual testContext.run(s).string
+
+    val t = TestEntity("s", 1, 2L, Some(3))
+    "insertValue" in {
+      test(
+        dynamicQuery[TestEntity].insertValue(t),
+        query[TestEntity].insert(lift(t))
+      )
+    }
+
+    "updateValue" in {
+      test(
+        dynamicQuery[TestEntity].updateValue(t),
+        query[TestEntity].update(lift(t))
+      )
+    }
+
+    "insert" - {
+      "one column" in {
+        test(
+          dynamicQuery[TestEntity].insert(set(_.i, 1)),
+          query[TestEntity].insert(v => v.i -> 1)
+        )
+      }
+      "multiple columns" in {
+        test(
+          dynamicQuery[TestEntity].insert(set(_.i, 1), set(_.l, 2L)),
+          query[TestEntity].insert(v => v.i -> 1, v => v.l -> 2L)
+        )
+      }
+      "setOpt" in {
+        test(
+          dynamicQuery[TestEntity].insert(setOpt(_.i, None), setOpt(_.l, Some(2L))),
+          query[TestEntity].insert(v => v.l -> lift(2L))
+        )
+      }
+      "string column name" in {
+        val d = dynamicQuery[TestEntity].insert(set("ii", 1), set("ll", 2L))
+        testContext.run(d).string mustEqual """querySchema("TestEntity").insert(v => "ii" -> 1, v => "ll" -> 2)"""
+      }
+      "returning" in {
+        test(
+          dynamicQuery[TestEntity].insert(set(_.i, 1)).returning(v0 => v0.l),
+          query[TestEntity].insert(v => v.i -> 1).returning(v0 => v0.l)
+        )
+      }
+      "onConflictIgnore" - {
+        "simple" in {
+          test(
+            dynamicQuery[TestEntity].insert(set(_.i, 1)).onConflictIgnore,
+            query[TestEntity].insert(v => v.i -> 1).onConflictIgnore
+          )
+        }
+        "with targets" in {
+          test(
+            dynamicQuery[TestEntity].insert(set(_.i, 1)).onConflictIgnore(_.i),
+            query[TestEntity].insert(v => v.i -> 1).onConflictIgnore(_.i)
+          )
+        }
+      }
+    }
+
+    "update" - {
+      "one column" in {
+        test(
+          dynamicQuery[TestEntity].update(set(_.i, 1)),
+          query[TestEntity].update(v => v.i -> 1)
+        )
+      }
+      "multiple columns" in {
+        test(
+          dynamicQuery[TestEntity].update(set(_.i, 1), set(_.l, 2L)),
+          query[TestEntity].update(v => v.i -> 1, v => v.l -> 2L)
+        )
+      }
+      "string column name" in {
+        val d = dynamicQuery[TestEntity].update(set("ii", 1), set("ll", 2L))
+        testContext.run(d).string mustEqual """querySchema("TestEntity").update(v => "ii" -> 1, v => "ll" -> 2)"""
+      }
+    }
+
+    "delete" in {
+      test(
+        dynamicQuery[TestEntity].delete,
+        query[TestEntity].delete
+      )
+    }
+
+  }
+
+}

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -1024,8 +1024,8 @@ class QuotationSpec extends Spec {
         }
       }
       "forced" in {
-        val q = quote(1).dynamic
-        "q.ast: Constant" mustNot compile
+        val q = qr1.dynamic
+        "q.ast: Query[_]" mustNot compile
       }
     }
     "if" - {


### PR DESCRIPTION
Fixes #842
Fixes #745
Fixes #563
Fixes #803
Fixes #562

### Problem

Quill doesn't provide convenient APIs to deal with dynamic queries

### Solution

Introduce a new API with methods similar to the regular query API, but using open quotation, which makes it much easier to build dynamic queries. 

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
