### PR TITLE
Update mockito version and deprecated code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -438,13 +438,13 @@ lazy val jdbcTestingSettings = Seq(
   libraryDependencies ++= {
     val deps =
       Seq(
-        "com.zaxxer"              % "HikariCP"             % "3.3.1",
-        "mysql"                   % "mysql-connector-java" % "8.0.16"             % Test,
-        "com.h2database"          % "h2"                   % "1.4.199"            % Test,
-        "org.postgresql"          % "postgresql"           % "42.2.5"             % Test,
-        "org.xerial"              % "sqlite-jdbc"          % "3.27.2.1"             % Test,
-        "com.microsoft.sqlserver" % "mssql-jdbc"           % "7.1.1.jre8-preview" % Test,
-        "org.mockito"             %% "mockito-scala"       % "1.3.1"              % Test
+        "com.zaxxer"              %  "HikariCP"                % "3.3.1",
+        "mysql"                   %  "mysql-connector-java"    % "8.0.16"             % Test,
+        "com.h2database"          %  "h2"                      % "1.4.199"            % Test,
+        "org.postgresql"          %  "postgresql"              % "42.2.5"             % Test,
+        "org.xerial"              %  "sqlite-jdbc"             % "3.27.2.1"           % Test,
+        "com.microsoft.sqlserver" %  "mssql-jdbc"              % "7.1.1.jre8-preview" % Test,
+        "org.mockito"             %% "mockito-scala-scalatest" % "1.5.8"              % Test
       )
 
     deps ++ includeIfOracle(

--- a/quill-jdbc-monix/src/test/scala/io/getquill/mock/MockTests.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/mock/MockTests.scala
@@ -1,20 +1,20 @@
 package io.getquill.mock
 
 import java.io.Closeable
-import java.sql.{ Connection, PreparedStatement, ResultSet, SQLException }
+import java.sql._
+import javax.sql.DataSource
 
 import io.getquill.context.monix.Runner
 import io.getquill.{ Literal, PostgresMonixJdbcContext, Spec }
-import javax.sql.DataSource
 import monix.eval.Task
 import monix.execution.Scheduler
-import org.mockito.integrations.scalatest.MockitoFixture
+import org.mockito.scalatest.AsyncMockitoSugar
 import org.scalatest.Matchers._
 
 import scala.reflect.ClassTag
 import scala.util.Try
 
-class MockTests extends Spec with MockitoFixture {
+class MockTests extends Spec with AsyncMockitoSugar {
   import scala.reflect.runtime.{ universe => ru }
   implicit val scheduler = Scheduler.io()
 


### PR DESCRIPTION
The current PRs from scala-steward related to mockito are broken due to some deprecated code. This is the fix.

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
