### PR TITLE
Allow == for Option[T] and/or T columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ MySparkTest.scala
 MyTestJdbc.scala
 MyJdbcTest.scala
 MySqlTest.scala
+MyTest.scala
 quill-core/src/main/resources/logback.xml
 quill-jdbc/src/main/resources/logback.xml
 log.txt*

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,10 @@ lazy val `quill-core` =
     .settings(libraryDependencies ++= Seq(
       "com.typesafe"               %  "config"        % "1.3.4",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
-      "org.scala-lang"             %  "scala-reflect" % scalaVersion.value
+      "org.scala-lang"             %  "scala-reflect" % scalaVersion.value,
+
+      "org.scala-lang"   %  "scala-library"     % "2.11.11",
+      "org.scala-lang"   %  "scala-compiler"     % "2.11.11"
     ))
     .jsSettings(
       libraryDependencies += "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
@@ -474,6 +477,10 @@ lazy val basicSettings = Seq(
   scalaVersion := "2.11.12",
   crossScalaVersions := Seq("2.11.12","2.12.7"),
   libraryDependencies ++= Seq(
+    "org.scala-lang"   %  "scala-library"     % "2.11.11",
+    "org.scala-lang"   %  "scala-compiler"     % "2.11.11",
+    "org.scala-lang"   %  "scala-reflect"     % "2.11.11",
+
     "org.scalamacros" %% "resetallattrs"  % "1.0.0",
     "org.scalatest"   %%% "scalatest"     % "3.0.7"     % Test,
     "ch.qos.logback"  % "logback-classic" % "1.2.3"     % Test,

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -21,6 +21,36 @@ private[dsl] trait QueryDsl {
       )
   }
 
+  object extras extends LowPriorityExtras {
+    implicit class NumericOptionOps[A: Numeric](a: Option[A]) {
+      def ===[B: Numeric](b: Option[B]): Boolean = a.exists(av => b.exists(bv => av == bv))
+      def ===[B: Numeric](b: B): Boolean = a.exists(av => av == b)
+      def =!=[B: Numeric](b: Option[B]): Boolean = a.exists(av => b.exists(bv => av != bv))
+      def =!=[B: Numeric](b: B): Boolean = a.exists(av => av != b)
+    }
+    implicit class NumericRegOps[A: Numeric](a: A) {
+      def ===[B: Numeric](b: Option[B]): Boolean = b.exists(bv => bv == a)
+      def ===[B: Numeric](b: B): Boolean = a == b
+      def =!=[B: Numeric](b: Option[B]): Boolean = b.exists(bv => bv != a)
+      def =!=[B: Numeric](b: B): Boolean = a != b
+    }
+  }
+
+  trait LowPriorityExtras {
+    implicit class OptionOps[T](a: Option[T]) {
+      def ===(b: Option[T]): Boolean = a.exists(av => b.exists(bv => av == bv))
+      def ===(b: T): Boolean = a.exists(av => av == b)
+      def =!=(b: Option[T]): Boolean = a.exists(av => b.exists(bv => av != bv))
+      def =!=(b: T): Boolean = a.exists(av => av != b)
+    }
+    implicit class RegOps[T](a: T) {
+      def ===(b: Option[T]): Boolean = b.exists(bv => bv == a)
+      def ===(b: T): Boolean = a == b
+      def =!=(b: Option[T]): Boolean = b.exists(bv => bv != a)
+      def =!=(b: T): Boolean = a != b
+    }
+  }
+
   sealed trait Query[+T] {
 
     def map[R](f: T => R): Query[R]

--- a/quill-core/src/test/scala/io/getquill/MoreAstOps.scala
+++ b/quill-core/src/test/scala/io/getquill/MoreAstOps.scala
@@ -1,0 +1,15 @@
+package io.getquill
+import io.getquill.ast._
+
+object MoreAstOps {
+  implicit class AstOpsExt2(body: Ast) {
+    def +++(other: Constant) =
+      if (other.v.isInstanceOf[String])
+        BinaryOperation(body, StringOperator.`+`, other)
+      else
+        BinaryOperation(body, NumericOperator.`+`, other)
+
+    def +>+(other: Ast) = BinaryOperation(body, NumericOperator.`>`, other)
+    def +!=+(other: Ast) = BinaryOperation(body, EqualityOperator.`!=`, other)
+  }
+}

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -6,19 +6,9 @@ import io.getquill.testContext._
 import io.getquill.ast.NumericOperator
 import io.getquill.ast.Implicits._
 import io.getquill.norm.ConcatBehavior.{ AnsiConcat, NonAnsiConcat }
+import io.getquill.MoreAstOps._
 
 class FlattenOptionOperationSpec extends Spec {
-
-  implicit class AstOpsExt2(body: Ast) {
-    def +++(other: Constant) =
-      if (other.v.isInstanceOf[String])
-        BinaryOperation(body, StringOperator.`+`, other)
-      else
-        BinaryOperation(body, NumericOperator.`+`, other)
-
-    def +>+(other: Ast) = BinaryOperation(body, NumericOperator.`>`, other)
-    def +!=+(other: Ast) = BinaryOperation(body, EqualityOperator.`!=`, other)
-  }
 
   def o = Ident("o")
   def c1 = Constant(1)


### PR DESCRIPTION
Doing `a.exists(av => b.exists(bv => a ==b))` everywhere is really, really annoying. We disallowed doing `==` when one side was optional because we were concerned that databases would treat them differently but after the learnings of #1053 and #1295 I am significantly more confident that we are doing the right thing across different kinds of databases. Many databases in the BI world have nearly every column being nullable. It is time to improve the developer ergonomics in this matter.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers