### PR TITLE
Replace newInstance() with getConstructor().newInstance()

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/cluster/ClusterBuilder.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/cluster/ClusterBuilder.scala
@@ -71,8 +71,8 @@ object ClusterBuilder {
       else if (tpe.isEnum)
         tpe.getMethod("valueOf", classOf[String]).invoke(tpe, cfg.getString(key))
       else if (cfg.getValue(key).valueType == ConfigValueType.STRING)
-        getClass.getClassLoader.loadClass(cfg.getString(key)).newInstance
+        getClass.getClassLoader.loadClass(cfg.getString(key)).getDeclaredConstructor().newInstance()
       else
-        set(tpe.newInstance, cfg.getConfig(key))
+        set(tpe.getDeclaredConstructor().newInstance(), cfg.getConfig(key))
     }
 }


### PR DESCRIPTION
java.lang.Class#newInstance() has been deprecated in Java 9+

https://docs.oracle.com/javase/9/docs/api/java/lang/Class.html#newInstance--