### PR TITLE
Add explicit format checks to all builds

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -65,8 +65,11 @@ fi
 function wait_for_databases() {
     show_mem
 
+    sbt clean scalariformFormat test:scalariformFormat
+    sbt checkUnformattedFiles
+
     # Start sbt compilation and database setup in parallel
-    sbt clean scalariformFormat test:scalariformFormat -Dmodules=base $SBT_ARGS test & COMPILE=$!
+    sbt -Dmodules=base $SBT_ARGS test & COMPILE=$!
     ./build/setup_databases.sh & SETUP=$!
 
     # Wait on database setup. If it has failed then kill compilation process and exit with error
@@ -94,7 +97,10 @@ function wait_for_databases() {
 function wait_for_bigdata() {
     show_mem
 
-    sbt clean scalariformFormat test:scalariformFormat $SBT_ARGS quill-coreJVM/test:compile & COMPILE=$!
+    sbt clean scalariformFormat test:scalariformFormat
+    sbt checkUnformattedFiles
+
+    sbt clean $SBT_ARGS quill-coreJVM/test:compile & COMPILE=$!
     ./build/setup_bigdata.sh & SETUP=$!
 
     wait $SETUP


### PR DESCRIPTION
Release 3.1.0 failed due to uncaught formatting checks in #1371. Adding some more explicit format checks which should hopefully be caught but this build. Then #1374 can be merged and this commit updated.

@getquill/maintainers
