### PR TITLE
fix for scalar values with oracle

### DIFF
--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/ScalarValueSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/ScalarValueSpec.scala
@@ -1,0 +1,21 @@
+package io.getquill.context.jdbc.oracle
+
+import io.getquill.Spec
+
+class ScalarValueSpec  extends Spec {
+
+  val context = testContext
+  import testContext._
+
+  "Simple Scalar Select" in {
+    context.run(1) mustEqual 1
+  }
+
+  "Multi Scalar Select" in {
+    context.run(quote(1 + quote(1))) mustEqual 2
+  }
+
+  "Multi Scalar Select with Infix" in {
+    context.run("foo"+infix"""'bar'""".as[String]) mustEqual "foobar"
+  }
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
@@ -52,9 +52,23 @@ class OracleDialectSpec extends Spec {
         "SELECT t.s FROM TestEntity t OFFSET 2 ROWS FETCH NEXT 3 ROWS ONLY"
     }
 
-    "featch" in {
+    "fetch" in {
       ctx.run(fetch(withOrd)).string mustEqual
         "SELECT t.s FROM TestEntity t FETCH FIRST 3 ROWS ONLY"
+    }
+  }
+
+  "uses dual for scalars" - {
+    "Simple Scalar Select" in {
+      ctx.run(1).string mustEqual "SELECT 1 FROM DUAL"
+    }
+
+    "Multi Scalar Select" in {
+      ctx.run(quote(1 + quote(1))).string mustEqual "SELECT 1 + 1 FROM DUAL"
+    }
+
+    "Multi Scalar Select with Infix" in {
+      ctx.run("foo"+infix"""'bar'""".as[String]).string mustEqual "SELECT 'foo' || 'bar' FROM DUAL"
     }
   }
 


### PR DESCRIPTION
Fixes #1364

### Problem

All queries in Oracle need a `From` clause. Scalar selects need to have a `from DUAL` suffix.

### Solution

Modify the query tokenizer for `OracleDialect` to add `from DUAL` for queries where there is no suffix. To make this easier the `FlattenSqlQuery` case of sqlQueryTokenizer needs to be modified to be a bit more extensible.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
