### PR TITLE
[WIP] Char encoders for all possible contexts

### DIFF
--- a/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayDecoders.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayDecoders.scala
@@ -14,6 +14,7 @@ trait ArrayDecoders extends ArrayEncoding {
   self: PostgresAsyncContext[_] =>
 
   implicit def arrayStringDecoder[Col <: Seq[String]](implicit bf: CBF[String, Col]): Decoder[Col] = arrayRawEncoder[String, Col]
+  implicit def arrayCharDecoder[Col <: Seq[Char]](implicit bf: CBF[Char, Col]): Decoder[Col] = arrayRawEncoder[Char, Col]
   implicit def arrayBigDecimalDecoder[Col <: Seq[BigDecimal]](implicit bf: CBF[BigDecimal, Col]): Decoder[Col] = arrayRawEncoder[BigDecimal, Col]
   implicit def arrayBooleanDecoder[Col <: Seq[Boolean]](implicit bf: CBF[Boolean, Col]): Decoder[Col] = arrayRawEncoder[Boolean, Col]
   implicit def arrayByteDecoder[Col <: Seq[Byte]](implicit bf: CBF[Byte, Col]): Decoder[Col] = arrayDecoder[Short, Byte, Col](_.toByte)

--- a/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayEncoders.scala
+++ b/quill-async-postgres/src/main/scala/io/getquill/context/async/ArrayEncoders.scala
@@ -11,6 +11,7 @@ trait ArrayEncoders extends ArrayEncoding {
   self: PostgresAsyncContext[_] =>
 
   implicit def arrayStringEncoder[Col <: Seq[String]]: Encoder[Col] = arrayRawEncoder[String, Col]
+  implicit def arrayCharEncoder[Col <: Seq[Char]]: Encoder[Col] = arrayRawEncoder[Char, Col]
   implicit def arrayBigDecimalEncoder[Col <: Seq[BigDecimal]]: Encoder[Col] = arrayRawEncoder[BigDecimal, Col]
   implicit def arrayBooleanEncoder[Col <: Seq[Boolean]]: Encoder[Col] = arrayRawEncoder[Boolean, Col]
   implicit def arrayByteEncoder[Col <: Seq[Byte]]: Encoder[Col] = arrayRawEncoder[Byte, Col]

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ArrayAsyncEncodingSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/ArrayAsyncEncodingSpec.scala
@@ -97,6 +97,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
       v12: EncodingTestType,
       v13: LocalDate,
       v14: UUID,
+      v15: Char,
       o1:  Option[String],
       o2:  Option[BigDecimal],
       o3:  Option[Boolean],
@@ -111,7 +112,8 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
       o12: Option[EncodingTestType],
       o13: Option[LocalDate],
       o14: Option[UUID],
-      o15: Option[io.getquill.context.sql.Number]
+      o15: Option[io.getquill.context.sql.Number],
+      o16: Option[Char]
     )
 
     val insertValue =
@@ -130,6 +132,7 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
         EncodingTestType("s"),
         LocalDate.of(2013, 11, 23),
         UUID.randomUUID(),
+        'c',
         Some("s"),
         Some(BigDecimal(1.1)),
         Some(true),
@@ -144,7 +147,8 @@ class ArrayAsyncEncodingSpec extends ArrayEncodingBaseSpec {
         Some(EncodingTestType("s")),
         Some(LocalDate.of(2013, 11, 23)),
         Some(UUID.randomUUID()),
-        Some(io.getquill.context.sql.Number("0"))
+        Some(io.getquill.context.sql.Number("0")),
+        Some('c')
       )
 
     val realEntity = quote {

--- a/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Decoders.scala
@@ -141,6 +141,16 @@ trait Decoders {
     case localDate: JodaLocalDate         => localDate.toDate
   }, SqlTypes.TIMESTAMP)
 
+  implicit val charDecoder: Decoder[Char] =
+    AsyncDecoder[Char](SqlTypes.VARCHAR)(new BaseDecoder[Char] {
+      override def apply(index: Index, row: ResultRow): Char = {
+        val str = row(index).asInstanceOf[String]
+        if (str.length != 1)
+          throw new IllegalStateException(s"""The column number ${index} is being decoded as a Char but it's value "${str}" does not have one character as is required (${str.length} characters).""")
+        str.charAt(0)
+      }
+    })
+
   implicit val decodeZonedDateTime: MappedEncoding[JodaDateTime, ZonedDateTime] =
     MappedEncoding(jdt => ZonedDateTime.ofInstant(Instant.ofEpochMilli(jdt.getMillis), ZoneId.of(jdt.getZone.getID)))
 

--- a/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/Encoders.scala
@@ -44,7 +44,6 @@ trait Encoders {
     })
 
   private[this] val nullEncoder: Encoder[Null] = encoder[Null](SqlTypes.NULL)
