### PR TITLE
Move to Oracle18c XE and Fix Build Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ MyTestSql.scala
 quill-core/src/main/resources/logback.xml
 quill-jdbc/src/main/resources/logback.xml
 log.txt*
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 sudo: required
 language: scala
-scala:
-  - 2.11.12
-  - 2.12.6
 jdk: oraclejdk8
+dist: trusty
 services:
   - docker
   - postgresql
   - mysql
 addons:
   postgresql: "9.6"
-script:
-  -        ./build/build.sh
 branches:
   except:
     - release
@@ -29,7 +25,23 @@ env:
     - secure: YWJ9ho4mwXjy4GrnbjehDlP5wFA6P8KLZMb+jOCEFNI9wKSiKzUUeIqGNog6Q9KCHE+RMEFz/kqE+7jNhhOgGGv0mRF0RVfHL0SkamhD0NMxiC1vITk3+oqMi/v1sK/V88WbfM4+1sAcFqV7yoptyWw/Db7U/MdLcRZaVe2zMz6s4P811CZjpT2Y/EkwxWcxejTCxptAvAkIfrgIyI28xW9hgA9oWvQJjD42ShKd445AC9qNq8E2cY8ukFIMik/FNHYWQMmdUTYOqX68O6fn2lPcIayPNCl0UuY6L9DB0KS0ZxrItX6/0JQU/CR8iFHWxshACvxLAMLUofPl/0QVkoSVaCGrKCX8WpjQ4K2FV/xiXa6xPXSFcI4RRsGkpXe3S6BHdWdH7whEsLDhvIJN3WQREWYqujXNi2imCO08+N0/GuDxfIcCzkrsEZYk5d1h8HQTk6Ml9ahhbL5EbrgEO6z8C/cLoSwebeYPeO7Wlw8y1f0pT8yIMH0cAI0PrdUzhQOgSgMUZGgntCynHyJymwtlHV7y829qsxvf3M0IpjCwK3VAdQLQKt2evFOT2hIbubpzvR6u26zeflpiMr/U8/uZnu3XYCPFLwkAZEDLb1LNfDiXOZY+cG+aX0R/m3hPDv5G5iH0OCTCwJ/usGSRMxdhwgQqltXrhGLUkvKcy8w=
 jobs:
   include:
-      stage: release
+    - stage: build
+      script: ./build/build.sh db
+      scala: 2.11.12
+      name: "Databases 2.11 - MySQL, Postgres, Sqlite, H2, SQL Server, Oracle"
+    - stage: build
+      script: ./build/build.sh db
+      scala: 2.12.6
+      name: "Databases 2.12 - MySQL, Postgres, Sqlite, H2, SQL Server, Oracle"
+    - stage: build
+      script: ./build/build.sh bigdata
+      scala: 2.11.12
+      name: "BigData Databases 2.11 - Cassandra, OrientDB, Spark"
+    - stage: build
+      script: ./build/build.sh bigdata
+      scala: 2.12.6
+      name: "BigData Databases 2.12 - Cassandra, OrientDB, Spark"
+    - stage: release
       if: type != pull_request
       script:
         - travis_retry ./build/release.sh

