### PR TITLE
Make string column name as property

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
@@ -84,7 +84,7 @@ trait DynamicQueryDsl {
     }
 
   def set[T, U](property: String, value: Quoted[U]): DynamicSet[T, U] =
-    set((f: Quoted[T]) => splice(Constant(property)), value)
+    set((f: Quoted[T]) => splice(Property(f.ast, property)), value)
 
   def setValue[T, U](property: String, value: U)(implicit enc: Encoder[U]): DynamicSet[T, U] =
     set(property, spliceLift(value))

--- a/quill-core/src/test/scala/io/getquill/quotation/DynamicQuerySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/DynamicQuerySpec.scala
@@ -550,8 +550,10 @@ class DynamicQuerySpec extends Spec {
         )
       }
       "string column name" in {
-        val d = dynamicQuery[TestEntity].insert(set("ii", 1), set("ll", 2L))
-        testContext.run(d).string mustEqual """querySchema("TestEntity").insert(v => "ii" -> 1, v => "ll" -> 2)"""
+        test(
+          dynamicQuery[TestEntity].insert(set("i", 1), set("l", 2L)),
+          query[TestEntity].insert(v => v.i -> 1, v => v.l -> 2L)
+        )
       }
       "returning" in {
         test(
@@ -589,8 +591,10 @@ class DynamicQuerySpec extends Spec {
         )
       }
       "string column name" in {
-        val d = dynamicQuery[TestEntity].update(set("ii", 1), set("ll", 2L))
-        testContext.run(d).string mustEqual """querySchema("TestEntity").update(v => "ii" -> 1, v => "ll" -> 2)"""
+        test(
+          dynamicQuery[TestEntity].update(set("i", 1), set("l", 2L)),
+          query[TestEntity].update(v => v.i -> 1, v => v.l -> 2L)
+        )
       }
     }
 


### PR DESCRIPTION
### Problem

String column name in dynamic `set` was treated as string

### Solution

Make it a `Property`
