### PR TITLE
Provide a better "Can't tokenize a non-scalar lifting" error message

### DIFF
--- a/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
@@ -35,7 +35,18 @@ object StatementInterpolator {
   implicit def liftTokenizer: Tokenizer[Lift] =
     Tokenizer[Lift] {
       case lift: ScalarLift => ScalarLiftToken(lift)
-      case lift             => fail(s"Can't tokenize a non-scalar lifting. ${lift.name}")
+      case lift             => fail(
+        s"Can't tokenize a non-scalar lifting. ${lift.name}\n" +
+        s"\n" +
+        s"This might happen because:\n" +
+        s"* You are trying to insert or update whole Embedded case class. For example:\n" +
+        s"    run(query[Users].update(_.embeddedCaseClass -> lift(someInstance))\n" +
+        s"  In that case, make sure you are updating individual columns, for example:\n" +
+        s"    run(query[Users].update(\n" + 
+        s"       _.embeddedCaseClass.a -> lift(someInstance.a),\n" +
+        s"       _.embeddedCaseClass.b -> lift(someInstance.b)\n" +
+        s"    )"
+      )
     }
 
   implicit def tokenTokenizer: Tokenizer[Token] = Tokenizer[Token](identity)

--- a/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
@@ -35,25 +35,25 @@ object StatementInterpolator {
   implicit def liftTokenizer: Tokenizer[Lift] =
     Tokenizer[Lift] {
       case lift: ScalarLift => ScalarLiftToken(lift)
-      case lift             => fail(
+      case lift => fail(
         s"Can't tokenize a non-scalar lifting. ${lift.name}\n" +
-        s"\n" +
-        s"This might happen because:\n" +
-        s"* You are trying to insert or update an `Option[A]` field, but Scala infers the type\n" +
-        s"  to `Some[A]` or `None.type`. For example:\n" +
-        s"    run(query[Users].update(_.optionalField -> lift(Some(value))))" +
-        s"  In that case, make sure the type is `Option`:\n" + 
-        s"    run(query[Users].update(_.optionalField -> lift(Some(value): Option[Int])))\n" +
-        s"  or\n"+
-        s"    run(query[Users].update(_.optionalField -> lift(Option(value))))\n" +
-        s"\n" +
-        s"* You are trying to insert or update whole Embedded case class. For example:\n" +
-        s"    run(query[Users].update(_.embeddedCaseClass -> lift(someInstance)))\n" +
-        s"  In that case, make sure you are updating individual columns, for example:\n" +
-        s"    run(query[Users].update(\n" + 
-        s"       _.embeddedCaseClass.a -> lift(someInstance.a),\n" +
-        s"       _.embeddedCaseClass.b -> lift(someInstance.b)\n" +
-        s"    ))"
+          s"\n" +
+          s"This might happen because:\n" +
+          s"* You are trying to insert or update an `Option[A]` field, but Scala infers the type\n" +
+          s"  to `Some[A]` or `None.type`. For example:\n" +
+          s"    run(query[Users].update(_.optionalField -> lift(Some(value))))" +
+          s"  In that case, make sure the type is `Option`:\n" +
+          s"    run(query[Users].update(_.optionalField -> lift(Some(value): Option[Int])))\n" +
+          s"  or\n" +
+          s"    run(query[Users].update(_.optionalField -> lift(Option(value))))\n" +
+          s"\n" +
+          s"* You are trying to insert or update whole Embedded case class. For example:\n" +
+          s"    run(query[Users].update(_.embeddedCaseClass -> lift(someInstance)))\n" +
+          s"  In that case, make sure you are updating individual columns, for example:\n" +
+          s"    run(query[Users].update(\n" +
+          s"       _.embeddedCaseClass.a -> lift(someInstance.a),\n" +
+          s"       _.embeddedCaseClass.b -> lift(someInstance.b)\n" +
+          s"    ))"
       )
     }
 

--- a/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
@@ -39,13 +39,21 @@ object StatementInterpolator {
         s"Can't tokenize a non-scalar lifting. ${lift.name}\n" +
         s"\n" +
         s"This might happen because:\n" +
+        s"* You are trying to insert or update an `Option[A]` field, but Scala infers the type\n" +
+        s"  to `Some[A]` or `None.type`. For example:\n" +
+        s"    run(query[Users].update(_.optionalField -> lift(Some(value))))" +
+        s"  In that case, make sure the type is `Option`:\n" + 
+        s"    run(query[Users].update(_.optionalField -> lift(Some(value): Option[Int])))\n" +
+        s"  or\n"+
+        s"    run(query[Users].update(_.optionalField -> lift(Option(value))))\n" +
+        s"\n" +
         s"* You are trying to insert or update whole Embedded case class. For example:\n" +
-        s"    run(query[Users].update(_.embeddedCaseClass -> lift(someInstance))\n" +
+        s"    run(query[Users].update(_.embeddedCaseClass -> lift(someInstance)))\n" +
         s"  In that case, make sure you are updating individual columns, for example:\n" +
         s"    run(query[Users].update(\n" + 
         s"       _.embeddedCaseClass.a -> lift(someInstance.a),\n" +
         s"       _.embeddedCaseClass.b -> lift(someInstance.b)\n" +
-        s"    )"
+        s"    ))"
       )
     }
 


### PR DESCRIPTION
### Problem

Currently "Can't tokenize a non-scalar lifting" error message is hard to understand for library users.

It is full of library lingo, like "tokenize", "non-scalar" and to extent "lifting" which is not explained in the manual in any way.

### Solution

This commit improves the error message to help users with the common causes of this error.

@getquill/maintainers