--- a/build.sbt
+++ b/build.sbt
@@ -315,7 +315,7 @@ def updateWebsiteTag =
 
 lazy val jdbcTestingSettings = Seq(
   fork in Test := true,
-  resolvers ++= includeIfOracle( // read ojdbc7 jar in case it is deployed
+  resolvers ++= includeIfOracle( // read ojdbc8 jar in case it is deployed
     Resolver.mavenLocal
   ),
   libraryDependencies ++= {
@@ -331,7 +331,7 @@ lazy val jdbcTestingSettings = Seq(
       )
 
     deps ++ includeIfOracle(
-      "com.oracle.jdbc" % "ojdbc7" % "12.1.0.2" % Test
+      "com.oracle.jdbc" % "ojdbc8" % "18.3.0.0.0" % Test
     )
   },
   excludeFilter in unmanagedSources := {

--- a/build/Dockerfile-cassandra
+++ b/build/Dockerfile-cassandra
@@ -1,0 +1,4 @@
+FROM cassandra:3.11
+MAINTAINER deusaquilus@gmail.com
+
+RUN apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends default-jdk

--- a/build/build.sh
+++ b/build/build.sh
@@ -4,7 +4,16 @@ set -e
 
 function show_mem() {
     free -m | awk 'NR==2{printf "Memory Usage: %s/%sMB (%.2f%%)\n", $3,$2,$3*100/$2 }'
-    docker stats --no-stream
+
+    echo "===== System Memory Stats Start ====="
+    ps -eo size,%mem,cmd --sort=-size | head -10 | awk '{ hr=$1/1024 ; printf("%13.2fMb ",hr); print($2 " " $0) }'
+    sleep 2
+    echo "===== System Memory Stats End ====="
+
+    echo "===== Docker Stats Start ====="
+    docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}" --no-stream
+    sleep 4
+    echo "===== Docker Stats End ====="
 }
 export -f show_mem
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -2,21 +2,6 @@
 
 set -e
 
-function show_mem() {
-    free -m | awk 'NR==2{printf "Memory Usage: %s/%sMB (%.2f%%)\n", $3,$2,$3*100/$2 }'
-
-    echo "===== System Memory Stats Start ====="
-    ps -eo size,%mem,cmd --sort=-size | head -10 | awk '{ hr=$1/1024 ; printf("%13.2fMb ",hr); print($2 " " $0) }'
-    sleep 2
-    echo "===== System Memory Stats End ====="
-
-    echo "===== Docker Stats Start ====="
-    docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}" --no-stream
-    sleep 4
-    echo "===== Docker Stats End ====="
-}
-export -f show_mem
-
 export POSTGRES_HOST=127.0.0.1
 export POSTGRES_PORT=5432
 
@@ -35,52 +20,138 @@ export CASSANDRA_PORT=19042
 export ORIENTDB_HOST=127.0.0.1
 export ORIENTDB_PORT=12424
 
-export SBT_ARGS="-Doracle=true -Dquill.macro.log=false -Xms1024m -Xmx3g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC ++$TRAVIS_SCALA_VERSION"
+export SBT_ARGS="-Dquill.macro.log=false -Xms1024m -Xmx3g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC ++$TRAVIS_SCALA_VERSION"
+
+modules=$1
+
+echo "Modules: $modules"
+
+function show_mem() {
+    free -m | awk 'NR==2{printf "Memory Usage: %s/%sMB (%.2f%%)\n", $3,$2,$3*100/$2 }'
+    # mem_details
+    # free_details
+    # docker_stats
+}
+export -f show_mem
+
+function mem_details() {
+    echo "===== System Memory Stats Start ====="
+    ps -eo size,rss,%mem,cmd --sort=-size | head -20 | awk '{ hr=$1/1024; rr=$2/1024; printf("%13.2fMb ",hr); printf("%13.2fMb ",rr); print(" " $0) }'
+    sleep 2
+    echo "===== System Memory Stats End ====="
+}
+export -f mem_details
+
+function free_details() {
+    echo "===== Free Memory Stats Start ====="
+    free
+    sleep 2
+    echo "===== Free Memory Stats End ====="
+}
+export -f free_details
+
+function docker_stats() {
+    echo "===== Docker Stats Start ====="
+    docker stats --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}" --no-stream
+    sleep 4
+    echo "===== Docker Stats End ====="
+}
+export -f docker_stats
 
 if [[ $TRAVIS_SCALA_VERSION == 2.11* ]]; then
     export SBT_ARGS="$SBT_ARGS coverage"
 fi
 
