### PR TITLE
Fix Monix JDBC Connection Leak

### DIFF
--- a/quill-jdbc-monix/src/test/resources/application.conf
+++ b/quill-jdbc-monix/src/test/resources/application.conf
@@ -12,6 +12,15 @@ testPostgresDB.dataSource.databaseName=quill_test
 testPostgresDB.dataSource.portNumber=${?POSTGRES_PORT}
 testPostgresDB.dataSource.serverName=${?POSTGRES_HOST}
 
+testPostgresLeakDB.dataSourceClassName=org.postgresql.ds.PGSimpleDataSource
+testPostgresLeakDB.dataSource.user=postgres
+testPostgresLeakDB.dataSource.databaseName=quill_test
+testPostgresLeakDB.dataSource.portNumber=${?POSTGRES_PORT}
+testPostgresLeakDB.dataSource.serverName=${?POSTGRES_HOST}
+testPostgresLeakDB.connectionTimeout = 30000
+testPostgresLeakDB.maximumPoolSize = 6
+testPostgresLeakDB.leakDetectionThreshold = 1000
+
 testH2DB.dataSourceClassName=org.h2.jdbcx.JdbcDataSource
 testH2DB.dataSource.url="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:sql/h2-schema.sql'"
 testH2DB.dataSource.user=sa

--- a/quill-jdbc-monix/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/postgres/ConnectionLeakTest.scala
@@ -1,0 +1,54 @@
+package io.getquill.postgres
+
+import java.util.UUID
+
+import io.getquill.context.monix.Runner
+import io.getquill.{ JdbcContextConfig, Literal, PostgresMonixJdbcContext }
+import io.getquill.context.sql.ProductSpec
+import io.getquill.util.LoadConfig
+import monix.execution.Scheduler
+
+import scala.util.Random
+
+class ConnectionLeakTest extends ProductSpec {
+
+  implicit val scheduler = Scheduler.global
+
+  val dataSource = JdbcContextConfig(LoadConfig("testPostgresLeakDB")).dataSource
+
+  val context = new PostgresMonixJdbcContext(Literal, dataSource, Runner.default)
+  import context._
+
+  override def beforeAll = {
+    context.run(quote(query[Product].delete)).runSyncUnsafe()
+    ()
+  }
+
+  "insert and select without leaking" in {
+    val result =
+      context.transaction {
+        for {
+          _ <- context.run {
+            quote {
+              query[Product].insert(
+                lift(Product(1, UUID.randomUUID().toString, Random.nextLong()))
+              )
+            }
+          }
+          result <- context.run {
+            query[Product].filter(p => query[Product].map(_.id).max.exists(_ == p.id))
+          }
+        } yield (result)
+      }
+        .map(_.headOption.map(_.id))
+        .runSyncUnsafe()
+
+    Thread.sleep(2000)
+
+    result mustEqual Option(1)
+    dataSource.getHikariPoolMXBean.getActiveConnections mustEqual 0
+
+    context.close()
+  }
+
+}

--- a/quill-jdbc-monix/src/test/scala/io/getquill/postgres/ProductJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/postgres/ProductJdbcSpec.scala
@@ -8,12 +8,12 @@ class ProductJdbcSpec extends ProductSpec {
   val context = testContext
   import testContext._
 
+  implicit val scheduler = Scheduler.global
+
   override def beforeAll = {
-    testContext.run(quote(query[Product].delete))
+    testContext.run(quote(query[Product].delete)).runSyncUnsafe()
     ()
   }
-
-  implicit val scheduler = Scheduler.global
 
   "Product" - {
     "Insert multiple products" in {


### PR DESCRIPTION
Fixes #1305

### Problem

When using `context.transaction`, JDBC connections leak

### Solution

Make sure connection operation is wrapped with closing bracket.

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
