### PR TITLE
pluralize with evo-inflector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2264,6 +2264,25 @@ def createDataSource: javax.sql.DataSource with java.io.Closeable = ???
 lazy val ctx = new MysqlJdbcContext(SnakeCase, createDataSource)
 ```
 
+### Third party naming strategy
+
+Third party naming strategy can be used. 
+
+#### sbt dependencies
+```
+libraryDependencies ++= Seq(
+  "io.getquill" %% "quill-pluralize" % "3.2.2-SNAPSHOT"
+)
+```
+
+#### Configuration
+
+```scala
+def createDataSource: javax.sql.DataSource with java.io.Closeable = ???
+lazy val ctx = new MysqlJdbcContext(Pluralize, createDataSource)
+```
+
+
 ## quill-jdbc
 
 The `quill-jdbc` module provides a simple blocking JDBC context for standard use-cases. For transactions, the JDBC connection is kept in a thread-local variable.

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ import java.io.{File => JFile}
 enablePlugins(TutPlugin)
 
 lazy val baseModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
-  `quill-core-jvm`, `quill-core-js`, `quill-sql-jvm`, `quill-sql-js`, `quill-monix`
+  `quill-core-jvm`, `quill-core-js`, `quill-sql-jvm`, `quill-sql-js`, `quill-monix`, `quill-pluralize`
 )
 
 lazy val dbModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
@@ -353,6 +353,20 @@ lazy val `quill-orientdb` =
         )
       )
       .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
+
+
+lazy val `quill-pluralize` =
+  (project in file("quill-pluralize"))
+    .settings(commonSettings: _*)
+    .settings(mimaSettings: _*)
+    .settings(
+      fork in Test := true,
+      libraryDependencies ++= Seq(
+        "org.atteo" % "evo-inflector" % "1.2.2"
+      )
+    )
+    .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
+
 
 lazy val `tut-sources` = Seq(
   "CASSANDRA.md",

--- a/quill-pluralize/src/main/scala/io.getquill/Pluralize.scala
+++ b/quill-pluralize/src/main/scala/io.getquill/Pluralize.scala
@@ -1,0 +1,9 @@
+package io.getquill
+
+import org.atteo.evo.inflector.English
+
+trait Pluralize extends NamingStrategy {
+  override def table(s: String): String = English.plural(s)
+  override def default(s: String): String = s
+}
+object Pluralize extends Pluralize

--- a/quill-pluralize/src/test/scala/io/getquill/PluralizeSpec.scala
+++ b/quill-pluralize/src/test/scala/io/getquill/PluralizeSpec.scala
@@ -1,0 +1,14 @@
+package io.getquill
+
+class PluralizeSpec extends Spec {
+  "pluralize" - {
+    val s = new NamingStrategy with Pluralize
+
+    "ending with something other than s" in {
+      s.table("user") mustEqual "users"
+    }
+    "special inflection rules" in {
+      s.table("activity") mustEqual "activities"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1040

### Problem

PluralizedTableNames doesn't follow English pluralization rules

### Solution

create new project for pluralize using evo-inflector 

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
