### PR TITLE
Enhanced printing of elements with opinions

### DIFF
--- a/quill-core/src/main/scala/io/getquill/AstPrinter.scala
+++ b/quill-core/src/main/scala/io/getquill/AstPrinter.scala
@@ -1,0 +1,39 @@
+package io.getquill
+
+import io.getquill.ast.Renameable.{ ByStrategy, Fixed }
+import io.getquill.ast.{ Entity, Property, Renameable }
+import pprint.{ Renderer, Tree, Truncated }
+
+class AstPrinter(traceOpinions: Boolean) extends pprint.Walker {
+  val defaultWidth: Int = 150
+  val defaultHeight: Int = Integer.MAX_VALUE
+  val defaultIndent: Int = 2
+  val colorLiteral: fansi.Attrs = fansi.Color.Green
+  val colorApplyPrefix: fansi.Attrs = fansi.Color.Yellow
+
+  private def printRenameable(r: Renameable) =
+    r match {
+      case ByStrategy => Tree.Literal("S")
+      case Fixed      => Tree.Literal("F")
+    }
+
+  override def additionalHandlers: PartialFunction[Any, Tree] = {
+    case p: Property if (traceOpinions) =>
+      Tree.Apply("Property", List[Tree](treeify(p.ast), treeify(p.name), printRenameable(p.renameable)).iterator)
+
+    case e: Entity if (traceOpinions) =>
+      Tree.Apply("Property", List[Tree](treeify(e.name), treeify(e.properties), printRenameable(e.renameable)).iterator)
+  }
+
+  def apply(x: Any): fansi.Str = {
+    fansi.Str.join(this.tokenize(x).toSeq: _*)
+  }
+
+  def tokenize(x: Any): Iterator[fansi.Str] = {
+    val tree = this.treeify(x)
+    val renderer = new Renderer(defaultWidth, colorApplyPrefix, colorLiteral, defaultIndent)
+    val rendered = renderer.rec(tree, 0, 0).iter
+    val truncated = new Truncated(rendered, defaultWidth, defaultHeight)
+    truncated
+  }
+}

--- a/quill-core/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core/src/main/scala/io/getquill/util/Messages.scala
@@ -1,5 +1,7 @@
 package io.getquill.util
 
+import io.getquill.AstPrinter
+
 import scala.reflect.macros.blackbox.{ Context => MacroContext }
 
 object Messages {
@@ -11,6 +13,9 @@ object Messages {
 
   private val traceEnabled = false
   private val traceColors = false
+  private val traceOpinions = false
+
+  val qprint = new AstPrinter(traceOpinions)
 
   def fail(msg: String) =
     throw new IllegalStateException(msg)
@@ -19,7 +24,7 @@ object Messages {
     (v: T) =>
       {
         if (traceEnabled)
-          println(s"$label${{ if (traceColors) pprint.apply(v, height = Integer.MAX_VALUE).render else pprint.apply(v, height = Integer.MAX_VALUE).plainText }.split("\n").map("    " + _).mkString("\n")}")
+          println(s"$label\n${{ if (traceColors) qprint.apply(v).render else qprint.apply(v).plainText }.split("\n").map("    " + _).mkString("\n")}")
         v
       }
 


### PR DESCRIPTION
Allow configuration to print AST elements with opinions or without them.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
