### PR TITLE
Using 1=1 and 1=0 instead of true and false

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/SQLServerDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/SQLServerDialect.scala
@@ -2,10 +2,9 @@ package io.getquill
 
 import io.getquill.ast._
 import io.getquill.context.sql.{ FlattenSqlQuery, SqlQuery }
-import io.getquill.idiom.{ Statement, StringToken, Token }
-import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.sql.idiom.QuestionMarkBindVariables
-import io.getquill.context.sql.idiom.ConcatSupport
+import io.getquill.context.sql.idiom._
+import io.getquill.idiom.{ StringToken, Token }
+import io.getquill.idiom.Statement
 import io.getquill.idiom.StatementInterpolator._
 import io.getquill.util.Messages.fail
 
@@ -37,6 +36,12 @@ trait SQLServerDialect
     Tokenizer[Operation] {
       case BinaryOperation(a, StringOperator.`+`, b) => stmt"${scopedTokenizer(a)} + ${scopedTokenizer(b)}"
       case other                                     => super.operationTokenizer.token(other)
+    }
+
+  override implicit def valueTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Value] =
+    Tokenizer[Value] {
+      case Constant(b: Boolean) => StringToken(if (b) "1=1" else "1=0")
+      case other                => super.valueTokenizer.token(other)
     }
 }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SQLServerDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SQLServerDialectSpec.scala
@@ -28,6 +28,18 @@ class SQLServerDialectSpec extends Spec {
       "SELECT TOP 15 t.i FROM TestEntity t"
   }
 
+  "literal booleans" - {
+    "uses 1=1 instead of true" in {
+      ctx.run(qr4.filter(t => true)).string mustEqual
+        "SELECT t.i FROM TestEntity4 t WHERE 1=1"
+    }
+
+    "uses 1=0 instead of false" in {
+      ctx.run(qr4.filter(t => false)).string mustEqual
+        "SELECT t.i FROM TestEntity4 t WHERE 1=0"
+    }
+  }
+
   "offset/fetch" - {
 
     val withOrd = quote {


### PR DESCRIPTION
Fixes #1331 

### Problem

SQL Server doesn't have a boolean datatype, making `WHERE TRUE` or `WHERE FALSE` invalid statements. 

### Solution

Using `WHERE 1=1` or `WHERE 1=0` instead

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
