### PR TITLE
Refactoring Cassandra for more modularity

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -1,22 +1,20 @@
 package io.getquill
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import io.getquill.context.cassandra.util.FutureConversions.toScalaFuture
-import io.getquill.util.{ ContextLogger, LoadConfig }
-import com.typesafe.config.Config
-import scala.collection.JavaConverters._
-import io.getquill.context.cassandra.CassandraSessionContext
 import com.datastax.driver.core.Cluster
+import com.typesafe.config.Config
+import io.getquill.context.cassandra.{CassandraFutureContextEffect, CassandraSessionContext}
 import io.getquill.monad.ScalaFutureIOMonad
+import io.getquill.util.{ContextLogger, LoadConfig}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class CassandraAsyncContext[N <: NamingStrategy](
-  naming:                     N,
-  cluster:                    Cluster,
-  keyspace:                   String,
-  preparedStatementCacheSize: Long
+  val naming:                     N,
+  val cluster:                    Cluster,
+  val keyspace:                   String,
+  val preparedStatementCacheSize: Long
 )
-  extends CassandraSessionContext[N](naming, cluster, keyspace, preparedStatementCacheSize)
+  extends CassandraSessionContext[N]
   with ScalaFutureIOMonad {
 
   def this(naming: N, config: CassandraContextConfig) = this(naming, config.cluster, config.keyspace, config.preparedStatementCacheSize)
@@ -25,41 +23,30 @@ class CassandraAsyncContext[N <: NamingStrategy](
 
   private val logger = ContextLogger(classOf[CassandraAsyncContext[_]])
 
+  override type RunContext = ExecutionContext
+  override type Completed = Unit
   override type Result[T] = Future[T]
   override type RunQueryResult[T] = List[T]
   override type RunQuerySingleResult[T] = T
-  override type RunActionResult = Unit
-  override type RunBatchActionResult = Unit
+  override def complete: Unit = ()
+
+  override protected val effect = new CassandraFutureContextEffect
 
   override def performIO[T](io: IO[T, _], transactional: Boolean = false)(implicit ec: ExecutionContext): Result[T] = {
     if (transactional) logger.underlying.warn("Cassandra doesn't support transactions, ignoring `io.transactional`")
     super.performIO(io)
   }
 
-  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[List[T]] =
-    this.prepareAsync(cql).map(prepare).flatMap {
-      case (params, bs) =>
-        logger.logQuery(cql, params)
-        session.executeAsync(bs)
-          .map(_.all.asScala.toList.map(extractor))
-    }
+  override def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[List[T]] =
+    super.executeQuery(cql, prepare, extractor)
 
-  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[T] =
-    executeQuery(cql, prepare, extractor).map(handleSingleResult)
+  override def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[T] =
+    super.executeQuerySingle(cql, prepare, extractor)
 
-  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Unit] = {
-    this.prepareAsync(cql).map(prepare).flatMap {
-      case (params, bs) =>
-        logger.logQuery(cql, params)
-        session.executeAsync(bs).map(_ => ())
-    }
-  }
+  override def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Unit] =
+    super.executeAction(cql, prepare)
 
