### PR TITLE
Publish and release by individual module

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -11,7 +11,7 @@ then
     openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/pubring.gpg.enc -out local.pubring.gpg -d
     openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/credentials.sbt.enc -out local.credentials.sbt -d
     openssl aes-256-cbc -pass pass:$ENCRYPTION_PASSWORD -in ./build/deploy_key.pem.enc -out local.deploy_key.pem -d
-    
+
     ls -ltr
     sleep 3 # Need to wait until credential files fully written or build fails sometimes
 
@@ -28,16 +28,40 @@ then
         git reset --hard origin/master
         git push --delete origin website || true
 
-        $SBT_2_12 'release with-defaults'
-        $SBT_2_11 'release with-defaults'
+        $SBT_2_12 -Dmodules=base 'release with-defaults'
+        $SBT_2_12 -Dmodules=db 'release with-defaults'
+        $SBT_2_12 -Dmodules=async 'release with-defaults'
+        $SBT_2_12 -Dmodules=codegen 'release with-defaults'
+        $SBT_2_12 -Dmodules=bigdata 'release with-defaults'
+        $SBT_2_11 -Dmodules=base 'release with-defaults'
+        $SBT_2_11 -Dmodules=db 'release with-defaults'
+        $SBT_2_11 -Dmodules=async 'release with-defaults'
+        $SBT_2_11 -Dmodules=codegen 'release with-defaults'
+        $SBT_2_11 -Dmodules=bigdata 'release with-defaults'
 
     elif [[ $TRAVIS_BRANCH == "master" ]]
     then
-        $SBT_2_12 publish
-        $SBT_2_11 publish
+        $SBT_2_12 -Dmodules=base publish
+        $SBT_2_12 -Dmodules=db publish
+        $SBT_2_12 -Dmodules=async publish
+        $SBT_2_12 -Dmodules=codegen publish
+        $SBT_2_12 -Dmodules=bigdata publish
+        $SBT_2_11 -Dmodules=base publish
+        $SBT_2_11 -Dmodules=db publish
+        $SBT_2_11 -Dmodules=async publish
+        $SBT_2_11 -Dmodules=codegen publish
+        $SBT_2_11 -Dmodules=bigdata publish
     else
         echo "version in ThisBuild := \"$TRAVIS_BRANCH-SNAPSHOT\"" > version.sbt
-        $SBT_2_12 publish
-        $SBT_2_11 publish
+        $SBT_2_12 -Dmodules=base publish
+        $SBT_2_12 -Dmodules=db publish
+        $SBT_2_12 -Dmodules=async publish
+        $SBT_2_12 -Dmodules=codegen publish
+        $SBT_2_12 -Dmodules=bigdata publish
+        $SBT_2_11 -Dmodules=base publish
+        $SBT_2_11 -Dmodules=db publish
+        $SBT_2_11 -Dmodules=async publish
+        $SBT_2_11 -Dmodules=codegen publish
+        $SBT_2_11 -Dmodules=bigdata publish
     fi
 fi


