### PR TITLE
Rely on ANSI null-fallthrough where possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 addons:
   postgresql: "9.6"
 script:
-  - ./build/build.sh
+  -        ./build/build.sh
 branches:
   except:
     - release

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlNormalize.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlNormalize.scala
@@ -1,6 +1,7 @@
 package io.getquill.context.cassandra
 
 import io.getquill.ast._
+import io.getquill.norm.ConcatBehavior.AnsiConcat
 import io.getquill.norm.{ FlattenOptionOperation, Normalize, RenameProperties, SimplifyNullChecks }
 
 object CqlNormalize {
@@ -10,7 +11,7 @@ object CqlNormalize {
 
   private[this] val normalize =
     (identity[Ast] _)
-      .andThen(FlattenOptionOperation.apply _)
+      .andThen(new FlattenOptionOperation(AnsiConcat).apply _)
       .andThen(SimplifyNullChecks.apply _)
       .andThen(Normalize.apply _)
       .andThen(RenameProperties.apply _)

--- a/quill-core/src/main/scala/io/getquill/norm/ConcatBehavior.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/ConcatBehavior.scala
@@ -1,0 +1,7 @@
+package io.getquill.norm
+
+trait ConcatBehavior
+object ConcatBehavior {
+  case object AnsiConcat extends ConcatBehavior
+  case object NonAnsiConcat extends ConcatBehavior
+}

--- a/quill-sql/src/main/scala/io/getquill/OracleDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/OracleDialect.scala
@@ -5,11 +5,15 @@ import io.getquill.context.sql._
 import io.getquill.context.sql.idiom._
 import io.getquill.idiom.StatementInterpolator._
 import io.getquill.idiom.{ Statement, StringToken, Token }
+import io.getquill.norm.ConcatBehavior
+import io.getquill.norm.ConcatBehavior.NonAnsiConcat
 
 trait OracleDialect
   extends SqlIdiom
   with QuestionMarkBindVariables
   with ConcatSupport {
+
+  override def concatBehavior: ConcatBehavior = NonAnsiConcat
 
   override def emptySetContainsToken(field: Token) = StringToken("1 <> 1")
 

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -11,13 +11,17 @@ import io.getquill.NamingStrategy
 import io.getquill.util.Interleave
 import io.getquill.util.Messages.{ fail, trace }
 import io.getquill.idiom.Token
+import io.getquill.norm.ConcatBehavior
+import io.getquill.norm.ConcatBehavior.AnsiConcat
 
 trait SqlIdiom extends Idiom {
 
   override def prepareForProbing(string: String): String
 
+  protected def concatBehavior: ConcatBehavior = AnsiConcat
+
   override def translate(ast: Ast)(implicit naming: NamingStrategy) = {
-    val normalizedAst = SqlNormalize(ast)
+    val normalizedAst = SqlNormalize(ast, concatBehavior)
 
     implicit val tokernizer = defaultTokenizer
 

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
@@ -2,14 +2,20 @@ package io.getquill.context.sql.norm
 
 import io.getquill.norm._
 import io.getquill.ast.Ast
+import io.getquill.norm.ConcatBehavior.AnsiConcat
 import io.getquill.util.Messages.trace
 
 object SqlNormalize {
+  def apply(ast: Ast, concatBehavior: ConcatBehavior = AnsiConcat) =
+    new SqlNormalize(concatBehavior)(ast)
+}
+
+class SqlNormalize(concatBehavior: ConcatBehavior) {
 
   private val normalize =
     (identity[Ast] _)
       .andThen(trace("original"))
-      .andThen(FlattenOptionOperation.apply _)
+      .andThen(new FlattenOptionOperation(concatBehavior).apply _)
       .andThen(trace("FlattenOptionOperation"))
       .andThen(SimplifyNullChecks.apply _)
       .andThen(trace("SimplifyNullChecks"))


### PR DESCRIPTION
Fixes #1340 

### Problem

Explain here the context, and why you're making that change.
What is the problem you're trying to solve?

Check the body of Option `exists`, `forall`, `map`, and `flatMap` to see if there is an instance of `If`, `Infix`, or string-concat inside (this is only done when the `ConcatBehavior` in `FlattenOptionOperation` is set to `NonAnsiConcat` since outside of oracle, we don't need to have explicit null checks for every string concationation.

Although I am posting the PR now, I would like to wait until Oracle can be merged in #1295

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
