### PR TITLE
Fix onConflict with custom schemaMeta

### DIFF
--- a/quill-core/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/Ast.scala
@@ -292,8 +292,14 @@ case class Foreach(query: Ast, alias: Ident, body: Ast) extends Action
 case class OnConflict(insert: Ast, target: OnConflict.Target, action: OnConflict.Action) extends Action
 object OnConflict {
 
-  case class Excluded(alias: Ident) extends Ast
-  case class Existing(alias: Ident) extends Ast
+  case class Excluded(alias: Ident) extends Ast {
+    override def neutral: Ast =
+      alias.neutral
+  }
+  case class Existing(alias: Ident) extends Ast {
+    override def neutral: Ast =
+      alias.neutral
+  }
 
   sealed trait Target
   case object NoTarget extends Target

--- a/quill-core/src/main/scala/io/getquill/norm/Replacements.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/Replacements.scala
@@ -17,21 +17,21 @@ import io.getquill.ast.Ast
 case class Replacements(map: collection.Map[Ast, Ast]) {
 
   /** First transformed object to meet criteria **/
-  def apply(key: Ast) =
+  def apply(key: Ast): Ast =
     map.map { case (k, v) => (k.neutralize, v) }.filter(_._1 == key.neutralize).head._2
 
   /** First transformed object to meet criteria or none of none meets **/
-  def get(key: Ast) =
+  def get(key: Ast): Option[Ast] =
     map.map { case (k, v) => (k.neutralize, v) }.filter(_._1 == key.neutralize).headOption.map(_._2)
 
   /** Does the map contain a normalized version of the view you want to see */
-  def contains(key: Ast) =
+  def contains(key: Ast): Boolean =
     map.map { case (k, v) => k.neutralize }.toList.contains(key.neutralize)
 
   def ++(otherMap: collection.Map[Ast, Ast]): Replacements =
     Replacements(map ++ otherMap)
 
-  def -(key: Ast) = {
+  def -(key: Ast): Replacements = {
     val newMap = map.toList.filterNot { case (k, v) => k.neutralize == key.neutralize }.toMap
     Replacements(newMap)
   }

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -36,6 +36,16 @@ class BetaReductionSpec extends Spec {
       BetaReduction(ast, Ident("a") -> Ident("a'")) mustEqual
         Ident("a'")
     }
+    "with OnConflict.Excluded" in {
+      val ast: Ast = OnConflict.Excluded(Ident("a"))
+      BetaReduction(ast, Ident("a") -> Ident("a'")) mustEqual
+        Ident("a'")
+    }
+    "with OnConflict.Existing" in {
+      val ast: Ast = OnConflict.Existing(Ident("a"))
+      BetaReduction(ast, Ident("a") -> Ident("a'")) mustEqual
+        Ident("a'")
+    }
     "with inline" - {
       val entity = Entity("a", Nil)
       val (a, b, c, d) = (Ident("a"), Ident("b"), Ident("c"), Ident("d"))

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OnConflictJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OnConflictJdbcSpec.scala
@@ -32,4 +32,24 @@ class OnConflictJdbcSpec extends OnConflictSpec {
     ctx.run(testQuery(e3)) mustEqual res3
     ctx.run(testQuery4) mustEqual res4
   }
+
+  "ON CONFLICT (i) DO UPDATE with schemaMeta ..." in {
+    case class TestEntityRename(s2: String, i2: Int, l2: Long, o2: Option[Int])
+
+    def testQuery(e: TestEntityRename) = quote {
+      querySchema[TestEntityRename](
+        "TestEntity",
+        _.s2 -> "s",
+        _.i2 -> "i",
+        _.l2 -> "l",
+        _.o2 -> "o"
+      ).insert(lift(e)).onConflictUpdate(_.i2)(
+          (t, _) => t.l2 -> (t.l2 + 1)
+        )
+    }
+
+    val e1Rename = TestEntityRename("r1", 4, 0, None)
+
+    ctx.run(testQuery(e1Rename)) mustEqual 1
+  }
 }


### PR DESCRIPTION
Fixes #1527 

### Problem

Currently `onConflict` and its variants completely ignore `SchemaMeta` (whether you provide a custom one or a default one although you only notice a difference with a custom `SchemaMeta`)

### Solution

There were various issues that I found which caused the problem, they are detailed below

* When you have an `OnConflict`, `BetaReduction` was never applied on the `target` if the `target` happened to be a `OnConflict.Target.Properties`. The solution here was to apply `BetaReduction` on the `target` if it happened to be a `OnConflict.Target.Properties`.
* When you had a `OnConflict.Update`, `BetaReduction` was never applied to the assignments for the update body. The solution here was to apply `BetaReduction` on all assignments
*  The `neutralize` method on `OnConflict.Excluded` and `OnConflict.Existing` was incorrect which meant that 
    ```scala
    case ast if replacements.contains(ast) =>
      BetaReduction(replacements - ast - replacements(ast))(replacements(ast))
    ```
    Didn't work correctly when we were doing `BetaReduction` on a `OnConflict.Excluded`/`OnConflict.Existing`

### Notes

In on case we happen to use `asInstanceOf`, i.e. when we apply a `BetaReduction` to a property. This will always return a `Property`. Alternately we can match on it, see if its a property and return a failure otherwise (not sure how strict we want to be here).

I also did some minor syntax improvements + ascribed manual type annotations (in general we should put type annotations for the return type of methods/functions as it makes a non trivial difference in Scala's compilation speed)

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
