### PR TITLE
fix scaladoc generation

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -54,7 +54,7 @@ fi
 show_mem
 
 echo "Running tests"
-time sbt $SBT_ARGS checkUnformattedFiles test
+time sbt $SBT_ARGS checkUnformattedFiles test tut doc
 
 show_mem
 
@@ -66,9 +66,6 @@ if [[ $TRAVIS_SCALA_VERSION == 2.11* ]]; then
     time sbt $SBT_ARGS coverageReport coverageAggregate
     pip install --user codecov && codecov
 fi
-
-# for 2.11 and 2.12 we run tut
-time sbt tut
 
 show_mem
 

--- a/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
@@ -75,7 +75,7 @@ object StatementInterpolator {
               acc += stringToken.string
             (builder, acc)
           case ((builder, prev), b) if prev.isEmpty => (builder += b.token, prev)
-          case ((builder, prev), b) /** if prev.nonEmpty */ =>
+          case ((builder, prev), b) /* if prev.nonEmpty */ =>
             builder += StringToken(prev.result().mkString)
             builder += b.token
             (builder, new ListBuffer[String])


### PR DESCRIPTION
### Problem

The release phase of the build on master [is failing](https://travis-ci.org/getquill/quill/jobs/480321652#L1014) because of a malformed scaladoc.

### Solution

Fix the malformed scaladoc and add scaladoc generation to the test build phases so the build will fail for pull requests as well in case there's a malformed scaladoc.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
