### PR TITLE
Fixing Embedded Coproduct Column Duplication Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ MyTestJdbc.scala
 MyJdbcTest.scala
 MySqlTest.scala
 MyTest.scala
+MyCqlTest.scala
 quill-core/src/main/resources/logback.xml
 quill-jdbc/src/main/resources/logback.xml
 log.txt*

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
@@ -112,9 +112,12 @@ trait CqlIdiom extends Idiom {
     case other                  => fail(s"Cql doesn't support the '$other' operator.")
   }
 
+  // Note: The CqlIdiom does not support joins so there is no need for any complex un-nesting logic like in SqlIdiom
+  // if there are Embedded classes, they will result in Property(Property(embedded, embeddedProp), actualProp)
+  // and we only need to take the top-level property i.e. `actualProp`.
   implicit def propertyTokenizer(implicit valueTokenizer: Tokenizer[Value], identTokenizer: Tokenizer[Ident], strategy: NamingStrategy): Tokenizer[Property] =
     Tokenizer[Property] {
-      case Property.Opinionated(_, name, renameable) => renameable.fixedOr(name.token)(strategy.column(name).token)
+      case Property.Opinionated(_, name, renameable, _) => renameable.fixedOr(name.token)(strategy.column(name).token)
     }
 
   implicit def valueTokenizer(implicit strategy: NamingStrategy): Tokenizer[Value] = Tokenizer[Value] {

--- a/quill-core/src/main/scala/io/getquill/AstPrinter.scala
+++ b/quill-core/src/main/scala/io/getquill/AstPrinter.scala
@@ -2,7 +2,8 @@ package io.getquill
 
 import fansi.Str
 import io.getquill.ast.Renameable.{ ByStrategy, Fixed }
-import io.getquill.ast.{ Ast, Entity, Property, Renameable }
+import io.getquill.ast.Visibility.{ Hidden, Visible }
+import io.getquill.ast._
 import pprint.{ Renderer, Tree, Truncated }
 
 object AstPrinter {
@@ -28,6 +29,12 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean) extends pprint
       case Fixed      => Tree.Literal("F")
     }
 
+  private def printVisibility(v: Visibility) =
+    v match {
+      case Visible => Tree.Literal("Vis")
+      case Hidden  => Tree.Literal("Hide")
+    }
+
   override def additionalHandlers: PartialFunction[Any, Tree] = {
     case ast: Ast if (traceAstSimple) =>
       Tree.Literal(ast + "") // Do not blow up if it is null
@@ -36,7 +43,7 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean) extends pprint
       Tree.Literal(past + "") // Do not blow up if it is null
 
     case p: Property if (traceOpinions) =>
-      Tree.Apply("Property", List[Tree](treeify(p.ast), treeify(p.name), printRenameable(p.renameable)).iterator)
+      Tree.Apply("Property", List[Tree](treeify(p.ast), treeify(p.name), printRenameable(p.renameable), printVisibility(p.visibility)).iterator)
 
     case e: Entity if (traceOpinions) =>
       Tree.Apply("Entity", List[Tree](treeify(e.name), treeify(e.properties), printRenameable(e.renameable)).iterator)

