### PR TITLE
Nest queries with infix values to allow infix-impurity

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,10 @@ lazy val `quill-core` =
       "org.scala-lang"             %  "scala-reflect" % scalaVersion.value
     ))
     .jsSettings(
-      libraryDependencies += "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
+      libraryDependencies ++= Seq(
+        "com.lihaoyi" %%% "pprint" % "0.5.4",
+        "org.scala-js" %%% "scalajs-java-time" % "0.2.5"
+      ),
       coverageExcludedPackages := ".*"
     )
 
@@ -514,6 +517,7 @@ lazy val basicSettings = Seq(
   scalaVersion := "2.11.12",
   crossScalaVersions := Seq("2.11.12","2.12.7"),
   libraryDependencies ++= Seq(
+    "com.lihaoyi"     %% "pprint"         % "0.5.4",
     "org.scalamacros" %% "resetallattrs"  % "1.0.0",
     "org.scalatest"   %%% "scalatest"     % "3.0.8"          % Test,
     "ch.qos.logback"  % "logback-classic" % "1.2.3"          % Test,

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
@@ -127,7 +127,7 @@ trait CqlIdiom extends Idiom {
   }
 
   implicit def infixTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy, queryTokenizer: Tokenizer[Query]): Tokenizer[Infix] = Tokenizer[Infix] {
-    case Infix(parts, params) =>
+    case Infix(parts, params, _) =>
       val pt = parts.map(_.token)
       val pr = params.map(_.token)
       Statement(Interleave(pt, pr))

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/ExpandMappedInfix.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/ExpandMappedInfix.scala
@@ -9,13 +9,13 @@ object ExpandMappedInfix extends StatelessTransformer {
     q match {
       case Map(q: Infix, x, p) if (x == p) =>
         q
-      case q @ Map(Infix(parts, params), x, p) =>
+      case q @ Map(Infix(parts, params, pure), x, p) =>
         params.zipWithIndex
           .collect {
             case (q: Query, i) => (q, i)
           } match {
             case List((q, i)) =>
-              Infix(parts, params.updated(i, Map(q, x, p)))
+              Infix(parts, params.updated(i, Map(q, x, p)), pure)
             case other =>
               super.apply(q)
           }

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -245,7 +245,7 @@ trait MirrorIdiomBase extends Idiom {
   }
 
   implicit def infixTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Infix] = Tokenizer[Infix] {
-    case Infix(parts, params) =>
+    case Infix(parts, params, _) =>
       def tokenParam(ast: Ast) =
         ast match {
           case ast: Ident => stmt"$$${ast.token}"

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -63,7 +63,7 @@ case class Nested(a: Ast) extends Query
 
 //************************************************************
 
-case class Infix(parts: List[String], params: List[Ast]) extends Ast
+case class Infix(parts: List[String], params: List[Ast], pure:Boolean) extends Ast
 
 case class Function(params: List[Ident], body: Ast) extends Ast
 

--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -63,7 +63,7 @@ case class Nested(a: Ast) extends Query
 
 //************************************************************
 
-case class Infix(parts: List[String], params: List[Ast], pure:Boolean) extends Ast
+case class Infix(parts: List[String], params: List[Ast], pure: Boolean) extends Ast
 
 case class Function(params: List[Ident], body: Ast) extends Ast
 

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -23,9 +23,9 @@ trait StatefulTransformer[T] {
         val (bt, btt) = apply(b)
         (Function(a, bt), btt)
 
-      case Infix(a, b) =>
+      case Infix(a, b, pure) =>
         val (bt, btt) = apply(b)(_.apply)
-        (Infix(a, bt), btt)
+        (Infix(a, bt, pure), btt)
 
       case If(a, b, c) =>
         val (at, att) = apply(a)

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -13,7 +13,7 @@ trait StatelessTransformer {
       case e: Ident                => e
       case e: ExternalIdent        => e
       case e: Property             => apply(e)
-      case Infix(a, b)             => Infix(a, b.map(apply))
+      case Infix(a, b, pure)       => Infix(a, b.map(apply), pure)
       case e: OptionOperation      => apply(e)
       case e: TraversableOperation => apply(e)
       case If(a, b, c)             => If(apply(a), apply(b), apply(c))

--- a/quill-core/src/main/scala/io/getquill/dsl/InfixDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/InfixDsl.scala
@@ -7,6 +7,7 @@ private[dsl] trait InfixDsl {
 
   private[dsl] trait InfixValue {
     def as[T]: T
+    def pure: InfixValue
   }
 
   implicit class InfixInterpolator(val sc: StringContext) {

--- a/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/FlattenOptionOperation.scala
@@ -20,7 +20,7 @@ class FlattenOptionOperation(concatBehavior: ConcatBehavior) extends StatelessTr
   def containsNonFallthroughElement(ast: Ast) =
     CollectAst(ast) {
       case If(_, _, _) => true
-      case Infix(_, _) => true
+      case Infix(_, _, _) => true
       case BinaryOperation(_, StringOperator.`+`, _) if (concatBehavior == NonAnsiConcat) => true
     }.nonEmpty
 

--- a/quill-core/src/main/scala/io/getquill/norm/NestImpureMappedInfix.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/NestImpureMappedInfix.scala
@@ -1,0 +1,58 @@
+package io.getquill.norm
+
+import io.getquill.ast._
+
+/**
+ * A problem occurred in the original way infixes were done in that it was assumed that infix
+ * clauses represented pure functions. While this is true of many UDFs (e.g. `CONCAT`, `GETDATE`)
+ * it is certainly not true of many others e.g. `RAND()`, and most importantly `RANK()`. For this reason,
+ * the operations that are done in `ApplyMap` on standard AST `Map` clauses cannot be done therefore additional
+ * safety checks were introduced there in order to assure this does not happen. In addition to this however,
+ * it is necessary to add this normalization step which inserts `Nested` AST elements in every map
+ * that contains impure infix. See more information and examples in #1534.
+ */
+object NestImpureMappedInfix extends StatelessTransformer {
+
+  // Are there any impure infixes that exist inside the specified ASTs
+  def hasInfix(asts: Ast*): Boolean =
+    asts.exists(ast => CollectAst(ast) {
+      case i @ Infix(_, _, false) => i
+    }.nonEmpty)
+
+  // Continue exploring into the Map to see if there are additional impure infix clauses inside.
+  private def applyInside(m: Map) =
+    Map(apply(m.query), m.alias, m.body)
+
+  override def apply(ast: Ast): Ast =
+    ast match {
+      // If there is already a nested clause inside the map, there is no reason to insert another one
+      case Nested(Map(inner, a, b)) =>
+        Nested(Map(apply(inner), a, b))
+
+      case m @ Map(_, x, cc @ CaseClass(values)) if hasInfix(cc) => //Nested(m)
+        Map(Nested(applyInside(m)), x,
+          CaseClass(values.map {
+            case (str, _) => (str, Property(x, str))
+          }))
+
+      case m @ Map(_, x, tup @ Tuple(values)) if hasInfix(tup) =>
+        Map(Nested(applyInside(m)), x,
+          Tuple(values.zipWithIndex.map {
+            case (_, i) => Property(x, s"_${i + 1}")
+          }))
+
+      case m @ Map(_, x, i @ Infix(_, _, false)) =>
+        Map(Nested(applyInside(m)), x, Property(x, "_1"))
+
+      case m @ Map(_, x, Property(prop, _)) if hasInfix(prop) =>
+        Map(Nested(applyInside(m)), x, Property(x, "_1"))
+
+      case m @ Map(_, x, BinaryOperation(a, _, b)) if hasInfix(a, b) =>
+        Map(Nested(applyInside(m)), x, Property(x, "_1"))
+
+      case m @ Map(_, x, UnaryOperation(_, a)) if hasInfix(a) =>
+        Map(Nested(applyInside(m)), x, Property(x, "_1"))
+
+      case other => super.apply(other)
+    }
+}

--- a/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -116,7 +116,7 @@ object RenameProperties extends StatelessTransformer {
       case Map(q: Operation, x, p) if x == p =>
         (Map(apply(q), x, p), Tuple(List.empty))
 
-      case Map(Infix(parts, params), x, p) =>
+      case Map(Infix(parts, params, pure), x, p) =>
 
         val transformed =
           params.map {
@@ -138,7 +138,7 @@ object RenameProperties extends StatelessTransformer {
         val pr = BetaReduction(p, replace: _*)
         val prr = apply(pr)
 
-        (Map(Infix(parts, transformed.map(_._1)), x, prr), schema)
+        (Map(Infix(parts, transformed.map(_._1), pure), x, prr), schema)
 
       case q =>
         (q, Tuple(List.empty))

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -29,7 +29,7 @@ trait Liftables {
     case FunctionApply(a, b) => q"$pack.FunctionApply($a, $b)"
     case BinaryOperation(a, b, c) => q"$pack.BinaryOperation($a, $b, $c)"
     case UnaryOperation(a, b) => q"$pack.UnaryOperation($a, $b)"
-    case Infix(a, b) => q"$pack.Infix($a, $b)"
+    case Infix(a, b, pure) => q"$pack.Infix($a, $b, $pure)"
     case If(a, b, c) => q"$pack.If($a, $b, $c)"
     case Dynamic(tree: Tree) if (tree.tpe <:< c.weakTypeOf[CoreDsl#Quoted[Any]]) => q"$tree.ast"
     case Dynamic(tree: Tree) => q"$pack.Constant($tree)"

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -24,7 +24,7 @@ trait Unliftables {
     case q"$pack.BinaryOperation.apply(${ a: Ast }, ${ b: BinaryOperator }, ${ c: Ast })" => BinaryOperation(a, b, c)
     case q"$pack.UnaryOperation.apply(${ a: UnaryOperator }, ${ b: Ast })" => UnaryOperation(a, b)
     case q"$pack.Aggregation.apply(${ a: AggregationOperator }, ${ b: Ast })" => Aggregation(a, b)
-    case q"$pack.Infix.apply(${ a: List[String] }, ${ b: List[Ast] })" => Infix(a, b)
+    case q"$pack.Infix.apply(${ a: List[String] }, ${ b: List[Ast] }, ${ pure: Boolean })" => Infix(a, b, pure)
     case q"$pack.If.apply(${ a: Ast }, ${ b: Ast }, ${ c: Ast })" => If(a, b, c)
     case q"$pack.OnConflict.Excluded.apply(${ a: Ident })" => OnConflict.Excluded(a)
     case q"$pack.OnConflict.Existing.apply(${ a: Ident })" => OnConflict.Existing(a)

--- a/quill-core/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core/src/main/scala/io/getquill/util/Messages.scala
@@ -10,16 +10,18 @@ object Messages {
   }
 
   private val traceEnabled = false
+  private val traceColors = false
 
   def fail(msg: String) =
     throw new IllegalStateException(msg)
 
   def trace[T](label: String) =
-    (v: T) => {
-      if (traceEnabled)
-        println(s"$label:\n 		$v")
-      v
-    }
+    (v: T) =>
+      {
+        if (traceEnabled)
+          println(s"$label${{ if (traceColors) pprint.apply(v, height = Integer.MAX_VALUE).render else pprint.apply(v, height = Integer.MAX_VALUE).plainText }.split("\n").map("    " + _).mkString("\n")}")
+        v
+      }
 
   implicit class RichContext(c: MacroContext) {
 

--- a/quill-core/src/test/scala/io/getquill/OpsSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/OpsSpec.scala
@@ -48,13 +48,13 @@ class OpsSpec extends Spec {
       val q = quote {
         infix"true".as[Boolean]
       }
-      q.ast mustEqual Infix(List("true"), Nil)
+      q.ast mustEqual Infix(List("true"), Nil, false)
     }
     "without `as`" in {
       val q = quote {
         infix"true"
       }
-      q.ast mustEqual Infix(List("true"), Nil)
+      q.ast mustEqual Infix(List("true"), Nil, false)
     }
   }
 

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -319,10 +319,19 @@ class StatefulTransformerSpec extends Spec {
     }
 
     "infix" in {
-      val ast: Ast = Infix(List("test"), List(Ident("a")))
+      val ast: Ast = Infix(List("test"), List(Ident("a")), false)
       Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {
         case (at, att) =>
-          at mustEqual Infix(List("test"), List(Ident("a'")))
+          at mustEqual Infix(List("test"), List(Ident("a'")), false)
+          att.state mustEqual List(Ident("a"))
+      }
+    }
+
+    "infix - pure" in {
+      val ast: Ast = Infix(List("test"), List(Ident("a")), true)
+      Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {
+        case (at, att) =>
+          at mustEqual Infix(List("test"), List(Ident("a'")), true)
           att.state mustEqual List(Ident("a"))
       }
     }

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -208,9 +208,15 @@ class StatelessTransformerSpec extends Spec {
     }
 
     "infix" in {
-      val ast: Ast = Infix(List("test"), List(Ident("a"), Ident("b")))
+      val ast: Ast = Infix(List("test"), List(Ident("a"), Ident("b")), false)
       Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) mustEqual
-        Infix(List("test"), List(Ident("a'"), Ident("b'")))
+        Infix(List("test"), List(Ident("a'"), Ident("b'")), false)
+    }
+
+    "infix - pure" in {
+      val ast: Ast = Infix(List("test"), List(Ident("a"), Ident("b")), true)
+      Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"))(ast) mustEqual
+        Infix(List("test"), List(Ident("a'"), Ident("b'")), true)
     }
 
     "option operation" - {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -1109,30 +1109,30 @@ class QuotationSpec extends Spec {
         val q = quote {
           infix"true"
         }
-        quote(unquote(q)).ast mustEqual Infix(List("true"), Nil)
+        quote(unquote(q)).ast mustEqual Infix(List("true"), Nil, false)
       }
       "with `as`" in {
         val q = quote {
           infix"true".as[Boolean]
         }
-        quote(unquote(q)).ast mustEqual Infix(List("true"), Nil)
+        quote(unquote(q)).ast mustEqual Infix(List("true"), Nil, false)
       }
       "with params" in {
         val q = quote {
           (a: String, b: String) =>
             infix"$a || $b".as[String]
         }
-        quote(unquote(q)).ast.body mustEqual Infix(List("", " || ", ""), List(Ident("a"), Ident("b")))
+        quote(unquote(q)).ast.body mustEqual Infix(List("", " || ", ""), List(Ident("a"), Ident("b")), false)
       }
       "with dynamic string" - {
         "at the end" in {
           val b = "dyn"
           val q = quote {
             (a: String) =>
-              infix"$a || #$b".as[String]
+              infix"$a || #$b".pure.as[String]
           }
           quote(unquote(q)).ast must matchPattern {
-            case Function(_, Infix(List("", " || dyn"), List(Ident("a")))) =>
+            case Function(_, Infix(List("", " || dyn"), List(Ident("a")), false)) =>
           }
         }
         "at the beginning" in {
@@ -1142,7 +1142,7 @@ class QuotationSpec extends Spec {
               infix"#$a || $b".as[String]
           }
           quote(unquote(q)).ast must matchPattern {
-            case Function(_, Infix(List("dyn || ", ""), List(Ident("b")))) =>
+            case Function(_, Infix(List("dyn || ", ""), List(Ident("b")), false)) =>
           }
         }
         "only" in {
@@ -1150,7 +1150,7 @@ class QuotationSpec extends Spec {
           val q = quote {
             infix"#$a".as[String]
           }
-          quote(unquote(q)).ast mustEqual Infix(List("dyn1"), List())
+          quote(unquote(q)).ast mustEqual Infix(List("dyn1"), List(), false)
         }
         "sequential" in {
           val a = "dyn1"
@@ -1158,7 +1158,7 @@ class QuotationSpec extends Spec {
           val q = quote {
             infix"#$a#$b".as[String]
           }
-          quote(unquote(q)).ast mustEqual Infix(List("dyn1dyn2"), List())
+          quote(unquote(q)).ast mustEqual Infix(List("dyn1dyn2"), List(), false)
         }
         "non-string value" in {
           case class Value(a: String)
@@ -1166,7 +1166,7 @@ class QuotationSpec extends Spec {
           val q = quote {
             infix"#$a".as[String]
           }
-          quote(unquote(q)).ast mustEqual Infix(List("Value(dyn)"), List())
+          quote(unquote(q)).ast mustEqual Infix(List("Value(dyn)"), List(), false)
         }
       }
     }

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -1125,14 +1125,34 @@ class QuotationSpec extends Spec {
         quote(unquote(q)).ast.body mustEqual Infix(List("", " || ", ""), List(Ident("a"), Ident("b")), false)
       }
       "with dynamic string" - {
-        "at the end" in {
+        "at the end - pure" in {
           val b = "dyn"
           val q = quote {
             (a: String) =>
               infix"$a || #$b".pure.as[String]
           }
           quote(unquote(q)).ast must matchPattern {
+            case Function(_, Infix(List("", " || dyn"), List(Ident("a")), true)) =>
+          }
+        }
+        "at the end" in {
+          val b = "dyn"
+          val q = quote {
+            (a: String) =>
+              infix"$a || #$b".as[String]
+          }
+          quote(unquote(q)).ast must matchPattern {
             case Function(_, Infix(List("", " || dyn"), List(Ident("a")), false)) =>
+          }
+        }
+        "at the beginning - pure" in {
+          val a = "dyn"
+          val q = quote {
+            (b: String) =>
+              infix"#$a || $b".pure.as[String]
+          }
+          quote(unquote(q)).ast must matchPattern {
+            case Function(_, Infix(List("dyn || ", ""), List(Ident("b")), true)) =>
           }
         }
         "at the beginning" in {
@@ -1151,6 +1171,14 @@ class QuotationSpec extends Spec {
             infix"#$a".as[String]
           }
           quote(unquote(q)).ast mustEqual Infix(List("dyn1"), List(), false)
+        }
+        "sequential - pure" in {
+          val a = "dyn1"
+          val b = "dyn2"
+          val q = quote {
+            infix"#$a#$b".pure.as[String]
+          }
+          quote(unquote(q)).ast mustEqual Infix(List("dyn1dyn2"), List(), true)
         }
         "sequential" in {
           val a = "dyn1"

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
@@ -248,7 +248,7 @@ trait OrientDBIdiom extends Idiom {
   }
 
   implicit def infixTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy): Tokenizer[Infix] = Tokenizer[Infix] {
-    case Infix(parts, params) =>
+    case Infix(parts, params, _) =>
       val pt = parts.map(_.token)
       val pr = params.map(_.token)
       Statement(Interleave(pt, pr))

--- a/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
+++ b/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
@@ -45,7 +45,7 @@ trait QuillSparkContext
 
   def liftQuery[T](ds: Dataset[T]) =
     quote {
-      infix"${lift(ds)}".as[Query[T]]
+      infix"${lift(ds)}".pure.as[Query[T]]
     }
 
   // Helper class for the perculateNullArrays method

--- a/quill-spark/src/main/scala/io/getquill/context/spark/norm/EscapeQuestionMarks.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/norm/EscapeQuestionMarks.scala
@@ -9,8 +9,8 @@ object EscapeQuestionMarks extends StatelessTransformer {
     ast match {
       case Constant(value) =>
         Constant(if (value.isInstanceOf[String]) escape(value.asInstanceOf[String]) else value)
-      case Infix(parts, params) =>
-        Infix(parts.map(escape(_)), params)
+      case Infix(parts, params, pure) =>
+        Infix(parts.map(escape(_)), params, pure)
       case other =>
         super.apply(other)
     }

--- a/quill-spark/src/test/scala/io/getquill/context/spark/DepartmentsSparkSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/DepartmentsSparkSpec.scala
@@ -47,26 +47,26 @@ class DepartmentsSparkSpec extends Spec {
     ).toDS
   }
 
-  "Example 8 - nested naive" in {
-    val q = quote {
-      (u: String) =>
-        for {
-          d <- departments if (
-            (for {
-              e <- employees if (
-                e.dpt == d.dpt && (
-                  for {
-                    t <- tasks if (e.emp == t.emp && t.tsk == u)
-                  } yield {}
-                ).isEmpty
-              )
-            } yield {}).isEmpty
-          )
-        } yield d.dpt
-    }
-    testContext.run(q("abstract")).collect().toList mustEqual
-      List("Quality", "Research")
-  }
+//  "Example 8 - nested naive" in {
+//    val q = quote {
+//      (u: String) =>
+//        for {
+//          d <- departments if (
+//            (for {
+//              e <- employees if (
+//                e.dpt == d.dpt && (
+//                  for {
+//                    t <- tasks if (e.emp == t.emp && t.tsk == u)
+//                  } yield {}
+//                ).isEmpty
+//              )
+//            } yield {}).isEmpty
+//          )
+//        } yield d.dpt
+//    }
+//    testContext.run(q("abstract")).collect().toList mustEqual
+//      List("Quality", "Research")
+//  }
 
   "Example 9 - nested db" in {
     val q = {

--- a/quill-spark/src/test/scala/io/getquill/context/spark/DepartmentsSparkSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/DepartmentsSparkSpec.scala
@@ -47,26 +47,26 @@ class DepartmentsSparkSpec extends Spec {
     ).toDS
   }
 
-//  "Example 8 - nested naive" in {
-//    val q = quote {
-//      (u: String) =>
-//        for {
-//          d <- departments if (
-//            (for {
-//              e <- employees if (
-//                e.dpt == d.dpt && (
-//                  for {
-//                    t <- tasks if (e.emp == t.emp && t.tsk == u)
-//                  } yield {}
-//                ).isEmpty
-//              )
-//            } yield {}).isEmpty
-//          )
-//        } yield d.dpt
-//    }
-//    testContext.run(q("abstract")).collect().toList mustEqual
-//      List("Quality", "Research")
-//  }
+  "Example 8 - nested naive" in {
+    val q = quote {
+      (u: String) =>
+        for {
+          d <- departments if (
+            (for {
+              e <- employees if (
+                e.dpt == d.dpt && (
+                  for {
+                    t <- tasks if (e.emp == t.emp && t.tsk == u)
+                  } yield {}
+                ).isEmpty
+              )
+            } yield {}).isEmpty
+          )
+        } yield d.dpt
+    }
+    testContext.run(q("abstract")).collect().toList mustEqual
+      List("Quality", "Research")
+  }
 
   "Example 9 - nested db" in {
     val q = {

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -354,7 +354,7 @@ trait SqlIdiom extends Idiom {
   }
 
   implicit def infixTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Infix] = Tokenizer[Infix] {
-    case Infix(parts, params) =>
+    case Infix(parts, params, _) =>
       val pt = parts.map(_.token)
       val pr = params.map(_.token)
       Statement(Interleave(pt, pr))

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandMappedInfix.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandMappedInfix.scala
@@ -5,8 +5,8 @@ import io.getquill.ast._
 object ExpandMappedInfix {
   def apply(q: Ast): Ast = {
     Transform(q) {
-      case Map(Infix("" :: parts, (q: Query) :: params), x, p) =>
-        Infix("" :: parts, Map(q, x, p) :: params)
+      case Map(Infix("" :: parts, (q: Query) :: params, pure), x, p) =>
+        Infix("" :: parts, Map(q, x, p) :: params, pure)
     }
   }
 }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/SqlNormalize.scala
@@ -29,6 +29,8 @@ class SqlNormalize(concatBehavior: ConcatBehavior, equalityBehavior: EqualityBeh
       .andThen(trace("RenameProperties"))
       .andThen(ExpandDistinct.apply _)
       .andThen(trace("ExpandDistinct"))
+      .andThen(NestImpureMappedInfix.apply _)
+      .andThen(trace("NestMappedInfix"))
       .andThen(Normalize.apply _)
       .andThen(trace("Normalize"))
       .andThen(ExpandJoin.apply _)

--- a/quill-sql/src/test/scala/io/getquill/context/sql/InfixSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/InfixSpec.scala
@@ -1,0 +1,93 @@
+package io.getquill.context
+
+import io.getquill.SqlMirrorContext
+import io.getquill.MirrorSqlDialect
+import io.getquill.TestEntities
+import io.getquill.Literal
+import io.getquill.Spec
+
+class InfixSpec extends Spec {
+
+  "queries with infix should" - {
+
+    val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal) with TestEntities
+    import ctx._
+
+    case class Data(id: Int)
+    case class TwoValue(id: Int, value: Int)
+
+    "preserve nesting where needed" in {
+      val q = quote {
+        query[Data].map(e => TwoValue(e.id, infix"RAND()".as[Int])).filter(r => r.value > 10)
+      }
+      ctx.run(q).string mustEqual "SELECT e.id, e.value FROM (SELECT RAND() AS value, e.id AS id FROM Data e) AS e WHERE e.value > 10"
+    }
+
+    "collapse nesting where not needed" in {
+      val q = quote {
+        query[Data].map(e => TwoValue(e.id, infix"SOMETHINGPURE()".pure.as[Int])).filter(r => r.value > 10)
+      }
+      ctx.run(q).string mustEqual "SELECT e.id, SOMETHINGPURE() FROM Data e WHERE SOMETHINGPURE() > 10"
+    }
+
+    "preserve nesting with single value" in {
+      val q = quote {
+        query[Data].map(e => infix"RAND()".as[Int]).filter(r => r > 10).map(r => r + 1)
+      }
+      ctx.run(q).string mustEqual "SELECT e._1 + 1 FROM (SELECT RAND() AS _1 FROM Data e) AS e WHERE e._1 > 10"
+    }
+
+    "do not double-nest" in {
+      val q = quote {
+        query[Data].map(e => TwoValue(e.id, infix"RAND()".as[Int])).nested.filter(r => r.value > 10).map(r => (r.id, r.value + 1))
+      }
+      ctx.run(q).string mustEqual "SELECT r.id, r.value + 1 FROM (SELECT RAND() AS value, e.id AS id FROM Data e) AS r WHERE r.value > 10"
+    }
+
+    "preserve nesting with single value binary op" in {
+      val q = quote {
+        query[Data].map(e => infix"RAND()".as[Int] + 1).filter(r => r > 10).map(r => r + 1)
+      }
+      ctx.run(q).string mustEqual "SELECT e._1 + 1 FROM (SELECT RAND() + 1 AS _1 FROM Data e) AS e WHERE e._1 > 10"
+    }
+
+    "preserve nesting with single value unary op" in {
+      val q = quote {
+        query[Data].map(e => !infix"RAND()".as[Boolean]).filter(r => r == true).map(r => !r)
+      }
+      ctx.run(q).string mustEqual "SELECT NOT (e._1) FROM (SELECT NOT (RAND()) AS _1 FROM Data e) AS e WHERE e._1 = true"
+    }
+
+    "preserve triple nesting with filter in between" in {
+      val q = quote {
+        query[Data].map(e => TwoValue(e.id, infix"RAND()".as[Int])).filter(r => r.value > 10).map(r => TwoValue(r.id, r.value + 1))
+      }
+      ctx.run(q).string mustEqual "SELECT e.id, e.value + 1 FROM (SELECT RAND() AS value, e.id AS id FROM Data e) AS e WHERE e.value > 10"
+    }
+
+    "preserve triple nesting with filter in between plus second filter" in {
+      val q = quote {
+        query[Data].map(e => TwoValue(e.id, infix"RAND()".as[Int])).filter(r => r.value > 10).map(r => TwoValue(r.id, r.value + 1)).filter(_.value > 111)
+      }
+      ctx.run(q).string mustEqual "SELECT e.id, e.value + 1 FROM (SELECT RAND() AS value, e.id AS id FROM Data e) AS e WHERE e.value > 10 AND (e.value + 1) > 111"
+    }
+
+    "preserve nesting of query in query" in {
+      case class ThreeData(id: Int, value: Int, secondValue: Int)
+
+      val q1 = quote {
+        for {
+          d <- query[Data]
+        } yield TwoValue(d.id, infix"foo".as[Int])
+      }
+
+      val q2 = quote {
+        for {
+          r <- q1 if (r.value == 1)
+        } yield ThreeData(r.id, r.value, infix"bar".as[Int])
+      }
+
+      ctx.run(q2).string mustEqual "SELECT d._1, d._2, d._3 FROM (SELECT d.id AS _1, d.value AS _2, bar AS _3 FROM (SELECT foo AS value, d.id AS id FROM Data d) AS d WHERE d.value = 1) AS d"
+    }
+  }
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -1062,12 +1062,19 @@ class SqlIdiomSpec extends Spec {
       }
     }
     "infix" - {
+      "part of the query - pure" in {
+        val q = quote {
+          qr1.map(t => infix"CONCAT(${t.s}, ${t.s})".pure.as[String])
+        }
+        testContext.run(q).string mustEqual
+          "SELECT CONCAT(t.s, t.s) FROM TestEntity t"
+      }
       "part of the query" in {
         val q = quote {
           qr1.map(t => infix"CONCAT(${t.s}, ${t.s})".as[String])
         }
         testContext.run(q).string mustEqual
-          "SELECT CONCAT(t.s, t.s) FROM TestEntity t"
+          "SELECT t._1 FROM (SELECT CONCAT(t.s, t.s) AS _1 FROM TestEntity t) AS t"
       }
       "source query" in {
         case class Entity(i: Int)


### PR DESCRIPTION
Fixes #1533 

Let's take a query that uses a infix (that is not supposed to be a pure function):
```scala
val q = quote {
  query[Data].map(d => TwoData(d.id, infix"RAND()".as[Int])).filter(d => d.value == 2).map(d => TwoData(d.id, d.value))
}
```

The problem infix-duplication occurs in `ApplyMap` where the AST turns from this:
```scala
Map(
  Map(
    Filter(
      Map(
        Entity("Data", List()),
        Ident("d"),
        CaseClass(
          List(("id", Property(Ident("d"), "id")), ("value", Infix(List("RAND()"), List())))
        )
      ),
      Ident("d"),
      BinaryOperation(Property(Ident("d"), "value"), ==, Constant(2))
    ),
    Ident("d"),
    CaseClass(List(("id", Property(Ident("d"), "id")), ("value", Property(Ident("d"), "value"))))
  ),
  Ident("x"),
  Tuple(List(Property(Ident("x"), "id"), Property(Ident("x"), "value")))
)
```
Into this:
```scala
Map(
  Filter(
    Entity("Data", List()),
    Ident("d"),
    BinaryOperation(Infix(List("RAND()"), List()), ==, Constant(2))
  ),
  Ident("d"),
  Tuple(List(Property(Ident("d"), "id"), Infix(List("RAND()"), List())))
)
```

Even if you fix that however, you still something like this:
```scala
Map(
  Filter(
    Map(
      Entity("Data", List()),
      Ident("d"),
      CaseClass(List(("id", Property(Ident("d"), "id")), ("value", Infix(List("RAND()"), List()))))
    ),
    Ident("d"),
    BinaryOperation(Property(Ident("d"), "value"), ==, Constant(1))
  ),
  Ident("d"),
  Tuple(List(Property(Ident("d"), "id"), Property(Ident("d"), "value")))
)
```
Which turns into this:
```sql
SELECT d.id, d.value FROM Data d WHERE d.value = 1
```
So, some additional steps need to be taken to actually create a `Nested` object outside the inner map. Therefore NestMappedInfix needs to be introduced.

Also, some infixes definitely are pure functions and should be normalized as such. For example, the infixes used as dataframes in quill-spark which actually rely on this behavior. I added the `infix"...".pure` for this reason.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
