### PR TITLE
Fix join subquery+map+distinct and sortBy+distinct

### DIFF
--- a/quill-core/src/main/scala/io/getquill/norm/ApplyMap.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/ApplyMap.scala
@@ -57,6 +57,12 @@ object ApplyMap {
         val er = BetaReduction(e, d -> c)
         Some(Map(SortBy(a, b, er, f), b, c))
 
+      // a.map(b => c).sortBy(d => e).distinct =>
+      //    a.sortBy(b => e[d := c]).map(b => c).distinct
+      case SortBy(Distinct(DetachableMap(a, b, c)), d, e, f) =>
+        val er = BetaReduction(e, d -> c)
+        Some(Distinct(Map(SortBy(a, b, er, f), b, c)))
+
       // a.map(b => c).groupBy(d => e) =>
       //    a.groupBy(b => e[d := c]).map(x => (x._1, x._2.map(b => c)))
       case GroupBy(DetachableMap(a, b, c), d, e) =>

--- a/quill-core/src/test/scala/io/getquill/norm/ApplyMapSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ApplyMapSpec.scala
@@ -146,6 +146,15 @@ class ApplyMapSpec extends Spec {
       }
       ApplyMap.unapply(q.ast) mustEqual Some(n.ast)
     }
+    "distinct + sort" in {
+      val q = quote {
+        query[TestEntity].map(i => (i.i, i.l)).distinct.sortBy(_._1)
+      }
+      val n = quote {
+        query[TestEntity].sortBy(i => i.i).map(i => (i.i, i.l)).distinct
+      }
+      ApplyMap.unapply(q.ast) mustEqual Some(n.ast)
+    }
     "take" in {
       val q = quote {
         qr1.map(y => y.s).take(1)

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/DistinctJdbcSpec.scala
@@ -1,0 +1,51 @@
+package io.getquill.context.jdbc.h2
+
+import io.getquill.context.sql.DistinctSpec
+import org.scalatest.Matchers._
+
+class DistinctJdbcSpec extends DistinctSpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Couple].delete)
+      testContext.run(query[Person].filter(_.age > 0).delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(couplesEntries).foreach(p => couplesInsert(p)))
+    }
+    ()
+  }
+
+  "Ex 1 Distinct One Field" in {
+    testContext.run(`Ex 1 Distinct One Field`) should contain theSameElementsAs `Ex 1 Distinct One Field Result`
+  }
+  "Ex 2 Distinct Two Field Tuple`" in {
+    testContext.run(`Ex 2 Distinct Two Field Tuple`) should contain theSameElementsAs `Ex 2 Distinct Two Field Tuple Result`
+  }
+  "Ex 2a Distinct Two Field Tuple Same Element`" in {
+    testContext.run(`Ex 2a Distinct Two Field Tuple Same Element`) should contain theSameElementsAs `Ex 2a Distinct Two Field Tuple Same Element Result`
+  }
+  "Ex 3 Distinct Two Field Case Class`" in {
+    testContext.run(`Ex 3 Distinct Two Field Case Class`) should contain theSameElementsAs `Ex 3 Distinct Two Field Case Class Result`
+  }
+  "Ex 4-base non-Distinct Subquery`" in {
+    testContext.run(`Ex 4-base non-Distinct Subquery`) should contain theSameElementsAs `Ex 4-base non-Distinct Subquery Result`
+  }
+  "Ex 4 Distinct Subquery`" in {
+    testContext.run(`Ex 4 Distinct Subquery`) should contain theSameElementsAs `Ex 4 Distinct Subquery Result`
+  }
+  "Ex 5 Distinct Subquery with Map Single Field" in {
+    testContext.run(`Ex 5 Distinct Subquery with Map Single Field`) should contain theSameElementsAs `Ex 5 Distinct Subquery with Map Single Field Result`
+  }
+  "Ex 6 Distinct Subquery with Map Multi Field" in {
+    testContext.run(`Ex 6 Distinct Subquery with Map Multi Field`) should contain theSameElementsAs `Ex 6 Distinct Subquery with Map Multi Field Result`
+  }
+  "Ex 7 Distinct Subquery with Map Multi Field Tuple" in {
+    testContext.run(`Ex 7 Distinct Subquery with Map Multi Field Tuple`) should contain theSameElementsAs `Ex 7 Distinct Subquery with Map Multi Field Tuple Result`
+  }
+  "Ex 8 Distinct With Sort" in {
+    testContext.run(`Ex 8 Distinct With Sort`) mustEqual `Ex 8 Distinct With Sort Result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/DistinctJdbcSpec.scala
@@ -1,0 +1,51 @@
+package io.getquill.context.jdbc.mysql
+
+import io.getquill.context.sql.DistinctSpec
+import org.scalatest.Matchers._
+
+class DistinctJdbcSpec extends DistinctSpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Couple].delete)
+      testContext.run(query[Person].filter(_.age > 0).delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(couplesEntries).foreach(p => couplesInsert(p)))
+    }
+    ()
+  }
+
+  "Ex 1 Distinct One Field" in {
+    testContext.run(`Ex 1 Distinct One Field`) should contain theSameElementsAs `Ex 1 Distinct One Field Result`
+  }
+  "Ex 2 Distinct Two Field Tuple`" in {
+    testContext.run(`Ex 2 Distinct Two Field Tuple`) should contain theSameElementsAs `Ex 2 Distinct Two Field Tuple Result`
+  }
+  "Ex 2a Distinct Two Field Tuple Same Element`" in {
+    testContext.run(`Ex 2a Distinct Two Field Tuple Same Element`) should contain theSameElementsAs `Ex 2a Distinct Two Field Tuple Same Element Result`
+  }
+  "Ex 3 Distinct Two Field Case Class`" in {
+    testContext.run(`Ex 3 Distinct Two Field Case Class`) should contain theSameElementsAs `Ex 3 Distinct Two Field Case Class Result`
+  }
+  "Ex 4-base non-Distinct Subquery`" in {
+    testContext.run(`Ex 4-base non-Distinct Subquery`) should contain theSameElementsAs `Ex 4-base non-Distinct Subquery Result`
+  }
+  "Ex 4 Distinct Subquery`" in {
+    testContext.run(`Ex 4 Distinct Subquery`) should contain theSameElementsAs `Ex 4 Distinct Subquery Result`
+  }
+  "Ex 5 Distinct Subquery with Map Single Field" in {
+    testContext.run(`Ex 5 Distinct Subquery with Map Single Field`) should contain theSameElementsAs `Ex 5 Distinct Subquery with Map Single Field Result`
+  }
+  "Ex 6 Distinct Subquery with Map Multi Field" in {
+    testContext.run(`Ex 6 Distinct Subquery with Map Multi Field`) should contain theSameElementsAs `Ex 6 Distinct Subquery with Map Multi Field Result`
+  }
+  "Ex 7 Distinct Subquery with Map Multi Field Tuple" in {
+    testContext.run(`Ex 7 Distinct Subquery with Map Multi Field Tuple`) should contain theSameElementsAs `Ex 7 Distinct Subquery with Map Multi Field Tuple Result`
+  }
+  "Ex 8 Distinct With Sort" in {
+    testContext.run(`Ex 8 Distinct With Sort`) mustEqual `Ex 8 Distinct With Sort Result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/DistinctJdbcSpec.scala
@@ -1,0 +1,51 @@
+package io.getquill.context.jdbc.oracle
+
+import io.getquill.context.sql.DistinctSpec
+import org.scalatest.Matchers._
+
+class DistinctJdbcSpec extends DistinctSpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Couple].delete)
+      testContext.run(query[Person].filter(_.age > 0).delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(couplesEntries).foreach(p => couplesInsert(p)))
+    }
+    ()
+  }
+
+  "Ex 1 Distinct One Field" in {
+    testContext.run(`Ex 1 Distinct One Field`) should contain theSameElementsAs `Ex 1 Distinct One Field Result`
+  }
+  "Ex 2 Distinct Two Field Tuple`" in {
+    testContext.run(`Ex 2 Distinct Two Field Tuple`) should contain theSameElementsAs `Ex 2 Distinct Two Field Tuple Result`
+  }
+  "Ex 2a Distinct Two Field Tuple Same Element`" in {
+    testContext.run(`Ex 2a Distinct Two Field Tuple Same Element`) should contain theSameElementsAs `Ex 2a Distinct Two Field Tuple Same Element Result`
+  }
+  "Ex 3 Distinct Two Field Case Class`" in {
+    testContext.run(`Ex 3 Distinct Two Field Case Class`) should contain theSameElementsAs `Ex 3 Distinct Two Field Case Class Result`
+  }
+  "Ex 4-base non-Distinct Subquery`" in {
+    testContext.run(`Ex 4-base non-Distinct Subquery`) should contain theSameElementsAs `Ex 4-base non-Distinct Subquery Result`
+  }
+  "Ex 4 Distinct Subquery`" in {
+    testContext.run(`Ex 4 Distinct Subquery`) should contain theSameElementsAs `Ex 4 Distinct Subquery Result`
+  }
+  "Ex 5 Distinct Subquery with Map Single Field" in {
+    testContext.run(`Ex 5 Distinct Subquery with Map Single Field`) should contain theSameElementsAs `Ex 5 Distinct Subquery with Map Single Field Result`
+  }
+  "Ex 6 Distinct Subquery with Map Multi Field" in {
+    testContext.run(`Ex 6 Distinct Subquery with Map Multi Field`) should contain theSameElementsAs `Ex 6 Distinct Subquery with Map Multi Field Result`
+  }
+  "Ex 7 Distinct Subquery with Map Multi Field Tuple" in {
+    testContext.run(`Ex 7 Distinct Subquery with Map Multi Field Tuple`) should contain theSameElementsAs `Ex 7 Distinct Subquery with Map Multi Field Tuple Result`
+  }
+  "Ex 8 Distinct With Sort" in {
+    testContext.run(`Ex 8 Distinct With Sort`) mustEqual `Ex 8 Distinct With Sort Result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/DistinctJdbcSpec.scala
@@ -1,0 +1,51 @@
+package io.getquill.context.jdbc.postgres
+
+import io.getquill.context.sql.DistinctSpec
+import org.scalatest.Matchers._
+
+class DistinctJdbcSpec extends DistinctSpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Couple].delete)
+      testContext.run(query[Person].filter(_.age > 0).delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(couplesEntries).foreach(p => couplesInsert(p)))
+    }
+    ()
+  }
+
+  "Ex 1 Distinct One Field" in {
+    testContext.run(`Ex 1 Distinct One Field`) should contain theSameElementsAs `Ex 1 Distinct One Field Result`
+  }
+  "Ex 2 Distinct Two Field Tuple`" in {
+    testContext.run(`Ex 2 Distinct Two Field Tuple`) should contain theSameElementsAs `Ex 2 Distinct Two Field Tuple Result`
+  }
+  "Ex 2a Distinct Two Field Tuple Same Element`" in {
+    testContext.run(`Ex 2a Distinct Two Field Tuple Same Element`) should contain theSameElementsAs `Ex 2a Distinct Two Field Tuple Same Element Result`
+  }
+  "Ex 3 Distinct Two Field Case Class`" in {
+    testContext.run(`Ex 3 Distinct Two Field Case Class`) should contain theSameElementsAs `Ex 3 Distinct Two Field Case Class Result`
+  }
+  "Ex 4-base non-Distinct Subquery`" in {
+    testContext.run(`Ex 4-base non-Distinct Subquery`) should contain theSameElementsAs `Ex 4-base non-Distinct Subquery Result`
+  }
+  "Ex 4 Distinct Subquery`" in {
+    testContext.run(`Ex 4 Distinct Subquery`) should contain theSameElementsAs `Ex 4 Distinct Subquery Result`
+  }
+  "Ex 5 Distinct Subquery with Map Single Field" in {
+    testContext.run(`Ex 5 Distinct Subquery with Map Single Field`) should contain theSameElementsAs `Ex 5 Distinct Subquery with Map Single Field Result`
+  }
+  "Ex 6 Distinct Subquery with Map Multi Field" in {
+    testContext.run(`Ex 6 Distinct Subquery with Map Multi Field`) should contain theSameElementsAs `Ex 6 Distinct Subquery with Map Multi Field Result`
+  }
+  "Ex 7 Distinct Subquery with Map Multi Field Tuple" in {
+    testContext.run(`Ex 7 Distinct Subquery with Map Multi Field Tuple`) should contain theSameElementsAs `Ex 7 Distinct Subquery with Map Multi Field Tuple Result`
+  }
+  "Ex 8 Distinct With Sort" in {
+    testContext.run(`Ex 8 Distinct With Sort`) mustEqual `Ex 8 Distinct With Sort Result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/DistinctJdbcSpec.scala
@@ -1,0 +1,51 @@
+package io.getquill.context.jdbc.sqlite
+
+import io.getquill.context.sql.DistinctSpec
+import org.scalatest.Matchers._
+
+class DistinctJdbcSpec extends DistinctSpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Couple].delete)
+      testContext.run(query[Person].filter(_.age > 0).delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(couplesEntries).foreach(p => couplesInsert(p)))
+    }
+    ()
+  }
+
+  "Ex 1 Distinct One Field" in {
+    testContext.run(`Ex 1 Distinct One Field`) should contain theSameElementsAs `Ex 1 Distinct One Field Result`
+  }
+  "Ex 2 Distinct Two Field Tuple`" in {
+    testContext.run(`Ex 2 Distinct Two Field Tuple`) should contain theSameElementsAs `Ex 2 Distinct Two Field Tuple Result`
+  }
+  "Ex 2a Distinct Two Field Tuple Same Element`" in {
+    testContext.run(`Ex 2a Distinct Two Field Tuple Same Element`) should contain theSameElementsAs `Ex 2a Distinct Two Field Tuple Same Element Result`
+  }
+  "Ex 3 Distinct Two Field Case Class`" in {
+    testContext.run(`Ex 3 Distinct Two Field Case Class`) should contain theSameElementsAs `Ex 3 Distinct Two Field Case Class Result`
+  }
+  "Ex 4-base non-Distinct Subquery`" in {
+    testContext.run(`Ex 4-base non-Distinct Subquery`) should contain theSameElementsAs `Ex 4-base non-Distinct Subquery Result`
+  }
+  "Ex 4 Distinct Subquery`" in {
+    testContext.run(`Ex 4 Distinct Subquery`) should contain theSameElementsAs `Ex 4 Distinct Subquery Result`
+  }
+  "Ex 5 Distinct Subquery with Map Single Field" in {
+    testContext.run(`Ex 5 Distinct Subquery with Map Single Field`) should contain theSameElementsAs `Ex 5 Distinct Subquery with Map Single Field Result`
+  }
+  "Ex 6 Distinct Subquery with Map Multi Field" in {
+    testContext.run(`Ex 6 Distinct Subquery with Map Multi Field`) should contain theSameElementsAs `Ex 6 Distinct Subquery with Map Multi Field Result`
+  }
+  "Ex 7 Distinct Subquery with Map Multi Field Tuple" in {
+    testContext.run(`Ex 7 Distinct Subquery with Map Multi Field Tuple`) should contain theSameElementsAs `Ex 7 Distinct Subquery with Map Multi Field Tuple Result`
+  }
+  "Ex 8 Distinct With Sort" in {
+    testContext.run(`Ex 8 Distinct With Sort`) mustEqual `Ex 8 Distinct With Sort Result`
+  }
+}

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/DistinctJdbcSpec.scala
@@ -1,0 +1,51 @@
+package io.getquill.context.jdbc.sqlserver
+
+import io.getquill.context.sql.DistinctSpec
+import org.scalatest.Matchers._
+
+class DistinctJdbcSpec extends DistinctSpec {
+
+  val context = testContext
+  import testContext._
+
+  override def beforeAll = {
+    testContext.transaction {
+      testContext.run(query[Couple].delete)
+      testContext.run(query[Person].filter(_.age > 0).delete)
+      testContext.run(liftQuery(peopleEntries).foreach(p => peopleInsert(p)))
+      testContext.run(liftQuery(couplesEntries).foreach(p => couplesInsert(p)))
+    }
+    ()
+  }
+
+  "Ex 1 Distinct One Field" in {
+    testContext.run(`Ex 1 Distinct One Field`) should contain theSameElementsAs `Ex 1 Distinct One Field Result`
+  }
+  "Ex 2 Distinct Two Field Tuple`" in {
+    testContext.run(`Ex 2 Distinct Two Field Tuple`) should contain theSameElementsAs `Ex 2 Distinct Two Field Tuple Result`
+  }
+  "Ex 2a Distinct Two Field Tuple Same Element`" in {
+    testContext.run(`Ex 2a Distinct Two Field Tuple Same Element`) should contain theSameElementsAs `Ex 2a Distinct Two Field Tuple Same Element Result`
+  }
+  "Ex 3 Distinct Two Field Case Class`" in {
+    testContext.run(`Ex 3 Distinct Two Field Case Class`) should contain theSameElementsAs `Ex 3 Distinct Two Field Case Class Result`
+  }
+  "Ex 4-base non-Distinct Subquery`" in {
+    testContext.run(`Ex 4-base non-Distinct Subquery`) should contain theSameElementsAs `Ex 4-base non-Distinct Subquery Result`
+  }
+  "Ex 4 Distinct Subquery`" in {
+    testContext.run(`Ex 4 Distinct Subquery`) should contain theSameElementsAs `Ex 4 Distinct Subquery Result`
+  }
+  "Ex 5 Distinct Subquery with Map Single Field" in {
+    testContext.run(`Ex 5 Distinct Subquery with Map Single Field`) should contain theSameElementsAs `Ex 5 Distinct Subquery with Map Single Field Result`
+  }
+  "Ex 6 Distinct Subquery with Map Multi Field" in {
+    testContext.run(`Ex 6 Distinct Subquery with Map Multi Field`) should contain theSameElementsAs `Ex 6 Distinct Subquery with Map Multi Field Result`
+  }
+  "Ex 7 Distinct Subquery with Map Multi Field Tuple" in {
+    testContext.run(`Ex 7 Distinct Subquery with Map Multi Field Tuple`) should contain theSameElementsAs `Ex 7 Distinct Subquery with Map Multi Field Tuple Result`
+  }
+  "Ex 8 Distinct With Sort" in {
+    testContext.run(`Ex 8 Distinct With Sort`.drop(0)) mustEqual `Ex 8 Distinct With Sort Result`
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandDistinct.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandDistinct.scala
@@ -12,6 +12,16 @@ object ExpandDistinct {
         Transform(q) {
           case Aggregation(op, Distinct(q)) =>
             Aggregation(op, Distinct(apply(q)))
+          case Distinct(Map(q, x, cc @ Tuple(values))) =>
+            Map(Distinct(Map(q, x, cc)), x,
+              Tuple(values.zipWithIndex.map {
+                case (_, i) => Property(x, s"_${i + 1}")
+              }))
+          case Distinct(Map(q, x, cc @ CaseClass(values))) =>
+            Map(Distinct(Map(q, x, cc)), x,
+              CaseClass(values.map {
+                case (str, _) => (str, Property(x, str))
+              }))
           case Distinct(Map(q, x, p)) =>
             Map(Distinct(Map(q, x, p)), x, p)
         }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandJoin.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandJoin.scala
@@ -1,11 +1,6 @@
 package io.getquill.context.sql.norm
 
-import io.getquill.ast.Ast
-import io.getquill.ast.Ident
-import io.getquill.ast.Join
-import io.getquill.ast.Map
-import io.getquill.ast.Transform
-import io.getquill.ast.Tuple
+import io.getquill.ast._
 import io.getquill.norm.BetaReduction
 import io.getquill.norm.Normalize
 

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
@@ -26,6 +26,8 @@ class SqlNormalize(concatBehavior: ConcatBehavior, equalityBehavior: EqualityBeh
       .andThen(trace("RenameProperties"))
       .andThen(ExpandDistinct.apply _)
       .andThen(trace("ExpandDistinct"))
+      .andThen(Normalize.apply _)
+      .andThen(trace("Normalize"))
       .andThen(ExpandJoin.apply _)
       .andThen(trace("ExpandJoin"))
       .andThen(ExpandMappedInfix.apply _)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/DistinctSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/DistinctSpec.scala
@@ -1,0 +1,158 @@
+package io.getquill.context.sql
+
+import io.getquill.Spec
+
+trait DistinctSpec extends Spec {
+
+  val context: SqlContext[_, _]
+
+  import context._
+
+  case class Person(name: String, age: Int)
+  case class Couple(him: String, her: String)
+
+  val peopleInsert =
+    quote((p: Person) => query[Person].insert(p))
+
+  val peopleEntries = List(
+    Person("A", 1),
+    Person("B", 2),
+    Person("X", 10),
+    Person("Y", 11),
+    Person("Z", 12)
+  )
+
+  val couplesInsert =
+    quote((c: Couple) => query[Couple].insert(c))
+
+  val couplesEntries = List(
+    Couple("B", "X"),
+    Couple("B", "Y"),
+    Couple("B", "Z"),
+    Couple("A", "X"),
+    Couple("A", "X"),
+    Couple("A", "Y")
+  )
+
+  val `Ex 1 Distinct One Field` = quote {
+    query[Couple].map(_.him).distinct
+  }
+  val `Ex 1 Distinct One Field Result` =
+    List("B", "A")
+
+  val `Ex 2 Distinct Two Field Tuple` = quote {
+    query[Couple].map(c => (c.him, c.her)).distinct
+  }
+  val `Ex 2 Distinct Two Field Tuple Result` =
+    List(
+      ("B", "X"),
+      ("B", "Y"),
+      ("B", "Z"),
+      ("A", "X"),
+      ("A", "Y")
+    )
+
+  val `Ex 2a Distinct Two Field Tuple Same Element` = quote {
+    query[Couple].map(c => (c.him, c.him)).distinct
+  }
+  val `Ex 2a Distinct Two Field Tuple Same Element Result` =
+    List(
+      ("B", "B"),
+      ("A", "A")
+    )
+
+  val `Ex 3 Distinct Two Field Case Class` = quote {
+    query[Couple].distinct
+  }
+  val `Ex 3 Distinct Two Field Case Class Result` =
+    List(
+      Couple("B", "X"),
+      Couple("B", "Y"),
+      Couple("B", "Z"),
+      Couple("A", "X"),
+      Couple("A", "Y")
+    )
+
+  val `Ex 4-base non-Distinct Subquery` = quote {
+    query[Person].join(query[Couple]).on(_.name == _.him)
+  }
+  val `Ex 4-base non-Distinct Subquery Result` =
+    List(
+      (Person("A", 1), Couple("A", "X")),
+      (Person("A", 1), Couple("A", "X")),
+      (Person("A", 1), Couple("A", "Y")),
+      (Person("B", 2), Couple("B", "X")),
+      (Person("B", 2), Couple("B", "Y")),
+      (Person("B", 2), Couple("B", "Z"))
+    )
+
+  val `Ex 4 Distinct Subquery` = quote {
+    query[Person].join(query[Couple].distinct).on(_.name == _.him)
+  }
+  val `Ex 4 Distinct Subquery Result` =
+    List(
+      (Person("A", 1), Couple("A", "X")),
+      (Person("A", 1), Couple("A", "Y")),
+      (Person("B", 2), Couple("B", "X")),
+      (Person("B", 2), Couple("B", "Y")),
+      (Person("B", 2), Couple("B", "Z"))
+    )
+
+  val `Ex 5 Distinct Subquery with Map Single Field` = quote {
+    query[Person]
+      .join(
+        query[Couple].map(_.him).distinct
+      ).on((p, cm) => p.name == cm)
+  }
+  val `Ex 5 Distinct Subquery with Map Single Field Result` =
+    List(
+      (Person("A", 1), "A"),
+      (Person("B", 2), "B")
+    )
+
+  val `Ex 6 Distinct Subquery with Map Multi Field` = quote {
+    query[Person]
+      .join(
+        query[Couple].map(c => (c.him, c.her)).distinct
+      ).on(_.name == _._1)
+  }
+  val `Ex 6 Distinct Subquery with Map Multi Field Result` =
+    List(
+      (Person("A", 1), ("A", "X")),
+      (Person("A", 1), ("A", "Y")),
+      (Person("B", 2), ("B", "X")),
+      (Person("B", 2), ("B", "Y")),
+      (Person("B", 2), ("B", "Z"))
+    )
+
+  case class TwoField(one: String, two: String)
+  val `Ex 7 Distinct Subquery with Map Multi Field Tuple` = quote {
+    query[Person]
+      .join(
+        query[Couple].map(c => TwoField(c.him, c.her)).distinct
+      ).on(_.name == _.one)
+  }
+  val `Ex 7 Distinct Subquery with Map Multi Field Tuple Result` =
+    List(
+      (Person("A", 1), TwoField("A", "X")),
+      (Person("A", 1), TwoField("A", "Y")),
+      (Person("B", 2), TwoField("B", "X")),
+      (Person("B", 2), TwoField("B", "Y")),
+      (Person("B", 2), TwoField("B", "Z"))
+    )
+
+  val `Ex 8 Distinct With Sort` = quote {
+    query[Person]
+      .join(query[Couple]).on(_.name == _.him)
+      .distinct
+      .sortBy(_._1.name)(Ord.asc)
+  }
+  val `Ex 8 Distinct With Sort Result` =
+    List(
+      (Person("A", 1), Couple("A", "X")),
+      (Person("A", 1), Couple("A", "Y")),
+      (Person("B", 2), Couple("B", "X")),
+      (Person("B", 2), Couple("B", "Y")),
+      (Person("B", 2), Couple("B", "Z"))
+    )
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandDistinctSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandDistinctSpec.scala
@@ -1,0 +1,42 @@
+package io.getquill.context.sql.norm
+
+import io.getquill.Spec
+import io.getquill.context.sql.testContext.qr1
+import io.getquill.context.sql.testContext.quote
+import io.getquill.context.sql.testContext.unquote
+
+class ExpandDistinctSpec extends Spec {
+
+  "expands distinct map" - {
+    "simple" in {
+      val q = quote {
+        qr1.map(e => e.i).distinct.nested
+      }
+      ExpandDistinct(q.ast).toString mustEqual
+        """querySchema("TestEntity").map(e => e.i).distinct.map(e => e.i).nested"""
+    }
+    "aggregation" in {
+      val q = quote {
+        qr1.map(e => (e.i, e.l)).groupBy(g => g._1).map(_._2.max).distinct.nested
+      }
+      ExpandDistinct(q.ast).toString mustEqual
+        """querySchema("TestEntity").map(e => (e.i, e.l)).groupBy(g => g._1).map(x1 => x1._2.max).distinct.map(x1 => x1._2.max).nested"""
+    }
+    "with case class" in {
+      case class Rec(one: Int, two: Long)
+      val q = quote {
+        qr1.map(e => Rec(e.i, e.l)).distinct.nested
+      }
+      ExpandDistinct(q.ast).toString mustEqual
+        """querySchema("TestEntity").map(e => (e.i, e.l)).distinct.map(e => (e.one, e.two)).nested"""
+    }
+    "with tuple" in {
+      val q = quote {
+        qr1.map(e => (e.i, e.l)).distinct.nested
+      }
+      ExpandDistinct(q.ast).toString mustEqual
+        """querySchema("TestEntity").map(e => (e.i, e.l)).distinct.map(e => (e._1, e._2)).nested"""
+    }
+
+  }
+}


### PR DESCRIPTION
Fixes #1446, #1447 and #1472 

@fwbrasil I would appreciate it if you could review AST transformation changes. This one seems to be a very simple solution. Am I missing anything?
Alternatively, maybe every single case of `DetachableMap` in `ApplyMap` should have a variant with `Distinct(DetachableMap(...))`?

### Problem

Join+Distinct+Map fails:
```scala
case class Person(id: Int, name: String, age: Int)
case class Membership(personId: Int, team: Int)

val m = run(
  query[Person]
    .join(
      query[Membership]
        .filter(liftQuery(Set(1,2,3)) contains _.team)
        .map(_.personId)
        .distinct
    )
    .on(_.id == _)
    .map(_._1)
)
```
Results in:
```
exception during macro expansion: 
java.lang.IllegalStateException: The monad composition can't be expressed using applicative joins.
```

### Solution
To fix #1446 add the following clause to `ApplyMap`:
```scala
      // a.*join(b.map(c => d).distinct).on((iA, iB) => on)
      //    a.*join(b.distinct).on((iA, c) => on[iB := d]).map(t => (t._1, d[c := t._2]))
      case Join(tpe, a, Distinct(DetachableMap(b, c, d)), iA, iB, on) =>
        val onr = BetaReduction(on, iB -> d)
        val t = Ident("t")
        val t1 = Property(t, "_1")
        val t2 = BetaReduction(d, c -> Property(t, "_2"))
        Some(Map(Join(tpe, a, Distinct(b), iA, c, onr), t, Tuple(List(t1, t2))))
```
The following is then returned:
```sql
SELECT x1.id, x1.name, x1.age, m.person_id FROM person x1 INNER JOIN (SELECT DISTINCT x.person_id FROM membership x) AS m ON x1.id = m.person_id
```

Same thing with #1447, add the following to `ApplyMap`:
```scala
      // a.map(b => c).sortBy(d => e).distinct =>
      //    a.sortBy(b => e[d := c]).map(b => c).distinct
      case SortBy(Distinct(DetachableMap(a, b, c)), d, e, f) =>
        val er = BetaReduction(e, d -> c)
        Some(Distinct(Map(SortBy(a, b, er, f), b, c)))
```
Then you will get:
```sql
SELECT x5._1id, x5._1name, x5._1age, x5._2person_id, x5._2team FROM (SELECT DISTINCT x3.age AS _1age, x3.id AS _1id, x3.name AS _1name, x4.team AS _2team, x4.person_id AS _2person_id FROM person x3 INNER JOIN membership x4 ON x3.id = x4.person_id ORDER BY x3.id DESC) AS x5
```


- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
