### PR TITLE
update guava version to 27.0.1-jre

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,6 +208,7 @@ lazy val `quill-cassandra` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
+        "com.google.guava" % "guava" % "27.0.1-jre",
         "com.datastax.cassandra" %  "cassandra-driver-core" % "3.6.0"
       )
     )

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/util/FutureConversions.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/util/FutureConversions.scala
@@ -1,9 +1,9 @@
 package io.getquill.context.cassandra.util
 
-import com.google.common.util.concurrent.{ FutureCallback, Futures, ListenableFuture }
-import scala.concurrent.Promise
-import scala.concurrent.Future
-import language.implicitConversions
+import com.google.common.util.concurrent.{ FutureCallback, Futures, ListenableFuture, MoreExecutors }
+
+import scala.concurrent.{ Future, Promise }
+import scala.language.implicitConversions
 
 object FutureConversions {
 
@@ -20,7 +20,8 @@ object FutureConversions {
           p.failure(t)
           ()
         }
-      }
+      },
+      MoreExecutors.directExecutor()
     )
     p.future
   }

--- a/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
@@ -75,7 +75,7 @@ object StatementInterpolator {
               acc += stringToken.string
             (builder, acc)
           case ((builder, prev), b) if prev.isEmpty => (builder += b.token, prev)
-          case ((builder, prev), b) /** if prev.nonEmpty */ =>
+          case ((builder, prev), b) =>
             builder += StringToken(prev.result().mkString)
             builder += b.token
             (builder, new ListBuffer[String])


### PR DESCRIPTION
Fixes #1293 

### Problem

`quill-cassandra` is incompatible with latest guava.

### Solution

Modify `FutureConversions` to fit new guava version api


@getquill/maintainers
