### PR TITLE
[WIP] Fix SQL Server Subqueries with Order By

### DIFF
--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/DistinctJdbcSpec.scala
@@ -46,6 +46,6 @@ class DistinctJdbcSpec extends DistinctSpec {
     testContext.run(`Ex 7 Distinct Subquery with Map Multi Field Tuple`) should contain theSameElementsAs `Ex 7 Distinct Subquery with Map Multi Field Tuple Result`
   }
   "Ex 8 Distinct With Sort" in {
-    testContext.run(`Ex 8 Distinct With Sort`.drop(0)) mustEqual `Ex 8 Distinct With Sort Result`
+    testContext.run(`Ex 8 Distinct With Sort`) mustEqual `Ex 8 Distinct With Sort Result`
   }
 }

--- a/quill-sql/src/main/scala/io/getquill/SQLServerDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/SQLServerDialect.scala
@@ -3,6 +3,7 @@ package io.getquill
 import io.getquill.ast._
 import io.getquill.context.sql.{ FlattenSqlQuery, SqlQuery }
 import io.getquill.context.sql.idiom._
+import io.getquill.context.sql.norm.AddDropToNestedOrderBy
 import io.getquill.idiom.{ StringToken, Token }
 import io.getquill.idiom.Statement
 import io.getquill.idiom.StatementInterpolator._
