### PR TITLE
Revert "Fix 'finangle' typo."

### DIFF
--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlDecoders.scala
@@ -12,21 +12,21 @@ import scala.reflect.{ ClassTag, classTag }
 trait FinagleMysqlDecoders {
   this: FinagleMysqlContext[_] =>
 
-  type Decoder[T] = FinagleMysqlDecoder[T]
+  type Decoder[T] = FinangleMysqlDecoder[T]
 
-  case class FinagleMysqlDecoder[T](decoder: BaseDecoder[T]) extends BaseDecoder[T] {
+  case class FinangleMysqlDecoder[T](decoder: BaseDecoder[T]) extends BaseDecoder[T] {
     override def apply(index: Index, row: ResultRow) =
       decoder(index, row)
   }
 
   def decoder[T: ClassTag](f: PartialFunction[Value, T]): Decoder[T] =
-    FinagleMysqlDecoder((index, row) => {
+    FinangleMysqlDecoder((index, row) => {
       val value = row.values(index)
       f.lift(value).getOrElse(fail(s"Value '$value' can't be decoded to '${classTag[T].runtimeClass}'"))
     })
 
   implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] =
-    FinagleMysqlDecoder((index, row) => {
+    FinangleMysqlDecoder((index, row) => {
       row.values(index) match {
         case NullValue => None
         case _         => Some(d.decoder(index, row))
@@ -34,7 +34,7 @@ trait FinagleMysqlDecoders {
     })
 
   implicit def mappedDecoder[I, O](implicit mapped: MappedEncoding[I, O], d: Decoder[I]): Decoder[O] =
-    FinagleMysqlDecoder(mappedBaseDecoder(mapped, d.decoder))
+    FinangleMysqlDecoder(mappedBaseDecoder(mapped, d.decoder))
 
   implicit val stringDecoder: Decoder[String] =
     decoder[String] {

--- a/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/context/finagle/mysql/FinagleMysqlEncoders.scala
@@ -12,15 +12,15 @@ import io.getquill.FinagleMysqlContext
 trait FinagleMysqlEncoders {
   this: FinagleMysqlContext[_] =>
 
-  type Encoder[T] = FinagleMySqlEncoder[T]
+  type Encoder[T] = FinangleMySqlEncoder[T]
 
-  case class FinagleMySqlEncoder[T](encoder: BaseEncoder[T]) extends BaseEncoder[T] {
+  case class FinangleMySqlEncoder[T](encoder: BaseEncoder[T]) extends BaseEncoder[T] {
     override def apply(index: Index, value: T, row: PrepareRow) =
       encoder(index, value, row)
   }
 
   def encoder[T](f: T => Parameter): Encoder[T] =
-    FinagleMySqlEncoder((index, value, row) => row :+ f(value))
+    FinangleMySqlEncoder((index, value, row) => row :+ f(value))
 
   def encoder[T](implicit cbp: CanBeParameter[T]): Encoder[T] =
     encoder[T]((v: T) => v: Parameter)
@@ -28,7 +28,7 @@ trait FinagleMysqlEncoders {
   private[this] val nullEncoder = encoder((_: Null) => Parameter.NullParameter)
 
   implicit def optionEncoder[T](implicit e: Encoder[T]): Encoder[Option[T]] =
-    FinagleMySqlEncoder { (index, value, row) =>
+    FinangleMySqlEncoder { (index, value, row) =>
       value match {
         case None    => nullEncoder.encoder(index, null, row)
         case Some(v) => e.encoder(index, v, row)
@@ -36,7 +36,7 @@ trait FinagleMysqlEncoders {
     }
 
   implicit def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], e: Encoder[O]): Encoder[I] =
-    FinagleMySqlEncoder(mappedBaseEncoder(mapped, e.encoder))
+    FinangleMySqlEncoder(mappedBaseEncoder(mapped, e.encoder))
 
   implicit val stringEncoder: Encoder[String] = encoder[String]
   implicit val bigDecimalEncoder: Encoder[BigDecimal] =

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
@@ -14,15 +14,15 @@ trait FinaglePostgresDecoders {
 
   import ValueDecoder._
 
-  type Decoder[T] = FinaglePostgresDecoder[T]
+  type Decoder[T] = FinanglePostgresDecoder[T]
 
-  case class FinaglePostgresDecoder[T](decoder: BaseDecoder[T]) extends BaseDecoder[T] {
+  case class FinanglePostgresDecoder[T](decoder: BaseDecoder[T]) extends BaseDecoder[T] {
     override def apply(index: Index, row: ResultRow): T =
       decoder(index, row)
   }
 
   def decoder[T: ClassTag](f: PartialFunction[Any, T]): Decoder[T] =
-    FinaglePostgresDecoder((index, row) => {
+    FinanglePostgresDecoder((index, row) => {
       row.getAnyOption(index) match {
         case Some(v: T)                  => v
         case Some(v) if f.isDefinedAt(v) => f(v)
@@ -31,19 +31,19 @@ trait FinaglePostgresDecoders {
     })
 
   implicit def decoderDirectly[T: ClassTag](implicit vd: ValueDecoder[T]): Decoder[T] =
-    FinaglePostgresDecoder((index, row) =>
+    FinanglePostgresDecoder((index, row) =>
       row.get[T](index) match {
         case v: T => v
         case v    => fail(s"Cannot decode value $v at index $index to ${classTag[T]}")
       })
 
   implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] =
-    FinaglePostgresDecoder((index, row) => {
+    FinanglePostgresDecoder((index, row) => {
       row.getAnyOption(index).map(_ => d.decoder(index, row))
     })
 
   implicit def mappedDecoder[I, O](implicit mapped: MappedEncoding[I, O], d: Decoder[I]): Decoder[O] =
-    FinaglePostgresDecoder(mappedBaseDecoder(mapped, d.decoder))
+    FinanglePostgresDecoder(mappedBaseDecoder(mapped, d.decoder))
 
   implicit val stringDecoder: Decoder[String] = decoderDirectly[String]
   implicit val bigDecimalDecoder: Decoder[BigDecimal] = decoderDirectly[BigDecimal]

--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncoders.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresEncoders.scala
@@ -10,23 +10,23 @@ import java.time._
 trait FinaglePostgresEncoders {
   this: FinaglePostgresContext[_] =>
 
-  type Encoder[T] = FinaglePostgresEncoder[T]
+  type Encoder[T] = FinanglePostgresEncoder[T]
 
-  case class FinaglePostgresEncoder[T](encoder: ValueEncoder[T]) extends BaseEncoder[T] {
+  case class FinanglePostgresEncoder[T](encoder: ValueEncoder[T]) extends BaseEncoder[T] {
     override def apply(index: Index, value: T, row: PrepareRow) =
       row :+ Param(value)(encoder)
   }
 
-  def encoder[T](implicit e: ValueEncoder[T]): Encoder[T] = FinaglePostgresEncoder(e)
+  def encoder[T](implicit e: ValueEncoder[T]): Encoder[T] = FinanglePostgresEncoder(e)
 
   def encoder[T, U](f: U => T)(implicit e: ValueEncoder[T]): Encoder[U] =
     encoder[U](e.contraMap(f))
 
   implicit def mappedEncoder[I, O](implicit mapped: MappedEncoding[I, O], e: Encoder[O]): Encoder[I] =
-    FinaglePostgresEncoder(e.encoder.contraMap(mapped.f))
+    FinanglePostgresEncoder(e.encoder.contraMap(mapped.f))
 
   implicit def optionEncoder[T](implicit e: Encoder[T]): Encoder[Option[T]] =
-    FinaglePostgresEncoder[Option[T]](option(e.encoder))
+    FinanglePostgresEncoder[Option[T]](option(e.encoder))
 
   implicit val stringEncoder: Encoder[String] = encoder[String]
   implicit val bigDecimalEncoder: Encoder[BigDecimal] = encoder[BigDecimal]


### PR DESCRIPTION
Sorry. Need to revert this since I'm the middle of a rollout.