-show_mem
+function wait_for_databases() {
+    show_mem
 
-# Start sbt compilation and database setup in parallel
-sbt clean $SBT_ARGS scalariformFormat test:scalariformFormat quill-coreJVM/test:compile & COMPILE=$!
-./build/setup_travis.sh & SETUP=$!
+    # Start sbt compilation and database setup in parallel
+    sbt clean scalariformFormat test:scalariformFormat -Dmodules=base $SBT_ARGS test & COMPILE=$!
+    ./build/setup_databases.sh & SETUP=$!
 
-# Wait on database setup. If it has failed then kill compilation process and exit with error
-wait $SETUP
+    # Wait on database setup. If it has failed then kill compilation process and exit with error
+    wait $SETUP
 
-if [[ "$?" != "0" ]]; then
-   echo "Database setup failed"
-   sleep 10
-   kill -9 $COMPILE
-   exit 1
+    if [[ "$?" != "0" ]]; then
+       echo "Database setup failed"
+       sleep 10
+       kill -9 $COMPILE
+       exit 1
+    fi
+    echo "Database Setup is finished, waiting for the compilation of core module"
+
+    wait $COMPILE
+    if [[ "$?" != "0" ]]; then
+       echo "Compilation of core module has failed"
+       sleep 10
+       exit 1
+    fi
+
+    echo "Database Setup is finished"
+    show_mem
+}
+
+function wait_for_bigdata() {
+    show_mem
+
+    sbt clean scalariformFormat test:scalariformFormat $SBT_ARGS quill-coreJVM/test:compile & COMPILE=$!
+    ./build/setup_bigdata.sh & SETUP=$!
+
+    wait $SETUP
+    if [[ "$?" != "0" ]]; then
+       echo "BigData Database setup failed"
+       sleep 10
+       kill -9 $COMPILE
+       exit 1
+    fi
+
+    wait $COMPILE
+    if [[ "$?" != "0" ]]; then
+       echo "Compilation of core module has failed"
+       sleep 10
+       exit 1
+    fi
+
+    echo "BigData Database Setup is finished"
+    show_mem
+}
+
+function db_build() {
+    wait_for_databases
+    sbt -Dmodules=db $SBT_ARGS test doc
+}
+
+function bigdata_build() {
+    wait_for_bigdata
+    sbt -Dmodules=bigdata $SBT_ARGS test doc
+}
+
+function full_build() {
+    wait_for_databases
+    wait_for_bigdata
+    sbt $SBT_ARGS test tut doc
+}
+
+if [[ $modules == "db" ]]; then
+    echo "Build Script: Doing Database Build"
+    db_build
+elif [[ $modules == "bigdata" ]]; then
+    echo "Build Script: Doing BigData Build"
+    bigdata_build
+else
+    echo "Build Script: Doing Full Build"
+    full_build
 fi
-echo "Setup is finished, waiting for the compilation of core module"
-
-wait $COMPILE
-if [[ "$?" != "0" ]]; then
-   echo "Compilation of core module has failed"
-   sleep 10
-   exit 1
-fi
-show_mem
-
-time sbt $SBT_ARGS checkUnformattedFiles test tut doc
 
 show_mem
-
 echo "Tests completed. Shutting down"
-
 time docker-compose down
 # for 2.11 publish coverage
 if [[ $TRAVIS_SCALA_VERSION == 2.11* ]]; then
-
     echo "Coverage"
     time sbt $SBT_ARGS coverageReport coverageAggregate
     pip install --user codecov && codecov
 fi
-
 show_mem
 
 sleep 10

--- a/build/build.sh
+++ b/build/build.sh
@@ -4,6 +4,7 @@ set -e
 
 function show_mem() {
     free -m | awk 'NR==2{printf "Memory Usage: %s/%sMB (%.2f%%)\n", $3,$2,$3*100/$2 }'
+    docker stats --no-stream
 }
 export -f show_mem
 
@@ -25,7 +26,7 @@ export CASSANDRA_PORT=19042
 export ORIENTDB_HOST=127.0.0.1
 export ORIENTDB_PORT=12424
 
-export SBT_ARGS="-Doracle=true -Dquill.macro.log=false -Xms512m -Xmx1536m -Xss2m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC ++$TRAVIS_SCALA_VERSION"
+export SBT_ARGS="-Doracle=true -Dquill.macro.log=false -Xms1024m -Xmx3g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC ++$TRAVIS_SCALA_VERSION"
 
 if [[ $TRAVIS_SCALA_VERSION == 2.11* ]]; then
     export SBT_ARGS="$SBT_ARGS coverage"

--- a/build/oracle_setup/external_check_script.sh
+++ b/build/oracle_setup/external_check_script.sh
@@ -2,11 +2,12 @@
 
 set -e
 
-source /root/.bashrc
+source /home/oracle/.bashrc
+PATH=$ORACLE_HOME/bin:$PATH
 
 echo "Setting up Oracle"
 
-until source /root/.bashrc; sqlplus quill_test/QuillRocks! < /oracle_setup/external_match_script.sql; do
+until source /home/oracle/.bashrc; sqlplus quill_test/QuillRocks! < /oracle_setup/external_match_script.sql; do
   echo "Trying Again"
   sleep 5;
 done

