### PR TITLE
Update finagle-mysql to 19.2.0(fix compile errors)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -162,7 +162,7 @@ lazy val `quill-finagle-mysql` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "com.twitter" %% "finagle-mysql" % "18.12.0"
+        "com.twitter" %% "finagle-mysql" % "19.2.0"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContextConfig.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContextConfig.scala
@@ -2,7 +2,7 @@ package io.getquill
 
 import java.util.TimeZone
 
-import com.twitter.conversions.DurationOps.RichLong
+import com.twitter.conversions.DurationOps._
 import com.twitter.finagle.Mysql
 import com.twitter.finagle.client.DefaultPool
 import com.twitter.util.Try


### PR DESCRIPTION
Fixes #1372

### Problem
[com.twitter.conversions.DurationOps.RichLong was deleted](https://github.com/twitter/util/commit/2d5d6da989ab83e8701b9f57ae0708a5851beb07#diff-fc8ae882b8f7f5665fedbbb451d1fd91) in twitter/util 19.2.0.

### Solution
replace `com.twitter.conversions.DurationOps.RichLong`
to `com.twitter.conversions.DurationOps._`

### Checklist
- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
