### PR TITLE
quill-codegen-jdbc should not rely on quill-jdbc/test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,7 @@ lazy val `quill-codegen` =
 lazy val `quill-codegen-jdbc` =
   (project in file("quill-codegen-jdbc"))
     .settings(commonSettings: _*)
+    .settings(jdbcTestingLibraries: _*)
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
@@ -136,7 +137,7 @@ lazy val `quill-codegen-jdbc` =
       )
     )
     .dependsOn(`quill-codegen` % "compile->compile;test->test")
-    .dependsOn(`quill-jdbc` % "compile->compile;test->test")
+    .dependsOn(`quill-jdbc` % "compile->compile")
 
 lazy val `quill-codegen-tests` =
   (project in file("quill-codegen-tests"))
@@ -441,8 +442,8 @@ def updateWebsiteTag =
     st
   })
 
-lazy val jdbcTestingSettings = Seq(
-  fork in Test := true,
+
+lazy val jdbcTestingLibraries = Seq(
   resolvers ++= includeIfOracle( // read ojdbc8 jar in case it is deployed
     Resolver.mavenLocal
   ),
@@ -461,7 +462,11 @@ lazy val jdbcTestingSettings = Seq(
     deps ++ includeIfOracle(
       "com.oracle.jdbc" % "ojdbc8" % "18.3.0.0.0" % Test
     )
-  },
+  }
+)
+
+lazy val jdbcTestingSettings = jdbcTestingLibraries ++ Seq(
+  fork in Test := true,
   excludeFilter in unmanagedSources := {
     excludeTests match {
       case true =>

--- a/quill-codegen-jdbc/src/test/resources/application.conf
+++ b/quill-codegen-jdbc/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+../../../../quill-jdbc/src/test/resources/application.conf


### PR DESCRIPTION
The only reason why `quill-codegen-jdbc` currently relies on `quill-jdbc:test` is because the `application.conf` is needed. Unfortunately, including `application.conf` via a file path does not seem to work despite my various attempts to include it using these variants:
```
// This is what it should be according to official HOCON spec which states:
// "if the included file is a relative path, then it should be located relative to the directory containing the including file. 
// The current working directory of the process parsing a file must NOT be used when interpreting included paths."
include required(file("../../../../quill-jdbc/src/test/resources/application.conf"))

// Oddly, this works in some places but not others.
include required(file("quill-jdbc/src/test/resources/application.conf"))

// Even if I add a symlink for application.conf in the same directory, this still does not work.
include required(file("application.conf"))
```
After all these attempts, I decided to just add a symlink to `application.conf` in `quill-codegen-jdbc/src/test/resources` and include it in `application-codegen.conf` via `include required(classpath(...))`. Every other way seems to break the build in a different place.

@getquill /maintainers
