### PR TITLE
Fix support of nested transactions in Finagle-Postgres

### DIFF
--- a/quill-finagle-postgres/src/test/resources/application.conf
+++ b/quill-finagle-postgres/src/test/resources/application.conf
@@ -1,3 +1,4 @@
 testPostgresDB.host=${?POSTGRES_HOST}":"${?POSTGRES_PORT}
 testPostgresDB.user=postgres
 testPostgresDB.database=quill_test
+testPostgresDB.hostConnectionLimit=3

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/TransactionSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/TransactionSpec.scala
@@ -1,0 +1,56 @@
+package io.getquill.context.finagle.postgres
+
+import com.twitter.util.{ Await, Future, Throw }
+
+import io.getquill.context.sql.ProductSpec
+
+class TransactionSpec extends ProductSpec {
+  val context = testContext
+  import context._
+
+  def await[T](future: Future[T]) = Await.result(future)
+
+  val p = Product(0L, "Scala Compiler", 1L)
+
+  "If outer transaction fails, inner transactions shouldn't commit" in {
+    val id: Long = await {
+      context.transaction {
+        for {
+          id <- context.transaction {
+            context.run(productInsert(lift(p)))
+          }
+          Throw(_) <- context.transaction {
+            context.run(quote {
+              query[Product].insert(lift(p.copy(id = id)))
+            }).liftToTry
+          }
+        } yield id
+      }
+    }
+    // Since a query inside a transaction failed, the outermost transaction had
+    // to rollback.
+    val res: List[Product] = await { context.run(productById(lift(id))) }
+    res mustEqual List()
+  }
+
+  "Transaction inside transaction should not open a new client" in {
+    val res: Product = await {
+      context.transaction {
+        for {
+          id: Long <- context.run(productInsert(lift(p)))
+          // A subtransaction should have access to the previous queries of an
+          // outer transaction.
+          res: List[Product] <- context.transaction {
+            context.run(productById(lift(id)))
+          }
+        } yield res.head
+      }
+    }
+    res mustEqual p.copy(id = res.id)
+  }
+
+  override def beforeAll = {
+    await(context.run(quote { query[Product].delete }))
+    ()
+  }
+}


### PR DESCRIPTION
### Problem

When developing some queries, it might be useful to wrap them in transactions to ensure some ACID properties — specifically atomicity by performing a rollback on an outer transaction if an inner transaction fails/rollbacks — but the current implementation cleared the currentClient when an inner transaction finished and created a new client even if there was already one doing an outer transaction.

When composing queries, it might be useful to have a transaction that flattens nested transactions to simplify composition of queries in transactions.

Further documentation: https://www.postgresql.org/docs/current/tutorial-transactions.html

> The essential point of a transaction is that it bundles multiple steps into a single, all-or-nothing operation. The **intermediate states between the steps are not visible to other concurrent transactions**, and **if some failure occurs that prevents the transaction from completing, then none of the steps affect the database at all.**

### Solution

Changed from currentClient.set(c), f.ensure(currentClient.clear) to (currentClient.let(c) f) which manages setting and resetting the currentClient automatically. ( https://github.com/twitter/util/blob/ddabd458a60189bddfb0a57fb80d468df6dc6844/util-core/src/main/scala/com/twitter/util/Local.scala#L4901 )

Changed from creating a new transaction every time to reusing a transaction in use to allow for transaction nesting.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers

Related: #1420 