-  def executeBatchAction(groups: List[BatchGroup])(implicit ec: ExecutionContext): Future[Unit] =
-    Future.sequence {
-      groups.flatMap {
-        case BatchGroup(cql, prepare) =>
-          prepare.map(executeAction(cql, _))
-      }
-    }.map(_ => ())
+  override def executeBatchAction(groups: List[BatchGroup])(implicit ec: ExecutionContext): Future[Unit] =
+    super.executeBatchAction(groups)
+
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContextEffect.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraContextEffect.scala
@@ -1,0 +1,29 @@
+package io.getquill.context.cassandra
+
+import com.google.common.util.concurrent.ListenableFuture
+import io.getquill.context.ContextEffect
+
+import scala.util.Try
+import scala.language.higherKinds
+
+trait CassandraContextEffect[F[_], EC] extends ContextEffect[F] { self =>
+
+  object ImplicitsWithContext {
+    implicit class ResultTypeOps[A](result: F[A]) {
+      def map[B](f: A => B)(implicit executionContext: EC) = withContextActions.push(result)(f)
+      def flatMap[B](f: A => F[B])(implicit executionContext: EC) = withContextActions.flatPush(result)(f)
+    }
+  }
+
+  val executionContext: EC
+  def withContextActions: WithContextActions
+
+  trait WithContextActions {
+    def wrapListenableFuture[T](listenableFuture: ListenableFuture[T])(implicit executionContext: EC): F[T]
+    def tryAndThen[T, U](t: => F[T])(pf: PartialFunction[Try[T], U])(implicit executionContext: EC): F[T]
+    def wrap[T](t: => T)(implicit executionContext: EC): F[T]
+    def push[A, B](result: F[A])(f: A => B)(implicit executionContext: EC): F[B]
+    def flatPush[A, B](result: F[A])(f: A => F[B])(implicit executionContext: EC): F[B]
+    def seq[A, B](f: List[F[A]])(implicit executionContext: EC): F[List[A]]
+  }
+}

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraFutureContextEffect.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraFutureContextEffect.scala
@@ -1,0 +1,26 @@
+package io.getquill.context.cassandra
+
+import com.google.common.util.concurrent.ListenableFuture
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+// TODO Need to implement
+class CassandraFutureContextEffect extends CassandraContextEffect[Future, ExecutionContext] {
+
+  override def wrap[T](t: => T): Future[T] = ???
+  override def push[A, B](result: Future[A])(f: A => B): Future[B] = ???
+  override def flatPush[A, B](result: Future[A])(f: A => Future[B]): Future[B] = ???
+  override def seq[A, B](f: List[Future[A]]): Future[List[A]] = ???
+
+  override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  override def withContextActions: WithContextActions = new WithContextActions {
+    override def wrapListenableFuture[T](listenableFuture: ListenableFuture[T])(implicit executionContext: ExecutionContext): Future[T] = ???
+    override def tryAndThen[T, U](t: => Future[T])(pf: PartialFunction[Try[T], U])(implicit executionContext: ExecutionContext): Future[T] = ???
+    override def wrap[T](t: => T)(implicit executionContext: ExecutionContext): Future[T] = ???
+    override def push[A, B](result: Future[A])(f: A => B)(implicit executionContext: ExecutionContext): Future[B] = ???
+    override def flatPush[A, B](result: Future[A])(f: A => Future[B])(implicit executionContext: ExecutionContext): Future[B] = ???
+    override def seq[A, B](f: List[Future[A]])(implicit executionContext: ExecutionContext): Future[List[A]] = ???
+  }
+}

--- a/quill-core/src/main/scala/io/getquill/context/ContextEffect.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextEffect.scala
@@ -8,6 +8,14 @@ import scala.language.higherKinds
  * generic manner.
  */
 trait ContextEffect[F[_]] {
+
+  object Implicits {
+    implicit class ResultTypeOps[A](result: F[A]) {
+      def map[B](f: A => B) = push(result)(f)
+      def flatMap[B](f: A => F[B]) = flatPush(result)(f)
+    }
+  }
+
   /**
    * Lift an element or block of code in the context into the specified effect.
    */
@@ -17,6 +25,8 @@ trait ContextEffect[F[_]] {
    * Map a parameter of the effect. This is really just a functor.
    */
   def push[A, B](result: F[A])(f: A => B): F[B]
+
+  def flatPush[A, B](result: F[A])(f: A => F[B]): F[B]
 
   /**
    * Aggregate a list of effects into a single effect element. Most effect types

--- a/quill-core/src/main/scala/io/getquill/context/TranslateContext.scala
+++ b/quill-core/src/main/scala/io/getquill/context/TranslateContext.scala
@@ -14,6 +14,7 @@ trait TranslateContext extends TranslateContextBase {
   override private[getquill] val translateEffect: ContextEffect[TranslateResult] = new ContextEffect[TranslateResult] {
     override def wrap[T](t: => T): T = t
     override def push[A, B](result: A)(f: A => B): B = f(result)
+    override def flatPush[A, B](result: A)(f: A => B): B = f(result)
     override def seq[A, B](list: List[A]): List[A] = list
   }
 }


### PR DESCRIPTION
Sketch of what needs to be done in order to have modularity in the Cassandra module. Note how `CassandraAsyncContext` has a completely trivial implementation. `CassandraMonixContext`, and `CassandraStreamContext` should also be reworked to look like that.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
