### PR TITLE
Express Infix Clauses not in Select List

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,5 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
+
+addSbtPlugin("com.etsy" % "sbt-compile-quick-plugin" % "1.4.0")

--- a/quill-codegen-jdbc/src/test/resources/application-codegen.conf
+++ b/quill-codegen-jdbc/src/test/resources/application-codegen.conf
@@ -9,7 +9,7 @@ testPostgresDB.dataSource.databaseName=codegen_test
 # Otherwise can get PSQLException: FATAL: sorry, too many clients already
 testPostgresDB.maximumPoolSize=1
 
-testH2DB.dataSource.url="jdbc:h2:file:./codegen_test.h2"
+testH2DB.dataSource.url="jdbc:h2:file:./codegen_test.h2;DB_CLOSE_ON_EXIT=TRUE"
 
 testSqliteDB.jdbcUrl="jdbc:sqlite:codegen_test.db"
 

--- a/quill-core/src/main/scala/io/getquill/norm/ApplyMap.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/ApplyMap.scala
@@ -26,6 +26,15 @@ object ApplyMap {
       }
   }
 
+  object MapWithoutInfixes {
+    def unapply(ast: Ast): Option[(Ast, Ident, Ast)] =
+      ast match {
+        case Map(a, b, InfixedTailOperation(c)) => None
+        case Map(a, b, c)                       => Some((a, b, c))
+        case _                                  => None
+      }
+  }
+
   object DetachableMap {
     def unapply(ast: Ast): Option[(Ast, Ident, Ast)] =
       ast match {
@@ -50,7 +59,7 @@ object ApplyMap {
 
       // a.map(b => c).map(d => e) =>
       //    a.map(b => e[d := c])
-      case Map(Map(a, b, c), d, e) =>
+      case before @ Map(MapWithoutInfixes(a, b, c), d, e) =>
         val er = BetaReduction(e, d -> c)
         Some(Map(a, b, er))
 

--- a/quill-core/src/main/scala/io/getquill/norm/Normalize.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/Normalize.scala
@@ -5,6 +5,8 @@ import io.getquill.ast.Query
 import io.getquill.ast.StatelessTransformer
 import io.getquill.norm.capture.AvoidCapture
 import io.getquill.ast.Action
+import io.getquill.util.Messages.trace
+import io.getquill.util.Messages.TraceType.Normalizations
 
 import scala.annotation.tailrec
 
@@ -19,15 +21,31 @@ object Normalize extends StatelessTransformer {
   override def apply(q: Query): Query =
     norm(AvoidCapture(q))
 
+  private def traceNorm[T](label: String) =
+    trace[T](s"${label} (Normalize)", 1, Normalizations)
+
   @tailrec
   private def norm(q: Query): Query =
     q match {
-      case NormalizeNestedStructures(query) => norm(query)
-      case ApplyMap(query)                  => norm(query)
-      case SymbolicReduction(query)         => norm(query)
-      case AdHocReduction(query)            => norm(query)
-      case OrderTerms(query)                => norm(query)
-      case NormalizeAggregationIdent(query) => norm(query)
-      case other                            => other
+      case NormalizeNestedStructures(query) =>
+        traceNorm("NormalizeNestedStructures")(query)
+        norm(query)
+      case ApplyMap(query) =>
+        traceNorm("ApplyMap")(query)
+        norm(query)
+      case SymbolicReduction(query) =>
+        traceNorm("SymbolicReduction")(query)
+        norm(query)
+      case AdHocReduction(query) =>
+        traceNorm("AdHocReduction")(query)
+        norm(query)
+      case OrderTerms(query) =>
+        traceNorm("OrderTerms")(query)
+        norm(query)
+      case NormalizeAggregationIdent(query) =>
+        traceNorm("NormalizeAggregationIdent")(query)
+        norm(query)
+      case other =>
+        other
     }
 }

--- a/quill-core/src/main/scala/io/getquill/util/Interpolator.scala
+++ b/quill-core/src/main/scala/io/getquill/util/Interpolator.scala
@@ -1,0 +1,140 @@
+package io.getquill.util
+
+import java.io.PrintStream
+
+import io.getquill.AstPrinter
+import io.getquill.AstPrinter.Implicits._
+import io.getquill.util.Messages.TraceType
+
+import scala.collection.mutable
+import scala.util.matching.Regex
+
+class Interpolator(
+  traceType:     TraceType,
+  defaultIndent: Int                    = 0,
+  color:         Boolean                = Messages.traceColors,
+  qprint:        AstPrinter             = Messages.qprint,
+  out:           PrintStream            = System.out,
+  tracesEnabled: (TraceType) => Boolean = Messages.tracesEnabled(_)
+) {
+  implicit class InterpolatorExt(sc: StringContext) {
+    def trace(elements: Any*) = new Traceable(sc, elements)
+  }
+  implicit class StringOps(str: String) {
+    def fitsOnOneLine: Boolean = !str.contains("\n")
+    def multiline(indent: Int, prefix: String): String =
+      str.split("\n").map(elem => indent.prefix + prefix + elem).mkString("\n")
+  }
+  implicit class IndentOps(i: Int) {
+    def prefix = indentOf(i)
+  }
+  private def indentOf(num: Int) =
+    (0 to num).map(_ => "").mkString("  ")
+
+  class Traceable(sc: StringContext, elementsSeq: Seq[Any]) {
+
+    private val elementPrefix = "|  "
+
+    private sealed trait PrintElement
+    private case class Str(str: String, first: Boolean) extends PrintElement
+    private case class Elem(value: String) extends PrintElement
+    private case object Separator extends PrintElement
+
+    private def generateStringForCommand(value: Any, indent: Int) = {
+      val objectString = qprint(value).string(color)
+      val oneLine = objectString.fitsOnOneLine
+      oneLine match {
+        case true  => s"${indent.prefix}> ${objectString}"
+        case false => s"${indent.prefix}>\n${objectString.multiline(indent, elementPrefix)}"
+      }
+    }
+
+    private def readFirst(first: String) =
+      new Regex("%([0-9]+)(.*)").findFirstMatchIn(first) match {
+        case Some(matches) => (matches.group(2).trim, matches.group(1).toInt)
+        case None          => (first, defaultIndent)
+      }
+
+    private def readBuffers() = {
+      val parts = sc.parts.iterator.toList
+      val elements = elementsSeq.toList.map(qprint(_).string(color))
+
+      val (firstStr, indent) = readFirst(parts.head)
+
+      val partsIter = parts.iterator
+      partsIter.next() // already took care of the 1st element
+      val elementsIter = elements.iterator
+
+      val sb = new mutable.ArrayBuffer[PrintElement]()
+      sb.append(Str(firstStr.trim, true))
+
+      while (elementsIter.hasNext) {
+        sb.append(Separator)
+        sb.append(Elem(elementsIter.next()))
+        val nextPart = partsIter.next().trim
+        sb.append(Separator)
+        sb.append(Str(nextPart, false))
+      }
+
+      (sb.toList, indent)
+    }
+
+    def generateString() = {
+      val (elementsRaw, indent) = readBuffers()
+
+      val elements = elementsRaw.filter {
+        case Str(value, _) => value.trim != ""
+        case Elem(value)   => value.trim != ""
+        case _             => true
+      }
+
+      val oneLine = elements.forall {
+        case Elem(value)   => value.fitsOnOneLine
+        case Str(value, _) => value.fitsOnOneLine
+        case _             => true
+      }
+      val output =
+        elements.map {
+          case Str(value, true) if (oneLine)  => indent.prefix + value
+          case Str(value, false) if (oneLine) => value
+          case Elem(value) if (oneLine)       => value
+          case Separator if (oneLine)         => " "
+          case Str(value, true)               => value.multiline(indent, "")
+          case Str(value, false)              => value.multiline(indent, "|")
+          case Elem(value)                    => value.multiline(indent, "|  ")
+          case Separator                      => "\n"
+        }
+
+      (output.mkString, indent)
+    }
+
+    private def logIfEnabled[T]() =
+      if (tracesEnabled(traceType))
+        Some(generateString())
+      else
+        None
+
+    def andLog(): Unit =
+      logIfEnabled.foreach(value => out.println(value._1))
+
+    def andContinue[T](command: => T) = {
+      logIfEnabled.foreach(value => out.println(value._1))
+      command
+    }
+
+    def andReturn[T](command: => T) = {
+      logIfEnabled() match {
+        case Some((output, indent)) =>
+          // do the initial log
+          out.println(output)
+          // evaluate the command, this will activate any traces that were inside of it
+          val result = command
+          out.println(generateStringForCommand(result, indent))
+
+          result
+        case None =>
+          command
+      }
+    }
+  }
+}

--- a/quill-core/src/test/scala/io/getquill/util/InterpolatorSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/util/InterpolatorSpec.scala
@@ -1,0 +1,196 @@
+package io.getquill.util
+
+import java.io.{ ByteArrayOutputStream, PrintStream }
+
+import io.getquill.Spec
+import io.getquill.util.Messages.TraceType.Standard
+
+class InterpolatorSpec extends Spec {
+
+  val interp = new Interpolator(Standard, defaultIndent = 0, color = false, tracesEnabled = _ => true)
+  import interp._
+
+  case class Small(id: Int)
+  val small = Small(123)
+
+  "traces small objects on single line - single" in {
+    trace"small object: $small".generateString() mustEqual (("small object: Small(123) ", 0))
+  }
+
+  "traces multiple small objects on single line" in {
+    trace"small object: $small and $small".generateString() mustEqual (("small object: Small(123) and Small(123) ", 0))
+  }
+
+  "traces multiple small objects multline text" in {
+    trace"""small object: $small and foo
+and bar $small""".generateString() mustEqual (
+      (
+        """small object:
+        ||  Small(123)
+        ||and foo
+        ||and bar
+        ||  Small(123)
+        |""".stripMargin,
+        0
+      )
+    )
+  }
+
+  case class Large(id: Int, one: String, two: String, three: String, four: String, five: String, six: String, seven: String, eight: String, nine: String, ten: String)
+  val vars = (0 until 10).map(i => (0 until i).map(_ => "Test").mkString("")).toList
+  val large = Large(123, vars(0), vars(1), vars(2), vars(3), vars(4), vars(5), vars(6), vars(7), vars(8), vars(9))
+
+  "traces large objects on multiple line - single" in {
+    trace"large object: $large".generateString() mustEqual ((
+      """large object:
+        ||  Large(
+        ||    123,
+        ||    "",
+        ||    "Test",
+        ||    "TestTest",
+        ||    "TestTestTest",
+        ||    "TestTestTestTest",
+        ||    "TestTestTestTestTest",
+        ||    "TestTestTestTestTestTest",
+        ||    "TestTestTestTestTestTestTest",
+        ||    "TestTestTestTestTestTestTestTest",
+        ||    "TestTestTestTestTestTestTestTestTest"
+        ||  )
+        |""".stripMargin, 0
+    ))
+  }
+
+  "traces large objects on multiple line - single - custom indent" in {
+    trace"%2 large object: $large".generateString() mustEqual ((
+      """    large object:
+        |    |  Large(
+        |    |    123,
+        |    |    "",
+        |    |    "Test",
+        |    |    "TestTest",
+        |    |    "TestTestTest",
+        |    |    "TestTestTestTest",
+        |    |    "TestTestTestTestTest",
+        |    |    "TestTestTestTestTestTest",
+        |    |    "TestTestTestTestTestTestTest",
+        |    |    "TestTestTestTestTestTestTestTest",
+        |    |    "TestTestTestTestTestTestTestTestTest"
+        |    |  )
+        |""".stripMargin, 2
+    ))
+  }
+
+  "traces large objects on multiple line - multi" in {
+    trace"large object: $large and $large".generateString() mustEqual ((
+      """large object:
+        ||  Large(
+        ||    123,
+        ||    "",
+        ||    "Test",
+        ||    "TestTest",
+        ||    "TestTestTest",
+        ||    "TestTestTestTest",
+        ||    "TestTestTestTestTest",
+        ||    "TestTestTestTestTestTest",
+        ||    "TestTestTestTestTestTestTest",
+        ||    "TestTestTestTestTestTestTestTest",
+        ||    "TestTestTestTestTestTestTestTestTest"
+        ||  )
+        ||and
+        ||  Large(
+        ||    123,
+        ||    "",
+        ||    "Test",
+        ||    "TestTest",
+        ||    "TestTestTest",
+        ||    "TestTestTestTest",
+        ||    "TestTestTestTestTest",
+        ||    "TestTestTestTestTestTest",
+        ||    "TestTestTestTestTestTestTest",
+        ||    "TestTestTestTestTestTestTestTest",
+        ||    "TestTestTestTestTestTestTestTestTest"
+        ||  )
+        |""".stripMargin, 0
+    ))
+  }
+
+  "should log to print stream" - {
+    "do not log if traces disabled" in {
+      val buff = new ByteArrayOutputStream()
+      val ps = new PrintStream(buff)
+      val interp = new Interpolator(Standard, defaultIndent = 0, color = false, tracesEnabled = _ => false, out = ps)
+      import interp._
+
+      trace"small object: $small".andLog()
+      ps.flush()
+      buff.toString mustEqual ""
+    }
+
+    "log if traces disabled" in {
+      val buff = new ByteArrayOutputStream()
+      val ps = new PrintStream(buff)
+      val interp = new Interpolator(Standard, defaultIndent = 0, color = false, tracesEnabled = _ => true, out = ps)
+      import interp._
+
+      trace"small object: $small".andLog()
+      ps.flush()
+      buff.toString mustEqual "small object: Small(123) \n"
+    }
+
+    "traces large objects on multiple line - multi - with return" in {
+      val buff = new ByteArrayOutputStream()
+      val ps = new PrintStream(buff)
+      val interp = new Interpolator(Standard, defaultIndent = 0, color = false, tracesEnabled = _ => true, out = ps)
+      import interp._
+
+      trace"large object: $large and $large".andReturn(large) mustEqual large
+
+      buff.toString mustEqual (
+        """large object:
+          ||  Large(
+          ||    123,
+          ||    "",
+          ||    "Test",
+          ||    "TestTest",
+          ||    "TestTestTest",
+          ||    "TestTestTestTest",
+          ||    "TestTestTestTestTest",
+          ||    "TestTestTestTestTestTest",
+          ||    "TestTestTestTestTestTestTest",
+          ||    "TestTestTestTestTestTestTestTest",
+          ||    "TestTestTestTestTestTestTestTestTest"
+          ||  )
+          ||and
+          ||  Large(
+          ||    123,
+          ||    "",
+          ||    "Test",
+          ||    "TestTest",
+          ||    "TestTestTest",
+          ||    "TestTestTestTest",
+          ||    "TestTestTestTestTest",
+          ||    "TestTestTestTestTestTest",
+          ||    "TestTestTestTestTestTestTest",
+          ||    "TestTestTestTestTestTestTestTest",
+          ||    "TestTestTestTestTestTestTestTestTest"
+          ||  )
+          |
+          |>
+          ||  Large(
+          ||    123,
+          ||    "",
+          ||    "Test",
+          ||    "TestTest",
+          ||    "TestTestTest",
+          ||    "TestTestTestTest",
+          ||    "TestTestTestTestTest",
+          ||    "TestTestTestTestTestTest",
+          ||    "TestTestTestTestTestTestTest",
+          ||    "TestTestTestTestTestTestTestTest",
+          ||    "TestTestTestTestTestTestTestTestTest"
+          ||  )
+          |""".stripMargin
+      )
+    }
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/nested/Elements.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/nested/Elements.scala
@@ -1,0 +1,28 @@
+package io.getquill.context.sql.norm.nested
+
+import io.getquill.PseudoAst
+import io.getquill.context.sql.SelectValue
+
+object Elements {
+  /**
+   * In order to be able to reconstruct the original ordering of elements inside of a select clause,
+   * we need to keep track of their order, not only within the top-level select but also it's order
+   * within any possible tuples/case-classes that in which it is embedded.
+   * For example, in the query:
+   * <pre><code>
+   *   query[Person].map(p => (p.id, (p.name, p.age))).nested
+   *   // SELECT p.id, p.name, p.age FROM (SELECT x.id, x.name, x.age FROM person x) AS p
+   * </code></pre>
+   * Since the `p.name` and `p.age` elements are selected inside of a sub-tuple, their "order" is
+   * `List(2,1)` and `List(2,2)` respectively as opposed to `p.id` whose "order" is just `List(1)`.
+   *
+   * This class keeps track of the values needed in order to perform do this.
+   */
+  case class OrderedSelect(order: List[Int], selectValue: SelectValue) extends PseudoAst {
+    override def toString: String = s"[${order.mkString(",")}]${selectValue}"
+  }
+  object OrderedSelect {
+    def apply(order: Int, selectValue: SelectValue) =
+      new OrderedSelect(List(order), selectValue)
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/nested/ExpandSelect.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/nested/ExpandSelect.scala
@@ -1,0 +1,184 @@
+package io.getquill.context.sql.norm.nested
+
+import io.getquill.NamingStrategy
+import io.getquill.ast.Property
+import io.getquill.context.sql.SelectValue
+import io.getquill.util.Interpolator
+import io.getquill.util.Messages.TraceType.NestedQueryExpansion
+
+import scala.collection.mutable.LinkedHashSet
+import io.getquill.context.sql.norm.nested.Elements._
+import io.getquill.ast._
+
+/**
+ * Takes the `SelectValue` elements inside of a sub-query (if a super/sub-query constrct exists) and flattens
+ * them from a nested-hiearchical structure (i.e. tuples inside case classes inside tuples etc..) into
+ * into a single series of top-level select elements where needed. In cases where a user wants to select an element
+ * that contains an entire tuple (i.e. a sub-tuple of the outer select clause) we pull out the entire tuple
+ * that is being selected and leave it to the tokenizer to flatten later.
+ *
+ * The part about this operation that is tricky is if there are situations where there are infix clauses
+ * in a sub-query representing an element that has not been selected by the query-query but in order to ensure
+ * the SQL operation has the same meaning, we need to keep track for it. For example:
+ * <pre><code>
+ *   val q = quote {
+ *     query[Person].map(p => (infix"DISTINCT ON (${p.other})".as[Int], p.name, p.id)).map(t => (t._2, t._3))
+ *   }
+ *   run(q)
+ *   // SELECT p._2, p._3 FROM (SELECT DISTINCT ON (p.other), p.name AS _2, p.id AS _3 FROM Person p) AS p
+ * </code></pre>
+ * Since `DISTINCT ON` significantly changes the behavior of the outer query, we need to keep track of it
+ * inside of the inner query. In order to do this, we need to keep track of the location of the infix in the inner query
+ * so that we can reconstruct it. This is why the `OrderedSelect` and `DoubleOrderedSelect` objects are used.
+ * See the notes on these classes for more detail.
+ *
+ * See issue #1597 for more details and another example.
+ */
+private class ExpandSelect(selectValues: List[SelectValue], references: LinkedHashSet[Property], strategy: NamingStrategy) {
+  val interp = new Interpolator(NestedQueryExpansion, 3)
+  import interp._
+
+  object TupleIndex {
+    def unapply(s: String): Option[Int] =
+      if (s.matches("_[0-9]*"))
+        Some(s.drop(1).toInt - 1)
+      else
+        None
+  }
+
+  object MultiTupleIndex {
+    def unapply(s: String): Boolean =
+      if (s.matches("(_[0-9]+)+"))
+        true
+      else
+        false
+  }
+
+  val select =
+    selectValues.zipWithIndex.map {
+      case (value, index) => OrderedSelect(index, value)
+    }
+
+  def expandColumn(name: String, renameable: Renameable): String =
+    renameable.fixedOr(name)(strategy.column(name))
+
+  def apply: List[SelectValue] = {
+    trace"Expanding Select values: $selectValues into references: $references" andLog ()
+
+    def expandReference(ref: Property): OrderedSelect = {
+      trace"Expanding: $ref from $select" andLog ()
+
+      def expressIfTupleIndex(str: String) =
+        str match {
+          case MultiTupleIndex() => Some(str)
+          case _                 => None
+        }
+
+      def concat(alias: Option[String], idx: Int) =
+        Some(s"${alias.getOrElse("")}_${idx + 1}")
+
+      val orderedSelect = ref match {
+        case pp @ Property(ast: Property, TupleIndex(idx)) =>
+          trace"Reference is a sub-property of a tuple index: $idx. Walking inside." andContinue
+            expandReference(ast) match {
+              case OrderedSelect(o, SelectValue(Tuple(elems), alias, c)) =>
+                trace"Expressing Element $idx of $elems " andReturn
+                OrderedSelect(o :+ idx, SelectValue(elems(idx), concat(alias, idx), c))
+              case OrderedSelect(o, SelectValue(ast, alias, c)) =>
+                trace"Appending $idx to $alias " andReturn
+                OrderedSelect(o, SelectValue(ast, concat(alias, idx), c))
+            }
+        case pp @ Property.Opinionated(ast: Property, name, renameable) =>
+          trace"Reference is a sub-property. Walking inside." andContinue
+            expandReference(ast) match {
+              case OrderedSelect(o, SelectValue(ast, nested, c)) =>
+                // Alias is the name of the column after the naming strategy
+                // The clauses in `SqlIdiom` that use `Tokenizer[SelectValue]` select the
+                // alias field when it's value is Some(T).
+                // Technically the aliases of a column should not be using naming strategies
+                // but this is an issue to fix at a later date.
+
+                // In the current implementation, aliases we add nested tuple names to queries e.g.
+                // SELECT foo from
+                // SELECT x, y FROM (SELECT foo, bar, red, orange FROM baz JOIN colors)
+                // Typically becomes SELECT foo _1foo, _1bar, _2red, _2orange when
+                // this kind of query is the result of an applicative join that looks like this:
+                // query[baz].join(query[colors]).nested
+                // this may need to change based on how distinct appends table names instead of just tuple indexes
+                // into the property path.
+
+                OrderedSelect(o, SelectValue(
+                  Property.Opinionated(ast, name, renameable),
+                  Some(s"${nested.flatMap(expressIfTupleIndex(_)).getOrElse("")}${expandColumn(name, renameable)}"), c
+                ))
+            }
+        case pp @ Property(_, TupleIndex(idx)) =>
+          trace"Reference is a tuple index: $idx from $select." andContinue
+            select(idx) match {
+              case OrderedSelect(o, SelectValue(ast, alias, c)) =>
+                OrderedSelect(o, SelectValue(ast, concat(alias, idx), c))
+            }
+        case pp @ Property.Opinionated(_, name, renameable) =>
+          select match {
+            case List(OrderedSelect(o, SelectValue(cc: CaseClass, alias, c))) =>
+              // Currently case class element name is not being appended. Need to change that in order to ensure
+              // path name uniqueness in future.
+              val ((_, ast), index) = cc.values.zipWithIndex.find(_._1._1 == name) match {
+                case Some(v) => v
+                case None    => throw new IllegalArgumentException(s"Cannot find element $name in $cc")
+              }
+              trace"Reference is a case class member: " andReturn
+                OrderedSelect(o :+ index, SelectValue(ast, Some(expandColumn(name, renameable)), c))
+            case List(OrderedSelect(o, SelectValue(i: Ident, _, c))) =>
+              trace"Reference is an identifier: " andReturn
+                OrderedSelect(o, SelectValue(Property.Opinionated(i, name, renameable), None, c))
+            case other =>
+              trace"Reference is unidentified: " andReturn
+                OrderedSelect(Integer.MAX_VALUE, SelectValue(Ident(name), Some(expandColumn(name, renameable)), false))
+          }
+      }
+
+      trace"Expanded $ref into $orderedSelect"
+      orderedSelect
+    }
+
+    references.toList match {
+      case Nil => select.map(_.selectValue)
+      case refs => {
+        // elements first need to be sorted by their order in the select clause. Since some may map to multiple
+        // properties when expanded, we want to maintain this order of properties as a secondary value.
+        val mappedRefs = refs.map(expandReference)
+        trace"Mapped Refs: $mappedRefs" andLog ()
+
+        // are there any selects that have infix values which we have not already selected? We need to include
+        // them because they could be doing essential things e.g. RANK ... ORDER BY
+        val remainingSelectsWithInfixes =
+          trace"Searching Selects with Infix:" andReturn
+            new FindUnexpressedInfixes(select)(mappedRefs)
+
+        implicit val ordering: scala.math.Ordering[List[Int]] = new scala.math.Ordering[List[Int]] {
+          override def compare(x: List[Int], y: List[Int]): Int =
+            (x, y) match {
+              case (head1 :: tail1, head2 :: tail2) =>
+                val diff = head1 - head2
+                if (diff != 0) diff
+                else compare(tail1, tail2)
+              case (Nil, Nil)   => 0 // List(1,2,3) == List(1,2,3)
+              case (head1, Nil) => -1 // List(1,2,3) < List(1,2)
+              case (Nil, head2) => 1 // List(1,2) > List(1,2,3)
+            }
+        }
+
+        val sortedRefs =
+          (mappedRefs ++ remainingSelectsWithInfixes).sortBy(ref => ref.order) //(ref.order, ref.secondaryOrder)
+
+        sortedRefs.map(_.selectValue)
+      }
+    }
+  }
+}
+
+object ExpandSelect {
+  def apply(selectValues: List[SelectValue], references: LinkedHashSet[Property], strategy: NamingStrategy): List[SelectValue] =
+    new ExpandSelect(selectValues, references, strategy).apply
+}

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/nested/FindUnexpressedInfixes.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/nested/FindUnexpressedInfixes.scala
@@ -1,0 +1,82 @@
+package io.getquill.context.sql.norm.nested
+
+import io.getquill.context.sql.norm.nested.Elements._
+import io.getquill.util.Interpolator
+import io.getquill.util.Messages.TraceType.NestedQueryExpansion
+import io.getquill.ast._
+import io.getquill.context.sql.SelectValue
+
+/**
+ * The challenge with appeneding infixes (that have not been used but are still needed)
+ * back into the query, is that they could be inside of tuples/case-classes that have already
+ * been selected, or inside of sibling elements which have been selected.
+ * Take for instance a query that looks like this:
+ * <pre><code>
+ *   query[Person].map(p => (p.name, (p.id, infix"foo(\${p.other})".as[Int]))).map(p => (p._1, p._2._1))
+ * </code></pre>
+ * In this situation, `p.id` which is the sibling of the non-selected infix has been selected
+ * via `p._2._1` (whose select-order is List(1,0) to represent 1st element in 2nd tuple.
+ * We need to add it's sibling infix.
+ *
+ * Or take the following situation:
+ * <pre><code>
+ *   query[Person].map(p => (p.name, (p.id, infix"foo(\${p.other})".as[Int]))).map(p => (p._1, p._2))
+ * </code></pre>
+ * In this case, we have selected the entire 2nd element including the infix. We need to know that
+ * `P._2._2` does not need to be selected since `p._2` was.
+ *
+ * In order to do these things, we use the `order` property from `OrderedSelect` in order to see
+ * which sub-sub-...-element has been selected. If `p._2` (that has order `List(1)`)
+ * has been selected, we know that any infixes inside of it e.g. `p._2._1` (ordering `List(1,0)`)
+ * does not need to be.
+ */
+class FindUnexpressedInfixes(select: List[OrderedSelect]) {
+  val interp = new Interpolator(NestedQueryExpansion, 3)
+  import interp._
+
+  def apply(refs: List[OrderedSelect]) = {
+
+    def pathExists(path: List[Int]) =
+      refs.map(_.order).contains(path)
+
+    def containsInfix(ast: Ast) =
+      CollectAst.byType[Infix](ast).length > 0
+
+    // build paths to every infix and see these paths were not selected already
+    def findMissingInfixes(ast: Ast, parentOrder: List[Int]): List[(Ast, List[Int])] = {
+      trace"Searching for infix: $ast in the sub-path $parentOrder" andLog ()
+      if (pathExists(parentOrder))
+        trace"No infixes found" andContinue
+          List()
+      else
+        ast match {
+          case Tuple(values) =>
+            values.zipWithIndex
+              .filter(v => containsInfix(v._1))
+              .flatMap {
+                case (ast, index) =>
+                  findMissingInfixes(ast, parentOrder :+ index)
+              }
+          case CaseClass(values) =>
+            values.zipWithIndex
+              .filter(v => containsInfix(v._1._2))
+              .flatMap {
+                case ((_, ast), index) =>
+                  findMissingInfixes(ast, parentOrder :+ index)
+              }
+          case other if (containsInfix(other)) =>
+            trace"Found unexpressed infix inside $other in $parentOrder" andLog ()
+            List((other, parentOrder))
+          case _ =>
+            List()
+        }
+    }
+
+    select
+      .flatMap {
+        case OrderedSelect(o, sv) => findMissingInfixes(sv.ast, o)
+      }.map {
+        case (ast, order) => OrderedSelect(order, SelectValue(ast))
+      }
+  }
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EmbeddedSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EmbeddedSpec.scala
@@ -1,0 +1,21 @@
+package io.getquill.context.sql
+
+import io.getquill._
+
+class EmbeddedSpec extends Spec {
+
+  val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal) with TestEntities
+  import ctx._
+
+  "queries with embedded entities should" - {
+    "function property inside of nested distinct queries" in {
+      case class Parent(id: Int, emb1: Emb)
+      case class Emb(a: Int, b: Int) extends Embedded
+      val q = quote {
+        query[Emb].map(e => Parent(1, e)).distinct
+      }
+      ctx.run(q).string mustEqual "SELECT e.id, e.a, e.b FROM (SELECT DISTINCT 1 AS id, e.a AS a, e.b AS b FROM Emb e) AS e"
+    }
+  }
+
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -380,7 +380,7 @@ class SqlQuerySpec extends Spec {
               }
           }
           testContext.run(q).string mustEqual
-            "SELECT t._2i, SUM(t._1i) FROM (SELECT b.i AS _2i, a.i AS _1i FROM TestEntity a INNER JOIN TestEntity2 b ON a.s = b.s) AS t GROUP BY t._2i"
+            "SELECT t._2i, SUM(t._1i) FROM (SELECT a.i AS _1i, b.i AS _2i FROM TestEntity a INNER JOIN TestEntity2 b ON a.s = b.s) AS t GROUP BY t._2i"
         }
       }
     }


### PR DESCRIPTION
Fixes #1583, #1598, #1564 

### Problem

#### First Issue

As explained in #1583, select elements that are infix clauses cannot be simply removed from a query when the are not being selected (at least if they are not pure). For example:
```scala
val q = quote {
  query[Person].map(p => (infix"DISTINCT ON (${p.other})".as[Int], p.name, p.id)).map(t => (t._2, t._3))
}
// Normally Produces:
// SELECT p.name, p.id FROM person p
// ... this totally breaks the intent of the query
```

This typically occurs where multiple map clauses are combined into a single one. Since clearly this cannot be done for the aforementioned infix clauses, we need to express the chained map clauses as sub-super queries which Quill already does, however, when deciding which select-values should be in the sub-query Quill excludes the values of elements that are not in the outer select list. This is perfectly acceptable in normal cases e.g:
```scala
run {
  query[Person].map(p => (p.id, p.name, p.other)).nested.map(t => (t._1, t._2))
}
// SELECT p.id, p.name FROM (SELECT x.id, x.name FROM person x) AS p
// The 'p.other' property is excluded, this is perfectly reasonable and actually is an optimization.
// (SIDE NOTE: Although technically the SQL optimizer should do it for us... it doesn't always do it, especially when this column is actually coming from a view, from a view, from a view etc...)
```
However not in situations where the are infix clauses being used as explained above.
For this reason, we need to find which infixes of every sub-query have not been expressed in the `expandSelect` (now refactored into `ExpandSelect`) method and then put them back into the sub-query. This is tricky because these infixes could be inside of tuples or case classes whose sibling elements have been selected so blindly including all `SelectValue` objects with infixes will cause duplicate fields to be selected. For this reason, we need to recursively traverse all `SelectValue` objects containing case classes and tuples and extract the infix values inside. 

During the traversal, we need to keep track of which element inside the respective case class or tuple we are in and check if that element has already been expressed as a `SelectValue` because it matched some `Property` of the output. Since arbitrary things can be selected inside of arbitrary paths inside case-classes and tuples, we need to keep track of not only the order of elements in the initial selection (of the sub-query) but also which element of the respective tuple (or sub-tuple, or sub-sub tuple) the infix is in. For this reason, we created the `OrderedSelect` object which keeps a `List[Int]` that represents the "path" of an element inside a list of select values. For example, say you have a query like this:
```scala
case class Person(id:Int, name:String, age:String)
val q = quote {
  query[Person]
  .map(p => (p.id, (p.name, infix"RANK() OVER(ORDER BY ${p.age})")))
  .map(t => (t._1, t._2._1))
}
```
Once the `SqlQuery(ast)` has been created, it looks something like this:
```scala
Map(
  Map(
    Entity("Person", List()),
    Ident("p"),
    Tuple(List(Property(Ident("p"), "id"), Tuple(List(Property(Ident("p"), "name"), Infix(List("RANK() OVER(ORDER BY ", ")"), List(Property(Ident("p"), "age")), false)))))
  ),
  Ident("t"),
  Tuple(List(Property(Ident("t"), "_1"), Property(Property(Ident("t"), "_2"), "_1")))
)
```

The "orders" of the elements are the following:
Order = 1 - `Property(Ident("p"), "id")`
Order = 2 - `Tuple(List(Property(Ident("p"), "name"), Infix(List("RANK() OVER(ORDER BY ", ")"), List(Property(Ident("p"), "age")), false)`
Order = 2,1 - `Property(Ident("p"), "name")`
Order = 2,2 - Infix(List("RANK() OVER(ORDER BY ", ")")

Now, since we have already selected element 2,2 (i.e. `Property(Ident("p"), "name")`) we cannot just select element 2 (i.e. the entire tuple since that would cause the `name` property to be selected twice (i.e. `SELECT ... FROM (SELECT p.id, p.name, p.name, RANK() ...)`). For this reason, we need to search down into element 2 into 2,2 and then pull out the infix. Then we need to put this infix into the correct place in the resulting query.

#### Second Issue
A related issue #1583 is where tuples are mapped to ad-hoc case classes and then are part of a nested select. This typically breaks because when in certain situations, multiple nested clauses exist in the AST (i.e. `Nested(Nested(q))` and sub-query fields cannot be attached to the corresponding elements because of how the nested query expansion works.
```scala
case class TestEntity(s: String, i: Int, l: Long, o: Option[Int]) extends Embedded
case class Dual(ta: TestEntity, tb: TestEntity)

val qr1 = quote {
  query[TestEntity]
}

val q = quote {
  qr1.join(qr1).on((a, b) => a.i == b.i).nested.map(both => both match { case (a, b) => Dual(a, b) }).nested
}

println(run(q).string)
```
This occurs:
```
cmd21.sc:1: exception during macro expansion: 
java.lang.IndexOutOfBoundsException: 1
	at scala.collection.LinearSeqOptimized$class.apply(LinearSeqOptimized.scala:65)
	at scala.collection.immutable.List.apply(List.scala:84)
	at io.getquill.context.sql.norm.ExpandNestedQueries$.io$getquill$context$sql$norm$ExpandNestedQueries$$expandReference$1(ExpandNestedQueries.scala:90)
	at io.getquill.context.sql.norm.ExpandNestedQueries$.io$getquill$context$sql$norm$ExpandNestedQueries$$expandReference$1(ExpandNestedQueries.scala:80)
	at io.getquill.context.sql.norm.ExpandNestedQueries$$anonfun$expandSelect$1.apply(ExpandNestedQueries.scala:108)
	at io.getquill.context.sql.norm.ExpandNestedQueries$$anonfun$expandSelect$1.apply(ExpandNestedQueries.scala:108)
	at scala.collection.immutable.List.map(List.scala:288)
```
This is due to the fact that there are multiple `Nested` clauses in the AST:
```scala
// show(SqlNormalize(q.ast)) 
Map(
  Nested(
    Nested(
      Map(
        Join(
          InnerJoin,
          Entity("TestEntity", List()),
          Entity("TestEntity", List()),
          Ident("a"),
          Ident("b"),
          BinaryOperation(Property(Ident("a"), "i"), ==, Property(Ident("b"), "i"))
        ),
        Ident("ab"),
        Tuple(List(Ident("a"), Ident("b")))
      )
    )
  ),
  Ident("both"),
  CaseClass(List(("ta", Property(Ident("both"), "_1")), ("tb", Property(Ident("both"), "_2"))))
)
```
This leads to an AST that looks like this:
```scala
// show(SqlQuery(SqlNormalize(q.ast))) 
FlattenSqlQuery(
  List(
    QueryContext(
      FlattenSqlQuery(
        List(
          QueryContext(
            FlattenSqlQuery(
              List(
                JoinContext(
                  InnerJoin,
                  TableContext(Entity("TestEntity", List()), "a"),
                  TableContext(Entity("TestEntity", List()), "b"),
                  BinaryOperation(Property(Ident("a"), "i"), ==, Property(Ident("b"), "i"))
                )
              ),
              None,
              None,
              List(),
              None,
              None,
              List(SelectValue(Ident("a"), None, false), SelectValue(Ident("b"), None, false)),
              false
            ),
            "x"
          )
        ),
        None,
        None,
        List(),
        None,
        None,
        List(SelectValue(Ident("x"), None, false)), // (b) From here?
        false
      ),
      "both"
    )
  ),
  None,
  None,
  List(),
  None,
  None,
  List(
    SelectValue(
      // (a) We need to look up _1 and _2......
      CaseClass(List(("ta", Property(Ident("both"), "_1")), ("tb", Property(Ident("both"), "_2")))),
      None,
      false
    )
  ),
  false
)
```
Notice that we need to lookup the properties `_1` and `_2` from the `x` variable in the middle? This will obviously fail because `x` does not contain these values. The problem here is that the extra nested clause produces and incorrect expression between the `_1` and `_2` keys and the `a` and `b` select values to which they refer. Collapsing the `Nested(Nested(q))` inside of `SqlQuery` solves this problem.

#### Third Issue
The third issue involves using an embedded entity inside of a query using `distinct`. In addition to potentially having a double nesting issue (Second Issue), this kind of query fails in the `ValidateSqlQuery` step because it's elements are not properly expanded. This occurs because root-level tuples in map-clauses and root-level ad-hoc case classes are not treated equivalently. Take for instance the following nested query that maps to a tuple:
```scala
case class Emb(a: Int, b: Int)
val q = quote {
  query[Emb].map(e => (1, e)).distinct 
}
run(q)
// SELECT e._1, e._2a, e._2b FROM (SELECT DISTINCT 1 AS _1, e.a AS _2a, e.b AS _2b FROM emb e) AS e
````
The SqlQuery gets expanded to the following:
```scala
// SqlQuery(SqlNormalize(q.ast)) 
FlattenSqlQuery(
  List(TableContext(Entity("Emb", List()), "e")),
  None,
  None,
  List(),
  None,
  None,
  List(SelectValue(Constant(1), None, false), SelectValue(Ident("e"), None, false)),
  true
)
```

Then take the following nested query that maps to an ad-hoc case class:
```scala
case class Parent(id: Int, emb1: Emb)
case class Emb(a: Int, b: Int) extends Embedded
val q = quote { 
  query[Emb].map(e => Parent(1, e)).distinct
}
run(q)
// java.lang.IllegalStateException: The monad composition can't be expressed using applicative joins. Faulty expression: '(1, e)'. Free variables: 'List(e)'.
// 	at io.getquill.util.Messages$.fail(Messages.scala:21)
// 	at io.getquill.context.sql.idiom.SqlIdiom$$anonfun$3.apply(SqlIdiom.scala:43)
// 	at io.getquill.context.sql.idiom.SqlIdiom$$anonfun$3.apply(SqlIdiom.scala:43)
// 	at scala.Option.map(Option.scala:146)
```

The SqlQuery gets expanded to the following:
```scala
// SqlQuery(SqlNormalize(q.ast)) 
FlattenSqlQuery(
  List(TableContext(Entity("Emb", List()), "e")),
  None,
  None,
  List(),
  None,
  None,
  List(SelectValue(CaseClass(List(("id", Constant(1)), ("emb1", Ident("e")))), None, false)),
  true
)
```

Notice that in the former, the tuple has been flattened to an array of SelectValue elements as opposed to the latter has not.

The difference in behavior also has an impact on `ExpandNestedQueries`. Notice for instance that tuple indices are used to de-reference the Nth element of a given select:
```scala
        case pp @ Property(_, TupleIndex(idx)) =>
            select(idx) match {
              case OrderedSelect(o, SelectValue(ast, alias, c)) =>
                OrderedSelect(o, SelectValue(ast, concat(alias, idx), c))
            }
```

The reason why Quill behaves differently for Tuples and Ad-Hoc case classes is due to the treason that tuples are used as both a row-coproduct type i.e. most notably from applicative joins, as well as an element type from a standard map method. Due to having this double-meaning, Quill automatically expands element-type types inside of SqlQuery so that they behave the same was as coproduct-type tuples. Now when using Ad-Hoc case classes as coproduct-types (i.e. with the use of `Embedded`), some additional effort needs to be taken in order to expand them properly prior to verification in `VerifySqlQuery`. This allows `VerifySqlQuery` to properly exclude sub-element identities (i.e. identities inside of `SelectValue(CaseClass(...))` elements).

#### Potential Issues in Future
Are there situations where `SELECT ... FROM (SELECT C1, .... RANK() (...))` queries will change their results by the mere exclusion of a column that `C1` that is excluded from the outer select. If this is the case, there should exist a mode that dissallows `ExpandSelect` from excluding ANY columns from sub-queries. This is fairly straightfoward to do now since we are basically doing this for infixes, whereas instead of just infixes, we would do it for all kinds of columns.

#### Trace
Due to the complex nature of `ExpandNestedQueries` and the AST transformations in general, I have decided to add some tracing code that can give the user more insight into what is going on with these operations. This has been instrumented as a Interpolator so as to clearly distinguish itself from the surrounding code. Since these things are considered a "side effect" and are to be avoided in functional code (at least by some schools of thought), I have introduced various methods such as `andReturn` and `andContinune` to the trace Interpolator that should allow the user to keep code in the functional style, at least in some places.

#### Conclusion
Since map-chained infixes are the most typical cause of nested queries, and distincts are a close-second, all three of these issues are closely related and require the same set of functionality in `ExpandNestedQueries` and `VerifySqlQuery` in order to function properly. Therefore I have chosen to bundle them into a single PR.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
