### PR TITLE
Use scala-sbt Docker build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,9 @@ docker-compose run --rm setup
 
 After that you are ready to build and test the project. The following setp describes how to test the project with
 sbt built within docker image. If you would like to use your local sbt,
-please visit [Building locally](#building-locally-using-docker-only-for-databases).
+please visit [Building locally](#building-locally-using-docker-only-for-databases). This is highly recommended
+when running Docker on non-linux OS due to high IO overhead from running 
+[Docker in virtualized environments](https://docs.docker.com/docker-for-mac/osxfs/#performance-issues-solutions-and-roadmap).
 
 To build and test the project:
 

--- a/build/Dockerfile-sbt
+++ b/build/Dockerfile-sbt
@@ -1,29 +1,7 @@
-FROM debian:jessie-backports
-MAINTAINER gustavo.amigo@gmail.com
+FROM hseeberger/scala-sbt:8u212_1.2.8_2.12.9
+MAINTAINER mdedetrich@gmail.com
 
-RUN apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t jessie-backports \
-        bash \
-        curl \
-        git \
-        bc \
-        openjdk-8-jdk \
-        default-jre \
-        openssh-client \
-        openssl \
-        tar; \
-    update-alternatives --config java; \
-    update-java-alternatives -s java-1.8.0-openjdk-amd64; \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash -; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs
-
-ENV SBT_VERSION 1.1.1
-ENV SBT_HOME /usr/local/sbt
-ENV PATH ${PATH}:${SBT_HOME}/bin
+RUN apt-get install -y --no-install-recommends nodejs
 ENV JAVA_OPTS "-Dquill.macro.log=false -Xmx3G"
-
-# Install sbt
-RUN curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local --strip-components=1 && \
-    echo -ne "- with sbt $SBT_VERSION\n" >> /root/.built
 
 WORKDIR /app

--- a/build/build.sh
+++ b/build/build.sh
@@ -20,7 +20,7 @@ export CASSANDRA_PORT=19042
 export ORIENTDB_HOST=127.0.0.1
 export ORIENTDB_PORT=12424
 
-export SBT_ARGS="-Dquill.macro.log=false -Xms1024m -Xmx3g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC ++$TRAVIS_SCALA_VERSION"
+export JVM_OPTS="-Dquill.macro.log=false -Xms1024m -Xmx3g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 
 modules=$1
 
@@ -57,6 +57,8 @@ function docker_stats() {
     echo "===== Docker Stats End ====="
 }
 export -f docker_stats
+
+export SBT_ARGS="++$TRAVIS_SCALA_VERSION"
 
 if [[ $TRAVIS_SCALA_VERSION == 2.11* ]]; then
     export SBT_ARGS="$SBT_ARGS coverage"
@@ -135,7 +137,6 @@ function wait_for_bigdata() {
 
     sbt clean scalariformFormat test:scalariformFormat
     sbt checkUnformattedFiles
-
     sbt clean $SBT_ARGS quill-coreJVM/test:compile & COMPILE=$!
     ./build/setup_bigdata.sh & SETUP=$!
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - sqlserver:sqlserver
       - oracle:oracle
     volumes:
-      - ./:/app
+      - ./:/app:delegated
     command:
       - ./build/setup_local.sh
 
@@ -93,10 +93,10 @@ services:
       - sqlserver:sqlserver
       - oracle:oracle
     volumes:
-      - ./:/app
-      - ~/.ivy2:/root/.ivy2
-      - ~/.m2:/root/.m2
-      - ~/.sbt:/root/.sbt
+      - ./:/app:delegated
+      - ~/.ivy2:/root/.ivy2:cached
+      - ~/.m2:/root/.m2:cached
+      - ~/.sbt:/root/.sbt:cached
     environment:
       - SBT_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Dfile.encoding=UTF-8 -Xms512m -Xmx1536m -Xss2m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC
       - POSTGRES_HOST=postgres

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.8


### PR DESCRIPTION
### Problem

For some reason, the `Dockerfile-sbt` is no longer building on my machine with latest master, I am getting the following error

```
[~/g/quill]─[⎇ master]─[±]─> docker-compose run --rm sbt
Starting quill_orientdb_1 ... done
Starting quill_postgres_1 ... done
Starting quill_sqlserver_1 ... done
Starting quill_oracle_1    ... done
Starting quill_cassandra_1 ... done
Starting quill_mysql_1     ... done
Building sbt
Step 1/9 : FROM debian:jessie-backports
 ---> 0cb308fe1d83
Step 2/9 : MAINTAINER gustavo.amigo@gmail.com
 ---> Using cache
 ---> 25d19bb19e26
Step 3/9 : RUN apt-get update;     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t jessie-backports         bash         curl         git         bc         openjdk-8-jdk         default-jre         openssh-client         openssl         tar;     update-alternatives --config java;     update-java-alternatives -s java-1.8.0-openjdk-amd64;     curl -sL https://deb.nodesource.com/setup_8.x | bash -;     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nodejs
 ---> Using cache
 ---> 4470b3855397
Step 4/9 : ENV SBT_VERSION 1.1.1
 ---> Using cache
 ---> f81c80c8594b
Step 5/9 : ENV SBT_HOME /usr/local/sbt
 ---> Using cache
 ---> d157b7912834
Step 6/9 : ENV PATH ${PATH}:${SBT_HOME}/bin
 ---> Using cache
 ---> 611a8b9a90a5
Step 7/9 : ENV JAVA_OPTS "-Dquill.macro.log=false -Xmx3G"
 ---> Using cache
 ---> db31164286c5
Step 8/9 : RUN curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local --strip-components=1 &&     echo -ne "- with sbt $SBT_VERSION\n" >> /root/.built
 ---> Running in cf23989db3dc
/bin/sh: 1: curl: not found

gzip: stdin: unexpected end of file
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
ERROR: Service 'sbt' failed to build: The command '/bin/sh -c curl -sL "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | gunzip | tar -x -C /usr/local --strip-components=1 &&     echo -ne "- with sbt $SBT_VERSION\n" >> /root/.built' returned a non-zero code: 2

```

### Solution

Rather than trying to fix the cause of the problem, I have opted instead to use the https://hub.docker.com/r/hseeberger/scala-sbt dockerbuild. I have used this both at work and personally and it has worked without problems. It also gets almost immediately updated whenever a new scala/sbt version comes out. We also have one less thing to maintain (which is always good).

Note that previously the `Dockerfile-sbt` would start the Docker image with shell, so everytime you would invoke the `Docker` image you would need to do `sbt args...`. Since the scala-sbt already sets the `CMD` to be `sbt`, we now only need to parse args. Due to this we now only need to parse the args into sbt (scripts have been updated as appropriate).

Performance tuning was also done to improve the performance of using the docker sbt image on Mac. You can read https://docs.docker.com/docker-for-mac/osxfs-caching/ for more info but basically we cache directories such as `.sbt` and `.ivy` however the source code (mounted as `/app`) is set as delegated. This should make the performance on mac less terrible.

### Notes

I have also bumped the sbt version, on my end it doesn't appear to be causing any issues

### Checklist

- [X] Unit test all changes (N/A)
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