--- a/build/oracle_setup/external_setup_script.sh
+++ b/build/oracle_setup/external_setup_script.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
 echo "Running Global Oracle Init"
-
-# Start the oracle database
-nohup /entrypoint.sh &
+nohup ${ORACLE_BASE}/scripts/${RUN_FILE} &
 
 # Save the pid which we need to wait for (otherwise container will exit)
 pid=$!
 
+PATH=$ORACLE_HOME/bin:$PATH
+
 echo "Waiting for Oracle Setup to Complete"
 
-until source /root/.bashrc; sqlplus system/oracle@//localhost:1521/xe < /oracle_setup/external_match_script.sql | grep "match_this_test_to_pass"; do
-  echo "Trying Again"
+until source /home/oracle/.bashrc; $ORACLE_BASE/scripts/$CHECK_DB_FILE; do
+  echo "Oracle not running yet, Trying Again"
   sleep 5;
 done
 
-source /root/.bashrc
+source /home/oracle/.bashrc
 
 echo "Setting Up Test Database"
-sqlplus system/oracle@//localhost:1521/xe < /oracle_setup/create_quill_test.sql
+sqlplus sys/Oracle18@localhost/XE as sysdba < /oracle_setup/create_quill_test.sql
 
 echo "Setting Up Test Database Schema"
 sqlplus quill_test/QuillRocks! < /quill_setup/oracle-schema.sql

--- a/build/oracle_setup/load_jdbc.sh
+++ b/build/oracle_setup/load_jdbc.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copy the jdbc jar from the container to local
-docker cp "$(docker-compose ps -q oracle)":/u01/app/oracle-product/12.1.0/xe/jdbc/lib/ojdbc7.jar ./
+docker cp "$(docker-compose ps -q oracle)":/opt/oracle/product/18c/dbhomeXE/jdbc/lib/ojdbc8.jar ./
 
 mvn install:install-file \
-  -Dfile=ojdbc7.jar \
+  -Dfile=ojdbc8.jar \
   -DgroupId='com.oracle.jdbc' \
-  -DartifactId=ojdbc7 \
-  -Dversion=12.1.0.2 \
+  -DartifactId=ojdbc8 \
+  -Dversion=18.3.0.0.0 \
   -Dpackaging=jar
 
-rm ojdbc7.jar
+rm ojdbc8.jar

--- a/build/setup_bigdata.sh
+++ b/build/setup_bigdata.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+time docker-compose up -d cassandra orientdb
+
+# import setup functions
+. build/setup_db_scripts.sh
+
+# setup cassandra in docker
+send_script cassandra $CASSANDRA_SCRIPT cassandra-schema.cql
+send_script cassandra ./build/setup_db_scripts.sh setup_db_scripts.sh
+time docker-compose exec -T cassandra bash -c ". setup_db_scripts.sh && setup_cassandra cassandra-schema.cql 127.0.0.1"
+
+echo "Databases are ready!"

--- a/build/setup_databases.sh
+++ b/build/setup_databases.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-time docker-compose up -d cassandra sqlserver oracle orientdb
+time docker-compose up -d sqlserver oracle
 
 # import setup functions
 . build/setup_db_scripts.sh
@@ -14,11 +14,6 @@ time docker-compose up -d cassandra sqlserver oracle orientdb
 time setup_sqlite $SQLITE_SCRIPT 127.0.0.1
 time setup_mysql $MYSQL_SCRIPT 127.0.0.1
 time setup_postgres $POSTGRES_SCRIPT 127.0.0.1
-
-function send_script() {
-  echo "Send Script Args: 1: $1 - 2 $2 - 3: $3"
-  docker cp $2 "$(docker-compose ps -q $1)":/$3
-}
 
 # setup sqlserver in docker
 send_script sqlserver $SQL_SERVER_SCRIPT sqlserver-schema.sql
@@ -32,10 +27,5 @@ until docker-compose exec -T oracle "/oracle_setup_local/external_check_script.s
 done
 sleep 5;
 echo "Oracle Setup Complete"
-
-# setup cassandra in docker
-send_script cassandra $CASSANDRA_SCRIPT cassandra-schema.cql
-send_script cassandra ./build/setup_db_scripts.sh setup_db_scripts.sh
-time docker-compose exec -T cassandra bash -c ". setup_db_scripts.sh && setup_cassandra cassandra-schema.cql 127.0.0.1"
 
 echo "Databases are ready!"

