### PR TITLE
Fix variable shadowing issue in action metas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ quill-sql/io/
 MyTest.scala
 MySparkTest.scala
 MyTestJdbc.scala
-MyTestSql.scala
+MySqlTest.scala
 quill-core/src/main/resources/logback.xml
 quill-jdbc/src/main/resources/logback.xml
 log.txt*

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -7,6 +7,7 @@ import io.getquill.norm.BetaReduction
 import io.getquill.util.Messages.RichContext
 import io.getquill.util.Interleave
 import io.getquill.dsl.CoreDsl
+import io.getquill.norm.capture.AvoidAliasConflict
 
 import scala.annotation.tailrec
 import scala.collection.immutable.StringOps
@@ -16,6 +17,10 @@ trait Parsing {
   this: Quotation =>
 
   import c.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
+
+  // Variables that need to be sanitized out in various places due to internal conflicts with the way
+  // macros hard handeled in MetaDsl
+  private[getquill] val dangerousVariables = Set("v").map(Ident(_))
 
   case class Parser[T](p: PartialFunction[Tree, T])(implicit ct: ClassTag[T]) {
 
@@ -316,8 +321,15 @@ trait Parsing {
     case q"new { def apply[..$t1](...$params) = $body }" =>
       c.fail("Anonymous classes aren't supported for function declaration anymore. Use a method with a type parameter instead. " +
         "For instance, replace `val q = quote { new { def apply[T](q: Query[T]) = ... } }` by `def q[T] = quote { (q: Query[T] => ... }`")
-    case q"(..$params) => $body" =>
-      Function(params.map(identParser(_)), astParser(body))
+    case q"(..$params) => $body" => {
+      val subtree = Function(params.map(identParser(_)), astParser(body))
+      // If there are actions inside the subtree, we need to do some additional sanitizations
+      // of the variables so that their content will not collide with code that we have generated.
+      if (CollectAst.byType[Action](subtree).nonEmpty)
+        AvoidAliasConflict.sanitizeVariables(subtree, dangerousVariables)
+      else
+        subtree
+    }
   }
 
   val identParser: Parser[Ident] = Parser[Ident] {
@@ -699,7 +711,9 @@ trait Parsing {
     case q"$action.returning[$r](($alias) => $body)" =>
       Returning(astParser(action), identParser(alias), astParser(body))
     case q"$query.foreach[$t1, $t2](($alias) => $body)($f)" if (is[CoreDsl#Query[Any]](query)) =>
-      Foreach(astParser(query), identParser(alias), astParser(body))
+      // If there are actions inside the subtree, we need to do some additional sanitizations
+      // of the variables so that their content will not collide with code that we have generated.
+      AvoidAliasConflict.sanitizeVariables(Foreach(astParser(query), identParser(alias), astParser(body)), dangerousVariables)
   }
 
   private val assignmentParser: Parser[Assignment] = Parser[Assignment] {


### PR DESCRIPTION
Fixes #1408

### Solution
Remove `v` variables from functions that have `Action` AST elements inside of them during Parser and replace with a fresh variable using `AvoidAliasConflict`.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
