### PR TITLE
Change effect to protected

### DIFF
--- a/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
@@ -50,7 +50,7 @@ abstract class MonixJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](
   override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Task[List[T]] =
     super.executeBatchActionReturning(groups, extractor)
 
-  override private[getquill] val effect: Runner = runner
+  override protected val effect: Runner = runner
   import runner._
 
   private val currentConnection: Local[Option[Connection]] = Local(None)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
@@ -27,7 +27,7 @@ abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy]
   override type RunBatchActionResult = List[Long]
   override type RunBatchActionReturningResult[T] = List[T]
 
-  override private[getquill] val effect: ContextEffect[Result] = new ContextEffect[Result] {
+  override protected val effect: ContextEffect[Result] = new ContextEffect[Result] {
     override def wrap[T](t: => T): T = t
     override def push[A, B](result: A)(f: A => B): B = f(result)
     override def seq[A, B](list: List[A]): List[A] = list

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
@@ -20,7 +20,7 @@ trait JdbcContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy]
   override type PrepareRow = PreparedStatement
   override type ResultRow = ResultSet
 
-  private[getquill] val effect: ContextEffect[Result]
+  protected val effect: ContextEffect[Result]
   import effect._
 
   protected def withConnection[T](f: Connection => Result[T]): Result[T]

--- a/quill-monix/src/main/scala/io/getquill/context/monix/MonixContext.scala
+++ b/quill-monix/src/main/scala/io/getquill/context/monix/MonixContext.scala
@@ -17,5 +17,5 @@ trait MonixContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] e
   def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[List[T]]
   def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[T]
 
-  private[getquill] val effect: Runner
+  protected val effect: Runner
 }


### PR DESCRIPTION
It is reasonable for users to extend jdbc contexts and modify `effect` or at least use it (or choose not to). The requirement of being in the `io.getquill` to do that is too resrictive.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