--- a/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorIdiom.scala
@@ -184,8 +184,8 @@ trait MirrorIdiomBase extends Idiom {
     }
 
   implicit def propertyTokenizer(implicit liftTokenizer: Tokenizer[Lift]): Tokenizer[Property] = Tokenizer[Property] {
-    case Property.Opinionated(ExternalIdent(_), name, renameable) => stmt"${tokenizeName(name, renameable).token}"
-    case Property.Opinionated(ref, name, renameable)              => stmt"${scopedTokenizer(ref)}.${tokenizeName(name, renameable).token}"
+    case Property.Opinionated(ExternalIdent(_), name, renameable, _) => stmt"${tokenizeName(name, renameable).token}"
+    case Property.Opinionated(ref, name, renameable, _)              => stmt"${scopedTokenizer(ref)}.${tokenizeName(name, renameable).token}"
   }
 
   implicit val valueTokenizer: Tokenizer[Value] = Tokenizer[Value] {

--- a/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -210,9 +210,9 @@ trait StatefulTransformer[T] {
 
   def apply(e: Property): (Property, StatefulTransformer[T]) =
     e match {
-      case Property.Opinionated(a, b, renameable) =>
+      case Property.Opinionated(a, b, renameable, visibility) =>
         val (at, att) = apply(a)
-        (Property.Opinionated(at, b, renameable), att)
+        (Property.Opinionated(at, b, renameable, visibility), att)
     }
 
   def apply(e: Operation): (Operation, StatefulTransformer[T]) =

--- a/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -86,7 +86,7 @@ trait StatelessTransformer {
 
   def apply(e: Property): Property =
     e match {
-      case Property.Opinionated(a, name, renameable) => Property.Opinionated(apply(a), name, renameable)
+      case Property.Opinionated(a, name, renameable, visibility) => Property.Opinionated(apply(a), name, renameable, visibility)
     }
 
   def apply(e: Operation): Operation =

--- a/quill-core/src/main/scala/io/getquill/norm/NormalizeAggregationIdent.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/NormalizeAggregationIdent.scala
@@ -9,8 +9,8 @@ object NormalizeAggregationIdent {
 
       // a => a.b.map(x => x.c).agg =>
       //   a => a.b.map(a => a.c).agg
-      case Aggregation(op, Map(p @ Property(i: Ident, _), mi, Property.Opinionated(_: Ident, n, renameable))) if i != mi =>
-        Some(Aggregation(op, Map(p, i, Property.Opinionated(i, n, renameable)))) // in example aove, if c in x.c is fixed c in a.c should also be
+      case Aggregation(op, Map(p @ Property(i: Ident, _), mi, Property.Opinionated(_: Ident, n, renameable, visibility))) if i != mi =>
+        Some(Aggregation(op, Map(p, i, Property.Opinionated(i, n, renameable, visibility)))) // in example aove, if c in x.c is fixed c in a.c should also be
 
       case _ => None
     }

--- a/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -1,6 +1,7 @@
 package io.getquill.norm
 
 import io.getquill.ast.Renameable.Fixed
+import io.getquill.ast.Visibility.Visible
 import io.getquill.ast._
 
 object RenameProperties extends StatelessTransformer {
@@ -202,7 +203,7 @@ object RenameProperties extends StatelessTransformer {
                 case Nil          => base
                 case head :: tail => apply(Property(base, head), tail)
               }
-            apply(base, path) -> Property.Opinionated(base, alias, Fixed)
+            apply(base, path) -> Property.Opinionated(base, alias, Fixed, Visible) // Hidden properties cannot be renamed
         }
       case Tuple(values) =>
         values.zipWithIndex.flatMap {

--- a/quill-core/src/main/scala/io/getquill/norm/capture/DemarcateExternalAliases.scala
+++ b/quill-core/src/main/scala/io/getquill/norm/capture/DemarcateExternalAliases.scala
@@ -56,9 +56,9 @@ private[getquill] case class DemarcateExternalAliases(externalIdent: Ident) exte
     case FlatJoin(t, a, iA, o) =>
       FlatJoin(t, a, iA, applyNonOverride(iA)(o))
 
-    case p @ Property.Opinionated(id @ Ident(_), value, renameable) =>
+    case p @ Property.Opinionated(id @ Ident(_), value, renameable, visibility) =>
       if (id == externalIdent)
-        Property.Opinionated(ExternalIdent(externalIdent.name), value, renameable)
+        Property.Opinionated(ExternalIdent(externalIdent.name), value, renameable, visibility)
       else
         p
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -110,6 +110,11 @@ trait Liftables {
     case Renameable.ByStrategy => q"$pack.Renameable.ByStrategy"
   }
 
+  implicit val visibilityLiftable: Liftable[Visibility] = Liftable[Visibility] {
+    case Visibility.Visible => q"$pack.Visibility.Visible"
+    case Visibility.Hidden  => q"$pack.Visibility.Hidden"
+  }
+
   implicit val queryLiftable: Liftable[Query] = Liftable[Query] {
     case Entity.Opinionated(a, b, renameable) => q"$pack.Entity.Opinionated($a, $b, $renameable)"
     case Filter(a, b, c)                      => q"$pack.Filter($a, $b, $c)"
@@ -134,7 +139,7 @@ trait Liftables {
   }
 
   implicit val propertyLiftable: Liftable[Property] = Liftable[Property] {
-    case Property.Opinionated(a, b, renameable) => q"$pack.Property.Opinionated($a, $b, $renameable)"
+    case Property.Opinionated(a, b, renameable, visibility) => q"$pack.Property.Opinionated($a, $b, $renameable, $visibility)"
   }
 
   implicit val orderingLiftable: Liftable[Ordering] = Liftable[Ordering] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -15,6 +15,7 @@ import scala.collection.immutable.StringOps
 import scala.reflect.macros.TypecheckException
 import io.getquill.ast.Implicits._
 import io.getquill.ast.Renameable.Fixed
+import io.getquill.ast.Visibility.{ Hidden, Visible }
 import io.getquill.util.Interleave
 
 trait Parsing extends ValueComputation {
@@ -483,7 +484,17 @@ trait Parsing extends ValueComputation {
       if (caseAccessors.nonEmpty && !caseAccessors.contains(property))
         c.fail(s"Can't find case class property: ${property.decodedName.toString}")
 
-      Property(astParser(e), property.decodedName.toString)
+      val visibility = {
+        val tpe = c.typecheck(q"$e.$property")
+        val innerParam = innerOptionParam(q"$tpe".tpe, None)
+        if (is[Embedded](q"$innerParam")) Hidden
+        else Visible
+      }
+
+      Property.Opinionated(astParser(e), property.decodedName.toString,
+        Renameable.neutral, //Renameability of the property is determined later in the RenameProperties normalization phase
+        visibility // Visibility is decided here.
+      )
   }
 
   val operationParser: Parser[Operation] = Parser[Operation] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -143,9 +143,14 @@ trait Unliftables {
     case q"$pack.Renameable.Fixed"      => Renameable.Fixed
   }
 
+  implicit val visibilityUnliftable: Unliftable[Visibility] = Unliftable[Visibility] {
+    case q"$pack.Visibility.Visible" => Visibility.Visible
+    case q"$pack.Visibility.Hidden"  => Visibility.Hidden
+  }
+
   implicit val propertyUnliftable: Unliftable[Property] = Unliftable[Property] {
     case q"$pack.Property.apply(${ a: Ast }, ${ b: String })" => Property(a, b)
-    case q"$pack.Property.Opinionated.apply(${ a: Ast }, ${ b: String }, ${ renameable: Renameable })" => Property.Opinionated(a, b, renameable)
+    case q"$pack.Property.Opinionated.apply(${ a: Ast }, ${ b: String }, ${ renameable: Renameable }, ${ visibility: Visibility })" => Property.Opinionated(a, b, renameable, visibility)
   }
 
   implicit def optionUnliftable[T](implicit u: Unliftable[T]): Unliftable[Option[T]] = Unliftable[Option[T]] {

--- a/quill-core/src/test/scala/io/getquill/ast/OpinionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/OpinionSpec.scala
@@ -3,21 +3,22 @@ package io.getquill.ast
 import io.getquill.Spec
 import io.getquill.ast.Renameable.Fixed
 import io.getquill.ast.Renameable.neutral
+import io.getquill.ast.Visibility.Visible
 
 class OpinionSpec extends Spec {
 
   "properties should neutralize" - {
     "to renameable default" in {
-      Property.Opinionated(Ident("foo"), "bar", Fixed).neutralize mustEqual (Property.Opinionated(Ident("foo"), "bar", neutral))
+      Property.Opinionated(Ident("foo"), "bar", Fixed, Visible).neutralize mustEqual (Property.Opinionated(Ident("foo"), "bar", neutral, Visible))
     }
     "to renameable default when nested" in {
-      Property.Opinionated(Property.Opinionated(Ident("foo"), "bar", Fixed), "baz", Fixed).neutralize mustEqual (
-        Property.Opinionated(Property.Opinionated(Ident("foo"), "bar", neutral), "baz", neutral)
+      Property.Opinionated(Property.Opinionated(Ident("foo"), "bar", Fixed, Visible), "baz", Fixed, Visible).neutralize mustEqual (
+        Property.Opinionated(Property.Opinionated(Ident("foo"), "bar", neutral, Visible), "baz", neutral, Visible)
       )
     }
     "when inside other AST elements" in {
-      Map(Property.Opinionated(Ident("foo"), "bar", Fixed), Ident("v"), Property.Opinionated(Ident("v"), "prop", Fixed)).neutralize mustEqual (
-        Map(Property.Opinionated(Ident("foo"), "bar", neutral), Ident("v"), Property.Opinionated(Ident("v"), "prop", neutral))
+      Map(Property.Opinionated(Ident("foo"), "bar", Fixed, Visible), Ident("v"), Property.Opinionated(Ident("v"), "prop", Fixed, Visible)).neutralize mustEqual (
+        Map(Property.Opinionated(Ident("foo"), "bar", neutral, Visible), Ident("v"), Property.Opinionated(Ident("v"), "prop", neutral, Visible))
       )
     }
   }
@@ -27,7 +28,7 @@ class OpinionSpec extends Spec {
       Entity.Opinionated("foo", Nil, Fixed).neutralize mustEqual (Entity("foo", Nil))
     }
     "when inside other AST elements" in {
-      Map(Entity.Opinionated("foo", Nil, Fixed), Ident("v"), Property.Opinionated(Ident("v"), "prop", Fixed)).neutralize mustEqual (
+      Map(Entity.Opinionated("foo", Nil, Fixed), Ident("v"), Property.Opinionated(Ident("v"), "prop", Fixed, Visible)).neutralize mustEqual (
         Map(Entity("foo", Nil), Ident("v"), Property(Ident("v"), "prop"))
       )
     }

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -2,6 +2,7 @@ package io.getquill.ast
 
 import io.getquill.Spec
 import io.getquill.ast.Renameable.Fixed
+import io.getquill.ast.Visibility.Visible
 
 class StatefulTransformerSpec extends Spec {
 
@@ -311,10 +312,10 @@ class StatefulTransformerSpec extends Spec {
     }
 
     "property - fixed" in {
-      val ast: Ast = Property.Opinionated(Ident("a"), "b", Fixed)
+      val ast: Ast = Property.Opinionated(Ident("a"), "b", Fixed, Visible)
       Subject(Nil, Ident("a") -> Ident("a'"))(ast) match {
         case (at, att) =>
-          at mustEqual Property.Opinionated(Ident("a'"), "b", Fixed)
+          at mustEqual Property.Opinionated(Ident("a'"), "b", Fixed, Visible)
           att.state mustEqual List(Ident("a"))
       }
     }

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -2,6 +2,7 @@ package io.getquill.ast
 
 import io.getquill.Spec
 import io.getquill.ast.Renameable.Fixed
+import io.getquill.ast.Visibility.Visible
 
 class StatelessTransformerSpec extends Spec {
 
@@ -167,9 +168,9 @@ class StatelessTransformerSpec extends Spec {
           OnConflict.Properties(List(Property(Ident("a'"), "b")))
       }
       "properties - fixed" in {
-        val target: OnConflict.Target = OnConflict.Properties(List(Property.Opinionated(Ident("a"), "b", Fixed)))
+        val target: OnConflict.Target = OnConflict.Properties(List(Property.Opinionated(Ident("a"), "b", Fixed, Visible)))
         Subject(Ident("a") -> Ident("a'"))(target) mustEqual
-          OnConflict.Properties(List(Property.Opinionated(Ident("a'"), "b", Fixed)))
+          OnConflict.Properties(List(Property.Opinionated(Ident("a'"), "b", Fixed, Visible)))
       }
     }
 
@@ -214,9 +215,9 @@ class StatelessTransformerSpec extends Spec {
     }
 
     "property - fixed" in {
-      val ast: Ast = Property.Opinionated(Ident("a"), "b", Fixed)
+      val ast: Ast = Property.Opinionated(Ident("a"), "b", Fixed, Visible)
       Subject(Ident("a") -> Ident("a'"))(ast) mustEqual
-        Property.Opinionated(Ident("a'"), "b", Fixed)
+        Property.Opinionated(Ident("a'"), "b", Fixed, Visible)
     }
 
     "infix" in {

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -2,6 +2,7 @@ package io.getquill.norm
 
 import io.getquill.Spec
 import io.getquill.ast.Renameable.Fixed
+import io.getquill.ast.Visibility.Visible
 import io.getquill.ast._
 
 class BetaReductionSpec extends Spec {
@@ -12,7 +13,7 @@ class BetaReductionSpec extends Spec {
       BetaReduction(ast) mustEqual Ident("a")
     }
     "tuple field - fixed property" in {
-      val ast: Ast = Property.Opinionated(Tuple(List(Ident("a"))), "_1", Fixed)
+      val ast: Ast = Property.Opinionated(Tuple(List(Ident("a"))), "_1", Fixed, Visible)
       BetaReduction(ast) mustEqual Ident("a")
     }
     "caseclass field" in {
@@ -20,7 +21,7 @@ class BetaReductionSpec extends Spec {
       BetaReduction(ast) mustEqual Ident("a")
     }
     "caseclass field - fixed property" in {
-      val ast: Ast = Property.Opinionated(CaseClass(List(("foo", Ident("a")))), "foo", Fixed)
+      val ast: Ast = Property.Opinionated(CaseClass(List(("foo", Ident("a")))), "foo", Fixed, Visible)
       BetaReduction(ast) mustEqual Ident("a")
     }
     "function apply" in {

--- a/quill-core/src/test/scala/io/getquill/norm/ExpandReturningSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ExpandReturningSpec.scala
@@ -3,6 +3,7 @@ package io.getquill.norm
 import io.getquill.ReturnAction.{ ReturnColumns, ReturnRecord }
 import io.getquill._
 import io.getquill.ast.Renameable.ByStrategy
+import io.getquill.ast.Visibility.Visible
 import io.getquill.ast._
 import io.getquill.context.Expand
 
@@ -114,14 +115,14 @@ class ExpandReturningSpec extends Spec {
       Map(
         Entity.Opinionated("Person", List(), renameable),
         Ident("p"),
-        Tuple(List(Property.Opinionated(Ident("p"), "name", renameable), Property.Opinionated(Ident("p"), "age", renameable)))
+        Tuple(List(Property.Opinionated(Ident("p"), "name", renameable, Visible), Property.Opinionated(Ident("p"), "age", renameable, Visible)))
       ),
-      List(Assignment(Ident("pp"), Property.Opinionated(Ident("pp"), "name", renameable), Constant("Joe")))
+      List(Assignment(Ident("pp"), Property.Opinionated(Ident("pp"), "name", renameable, Visible), Constant("Joe")))
     )
     def retMulti =
-      Returning(insert, Ident("r"), Tuple(List(Property.Opinionated(Ident("r"), "name", renameable), Property.Opinionated(Ident("r"), "age", renameable))))
+      Returning(insert, Ident("r"), Tuple(List(Property.Opinionated(Ident("r"), "name", renameable, Visible), Property.Opinionated(Ident("r"), "age", renameable, Visible))))
     def retSingle =
-      Returning(insert, Ident("r"), Tuple(List(Property.Opinionated(Ident("r"), "name", renameable))))
+      Returning(insert, Ident("r"), Tuple(List(Property.Opinionated(Ident("r"), "name", renameable, Visible))))
 
     "returning single" - {
       val mi = MirrorIdiomReturningSingle

--- a/quill-core/src/test/scala/io/getquill/quotation/IsDynamicSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/IsDynamicSpec.scala
@@ -4,6 +4,7 @@ import io.getquill.Spec
 import io.getquill.ast.Dynamic
 import io.getquill.ast.Property
 import io.getquill.ast.Renameable.Fixed
+import io.getquill.ast.Visibility.Visible
 import io.getquill.testContext.qr1
 import io.getquill.testContext.qrRegular
 
@@ -18,7 +19,7 @@ class IsDynamicSpec extends Spec {
         IsDynamic(Property(Dynamic(1), "a")) mustEqual true
       }
       "partially dynamic - fixed" in {
-        IsDynamic(Property.Opinionated(Dynamic(1), "a", Fixed)) mustEqual true
+        IsDynamic(Property.Opinionated(Dynamic(1), "a", Fixed, Visible)) mustEqual true
       }
     }
     "false" in {

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
@@ -234,7 +234,7 @@ trait OrientDBIdiom extends Idiom {
       case Property(ast, "isEmpty")   => stmt"${ast.token} IS NULL"
       case Property(ast, "nonEmpty")  => stmt"${ast.token} IS NOT NULL"
       case Property(ast, "isDefined") => stmt"${ast.token} IS NOT NULL"
-      case Property.Opinionated(ast, name, renameable) =>
+      case Property.Opinionated(ast, name, renameable, _) =>
         renameable.fixedOr(name.token)(strategy.column(name).token)
     }
   }
@@ -269,10 +269,10 @@ trait OrientDBIdiom extends Idiom {
   implicit def actionTokenizer(implicit strategy: NamingStrategy): Tokenizer[Action] = {
 
     implicit def propertyTokenizer: Tokenizer[Property] = Tokenizer[Property] {
-      case Property(Property.Opinionated(_, name, renameable), "isEmpty")   => stmt"${renameable.fixedOr(name.token)(strategy.column(name).token)} IS NULL"
-      case Property(Property.Opinionated(_, name, renameable), "isDefined") => stmt"${renameable.fixedOr(name.token)(strategy.column(name).token)} IS NOT NULL"
-      case Property(Property.Opinionated(_, name, renameable), "nonEmpty")  => stmt"${renameable.fixedOr(name.token)(strategy.column(name).token)} IS NOT NULL"
-      case Property.Opinionated(_, name, renameable)                        => renameable.fixedOr(name.token)(strategy.column(name).token)
+      case Property(Property.Opinionated(_, name, renameable, _), "isEmpty")   => stmt"${renameable.fixedOr(name.token)(strategy.column(name).token)} IS NULL"
+      case Property(Property.Opinionated(_, name, renameable, _), "isDefined") => stmt"${renameable.fixedOr(name.token)(strategy.column(name).token)} IS NOT NULL"
+      case Property(Property.Opinionated(_, name, renameable, _), "nonEmpty")  => stmt"${renameable.fixedOr(name.token)(strategy.column(name).token)} IS NOT NULL"
+      case Property.Opinionated(_, name, renameable, _)                        => renameable.fixedOr(name.token)(strategy.column(name).token)
     }
 
     Tokenizer[Action] {

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -139,7 +139,7 @@ trait SparkIdiom extends SqlIdiom with CannotReturn { self =>
     def path(ast: Ast): Token =
       ast match {
         case Ident(name) => name.token
-        case Property.Opinionated(a, b, renameable) =>
+        case Property.Opinionated(a, b, renameable, _) =>
           stmt"${path(a)}.${renameable.fixedOr(b.token)(strategy.column(b).token)}"
         case other =>
           other.token

--- a/quill-sql/src/main/scala/io/getquill/MySQLDialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/MySQLDialect.scala
@@ -54,12 +54,13 @@ trait MySQLDialect
           fail("This upsert construct is not supported in MySQL. Please refer documentation for details.")
       }
 
+    // TODO Are there situations where you could have invisible properties here?
     val customAstTokenizer =
       Tokenizer.withFallback[Ast](MySQLDialect.this.astTokenizer(_, strategy)) {
-        case Property.Opinionated(Excluded(_), name, renameable) =>
+        case Property.Opinionated(Excluded(_), name, renameable, _) =>
           renameable.fixedOr(name.token)(stmt"VALUES(${strategy.column(name).token})")
 
-        case Property.Opinionated(_, name, renameable) =>
+        case Property.Opinionated(_, name, renameable, _) =>
           renameable.fixedOr(name.token)(strategy.column(name).token)
       }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/EmbeddedSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/EmbeddedSpec.scala
@@ -14,7 +14,45 @@ class EmbeddedSpec extends Spec {
       val q = quote {
         query[Emb].map(e => Parent(1, e)).distinct
       }
-      ctx.run(q).string mustEqual "SELECT e.id, e.a, e.b FROM (SELECT DISTINCT 1 AS id, e.a AS a, e.b AS b FROM Emb e) AS e"
+      ctx.run(q).string mustEqual "SELECT e.id, e.emb1a, e.emb1b FROM (SELECT DISTINCT 1 AS id, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS e"
+    }
+
+    "function property inside of nested distinct queries - tuple" in {
+      case class Parent(id: Int, emb1: Emb)
+      case class Emb(a: Int, b: Int) extends Embedded
+      val q = quote {
+        query[Emb].map(e => Parent(1, e)).distinct.map(p => (2, p)).distinct
+      }
+      ctx.run(q).string mustEqual "SELECT p._1, p._2id, p._2emb1a, p._2emb1b FROM (SELECT DISTINCT 2 AS _1, p.id AS _2id, p.emb1a AS _2emb1a, p.emb1b AS _2emb1b FROM (SELECT DISTINCT 1 AS id, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS p) AS p"
+    }
+
+    "function property inside of nested distinct queries through tuples" in {
+      case class Parent(id: Int, emb1: Emb)
+      case class Emb(a: Int, b: Int) extends Embedded
+      val q = quote {
+        query[Emb].map(e => (1, e)).distinct.map(t => Parent(t._1, t._2)).distinct
+      }
+      ctx.run(q).string mustEqual "SELECT t.id, t.emb1a, t.emb1b FROM (SELECT DISTINCT t._1 AS id, t._2a AS emb1a, t._2b AS emb1b FROM (SELECT DISTINCT 1 AS _1, e.a AS _2a, e.b AS _2b FROM Emb e) AS t) AS t"
+    }
+
+    "function property inside of nested distinct queries - twice" in {
+      case class Grandparent(idG: Int, par: Parent)
+      case class Parent(idP: Int, emb1: Emb) extends Embedded
+      case class Emb(a: Int, b: Int) extends Embedded
+      val q = quote {
+        query[Emb].map(e => Parent(1, e)).distinct.map(p => Grandparent(2, p)).distinct
+      }
+      ctx.run(q).string mustEqual "SELECT p.idG, p.paridP, p.paremb1a, p.paremb1b FROM (SELECT DISTINCT 2 AS idG, p.idP AS paridP, p.emb1a AS paremb1a, p.emb1b AS paremb1b FROM (SELECT DISTINCT 1 AS idP, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS p) AS p"
+    }
+
+    "function property inside of nested distinct queries - twice - into tuple" in {
+      case class Grandparent(idG: Int, par: Parent)
+      case class Parent(idP: Int, emb1: Emb) extends Embedded
+      case class Emb(a: Int, b: Int) extends Embedded
+      val q = quote {
+        query[Emb].map(e => Parent(1, e)).distinct.map(p => Grandparent(2, p)).distinct.map(g => (3, g)).distinct
+      }
+      ctx.run(q).string mustEqual "SELECT g._1, g._2idG, g._2paridP, g._2paremb1a, g._2paremb1b FROM (SELECT DISTINCT 3 AS _1, g.idG AS _2idG, g.paridP AS _2paridP, g.paremb1a AS _2paremb1a, g.paremb1b AS _2paremb1b FROM (SELECT DISTINCT 2 AS idG, p.idP AS paridP, p.emb1a AS paremb1a, p.emb1b AS paremb1b FROM (SELECT DISTINCT 1 AS idP, e.a AS emb1a, e.b AS emb1b FROM Emb e) AS p) AS g) AS g"
     }
   }
 


### PR DESCRIPTION
Fixes #1602

### Introduction

The primary challenge of managing sub-queries with row co-products is how to alias columns that have the same name. For example say that we have something like this:
```scala
val ps = query[Person]
  .join(query[Person]).on(_.id == _.partnerOf) //Returns a coproduct (Person, Address) i.e. a tuple
  .map { case (pa, pb) => (pa.name, pb.name) }
run(ps)
```
Running this should return something like this:
```
select pa.name, pb.name from Person pa join Person pb on pa.id = pb.partnerOf
```
Now let's say we make a subquery of this:
```scala
ps.nested.map { case (paName, pbName) => (paName + "-one", pb + "-two") }
```
Doing a subquery of this causes a problem. The inner query returns two name columns and SQL cannot determinte one from the other!
```sql
-- Two "name" columns coming out of "inner". Which one is which???
select name|'-one', name|'-two' name from (
  select pa.name, pb.name from Person pa join Person pb on pa.id = pb.partnerOf
) inner -- Side Note: Usually this is x or x1 etc... if you have not specified a name for it in the 2nd map
```
In order to solve this problem, Quill aliases the inner query with an alias which is the appended the tuple property name (i.e. `_+(tupleIndex+1)`) and the property name. I.e:
```sql
-- Two "name" columns coming out of "inner". Which one is which???
select name|'-one', name|'-two' name from (
  select pa.name as _1name, pb.name as _2name from Person pa join Person pb on pa.id = pb.partnerOf
)
```
This strategy works for tuples but what about if the co-product type is a case-class. This kind of scenario is more difficult to reproduce but as indicated by #1602 it is:
```scala
case class Person(id:Int, name:String, partnerOf:Int) extends Embedded
case class Dual(ta: Person, tb: Person)

val qr1 = quote { query[Person] }

val q = quote {
  qr1.join(qr1).on((a, b) => a.id == b.partnerOf).nested.map(both => both match { case (a, b) => Dual(a, b) }).distinct.nested
}
run(q)
```
This yields:
```sql
SELECT x.id, x.name, x.partner_of, x.id, x.name, x.partner_of FROM (SELECT DISTINCT both._1id AS taid, both._1name AS taname, both._1partner_of AS tapartner_of, both._2id AS tbid, both._2name AS tbname, both._2partner_of AS tbpartner_of FROM (SELECT a.id AS _1id, a.name AS _1name, a.partner_of AS _1partner_of, b.id AS _2id, b.name AS _2name, b.partner_of AS _2partner_of FROM person a INNER JOIN person b ON a.id = b.partner_of) AS both) AS x
```
Note how the "name" columns as well as others appear twice (and it also does not correspond to the inner aliast `taname`). This is because only tuple properties (e.g. `_1`, `_2` ...) are only appended to sub-query aliases as opposed to Ad-Hoc case class fields.
That is to say `Property(Property(x, "_1"), "name")` is expressed as `"_1name"` in `SqlIdiom` but `Property(Property(x, "pa"), "name")` just becomes `"name"`.
This is by design since we rely on the skipping of nested property objects in order to get correct SQL tokenization behavior in embedded entities. As the next section will explain.

### Sub-Properties and Embedded Entities
Typically the way embedded entities are expressed is as properties e.g. with a schema like this:
```scala
case class Emb(a: Int, b:Int) extends Embedded
case class Parent(id:Int, emb:Emb)
val q = quote { query[Parent] }
```
... selecting the field `a` from `Emb` inside of `Parent` would be `p.map(p => p.emb.a)`. This translates into `Property(Property(p, "emb"), "a")` in the AST. Now if we were to treat both tuple index (i.e. _1, _2, etc...) inner-properties, and all other inner-properties the same way, the query `q` (above) would become:
```sql
select id, emba, embb from Parent
```
... which is clearly incorrect.

### The Solution

Now, since we can no longer rely on the tuple-index format (i.e. _1, _2 etc...) to know whether a property should be tokenized, we need a way to identify which properties belong to embedded entities and which ones belong to Ad-Hoc case classes. Since this kind of information is not really related to AST transformations but rather is only used for SQL tokenization, it is a good candidate for AST Opinions. 

AST Opinions were first introduced in <> to handle situations where a property is not subject to NamingStrategy manipulation because it is defined in a querySchema (i.e. schema meta). Following, a similar pattern, which Properties are visible or not is introduced to Property opinions (extractable and constructible via `Property.Opinionated`), the actual value of this property is set in the parser (i.e. `Parsing.scala`). For example `Property.Opinionated(Property.Opinionated(x, "emb", ByStrategy, Hidden), "a", ByStrategy, Visible)` (*) tells us that the property `emb` is hidden and should not be expressed as part of SQL Tokenization but *DOES* need to be used for aliasing.

Due to these changes, the query mentioned above:
```scala
case class Person(id:Int, name:String, partnerOf:Int) extends Embedded
case class Dual(ta: Person, tb: Person)

val qr1 = quote { query[Person] }

val q = quote {
  qr1.join(qr1).on((a, b) => a.id == b.partnerOf).nested.map(both => both match { case (a, b) => Dual(a, b) }).distinct.nested
}
run(q)
```
Now produces the correct SQL:
```sql
SELECT x.taid, x.taname, x.tapartner_of, x.tbid, x.tbname, x.tbpartner_of FROM (SELECT DISTINCT both._1id AS taid, both._1name AS taname, both._1partner_of AS tapartner_of, both._2id AS tbid, both._2name AS tbname, both._2partner_of AS tbpartner_of FROM (SELECT a.id AS _1id, a.name AS _1name, a.partner_of AS _1partner_of, b.id AS _2id, b.name AS _2name, b.partner_of AS _2partner_of FROM person a INNER JOIN person b ON a.id = b.partner_of) AS both) AS x
```

(*) Also notice both properties have `renameable = ByStrategy`, this means that a `querySchema` has been defined for neither of them.




- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