-
   implicit val stringEncoder: Encoder[String] = encoder[String](SqlTypes.VARCHAR)
   implicit val bigDecimalEncoder: Encoder[BigDecimal] = encoder[BigDecimal](SqlTypes.REAL)
   implicit val booleanEncoder: Encoder[Boolean] = encoder[Boolean](SqlTypes.BOOLEAN)
@@ -59,6 +58,10 @@ trait Encoders {
   implicit val jodaLocalDateEncoder: Encoder[JodaLocalDate] = encoder[JodaLocalDate](SqlTypes.DATE)
   implicit val jodaLocalDateTimeEncoder: Encoder[JodaLocalDateTime] = encoder[JodaLocalDateTime](SqlTypes.TIMESTAMP)
   implicit val dateEncoder: Encoder[Date] = encoder[Date]((d: Date) => new JodaLocalDateTime(d), SqlTypes.TIMESTAMP)
+
+  implicit val encodeChar: MappedEncoding[Char, String] =
+    MappedEncoding(c => String.valueOf(c))
+  implicit val charEncoder: Encoder[Char] = mappedEncoder(encodeChar, stringEncoder)
 
   implicit val encodeZonedDateTime: MappedEncoding[ZonedDateTime, JodaDateTime] =
     MappedEncoding(zdt => new JodaDateTime(zdt.toInstant.toEpochMilli, JodaDateTimeZone.forID(zdt.getZone.getId)))

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
@@ -39,6 +39,12 @@ trait Decoders extends CollectionDecoders {
     CassandraDecoder(mappedBaseDecoder(mapped, decoder.decoder))
 
   implicit val stringDecoder: Decoder[String] = decoder(_.getString)
+  implicit val charDecoder: Decoder[Char] = decoder((index, row) => {
+    val str = row.getString(index)
+    if (str.length != 1)
+      throw new IllegalStateException(s"""The column number ${index} is being decoded as a Char but it's value "${str}" does not have one character as is required (${str.length} characters).""")
+    str.charAt(0)
+  })
   implicit val bigDecimalDecoder: Decoder[BigDecimal] =
     decoder((index, row) => row.getDecimal(index))
   implicit val booleanDecoder: Decoder[Boolean] = decoder(_.getBool)

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
@@ -36,6 +36,8 @@ trait Encoders extends CollectionEncoders {
     CassandraEncoder(mappedBaseEncoder(mapped, encoder.encoder))
 
   implicit val stringEncoder: Encoder[String] = encoder(_.setString)
+  implicit val charEncoder: Encoder[Char] = encoder((index, value, row) =>
+    row.setString(index, String.valueOf(value)))
   implicit val bigDecimalEncoder: Encoder[BigDecimal] =
     encoder((index, value, row) => row.setDecimal(index, value.bigDecimal))
   implicit val booleanEncoder: Encoder[Boolean] = encoder(_.setBool)

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ListsEncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ListsEncodingSpec.scala
@@ -21,11 +21,12 @@ class ListsEncodingSpec extends CollectionsSpec {
     doubles:    List[Double],
     dates:      List[LocalDate],
     timestamps: List[Date],
-    uuids:      List[UUID]
+    uuids:      List[UUID],
+    chars:      List[Char]
   )
   val e = ListsEntity(1, List("c"), List(BigDecimal(1.33)), List(true), List(0, 1), List(3, 2), List(1, 2), List(2, 3),
     List(1f, 3f), List(5d), List(LocalDate.fromMillisSinceEpoch(System.currentTimeMillis())),
-    List(new Date), List(UUID.randomUUID()))
+    List(new Date), List(UUID.randomUUID()), List('c'))
   val q = quote(query[ListsEntity])
 
   "List encoders/decoders for CassandraTypes and CassandraMappers" in {

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/SetsEncodingSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/SetsEncodingSpec.scala
@@ -19,11 +19,12 @@ class SetsEncodingSpec extends CollectionsSpec {
     doubles:    Set[Double],
     dates:      Set[LocalDate],
     timestamps: Set[Date],
-    uuids:      Set[UUID]
+    uuids:      Set[UUID],
+    chars:      Set[Char]
   )
   val e = SetsEntity(1, Set("c"), Set(BigDecimal(1.33)), Set(true), Set(1, 2), Set(2, 3), Set(1f, 3f),
     Set(5d), Set(LocalDate.fromMillisSinceEpoch(System.currentTimeMillis())),
-    Set(new Date), Set(UUID.randomUUID()))
+    Set(new Date), Set(UUID.randomUUID()), Set('a', 'b'))
   val q = quote(query[SetsEntity])
 
   "Set encoders/decoders" in {

--- a/quill-core/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
+++ b/quill-core/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
@@ -31,6 +31,7 @@ trait MirrorEncoders {
     })
 
   implicit val stringEncoder: Encoder[String] = encoder[String]
+  implicit val charEncoder: Encoder[Char] = encoder[Char]
   implicit val bigDecimalEncoder: Encoder[BigDecimal] = encoder[BigDecimal]
   implicit val booleanEncoder: Encoder[Boolean] = encoder[Boolean]
   implicit val byteEncoder: Encoder[Byte] = encoder[Byte]

--- a/quill-core/src/test/scala/io/getquill/context/EncodingSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/EncodingSpec.scala
@@ -24,6 +24,7 @@ trait EncodingSpec extends Spec {
     v9:  Double,
     v10: Array[Byte],
     v11: Date,
+    v12: Char,
     o1:  Option[String],
     o2:  Option[BigDecimal],
     o3:  Option[Boolean],
@@ -34,7 +35,8 @@ trait EncodingSpec extends Spec {
     o8:  Option[Float],
     o9:  Option[Double],
     o10: Option[Array[Byte]],
-    o11: Option[Date]
+    o11: Option[Date],
+    o12: Option[Char]
   )
 
   val delete = quote {
@@ -53,6 +55,7 @@ trait EncodingSpec extends Spec {
     v9: Double,
     v10: Array[Byte],
     v11: Date,
+    v12: Char,
     o1: Option[String],
     o2: Option[BigDecimal],
     o3: Option[Boolean],
@@ -63,7 +66,8 @@ trait EncodingSpec extends Spec {
     o8: Option[Float],
     o9: Option[Double],
     o10: Option[Array[Byte]],
-    o11: Option[Date]) =>
+    o11: Option[Date],
+    o12: Option[Char]) =>
       query[EncodingTestEntity].insert(
         _.v1 -> v1,
         _.v2 -> v2,
@@ -76,6 +80,7 @@ trait EncodingSpec extends Spec {
         _.v9 -> v9,
         _.v10 -> v10,
         _.v11 -> v11,
+        _.v12 -> v12,
         _.o1 -> o1,
         _.o2 -> o2,
         _.o3 -> o3,
@@ -86,7 +91,8 @@ trait EncodingSpec extends Spec {
         _.o8 -> o8,
         _.o9 -> o9,
         _.o10 -> o10,
-        _.o11 -> o11
+        _.o11 -> o11,
+        _.o12 -> o12
       )
   }
 
@@ -104,6 +110,7 @@ trait EncodingSpec extends Spec {
         42d,
         Array(1.toByte, 2.toByte),
         new Date(31200000),
+        'c',
         Some("s"),
         Some(BigDecimal(1.1)),
         Some(true),
@@ -114,7 +121,8 @@ trait EncodingSpec extends Spec {
         Some(34.4f),
         Some(42d),
         Some(Array(1.toByte, 2.toByte)),
-        Some(new Date(31200000))
+        Some(new Date(31200000)),
+        Some('c')
       ),
       ("",
         BigDecimal(0),
@@ -127,6 +135,8 @@ trait EncodingSpec extends Spec {
         0D,
         Array(),
         new Date(0),
+        '\0',
+        None,
         None,
         None,
         None,
@@ -156,6 +166,7 @@ trait EncodingSpec extends Spec {
         e1.v9 mustEqual 42d
         e1.v10.toList mustEqual List(1.toByte, 2.toByte)
         e1.v11 mustEqual new Date(31200000)
+        e1.v12 mustEqual 'c'
 
         e1.o1 mustEqual Some("s")
         e1.o2 mustEqual Some(BigDecimal(1.1))
@@ -168,6 +179,7 @@ trait EncodingSpec extends Spec {
         e1.o9 mustEqual Some(42d)
         e1.o10.map(_.toList) mustEqual Some(List(1.toByte, 2.toByte))
         e1.o11 mustEqual Some(new Date(31200000))
+        e1.o12 mustEqual Some('c')
 
         e2.v1 mustEqual ""
         e2.v2 mustEqual BigDecimal(0)
@@ -180,6 +192,7 @@ trait EncodingSpec extends Spec {
         e2.v9 mustEqual 0d
         e2.v10.toList mustEqual Nil
         e2.v11 mustEqual new Date(0)
+        e2.v12 mustEqual '\0'
 
         e2.o1 mustEqual None
         e2.o2 mustEqual None
@@ -192,5 +205,6 @@ trait EncodingSpec extends Spec {
         e2.o9 mustEqual None
         e2.o10.map(_.toList) mustEqual None
         e2.o11 mustEqual None
+        e2.o12 mustEqual None
     }
 }

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
@@ -40,6 +40,18 @@ trait FinagleMysqlDecoders {
     decoder[String] {
       case StringValue(v) => v
     }
+  implicit val charDecoder: Decoder[Char] =
+    FinangleMysqlDecoder((index, row) => {
+      row.values(index) match {
+        case strVal: StringValue =>
+          val str = strVal.s
+          if (str.length != 1)
+            throw new IllegalStateException(s"""The column number ${index} is being decoded as a Char but it's value "${str}" does not have one character as is required (${str.length} characters).""")
+          str.charAt(0)
+        case other =>
+          throw new IllegalStateException(s"""The column number ${index} is being decoded as a Char but it's value was not StringValue as is required. It was ${other}.""")
+      }
+    })
   implicit val bigDecimalDecoder: Decoder[BigDecimal] =
     decoder[BigDecimal] {
       case BigDecimalValue(v) => v

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
@@ -39,6 +39,10 @@ trait FinagleMysqlEncoders {
     FinangleMySqlEncoder(mappedBaseEncoder(mapped, e.encoder))
 
   implicit val stringEncoder: Encoder[String] = encoder[String]
+  implicit val charEncoder: Encoder[Char] =
+    encoder[Char] { (value: Char) =>
+      StringValue(String.valueOf(value)): Parameter
+    }
   implicit val bigDecimalEncoder: Encoder[BigDecimal] =
     encoder[BigDecimal] { (value: BigDecimal) =>
       BigDecimalValue(value): Parameter

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
@@ -46,6 +46,13 @@ trait FinaglePostgresDecoders {
     FinanglePostgresDecoder(mappedBaseDecoder(mapped, d.decoder))
 
   implicit val stringDecoder: Decoder[String] = decoderDirectly[String]
+  implicit val charDecoder: Decoder[Char] =
+    FinanglePostgresDecoder((index, row) => {
+      val str = row.get[String](index)
+      if (str.length != 1)
+        throw new IllegalStateException(s"""The column number ${index} is being decoded as a Char but it's value "${str}" does not have one character as is required (${str.length} characters).""")
+      str.charAt(0)
+    })
   implicit val bigDecimalDecoder: Decoder[BigDecimal] = decoderDirectly[BigDecimal]
   implicit val booleanDecoder: Decoder[Boolean] = decoderDirectly[Boolean]
   implicit val byteDecoder: Decoder[Byte] = decoder[Byte] {

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncoders.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncoders.scala
@@ -29,6 +29,8 @@ trait FinaglePostgresEncoders {
     FinanglePostgresEncoder[Option[T]](option(e.encoder))
 
   implicit val stringEncoder: Encoder[String] = encoder[String]
+  implicit val charEncoder: Encoder[Char] =
+    encoder[String, Char]((v: Char) => String.valueOf(v))
   implicit val bigDecimalEncoder: Encoder[BigDecimal] = encoder[BigDecimal]
   implicit val booleanEncoder: Encoder[Boolean] = encoder[Boolean]
   implicit val byteEncoder: Encoder[Byte] = encoder[Short, Byte](_.toShort)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayDecoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayDecoders.scala
@@ -16,6 +16,7 @@ trait ArrayDecoders extends ArrayEncoding {
   self: JdbcContextBase[_, _] =>
 
   implicit def arrayStringDecoder[Col <: Seq[String]](implicit bf: CanBuildFrom[Nothing, String, Col]): Decoder[Col] = arrayRawDecoder[String, Col]
+  implicit def arrayCharDecoder[Col <: Seq[Char]](implicit bf: CanBuildFrom[Nothing, Char, Col]): Decoder[Col] = arrayRawDecoder[Char, Col]
   implicit def arrayBigDecimalDecoder[Col <: Seq[BigDecimal]](implicit bf: CBF[BigDecimal, Col]): Decoder[Col] = arrayDecoder[JBigDecimal, BigDecimal, Col](BigDecimal.apply)
   implicit def arrayBooleanDecoder[Col <: Seq[Boolean]](implicit bf: CBF[Boolean, Col]): Decoder[Col] = arrayRawDecoder[Boolean, Col]
   implicit def arrayByteDecoder[Col <: Seq[Byte]](implicit bf: CBF[Byte, Col]): Decoder[Col] = arrayRawDecoder[Byte, Col]

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayEncoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/ArrayEncoders.scala
@@ -13,6 +13,7 @@ trait ArrayEncoders extends ArrayEncoding {
   self: JdbcContextBase[_, _] =>
 
   implicit def arrayStringEncoder[Col <: Seq[String]]: Encoder[Col] = arrayRawEncoder[String, Col](VARCHAR)
+  implicit def arrayCharEncoder[Col <: Seq[Char]]: Encoder[Col] = arrayRawEncoder[Char, Col](VARCHAR)
   implicit def arrayBigDecimalEncoder[Col <: Seq[BigDecimal]]: Encoder[Col] = arrayEncoder[BigDecimal, Col](parseJdbcType(NUMERIC), _.bigDecimal)
   implicit def arrayBooleanEncoder[Col <: Seq[Boolean]]: Encoder[Col] = arrayRawEncoder[Boolean, Col](BOOLEAN)
   implicit def arrayByteEncoder[Col <: Seq[Byte]]: Encoder[Col] = arrayRawEncoder[Byte, Col](TINYINT)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
@@ -43,6 +43,12 @@ trait Decoders {
     )
 
   implicit val stringDecoder: Decoder[String] = decoder(_.getString)
+  implicit val charDecoder: Decoder[Char] = decoder((index, row) => {
+    val str = row.getString(index)
+    if (str.length != 1)
+      throw new IllegalStateException(s"""The column number ${index} is being decoded as a Char but it's value "${str}" does not have one character as is required (${str.length} characters).""")
+    str.charAt(0)
+  })
   implicit val bigDecimalDecoder: Decoder[BigDecimal] =
     decoder((index, row) => {
       val v = row.getBigDecimal(index)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -42,6 +42,8 @@ trait Encoders {
     )
 
   implicit val stringEncoder: Encoder[String] = encoder(Types.VARCHAR, _.setString)
+  implicit val charEncoder: Encoder[Char] = encoder(Types.CHAR, (index, value, row) =>
+    row.setString(index, String.valueOf(value)))
   implicit val bigDecimalEncoder: Encoder[BigDecimal] =
     encoder(Types.NUMERIC, (index, value, row) => row.setBigDecimal(index, value.bigDecimal))
   implicit val byteEncoder: Encoder[Byte] = encoder(Types.TINYINT, _.setByte)

--- a/quill-jdbc/src/test/resources/sql/h2-schema.sql
+++ b/quill-jdbc/src/test/resources/sql/h2-schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     v12 VARCHAR(255),
     v13 DATE,
     v14 UUID,
+    v15 VARCHAR(1),
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -52,7 +53,8 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     o12 VARCHAR(255),
     o13 DATE,
     o14 UUID,
-    o15 VARCHAR(255)
+    o15 VARCHAR(255),
+    o16 VARCHAR(1)
 );
 
 CREATE TABLE IF NOT EXISTS TestEntity(

--- a/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
+++ b/quill-jdbc/src/test/resources/sql/sqlite-schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     v12 VARCHAR(255),
     v13 BIGINT,
     v14 VARCHAR(36),
+    v15 VARCHAR(1),
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -52,7 +53,8 @@ CREATE TABLE IF NOT EXISTS EncodingTestEntity(
     o12 VARCHAR(255),
     o13 BIGINT,
     o14 VARCHAR(36),
-    o15 VARCHAR(36)
+    o15 VARCHAR(36),
+    o16 VARCHAR(1)
 );
 
 CREATE TABLE IF NOT EXISTS TestEntity(

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/Decoders.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/Decoders.scala
@@ -42,6 +42,12 @@ trait Decoders extends CollectionDecoders {
   implicit val stringDecoder: Decoder[String] = decoder((index, row) => {
     row.field[String](row.fieldNames()(index))
   })
+  implicit val charDecoder: Decoder[Char] = decoder((index, row) => {
+    val str = row.field[String](row.fieldNames()(index))
+    if (str.length != 1)
+      throw new IllegalStateException(s"""The column number ${index} is being decoded as a Char but it's value "${str}" does not have one character as is required (${str.length} characters).""")
+    str.charAt(0)
+  })
   implicit val doubleDecoder: Decoder[Double] = decoder((index, row) => row.field[Double](row.fieldNames()(index)))
   implicit val bigDecimalDecoder: Decoder[BigDecimal] = decoder((index, row) => row.field[java.math.BigDecimal](row.fieldNames()(index)))
   implicit val booleanDecoder: Decoder[Boolean] = decoder((index, row) => row.field[Boolean](row.fieldNames()(index)))

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/Encoders.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/encoding/Encoders.scala
@@ -34,6 +34,7 @@ trait Encoders extends CollectionEncoders {
     OrientDBEncoder(mappedBaseEncoder(mapped, encoder.encoder))
 
   implicit val stringEncoder: Encoder[String] = encoder((index, value, row) => { row.insert(index, value); row })
+  implicit val charEncoder: Encoder[Char] = encoder((index, value, row) => { row.insert(index, String.valueOf(value)); row })
   implicit val bigDecimalEncoder: Encoder[BigDecimal] = encoder((index, value, row) => { row.insert(index, value.bigDecimal); row })
   implicit val booleanEncoder: Encoder[Boolean] = encoder((index, value, row) => { row.insert(index, value); row })
   implicit val intEncoder: Encoder[Int] = encoder((index, value, row) => { row.insert(index, value); row })

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/ListsEncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/ListsEncodingSpec.scala
@@ -14,10 +14,11 @@ class ListsEncodingSpec extends Spec {
     longs:      List[Long],
     floats:     List[Float],
     doubles:    List[Double],
-    timestamps: List[Date]
+    timestamps: List[Date],
+    chars:      List[Char]
   )
   val e = ListsEntity(1, List("c"), List(true), List(1, 2), List(2, 3), List(1.2f, 3.2f),
-    List(5.1d), List(new Date()))
+    List(5.1d), List(new Date()), List('c'))
 
   private def verify(expected: ListsEntity, actual: ListsEntity): Boolean = {
     expected.id mustEqual actual.id
@@ -27,6 +28,7 @@ class ListsEncodingSpec extends Spec {
     expected.longs mustEqual actual.longs
     expected.doubles mustEqual actual.doubles
     actual.timestamps.head.isInstanceOf[Date]
+    expected.chars mustEqual actual.chars
     true
   }
 

--- a/quill-orientdb/src/test/scala/io/getquill/context/orientdb/SetsEncodingSpec.scala
+++ b/quill-orientdb/src/test/scala/io/getquill/context/orientdb/SetsEncodingSpec.scala
@@ -13,11 +13,12 @@ class SetsEncodingSpec extends Spec {
     ints:       Set[Int],
     longs:      Set[Long],
     doubles:    Set[Double],
-    timestamps: Set[Date]
+    timestamps: Set[Date],
+    chars:      Set[Char]
   )
 
   val e = SetsEntity(1, Set("c"), Set(true), Set(1), Set(2),
-    Set(5.5d), Set(new Date()))
+    Set(5.5d), Set(new Date()), Set('c'))
 
   private def verify(expected: SetsEntity, actual: SetsEntity): Boolean = {
     expected.id mustEqual actual.id
@@ -26,6 +27,7 @@ class SetsEncodingSpec extends Spec {
     expected.ints mustEqual actual.ints
     expected.longs mustEqual actual.longs
     expected.doubles mustEqual actual.doubles
+    expected.chars mustEqual actual.chars
     expected.timestamps.isInstanceOf[Date]
   }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EncodingSpec.scala
@@ -38,6 +38,7 @@ trait EncodingSpec extends Spec {
     v12: EncodingTestType,
     v13: LocalDate,
     v14: UUID,
+    v15: Char,
     o1:  Option[String],
     o2:  Option[BigDecimal],
     o3:  Option[Boolean],
@@ -52,7 +53,8 @@ trait EncodingSpec extends Spec {
     o12: Option[EncodingTestType],
     o13: Option[LocalDate],
     o14: Option[UUID],
-    o15: Option[Number]
+    o15: Option[Number],
+    o16: Option[Char]
   )
 
   val delete = quote {
@@ -80,6 +82,7 @@ trait EncodingSpec extends Spec {
         EncodingTestType("s"),
         LocalDate.of(2013, 11, 23),
         UUID.randomUUID(),
+        'c',
         Some("s"),
         Some(BigDecimal(1.1)),
         Some(true),
@@ -94,7 +97,8 @@ trait EncodingSpec extends Spec {
         Some(EncodingTestType("s")),
         Some(LocalDate.of(2013, 11, 23)),
         Some(UUID.randomUUID()),
-        Some(Number("0"))
+        Some(Number("0")),
+        Some('c')
       ),
       EncodingTestEntity(
         "",
@@ -111,6 +115,8 @@ trait EncodingSpec extends Spec {
         EncodingTestType(""),
         LocalDate.ofEpochDay(0),
         UUID.randomUUID(),
+        '\0',
+        None,
         None,
         None,
         None,
@@ -147,6 +153,7 @@ trait EncodingSpec extends Spec {
         e1.v12 mustEqual e2.v12
         e1.v13 mustEqual e2.v13
         e1.v14 mustEqual e2.v14
+        e1.v15 mustEqual e2.v15
 
         e1.o1 mustEqual e2.o1
         e1.o2 mustEqual e2.o2
@@ -163,6 +170,7 @@ trait EncodingSpec extends Spec {
         e1.o13 mustEqual e2.o13
         e1.o14 mustEqual e2.o14
         e1.o15 mustEqual e2.o15
+        e1.o16 mustEqual e2.o16
     }
   }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingBaseSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/encoding/ArrayEncodingBaseSpec.scala
@@ -22,12 +22,13 @@ trait ArrayEncodingBaseSpec extends Spec with BeforeAndAfterEach {
     floats:     Seq[Float],
     doubles:    Seq[Double],
     timestamps: Seq[Date],
-    dates:      Seq[LocalDate]
+    dates:      Seq[LocalDate],
+    chars:      Seq[Char]
   )
 
   val e = ArraysTestEntity(List("test"), Seq(BigDecimal(2.33)), Vector(true, true), ListBuffer(1),
     IndexedSeq(3), Seq(2), Seq(1, 2, 3), Seq(1f, 2f), Seq(4d, 3d),
-    Seq(new Date(System.currentTimeMillis())), Seq(LocalDate.now()))
+    Seq(new Date(System.currentTimeMillis())), Seq(LocalDate.now()), Seq('a', 'b'))
 
   // casting types can be dangerous so we need to ensure that everything is ok
   def baseEntityDeepCheck(e1: ArraysTestEntity, e2: ArraysTestEntity): Assertion = {
@@ -42,6 +43,7 @@ trait ArrayEncodingBaseSpec extends Spec with BeforeAndAfterEach {
     e1.doubles.head mustBe e2.doubles.head
     e1.timestamps.head mustBe e2.timestamps.head
     e1.dates.head mustBe e2.dates.head
+    e1.chars.head mustBe e2.chars.head
   }
 
   // Support Seq encoding basing on MappedEncoding

--- a/quill-sql/src/test/sql/mysql-schema.sql
+++ b/quill-sql/src/test/sql/mysql-schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE EncodingTestEntity(
     v12 VARCHAR(255),
     v13 DATE,
     v14 VARCHAR(255),
+    v15 VARCHAR(1),
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -52,7 +53,8 @@ CREATE TABLE EncodingTestEntity(
     o12 VARCHAR(255),
     o13 DATE,
     o14 VARCHAR(255),
-    o15 VARCHAR(255)
+    o15 VARCHAR(255),
+    o16 VARCHAR(1)
 );
 
 Create TABLE DateEncodingTestEntity(

--- a/quill-sql/src/test/sql/oracle-schema.sql
+++ b/quill-sql/src/test/sql/oracle-schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE EncodingTestEntity(
   v12 VARCHAR(255),
   v13 DATE,
   v14 VARCHAR(36),
+  v15 VARCHAR(1),
   o1 VARCHAR(255),
   o2 DECIMAL(5,2),
   o3 SMALLINT,
@@ -52,7 +53,8 @@ CREATE TABLE EncodingTestEntity(
   o12 VARCHAR(255),
   o13 DATE,
   o14 VARCHAR(36),
-  o15 VARCHAR(36)
+  o15 VARCHAR(36),
+  o16 VARCHAR(1)
 );
 
 

--- a/quill-sql/src/test/sql/postgres-schema.sql
+++ b/quill-sql/src/test/sql/postgres-schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE EncodingTestEntity(
     v12 VARCHAR(255),
     v13 DATE,
     v14 UUID,
+    v15 VARCHAR(1),
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BOOLEAN,
@@ -52,7 +53,8 @@ CREATE TABLE EncodingTestEntity(
     o12 VARCHAR(255),
     o13 DATE,
     o14 UUID,
-    o15 TEXT
+    o15 TEXT,
+    o16 VARCHAR(1)
 );
 
 CREATE TABLE EncodingUUIDTestEntity(

--- a/quill-sql/src/test/sql/sqlserver-schema.sql
+++ b/quill-sql/src/test/sql/sqlserver-schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE EncodingTestEntity(
     v12 VARCHAR(255),
     v13 DATE,
     v14 VARCHAR(255),
+    v15 VARCHAR(1),
     o1 VARCHAR(255),
     o2 DECIMAL(5,2),
     o3 BIT,
@@ -52,7 +53,8 @@ CREATE TABLE EncodingTestEntity(
     o12 VARCHAR(255),
     o13 DATE,
     o14 VARCHAR(255),
-    o15 VARCHAR(255)
+    o15 VARCHAR(255),
+    o16 VARCHAR(1)
 );
 
 CREATE TABLE TestEntity(


### PR DESCRIPTION
Add `Char` encoders to all contexts except for Spark where it is not possible because we are using Spark for decoding and it does not support Chars.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
