### PR TITLE
Explicitly pass AsyncContext type params

### DIFF
--- a/quill-async-mysql/src/main/scala/io/getquill/MysqlAsyncContext.scala
+++ b/quill-async-mysql/src/main/scala/io/getquill/MysqlAsyncContext.scala
@@ -11,7 +11,7 @@ import io.getquill.util.Messages.fail
 import com.github.mauricio.async.db.general.ArrayRowData
 
 class MysqlAsyncContext[N <: NamingStrategy](naming: N, pool: PartitionedConnectionPool[MySQLConnection])
-  extends AsyncContext(MySQLDialect, naming, pool) with UUIDStringEncoding {
+  extends AsyncContext[MySQLDialect, N, MySQLConnection](MySQLDialect, naming, pool) with UUIDStringEncoding {
 
   def this(naming: N, config: MysqlAsyncContextConfig) = this(naming, config.pool)
   def this(naming: N, config: Config) = this(naming, MysqlAsyncContextConfig(config))

--- a/quill-async-mysql/src/test/scala/io/getquill/TypeParamExtensionTest.scala
+++ b/quill-async-mysql/src/test/scala/io/getquill/TypeParamExtensionTest.scala
@@ -1,0 +1,14 @@
+package io.getquill
+
+import io.getquill.context.Context
+
+// Testing we are passing type params explicitly into AsyncContext, otherwise
+// this file will fail to compile
+
+trait BaseExtensions {
+  val context: Context[MySQLDialect, _]
+}
+
+trait AsyncExtensions extends BaseExtensions {
+  override val context: MysqlAsyncContext[_]
+}

--- a/quill-async-postgres/src/main/scala/io/getquill/PostgresAsyncContext.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/PostgresAsyncContext.scala
@@ -9,7 +9,7 @@ import io.getquill.util.LoadConfig
 import io.getquill.util.Messages.fail
 
 class PostgresAsyncContext[N <: NamingStrategy](naming: N, pool: PartitionedConnectionPool[PostgreSQLConnection])
-  extends AsyncContext(PostgresDialect, naming, pool)
+  extends AsyncContext[PostgresDialect, N, PostgreSQLConnection](PostgresDialect, naming, pool)
   with ArrayEncoders
   with ArrayDecoders
   with UUIDObjectEncoding {

--- a/quill-async-postgres/src/test/scala/io/getquill/TypeParamExtensionTest.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/TypeParamExtensionTest.scala
@@ -1,0 +1,14 @@
+package io.getquill
+
+import io.getquill.context.Context
+
+// Testing we are passing type params explicitly into AsyncContext, otherwise
+// this file will fail to compile
+
+trait BaseExtensions {
+  val context: Context[PostgresDialect, _]
+}
+
+trait AsyncExtensions extends BaseExtensions {
+  override val context: PostgresAsyncContext[_]
+}

--- a/quill-jdbc-monix/src/main/scala/io/getquill/TypeParamExtensionTest.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/TypeParamExtensionTest.scala
@@ -1,0 +1,14 @@
+package io.getquill
+
+import io.getquill.context.Context
+
+// Testing we are passing type params explicitly into JdbcContextBase, otherwise
+// this file will fail to compile
+
+trait BaseExtensions {
+  val context: Context[PostgresDialect, _]
+}
+
+trait JDBCExtensions extends BaseExtensions {
+  override val context: PostgresMonixJdbcContext[_]
+}

--- a/quill-jdbc/src/test/scala/io/getquill/TypeParamExtensionTest.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/TypeParamExtensionTest.scala
@@ -1,0 +1,14 @@
+package io.getquill
+
+import io.getquill.context.Context
+
+// Testing we are passing type params explicitly into JdbcContextBase, otherwise
+// this file will fail to compile
+
+trait BaseExtensions {
+  val context: Context[PostgresDialect, _]
+}
+
+trait JDBCExtensions extends BaseExtensions {
+  override val context: PostgresJdbcContext[_]
+}


### PR DESCRIPTION
### Problem

Due to a bug with Scala's type inference, in some cases (due to ordering) when you don't explicitly pass in type params to a trait then anything that extends the parent trait fails to infer the inheritance hierarchy. The example below best indicates the changes.

Assume you have a base trait as follows

```scala
import io.getquill.context.Context

trait BaseExtensions {

  val context: Context[PostgresDialect, _]

  import context._
  
  // Do something here ...
}}} 
```

And now lets assume that you want to provide both postgres-async extensions as well as postgres jdbc extensions which will extend `BaseExtensions`. The JDBC version works fine, i.e.

```scala
import io.getquill.PostgresJdbcContext

trait JDBCExtensions extends BaseExtensions {
  override val context: PostgresJdbcContext[_]
}
```

However if you try to the equivalent version for postgres-async, i.e.


```scala
import io.getquill.PostgresAsyncContext

trait AsyncExtensions extends BaseJsonExtensions {
  override val context: PostgresAsyncContext[_]
}
```

You get the following compiler error

```
overriding value context in trait BaseExtensions of type io.getquill.context.Context[io.getquill.PostgresDialect, _];
[error]  value context has incompatible type
[error]   override val context: PostgresAsyncContext[_]
```

### Solution

Passed the type parameters explicitly to solve the issue

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
