### PR TITLE
API to get PreparedStatement from Query for Low Level Use-cases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -480,9 +480,10 @@ lazy val basicSettings = Seq(
   crossScalaVersions := Seq("2.11.12","2.12.7"),
   libraryDependencies ++= Seq(
     "org.scalamacros" %% "resetallattrs"  % "1.0.0",
-    "org.scalatest"   %%% "scalatest"     % "3.0.7"     % Test,
-    "ch.qos.logback"  % "logback-classic" % "1.2.3"     % Test,
-    "com.google.code.findbugs" % "jsr305" % "3.0.2"     % Provided // just to avoid warnings during compilation
+    "org.scalatest"   %%% "scalatest"     % "3.0.7"          % Test,
+    "ch.qos.logback"  % "logback-classic" % "1.2.3"          % Test,
+    "com.github.choppythelumberjack" %% "tryclose" % "1.0.0" % Test,
+    "com.google.code.findbugs" % "jsr305" % "3.0.2"          % Provided // just to avoid warnings during compilation
   ) ++ {
     if (debugMacro) Seq(
       "org.scala-lang"   %  "scala-library"     % scalaVersion.value,

--- a/quill-core/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-core/src/main/scala/io/getquill/context/Context.scala
@@ -34,11 +34,12 @@ trait Context[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy]
 
   def run[T](quoted: Quoted[T]): Result[RunQuerySingleResult[T]] = macro QueryMacro.runQuerySingle[T]
   def run[T](quoted: Quoted[Query[T]]): Result[RunQueryResult[T]] = macro QueryMacro.runQuery[T]
+  def prepare[T](quoted: Quoted[Query[T]]): Session => Result[PrepareRow] = macro QueryMacro.bindQuery[T]
+
   def run(quoted: Quoted[Action[_]]): Result[RunActionResult] = macro ActionMacro.runAction
   def run[T](quoted: Quoted[ActionReturning[_, T]]): Result[RunActionReturningResult[T]] = macro ActionMacro.runActionReturning[T]
   def run(quoted: Quoted[BatchAction[Action[_]]]): Result[RunBatchActionResult] = macro ActionMacro.runBatchAction
   def run[T](quoted: Quoted[BatchAction[ActionReturning[_, T]]]): Result[RunBatchActionReturningResult[T]] = macro ActionMacro.runBatchActionReturning[T]
-
   def prepare(quoted: Quoted[Action[_]]): Session => Result[PrepareRow] = macro ActionMacro.bindAction
   def prepare(quoted: Quoted[BatchAction[Action[_]]]): Session => Result[List[PrepareRow]] = macro ActionMacro.bindBatchAction
 

--- a/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
@@ -28,6 +28,9 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
   def translateQuery[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
     expandQuery[T](quoted, "translateQuery", DoesNotUseFetch)
 
+  def bindQuery[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
+    expandQuery[T](quoted, "bindQuery", DoesNotUseFetch)
+
   private def expandQuery[T](quoted: Tree, method: String, fetchBehavior: FetchSizeBehavior)(implicit t: WeakTypeTag[T]) =
     OptionalTypecheck(c)(q"implicitly[${c.prefix}.Decoder[$t]]") match {
       case Some(decoder) => expandQueryWithDecoder(quoted, method, decoder, fetchBehavior)

--- a/quill-jdbc-monix/src/main/scala/io/getquill/H2MonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/H2MonixJdbcContext.scala
@@ -9,9 +9,9 @@ import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
 class H2MonixJdbcContext[N <: NamingStrategy](
-  val naming: N,
-  dataSource: DataSource with Closeable,
-  runner:     Runner
+  val naming:     N,
+  val dataSource: DataSource with Closeable,
+  runner:         Runner
 ) extends MonixJdbcContext[H2Dialect, N](dataSource, runner)
   with H2JdbcContextBase[N] {
 

--- a/quill-jdbc-monix/src/main/scala/io/getquill/MysqlMonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/MysqlMonixJdbcContext.scala
@@ -9,9 +9,9 @@ import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
 class MysqlMonixJdbcContext[N <: NamingStrategy](
-  val naming: N,
-  dataSource: DataSource with Closeable,
-  runner:     Runner
+  val naming:     N,
+  val dataSource: DataSource with Closeable,
+  runner:         Runner
 ) extends MonixJdbcContext[MySQLDialect, N](dataSource, runner)
   with MysqlJdbcContextBase[N] {
 

--- a/quill-jdbc-monix/src/main/scala/io/getquill/OracleMonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/OracleMonixJdbcContext.scala
@@ -9,9 +9,9 @@ import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
 class OracleMonixJdbcContext[N <: NamingStrategy](
-  val naming: N,
-  dataSource: DataSource with Closeable,
-  runner:     Runner
+  val naming:     N,
+  val dataSource: DataSource with Closeable,
+  runner:         Runner
 ) extends MonixJdbcContext[OracleDialect, N](dataSource, runner)
   with OracleJdbcContextBase[N] {
 

--- a/quill-jdbc-monix/src/main/scala/io/getquill/SqlServerMonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/SqlServerMonixJdbcContext.scala
@@ -9,9 +9,9 @@ import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
 class SqlServerMonixJdbcContext[N <: NamingStrategy](
-  val naming: N,
-  dataSource: DataSource with Closeable,
-  runner:     Runner
+  val naming:     N,
+  val dataSource: DataSource with Closeable,
+  runner:         Runner
 ) extends MonixJdbcContext[SQLServerDialect, N](dataSource, runner)
   with SqlServerJdbcContextBase[N] {
 

--- a/quill-jdbc-monix/src/main/scala/io/getquill/SqliteMonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/SqliteMonixJdbcContext.scala
@@ -9,9 +9,9 @@ import io.getquill.util.LoadConfig
 import javax.sql.DataSource
 
 class SqliteMonixJdbcContext[N <: NamingStrategy](
-  val naming: N,
-  dataSource: DataSource with Closeable,
-  runner:     Runner
+  val naming:     N,
+  val dataSource: DataSource with Closeable,
+  runner:         Runner
 ) extends MonixJdbcContext[SqliteDialect, N](dataSource, runner)
   with SqliteJdbcContextBase[N] {
 

--- a/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
@@ -49,6 +49,12 @@ abstract class MonixJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](
     super.executeBatchAction(groups)
   override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Task[List[T]] =
     super.executeBatchActionReturning(groups, extractor)
+  override def bindQuery[T](sql: String, prepare: Prepare, extractor: Extractor[T] = identityExtractor): Connection => Task[PreparedStatement] =
+    super.bindQuery(sql, prepare, extractor)
+  override def bindAction(sql: String, prepare: Prepare): Connection => Task[PreparedStatement] =
+    super.bindAction(sql, prepare)
+  override def bindBatchAction(groups: List[BatchGroup]): Connection => Task[List[PreparedStatement]] =
+    super.bindBatchAction(groups)
 
   override protected val effect: Runner = runner
   import runner._

--- a/quill-jdbc-monix/src/test/scala/io/getquill/PrepareMonixJdbcSpecBase.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/PrepareMonixJdbcSpecBase.scala
@@ -1,0 +1,56 @@
+package io.getquill
+
+import java.sql.{ Connection, PreparedStatement, ResultSet }
+
+import io.getquill.context.jdbc.ResultSetExtractor
+import io.getquill.context.sql.ProductSpec
+import monix.eval.Task
+import org.scalactic.Equality
+
+trait PrepareMonixJdbcSpecBase extends ProductSpec {
+
+  implicit val productEq = new Equality[Product] {
+    override def areEqual(a: Product, b: Any): Boolean = b match {
+      case Product(_, desc, sku) => desc == a.description && sku == a.sku
+      case _                     => false
+    }
+  }
+
+  def productExtractor: ResultSet => Product
+
+  def withOrderedIds(products: List[Product]) =
+    products.zipWithIndex.map { case (product, id) => product.copy(id = id.toLong + 1) }
+
+  def singleInsert(conn: => Connection)(prep: Connection => Task[PreparedStatement]) = {
+    Task(conn).bracket { conn =>
+      prep(conn).bracket { stmt =>
+        Task(stmt.execute())
+      }(stmt => Task(stmt.close()))
+    }(conn => Task(conn.close()))
+  }
+
+  def batchInsert(conn: => Connection)(prep: Connection => Task[List[PreparedStatement]]) = {
+    Task(conn).bracket { conn =>
+      prep(conn).flatMap(stmts =>
+        Task.sequence(
+          stmts.map(stmt =>
+            Task(stmt).bracket { stmt =>
+              Task(stmt.execute())
+            }(stmt => Task(stmt.close())))
+        ))
+    }(conn => Task(conn.close()))
+  }
+
+  def extractResults[T](conn: => Connection)(prep: Connection => Task[PreparedStatement])(extractor: ResultSet => T) = {
+    Task(conn).bracket { conn =>
+      prep(conn).bracket { stmt =>
+        Task(stmt.executeQuery()).bracket { rs =>
+          Task(ResultSetExtractor(rs, extractor))
+        }(rs => Task(rs.close()))
+      }(stmt => Task(stmt.close()))
+    }(conn => Task(conn.close()))
+  }
+
+  def extractProducts(conn: => Connection)(prep: Connection => Task[PreparedStatement]) =
+    extractResults(conn)(prep)(productExtractor)
+}

--- a/quill-jdbc-monix/src/test/scala/io/getquill/h2/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/h2/PrepareJdbcSpec.scala
@@ -1,0 +1,36 @@
+package io.getquill.h2
+
+import java.sql.ResultSet
+
+import io.getquill.PrepareMonixJdbcSpecBase
+import monix.execution.Scheduler
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+  implicit val scheduler = Scheduler.global
+
+  before {
+    testContext.run(query[Product].delete).runSyncUnsafe()
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc-monix/src/test/scala/io/getquill/h2/ProductJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/h2/ProductJdbcSpec.scala
@@ -8,12 +8,12 @@ class ProductJdbcSpec extends ProductSpec {
   val context = testContext
   import testContext._
 
+  implicit val scheduler = Scheduler.global
+
   override def beforeAll = {
-    testContext.run(quote(query[Product].delete))
+    testContext.run(quote(query[Product].delete)).runSyncUnsafe()
     ()
   }
-
-  implicit val scheduler = Scheduler.global
 
   "Product" - {
     "Insert multiple products" in {

--- a/quill-jdbc-monix/src/test/scala/io/getquill/mysql/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/mysql/PrepareJdbcSpec.scala
@@ -1,0 +1,36 @@
+package io.getquill.mysql
+
+import java.sql.ResultSet
+
+import io.getquill.PrepareMonixJdbcSpecBase
+import monix.execution.Scheduler
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+  implicit val scheduler = Scheduler.global
+
+  before {
+    testContext.run(query[Product].delete).runSyncUnsafe()
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc-monix/src/test/scala/io/getquill/mysql/ProductJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/mysql/ProductJdbcSpec.scala
@@ -8,12 +8,12 @@ class ProductJdbcSpec extends ProductSpec {
   val context = testContext
   import testContext._
 
+  implicit val scheduler = Scheduler.global
+
   override def beforeAll = {
-    testContext.run(quote(query[Product].delete))
+    testContext.run(quote(query[Product].delete)).runSyncUnsafe()
     ()
   }
-
-  implicit val scheduler = Scheduler.global
 
   "Product" - {
     "Insert multiple products" in {

--- a/quill-jdbc-monix/src/test/scala/io/getquill/oracle/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/oracle/PrepareJdbcSpec.scala
@@ -1,0 +1,36 @@
+package io.getquill.oracle
+
+import java.sql.ResultSet
+
+import io.getquill.PrepareMonixJdbcSpecBase
+import monix.execution.Scheduler
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+  implicit val scheduler = Scheduler.global
+
+  before {
+    testContext.run(query[Product].delete).runSyncUnsafe()
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc-monix/src/test/scala/io/getquill/oracle/ProductJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/oracle/ProductJdbcSpec.scala
@@ -9,12 +9,12 @@ class ProductJdbcSpec extends ProductSpec {
   val context = testContext
   import testContext._
 
+  implicit val scheduler = Scheduler.global
+
   override def beforeAll = {
-    testContext.run(quote(query[Product].delete))
+    testContext.run(quote(query[Product].delete)).runSyncUnsafe()
     ()
   }
-
-  implicit val scheduler = Scheduler.global
 
   "Product" - {
     "Insert multiple products" in {

--- a/quill-jdbc-monix/src/test/scala/io/getquill/postgres/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/postgres/PrepareJdbcSpec.scala
@@ -1,0 +1,36 @@
+package io.getquill.postgres
+
+import java.sql.ResultSet
+
+import io.getquill.PrepareMonixJdbcSpecBase
+import monix.execution.Scheduler
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+  implicit val scheduler = Scheduler.global
+
+  before {
+    testContext.run(query[Product].delete).runSyncUnsafe()
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc-monix/src/test/scala/io/getquill/sqlite/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/sqlite/PrepareJdbcSpec.scala
@@ -1,0 +1,36 @@
+package io.getquill.sqlite
+
+import java.sql.ResultSet
+
+import io.getquill.PrepareMonixJdbcSpecBase
+import monix.execution.Scheduler
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+  implicit val scheduler = Scheduler.global
+
+  before {
+    testContext.run(query[Product].delete).runSyncUnsafe()
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc-monix/src/test/scala/io/getquill/sqlite/ProductJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/sqlite/ProductJdbcSpec.scala
@@ -9,12 +9,12 @@ class ProductJdbcSpec extends ProductSpec {
   val context = testContext
   import testContext._
 
+  implicit val scheduler = Scheduler.global
+
   override def beforeAll = {
-    testContext.run(quote(query[Product].delete))
+    testContext.run(quote(query[Product].delete)).runSyncUnsafe()
     ()
   }
-
-  implicit val scheduler = Scheduler.global
 
   "Product" - {
     "Insert multiple products" in {

--- a/quill-jdbc-monix/src/test/scala/io/getquill/sqlserver/PrepareJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/sqlserver/PrepareJdbcSpec.scala
@@ -1,0 +1,37 @@
+package io.getquill.sqlserver
+
+import java.sql.ResultSet
+
+import io.getquill.PrepareMonixJdbcSpecBase
+import monix.execution.Scheduler
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareMonixJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+  implicit val scheduler = Scheduler.global
+
+  before {
+    testContext.run(query[Product].delete).runSyncUnsafe()
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+  implicit val im = insertMeta[Product](_.id)
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert).runSyncUnsafe() mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).runSyncUnsafe().distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery).runSyncUnsafe() === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc-monix/src/test/scala/io/getquill/sqlserver/ProductJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/sqlserver/ProductJdbcSpec.scala
@@ -9,12 +9,12 @@ class ProductJdbcSpec extends ProductSpec {
   val context = testContext
   import testContext._
 
+  implicit val scheduler = Scheduler.global
+
   override def beforeAll = {
-    testContext.run(quote(query[Product].delete))
+    testContext.run(quote(query[Product].delete)).runSyncUnsafe()
     ()
   }
-
-  implicit val scheduler = Scheduler.global
 
   "Product" - {
     "Insert multiple products" in {

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContext.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc
 
 import java.io.Closeable
-import java.sql.Connection
+import java.sql.{ Connection, PreparedStatement }
 
 import javax.sql.DataSource
 import io.getquill.context.sql.idiom.SqlIdiom
@@ -46,6 +46,12 @@ abstract class JdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy]
     super.executeBatchAction(groups)
   override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): List[T] =
     super.executeBatchActionReturning(groups, extractor)
+  override def bindQuery[T](sql: String, prepare: Prepare, extractor: Extractor[T] = identityExtractor): Connection => PreparedStatement =
+    super.bindQuery(sql, prepare, extractor)
+  override def bindAction(sql: String, prepare: Prepare): Connection => PreparedStatement =
+    super.bindAction(sql, prepare)
+  override def bindBatchAction(groups: List[BatchGroup]): Connection => List[PreparedStatement] =
+    super.bindBatchAction(groups)
 
   protected val currentConnection = new DynamicVariable[Option[Connection]](None)
 

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ResultSetExtractor.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ResultSetExtractor.scala
@@ -1,0 +1,17 @@
+package io.getquill.context.jdbc
+import java.sql.ResultSet
+
+import scala.annotation.tailrec
+
+object ResultSetExtractor {
+
+  private[getquill] final def apply[T](rs: ResultSet, extractor: ResultSet => T): List[T] =
+    extractResult(rs, extractor, List())
+
+  @tailrec
+  private[getquill] final def extractResult[T](rs: ResultSet, extractor: ResultSet => T, acc: List[T]): List[T] =
+    if (rs.next)
+      extractResult(rs, extractor, extractor(rs) :: acc)
+    else
+      acc.reverse
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/PrepareJdbcSpecBase.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/PrepareJdbcSpecBase.scala
@@ -1,0 +1,68 @@
+package io.getquill.context.jdbc
+import java.sql.{ Connection, PreparedStatement, ResultSet }
+
+import com.github.choppythelumberjack.tryclose._
+import com.github.choppythelumberjack.tryclose.JavaImplicits._
+import io.getquill.context.sql.ProductSpec
+import org.scalactic.Equality
+
+trait PrepareJdbcSpecBase extends ProductSpec {
+
+  implicit val productEq = new Equality[Product] {
+    override def areEqual(a: Product, b: Any): Boolean = b match {
+      case Product(_, desc, sku) => desc == a.description && sku == a.sku
+      case _                     => false
+    }
+  }
+
+  def productExtractor: ResultSet => Product
+
+  def withOrderedIds(products: List[Product]) =
+    products.zipWithIndex.map { case (product, id) => product.copy(id = id.toLong + 1) }
+
+  def singleInsert(conn: => Connection)(prep: Connection => PreparedStatement) =
+    (for {
+      conn <- TryClose(conn)
+      stmt <- TryClose(prep(conn))
+      flag <- TryClose.wrap(stmt.execute())
+    } yield flag).unwrap match {
+      case Success(value) => value
+      case Failure(e)     => throw e
+    }
+
+  def batchInsert(conn: => Connection)(prep: Connection => List[PreparedStatement]) =
+    (for {
+      conn <- TryClose(conn)
+      list <- appendExecuteSequence(prep(conn))
+    } yield list).unwrap match {
+      case Success(value) => value
+      case Failure(e)     => throw e
+    }
+
+  def extractResults[T](conn: => Connection)(prep: Connection => PreparedStatement)(extractor: ResultSet => T) =
+    (for {
+      conn <- TryClose(conn)
+      stmt <- TryClose(prep(conn))
+      rs <- TryClose(stmt.executeQuery())
+    } yield {
+      wrap(ResultSetExtractor(rs, extractor))
+    }).unwrap match {
+      case Success(value) =>
+        value
+      case Failure(e) => throw e
+    }
+
+  def extractProducts(conn: => Connection)(prep: Connection => PreparedStatement): List[Product] =
+    extractResults(conn)(prep)(productExtractor)
+
+  def appendExecuteSequence(actions: => List[PreparedStatement]) = {
+    actions.foldLeft(TryClose.wrap(List[Boolean]())) {
+      case (currTry, stmt) => currTry.flatMap { wrap =>
+        val list = wrap.get
+        TryClose(stmt).flatMap { stmtInner =>
+          TryClose.wrap(stmtInner.execute() +: list)
+        }
+      }
+    }
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/PrepareJdbcSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.jdbc.h2
+
+import java.sql.ResultSet
+
+import io.getquill.context.jdbc.PrepareJdbcSpecBase
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+
+  before {
+    testContext.run(query[Product].delete)
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery) === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/PrepareJdbcSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.jdbc.mysql
+
+import java.sql.ResultSet
+
+import io.getquill.context.jdbc.PrepareJdbcSpecBase
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+
+  before {
+    testContext.run(query[Product].delete)
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery) === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/PrepareJdbcSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.jdbc.oracle
+
+import java.sql.ResultSet
+
+import io.getquill.context.jdbc.PrepareJdbcSpecBase
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+
+  before {
+    testContext.run(query[Product].delete)
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery) === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/PrepareJdbcSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.jdbc.postgres
+
+import java.sql.ResultSet
+
+import io.getquill.context.jdbc.PrepareJdbcSpecBase
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+
+  before {
+    testContext.run(query[Product].delete)
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery) === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/PrepareJdbcSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.jdbc.sqlite
+
+import java.sql.ResultSet
+
+import io.getquill.context.jdbc.PrepareJdbcSpecBase
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+
+  before {
+    testContext.run(query[Product].delete)
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+    singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery) === withOrderedIds(productEntries)
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/PrepareJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/PrepareJdbcSpec.scala
@@ -1,0 +1,36 @@
+package io.getquill.context.jdbc.sqlserver
+
+import java.sql.ResultSet
+
+import io.getquill.context.jdbc.PrepareJdbcSpecBase
+import org.scalatest.BeforeAndAfter
+
+class PrepareJdbcSpec extends PrepareJdbcSpecBase with BeforeAndAfter {
+
+  val context = testContext
+  import testContext._
+
+  before {
+    testContext.run(query[Product].delete)
+  }
+
+  def productExtractor = (rs: ResultSet) => materializeQueryMeta[Product].extract(rs)
+  val prepareQuery = prepare(query[Product])
+  implicit val im = insertMeta[Product](_.id)
+
+  "single" in {
+    val prepareInsert = prepare(query[Product].insert(lift(productEntries.head)))
+
+    singleInsert(dataSource.getConnection)(prepareInsert) mustEqual false
+    extractProducts(dataSource.getConnection)(prepareQuery) === List(productEntries.head)
+  }
+
+  "batch" in {
+    val prepareBatchInsert = prepare(
+      liftQuery(withOrderedIds(productEntries)).foreach(p => query[Product].insert(p))
+    )
+
+    batchInsert(dataSource.getConnection)(prepareBatchInsert).distinct mustEqual List(false)
+    extractProducts(dataSource.getConnection)(prepareQuery) === withOrderedIds(productEntries)
+  }
+}


### PR DESCRIPTION
Introduce `prepare` into JDBC contexts allowing users to extract a `PreparedStatement` from Queries, Actions, and Batch Actions.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
