### PR TITLE
Revert "trigger 3.1.0 release"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
-# 3.1.0
-
-- [oracle support](https://github.com/getquill/quill/pull/1295)
-- [quill cassandra for lagom](https://github.com/getquill/quill/pull/1299)
-- [Fix the problem with re-preparing already prepared statements](https://github.com/getquill/quill/issues/1268)
-- [Rely on ANSI null-fallthrough where possible](https://github.com/getquill/quill/pull/1341)
-- [Fix for non-fallthrough null operations in map/flatMap/exists](https://github.com/getquill/quill/pull/1302)
-- [Move basic encoders into EncodingDsl](https://github.com/getquill/quill/pull/1327)
-- [Make string column name as property](https://github.com/getquill/quill/pull/1332)
-- [Update MySQL driver/datasource](https://github.com/getquill/quill/pull/1326)
-- [Provide a better "Can't tokenize a non-scalar lifting" error message](https://github.com/getquill/quill/pull/1311)
-
 #3.0.1
 
 - [Fix Monix JDBC Connection Leak](https://github.com/getquill/quill/pull/1313)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.1.0"
+version in ThisBuild := "3.1.0-SNAPSHOT"


### PR DESCRIPTION
Reverts getquill/quill#1376 Deployment failed because there were artifacts correctly deployed from #1371. Need to temporarily change build to continue.