### PR TITLE
Move basic encoders into EncodingDsl

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
@@ -178,10 +178,10 @@ trait DynamicQueryDsl {
     def take(n: Quoted[Int]): DynamicQuery[T] =
       dyn(Take(q.ast, n.ast))
 
-    def take(n: Int)(implicit enc: Encoder[Int]): DynamicQuery[T] =
+    def take(n: Int): DynamicQuery[T] =
       take(spliceLift(n))
 
-    def takeOpt(opt: Option[Int])(implicit enc: Encoder[Int]): DynamicQuery[T] =
+    def takeOpt(opt: Option[Int]): DynamicQuery[T] =
       opt match {
         case Some(o) => take(o)
         case None    => this
@@ -190,10 +190,10 @@ trait DynamicQueryDsl {
     def drop(n: Quoted[Int]): DynamicQuery[T] =
       dyn(Drop(q.ast, n.ast))
 
-    def drop(n: Int)(implicit enc: Encoder[Int]): DynamicQuery[T] =
+    def drop(n: Int): DynamicQuery[T] =
       drop(spliceLift(n))
 
-    def dropOpt(opt: Option[Int])(implicit enc: Encoder[Int]): DynamicQuery[T] =
+    def dropOpt(opt: Option[Int]): DynamicQuery[T] =
       opt match {
         case Some(o) => drop(o)
         case None    => this

--- a/quill-core/src/main/scala/io/getquill/dsl/EncodingDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/EncodingDsl.scala
@@ -68,4 +68,13 @@ trait EncodingDsl extends LowPriorityImplicits {
 
   protected def mappedBaseDecoder[I, O](mapped: MappedEncoding[I, O], decoder: BaseDecoder[I]): BaseDecoder[O] =
     (index, row) => mapped.f(decoder(index, row))
+
+  implicit def stringEncoder: Encoder[String]
+  implicit def bigDecimalEncoder: Encoder[BigDecimal]
+  implicit def booleanEncoder: Encoder[Boolean]
+  implicit def byteEncoder: Encoder[Byte]
+  implicit def shortEncoder: Encoder[Short]
+  implicit def intEncoder: Encoder[Int]
+  implicit def longEncoder: Encoder[Long]
+  implicit def doubleEncoder: Encoder[Double]
 }


### PR DESCRIPTION
Fixes #1318, #1319 

### Problem

Creating a Multi-DB context across data-source (e.g. regular databases, spark etc...) is very difficult as documented in #1318.

### Solution

Added basic encoders into EncodingDsl.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