@@ -14,6 +15,8 @@ trait SQLServerDialect
   extends SqlIdiom
   with QuestionMarkBindVariables
   with ConcatSupport {
+
+  override def querifyAst(ast: Ast) = AddDropToNestedOrderBy(SqlQuery(ast))
 
   override def emptySetContainsToken(field: Token) = StringToken("1 <> 1")
 

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -22,6 +22,8 @@ trait SqlIdiom extends Idiom {
   protected def concatBehavior: ConcatBehavior = AnsiConcat
   protected def equalityBehavior: EqualityBehavior = AnsiEquality
 
+  def querifyAst(ast: Ast) = SqlQuery(ast)
+
   override def translate(ast: Ast)(implicit naming: NamingStrategy) = {
     val normalizedAst = SqlNormalize(ast, concatBehavior, equalityBehavior)
 
@@ -30,7 +32,7 @@ trait SqlIdiom extends Idiom {
     val token =
       normalizedAst match {
         case q: Query =>
-          val sql = SqlQuery(q)
+          val sql = querifyAst(q)
           trace("sql")(sql)
           VerifySqlQuery(sql).map(fail)
           val expanded = ExpandNestedQueries(sql, collection.Set.empty)

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/AddDropToNestedOrderBy.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/AddDropToNestedOrderBy.scala
@@ -1,0 +1,39 @@
+package io.getquill.context.sql.norm
+
+import io.getquill.ast.Constant
+import io.getquill.context.sql.{ FlattenSqlQuery, SqlQuery, _ }
+
+/**
+ * In SQL Server, `Order By` clauses are only allowed in sub-queries if the sub-query has a `TOP` or `OFFSET`
+ * modifier. Otherwise an exception will be thrown. This transformation adds a 'dummy' `OFFSET 0` in this
+ * scenario (if an `Offset` clause does not exist already).
+ */
+object AddDropToNestedOrderBy {
+
+  def applyInner(q: SqlQuery): SqlQuery =
+    q match {
+      case q: FlattenSqlQuery =>
+        q.copy(
+          offset = if (q.orderBy.nonEmpty) q.offset.orElse(Some(Constant(0))) else q.offset,
+          from = q.from.map(applyInner(_))
+        )
+
+      case SetOperationSqlQuery(a, op, b) => SetOperationSqlQuery(applyInner(a), op, applyInner(b))
+      case UnaryOperationSqlQuery(op, a)  => UnaryOperationSqlQuery(op, applyInner(a))
+    }
+
+  private def applyInner(f: FromContext): FromContext =
+    f match {
+      case QueryContext(a, alias)    => QueryContext(applyInner(a), alias)
+      case JoinContext(t, a, b, on)  => JoinContext(t, applyInner(a), applyInner(b), on)
+      case FlatJoinContext(t, a, on) => FlatJoinContext(t, applyInner(a), on)
+      case other                     => other
+    }
+
+  def apply(q: SqlQuery): SqlQuery =
+    q match {
+      case q: FlattenSqlQuery             => q.copy(from = q.from.map(applyInner(_)))
+      case SetOperationSqlQuery(a, op, b) => SetOperationSqlQuery(applyInner(a), op, applyInner(b))
+      case UnaryOperationSqlQuery(op, a)  => UnaryOperationSqlQuery(op, applyInner(a))
+    }
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/AddDropToNestedOrderBySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/AddDropToNestedOrderBySpec.scala
@@ -1,0 +1,90 @@
+package io.getquill.context.sql.norm
+
+import io.getquill._
+import io.getquill.context.sql.{ TestDecoders, TestEncoders }
+
+class AddDropToNestedOrderBySpec extends Spec {
+
+  val ctx = new SqlMirrorContext(SQLServerDialect, Literal) with TestEntities with TestEncoders with TestDecoders
+
+  import ctx._
+  val q2Sorted = quote { qr2.sortBy(r => r.i) }
+
+  "adds drop(0) to nested order-by" - {
+    "simple" in {
+      val q = quote {
+        qr1.sortBy(r => r.i).nested
+      }
+      val n = quote {
+        qr1.sortBy(r => r.i).drop(0).nested
+      }
+      translate(q) mustEqual translate(n)
+    }
+
+    "in join" in {
+      val q = quote {
+        qr1.join(q2Sorted).on((a, b) => a.i == b.i)
+      }
+      val n = quote {
+        qr1.join(q2Sorted.drop(0)).on((a, b) => a.i == b.i)
+      }
+      translate(q) mustEqual translate(n)
+    }
+
+    "in join with union" in {
+      val q = quote {
+        qr1.join(q2Sorted union q2Sorted).on((a, b) => a.i == b.i)
+      }
+      val n = quote {
+        qr1.join(q2Sorted.drop(0) union q2Sorted.drop(0)).on((a, b) => a.i == b.i)
+      }
+      translate(q) mustEqual translate(n)
+    }
+
+    "in join with external union" in {
+      val q = quote {
+        qr1.join(q2Sorted).on((a, b) => a.i == b.i) union qr1.join(q2Sorted).on((a, b) => a.i == b.i)
+      }
+      val n = quote {
+        qr1.join(q2Sorted.drop(0)).on((a, b) => a.i == b.i) union qr1.join(q2Sorted.drop(0)).on((a, b) => a.i == b.i)
+      }
+      translate(q) mustEqual translate(n)
+    }
+
+    "in flat" in {
+      val q = quote {
+        for {
+          q1 <- qr1
+          q2 <- qr2.sortBy(r => r.i).join(qj => qj.i == q1.i)
+        } yield (q1, q2)
+      }
+      val n = quote {
+        for {
+          q1 <- qr1
+          q2 <- qr2.sortBy(r => r.i).drop(0).join(qj => qj.i == q1.i)
+        } yield (q1, q2)
+      }
+      translate(q) mustEqual translate(n)
+    }
+
+    "in unary op" in {
+      val q = quote {
+        q2Sorted.nonEmpty
+      }
+      val n = quote {
+        q2Sorted.drop(0).nonEmpty
+      }
+      translate(q) mustEqual translate(n)
+    }
+
+    "in unary op external" in {
+      val q = quote {
+        qr1.join(q2Sorted).on((a, b) => a.i == b.i).nonEmpty
+      }
+      val n = quote {
+        qr1.join(q2Sorted.drop(0)).on((a, b) => a.i == b.i).nonEmpty
+      }
+      translate(q) mustEqual translate(n)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1474 

### Problem

SQL Server sub-queries with `ORDER BY` need either a `TOP` or `OFFSET` clause otherwise the following SQL error occurs:
```
The ORDER BY clause is invalid in views, inline functions, derived tables, subqueries, and common table expressions, unless TOP, OFFSET or FOR XML is also specified.
```

### Solution

Add a transformation to add `.drop(0)` to SQL Server sub-queries that have `Order By`.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