### PR DESCRIPTION
When publishing all modules together, there are very frequent intermittent failures like this:
```
[error] java.io.IOException: Access to URL https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/3.1.1-SNAPSHOT/quill-core_sjs0.6_2.12-3.1.1-SNAPSHOT.pom was refused by the server: Unauthorized
```
This occours because for some reason, SBT attempts to publish the same artifacts multiple times. You can see that beforehand, this particular module was published:
```
[info] Packaging /home/travis/build/getquill/quill/quill-core/.js/target/scala-2.12/quill-core_sjs0.6_2.12-3.1.1-SNAPSHOT.jar ...
[info] 	published quill-core_sjs0.6_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/3.1.1-SNAPSHOT/quill-core_sjs0.6_2.12-3.1.1-SNAPSHOT.pom
[info] 	published quill-core_sjs0.6_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/3.1.1-SNAPSHOT/quill-core_sjs0.6_2.12-3.1.1-SNAPSHOT.jar
[info] 	published quill-core_sjs0.6_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/3.1.1-SNAPSHOT/quill-core_sjs0.6_2.12-3.1.1-SNAPSHOT-sources.jar
[info] 	published quill-core_sjs0.6_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/3.1.1-SNAPSHOT/quill-core_sjs0.6_2.12-3.1.1-SNAPSHOT-javadoc.jar
...
[info] Packaging /home/travis/build/getquill/quill/quill-core/.js/target/scala-2.12/quill-core_sjs0.6_2.12-3.1.1-SNAPSHOT.jar ...
[error] java.io.IOException: Access to URL https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/3.1.1-SNAPSHOT/quill-core_sjs0.6_2.12-3.1.1-SNAPSHOT.pom was refused by the server: Unauthorized
```
In addition, SBT seems to complain that the credentials file does not work:
```
[error] Unable to find credentials for [Sonatype Nexus Repository Manager @ oss.sonatype.org].
```
I do not know why this problem is happening but after debugging for 2+ weeks, it seems that the presence of certain modules with multiple layers of transitive depdencies (e.g. `quill-codegen-tests`) seems to excerberate the problem to point where 3 retries in travis is *never* enough to get out of the intermittent issue. On the other hand, publishing different sets of modules (via using `-Dmodules`) separately seems to remove the problem entirely. Here is an example of `quill-core_sjs` which was failing basically of the time before:
```
[info] 	published quill-core_sjs0.6_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/build-individual-components-SNAPSHOT/quill-core_sjs0.6_2.12-build-individual-components-SNAPSHOT.pom
[info] 	published quill-core_sjs0.6_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/build-individual-components-SNAPSHOT/quill-core_sjs0.6_2.12-build-individual-components-SNAPSHOT.jar
[info] 	published quill-core_sjs0.6_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/build-individual-components-SNAPSHOT/quill-core_sjs0.6_2.12-build-individual-components-SNAPSHOT-sources.jar
[info] 	published quill-core_sjs0.6_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.12/build-individual-components-SNAPSHOT/quill-core_sjs0.6_2.12-build-individual-components-SNAPSHOT-javadoc.jar
[info] 	published quill-core_sjs0.6_2.11 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.11/build-individual-components-SNAPSHOT/quill-core_sjs0.6_2.11-build-individual-components-SNAPSHOT.pom
[info] 	published quill-core_sjs0.6_2.11 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.11/build-individual-components-SNAPSHOT/quill-core_sjs0.6_2.11-build-individual-components-SNAPSHOT.jar
[info] 	published quill-core_sjs0.6_2.11 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.11/build-individual-components-SNAPSHOT/quill-core_sjs0.6_2.11-build-individual-components-SNAPSHOT-sources.jar
[info] 	published quill-core_sjs0.6_2.11 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_sjs0.6_2.11/build-individual-components-SNAPSHOT/quill-core_sjs0.6_2.11-build-individual-components-SNAPSHOT-javadoc.jar
```
As you can see above, each module is only being published once (scroll to the end of the text on the right). The same for the JVM `quill-core`:
```
[info] 	published quill-core_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_2.12/build-individual-components-SNAPSHOT/quill-core_2.12-build-individual-components-SNAPSHOT.pom
[info] 	published quill-core_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_2.12/build-individual-components-SNAPSHOT/quill-core_2.12-build-individual-components-SNAPSHOT.jar
[info] 	published quill-core_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_2.12/build-individual-components-SNAPSHOT/quill-core_2.12-build-individual-components-SNAPSHOT-sources.jar
[info] 	published quill-core_2.12 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_2.12/build-individual-components-SNAPSHOT/quill-core_2.12-build-individual-components-SNAPSHOT-javadoc.jar
[info] 	published quill-core_2.11 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_2.11/build-individual-components-SNAPSHOT/quill-core_2.11-build-individual-components-SNAPSHOT.pom
[info] 	published quill-core_2.11 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_2.11/build-individual-components-SNAPSHOT/quill-core_2.11-build-individual-components-SNAPSHOT.jar
[info] 	published quill-core_2.11 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_2.11/build-individual-components-SNAPSHOT/quill-core_2.11-build-individual-components-SNAPSHOT-sources.jar
[info] 	published quill-core_2.11 to https://oss.sonatype.org/content/repositories/snapshots/io/getquill/quill-core_2.11/build-individual-components-SNAPSHOT/quill-core_2.11-build-individual-components-SNAPSHOT-javadoc.jar
```
As a result of these observations. I am going to separate out the publishing on the modules using `-Dmodules` and have each one as a separate target.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
