### PR TITLE
Monix JDBC scheduling fixes

### DIFF
--- a/quill-monix/src/main/scala/io/getquill/context/monix/Runner.scala
+++ b/quill-monix/src/main/scala/io/getquill/context/monix/Runner.scala
@@ -2,12 +2,14 @@ package io.getquill.context.monix
 import io.getquill.context.ContextEffect
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.reactive.Observable
 
 object Runner {
   def default = new Runner {}
   def using(scheduler: Scheduler) = new Runner {
     override def schedule[T](t: Task[T]): Task[T] = t.executeOn(scheduler, true)
     override def boundary[T](t: Task[T]): Task[T] = t.executeOn(scheduler, true)
+    override def scheduleObservable[T](o: Observable[T]): Observable[T] = o.executeOn(scheduler, true)
   }
 }
 
@@ -16,6 +18,7 @@ trait Runner extends ContextEffect[Task] {
   override def push[A, B](result: Task[A])(f: A => B): Task[B] = result.map(f)
   override def seq[A, B](list: List[Task[A]]): Task[List[A]] = Task.sequence(list)
   def schedule[T](t: Task[T]): Task[T] = t
+  def scheduleObservable[T](o: Observable[T]): Observable[T] = o
   def boundary[T](t: Task[T]): Task[T] = t.asyncBoundary
 
   /**


### PR DESCRIPTION
### Problem
* duplicate scheduling in transaction
* streaming doesn't use different thread context for fetching
@getquill/maintainers