--- a/build/setup_db_scripts.sh
+++ b/build/setup_db_scripts.sh
@@ -105,9 +105,15 @@ function setup_oracle() {
     sleep 5
 }
 
+function send_script() {
+  echo "Send Script Args: 1: $1 - 2 $2 - 3: $3"
+  docker cp $2 "$(docker-compose ps -q $1)":/$3
+}
+
 export -f setup_sqlite
 export -f setup_mysql
 export -f setup_postgres
 export -f setup_cassandra
 export -f setup_sqlserver
 export -f setup_oracle
+export -f send_script

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '2.2'
 
 services:
   postgres:
@@ -17,20 +17,27 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
 
   cassandra:
-    image: cassandra:3.11
+    build:
+      context: .
+      dockerfile: ./build/Dockerfile-cassandra
     ports:
       - "19042:9042"
+    # enable NativeMemoryTracking so that jcmd in possible in build.sh. For CompressedClassSpaceSize 1gig is default which is too high.
     environment:
       - MAX_HEAP_SIZE=256m
       - HEAP_NEWSIZE=64m
+      - JVM_OPTS=-XX:NativeMemoryTracking=summary -XX:CompressedClassSpaceSize=200m
+    init: true
 
   orientdb:
     image: orientdb:3.0.11
     ports:
       - "12424:2424"
+    # enable NativeMemoryTracking so that jcmd in possible in build.sh. For CompressedClassSpaceSize 1gig is default which is too high.
     environment:
       - ORIENTDB_ROOT_PASSWORD=root
-      - ORIENTDB_OPTS_MEMORY=-Xms256m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=64m -Xss1m
+      - ORIENTDB_OPTS_MEMORY=-XX:NativeMemoryTracking=summary -XX:CompressedClassSpaceSize=200m -Xms256m -Xmx512m -XX:MetaspaceSize=32m -XX:MaxMetaspaceSize=64m -Xss256k
+    init: true
 
   sqlserver:
     image: microsoft/mssql-server-linux
@@ -48,6 +55,9 @@ services:
       - ./build/oracle_setup:/oracle_setup
       - ./quill-sql/src/test/sql/:/quill_setup
     command: bash -c "mkdir /oracle_setup_local; cp /oracle_setup/* /oracle_setup_local && cd /oracle_setup_local && ./external_setup_script.sh"
+    # Opatch is an internal java-based daemon in the Oracle container that updates components, don't really need it here. Reduce it's memory settings.
+    environment:
+      - OPATCH_JRE_MEMORY_OPTIONS=-Xms128m -Xmx256m -XX:PermSize=16m -XX:MaxPermSize=32m -Xss1m
 
   setup:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - "12424:2424"
     environment:
       - ORIENTDB_ROOT_PASSWORD=root
+      - ORIENTDB_OPTS_MEMORY=-Xms256m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=64m -Xss1m
 
   sqlserver:
     image: microsoft/mssql-server-linux

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - SA_PASSWORD=QuillRocks!
 
   oracle:
-    image: medgetablelevvel/oracle-12c-base
+    image: quillbuilduser/oracle-18-xe
     ports:
       - "11521:1521"
     volumes:


### PR DESCRIPTION
Fixes
#1354
#1360 
#1363 

### Initial Problem

The Oracle 12c container we have been using has been DMCA'd.

### Solution

Use Oracle 18c XE. This is allowed for binary redistibution (see notes [here](url
https://blogs.oracle.com/imc/oracle-database-18c-xe-available-for-everyone) and license agreement [here](https://www.oracle.com/technetwork/licenses/db18c-express-license-5137264.html)) and will hopefully not get taken down.

### Additional Problems

As a result of instrumenting the new Oracle container ([here](https://hub.docker.com/r/quillbuilduser/oracle-18-xe)) the build became too large to fit on a single travis container. At first I thought we can work around the issue by decreasing memory consumption -especially of Cassandra and OrientDB containers which were the biggest culprits- however, after resolving this issue forced the build to run for a very long time passing the travis 50 limit mark. Thus there is no choice but to restrucutre the build so that the diffent databases can be tested in different Travis containers, in parallel.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
