### PR TITLE
Action task needs to flatMap

### DIFF
--- a/quill-cassandra-monix/src/main/scala/io/getquill/CassandraMonixContext.scala
+++ b/quill-cassandra-monix/src/main/scala/io/getquill/CassandraMonixContext.scala
@@ -70,7 +70,7 @@ class CassandraMonixContext[N <: NamingStrategy](
 
   def executeAction[T](cql: String, prepare: Prepare = identityPrepare): Task[Unit] = {
     prepareRowAndLog(cql, prepare)
-      .map(r => Task.fromFuture(session.executeAsync(r)))
+      .flatMap(r => Task.fromFuture(session.executeAsync(r)))
       .map(_ => ())
   }
 


### PR DESCRIPTION
Okay, so this is stupid. In `executeAction` in `CassandraMonixContext` I accidentally did a `map` where a `flatMap` is supposed to go. This created `Task[Task[Unit]]` in which the inner task does not sequece correctly. The problem was hidden because the end of the method does `.map(_ => ())`.

This issue results in non-deterministic behavior when it comes to monix actions. Most notably, the following is happening intermittently in our build:

```
 - stream *** FAILED ***
[info]   java.lang.IllegalStateException: Expected column at index 2 to be defined but is was empty
[info]   at io.getquill.util.Messages$.fail(Messages.scala:15)
[info]   at io.getquill.context.cassandra.encoding.Decoders$$anonfun$decoder$1.apply(Decoders.scala:22)
[info]   at io.getquill.context.cassandra.encoding.Decoders$$anonfun$decoder$1.apply(Decoders.scala:20)
[info]   at io.getquill.context.cassandra.encoding.Decoders$CassandraDecoder.apply(Decoders.scala:16)
[info]   at io.getquill.context.cassandra.monix.EncodingSpec$$anonfun$1$$anonfun$apply$mcV$sp$1$$anonfun$3$$anonfun$apply$5$$anon$1$$anonfun$4.apply(EncodingSpec.scala:14)
[info]   at io.getquill.context.cassandra.monix.EncodingSpec$$anonfun$1$$anonfun$apply$mcV$sp$1$$anonfun$3$$anonfun$apply$5$$anon$1$$anonfun$4.apply(EncodingSpec.scala:14)
[info]   at monix.reactive.internal.operators.MapOperator$$anon$1.onNext(MapOperator.scala:42)
[info]   at monix.reactive.internal.operators.ConcatMapObservable$ConcatMapSubscriber$ChildSubscriber.onNext(ConcatMapObservable.scala:349)
[info]   at monix.reactive.internal.builders.IteratorAsObservable.monix$reactive$internal$builders$IteratorAsObservable$$fastLoop(IteratorAsObservable.scala:140)
[info]   at monix.reactive.internal.builders.IteratorAsObservable.startLoop(IteratorAsObservable.scala:62)
```

### Solution

Change the `map` to a `flatMap` in executeAction.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
