### PR TITLE
Build had formatting errors previously. Fixing them.

### DIFF
--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/ScalarValueSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/ScalarValueSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.jdbc.oracle
 
 import io.getquill.Spec
 
-class ScalarValueSpec  extends Spec {
+class ScalarValueSpec extends Spec {
 
   val context = testContext
   import testContext._
@@ -16,6 +16,6 @@ class ScalarValueSpec  extends Spec {
   }
 
   "Multi Scalar Select with Infix" in {
-    context.run("foo"+infix"""'bar'""".as[String]) mustEqual "foobar"
+    context.run("foo" + infix"""'bar'""".as[String]) mustEqual "foobar"
   }
 }

--- a/quill-sql/src/main/scala/io/getquill/OracleDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/OracleDialect.scala
@@ -13,8 +13,8 @@ trait OracleDialect
   with QuestionMarkBindVariables
   with ConcatSupport {
 
-  class OracleFlattenSqlQueryTokenizerHelper(q:FlattenSqlQuery)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy)
-  extends FlattenSqlQueryTokenizerHelper(q)(astTokenizer, strategy) {
+  class OracleFlattenSqlQueryTokenizerHelper(q: FlattenSqlQuery)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy)
+    extends FlattenSqlQueryTokenizerHelper(q)(astTokenizer, strategy) {
     import q._
 
     override def withFrom: Statement = from match {

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -93,7 +93,7 @@ trait SqlIdiom extends Idiom {
   protected def tokenizeGroupBy(values: Ast)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Token =
     values.token
 
-  protected class FlattenSqlQueryTokenizerHelper(q:FlattenSqlQuery)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy) {
+  protected class FlattenSqlQueryTokenizerHelper(q: FlattenSqlQuery)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy) {
     import q._
 
     def distinctTokenizer = (if (distinct) "DISTINCT " else "").token

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
@@ -68,7 +68,7 @@ class OracleDialectSpec extends Spec {
     }
 
     "Multi Scalar Select with Infix" in {
-      ctx.run("foo"+infix"""'bar'""".as[String]).string mustEqual "SELECT 'foo' || 'bar' FROM DUAL"
+      ctx.run("foo" + infix"""'bar'""".as[String]).string mustEqual "SELECT 'foo' || 'bar' FROM DUAL"
     }
   }
 


### PR DESCRIPTION
Build has formatting errors. Formatting issues were probably not caught due to build restructure. Need to look into why this happened.

@getquill/maintainers
