### PR TITLE
Change == and != to be Scala-idiomatic 

### DIFF
--- a/quill-core/src/main/scala/io/getquill/ast/AstOps.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/AstOps.scala
@@ -5,6 +5,7 @@ object Implicits {
     def +||+(other: Ast) = BinaryOperation(body, BooleanOperator.`||`, other)
     def +&&+(other: Ast) = BinaryOperation(body, BooleanOperator.`&&`, other)
     def +==+(other: Ast) = BinaryOperation(body, EqualityOperator.`==`, other)
+    def +!=+(other: Ast) = BinaryOperation(body, EqualityOperator.`!=`, other)
   }
 }
 

--- a/quill-core/src/test/scala/io/getquill/MoreAstOps.scala
+++ b/quill-core/src/test/scala/io/getquill/MoreAstOps.scala
@@ -10,6 +10,5 @@ object MoreAstOps {
         BinaryOperation(body, NumericOperator.`+`, other)
 
     def +>+(other: Ast) = BinaryOperation(body, NumericOperator.`>`, other)
-    def +!=+(other: Ast) = BinaryOperation(body, EqualityOperator.`!=`, other)
   }
 }


### PR DESCRIPTION
As of 3.2.0, the implementation of `==` and `!=` is confusing because it's behavior is vastly different from how Scala's == works. This commit fixes this behavior. Also, it simplifies `===` to issue a database-level `=` operator regardless.

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
