### PR TITLE
Additional Fixes for Embedded Entities in Nested Queries

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -354,6 +354,11 @@ trait SqlIdiom extends Idiom {
             stmt"${
               actionAlias.map(alias => stmt"${scopedTokenizer(alias)}.").getOrElse(stmt"")
             }${tokenizePrefixedProperty(name, prefix, strategy, renameable)}"
+
+          // In the rare case that the Ident is invisible, do not show it. See the Ident documentation for more info.
+          case (Ident.Opinionated(_, Hidden), prefix) =>
+            stmt"${tokenizePrefixedProperty(name, prefix, strategy, renameable)}"
+
           // The normal case where `Property(Property(Ident("realTable"), embeddedTableAlias), realPropertyAlias)`
           // becomes `realTable.realPropertyAlias`.
           case (ast, prefix) =>

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandDistinct.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/ExpandDistinct.scala
@@ -1,5 +1,6 @@
 package io.getquill.context.sql.norm
 
+import io.getquill.ast.Visibility.Hidden
 import io.getquill.ast._
 
 object ExpandDistinct {
@@ -17,11 +18,28 @@ object ExpandDistinct {
               Tuple(values.zipWithIndex.map {
                 case (_, i) => Property(x, s"_${i + 1}")
               }))
+
+          // Situations like this:
+          //    case class AdHocCaseClass(id: Int, name: String)
+          //    val q = quote {
+          //      query[SomeTable].map(st => AdHocCaseClass(st.id, st.name)).distinct
+          //    }
+          // ... need some special treatment. Otherwise their values will not be correctly expanded.
           case Distinct(Map(q, x, cc @ CaseClass(values))) =>
             Map(Distinct(Map(q, x, cc)), x,
               CaseClass(values.map {
                 case (name, _) => (name, Property(x, name))
               }))
+
+          // Need some special handling to address issues with distinct returning a single embedded entity i.e:
+          // query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id))
+          // cannot treat such a case normally or "confused" queries will result e.g:
+          // SELECT p.embname, p.embid FROM (SELECT DISTINCT emb.name /* Where the heck is 'emb' coming from? */ AS embname, emb.id AS embid FROM Parent p) AS p
+          case d @ Distinct(Map(q, x, p @ Property.Opinionated(_, _, _, Hidden))) => d
+
+          // Problems with distinct were first discovered in #1032. Basically, unless
+          // the distinct is "expanded" adding an outer map, Ident's representing a Table will end up in invalid places
+          // such as "ORDER BY tableIdent" etc...
           case Distinct(Map(q, x, p)) =>
             Map(Distinct(Map(q, x, p)), x, p)
         }

--- a/quill-sql/src/main/scala/io/getquill/context/sql/norm/nested/ExpandSelect.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/norm/nested/ExpandSelect.scala
@@ -9,6 +9,7 @@ import io.getquill.util.Messages.TraceType.NestedQueryExpansion
 import scala.collection.mutable.LinkedHashSet
 import io.getquill.context.sql.norm.nested.Elements._
 import io.getquill.ast._
+import io.getquill.norm.BetaReduction
 
 /**
  * Takes the `SelectValue` elements inside of a sub-query (if a super/sub-query constrct exists) and flattens
@@ -62,122 +63,144 @@ private class ExpandSelect(selectValues: List[SelectValue], references: LinkedHa
   def expandColumn(name: String, renameable: Renameable): String =
     renameable.fixedOr(name)(strategy.column(name))
 
-  def apply: List[SelectValue] = {
-    trace"Expanding Select values: $selectValues into references: $references" andLog ()
+  def apply: List[SelectValue] =
+    trace"Expanding Select values: $selectValues into references: $references" andReturn {
 
-    def expandReference(ref: Property): OrderedSelect = {
-      trace"Expanding: $ref from $select" andLog ()
+      def expandReference(ref: Property): OrderedSelect =
+        trace"Expanding: $ref from $select" andReturn {
 
-      def expressIfTupleIndex(str: String) =
-        str match {
-          case MultiTupleIndex() => Some(str)
-          case _                 => None
-        }
-
-      def concat(alias: Option[String], idx: Int) =
-        Some(s"${alias.getOrElse("")}_${idx + 1}")
-
-      val orderedSelect = ref match {
-        case pp @ Property(ast: Property, TupleIndex(idx)) =>
-          trace"Reference is a sub-property of a tuple index: $idx. Walking inside." andContinue
-            expandReference(ast) match {
-              case OrderedSelect(o, SelectValue(Tuple(elems), alias, c)) =>
-                trace"Expressing Element $idx of $elems " andReturn
-                OrderedSelect(o :+ idx, SelectValue(elems(idx), concat(alias, idx), c))
-              case OrderedSelect(o, SelectValue(ast, alias, c)) =>
-                trace"Appending $idx to $alias " andReturn
-                OrderedSelect(o, SelectValue(ast, concat(alias, idx), c))
+          def expressIfTupleIndex(str: String) =
+            str match {
+              case MultiTupleIndex() => Some(str)
+              case _                 => None
             }
-        case pp @ Property.Opinionated(ast: Property, name, renameable, visible) =>
-          trace"Reference is a sub-property. Walking inside." andContinue
-            expandReference(ast) match {
-              case OrderedSelect(o, SelectValue(ast, nested, c)) =>
-                // Alias is the name of the column after the naming strategy
-                // The clauses in `SqlIdiom` that use `Tokenizer[SelectValue]` select the
-                // alias field when it's value is Some(T).
-                // Technically the aliases of a column should not be using naming strategies
-                // but this is an issue to fix at a later date.
 
-                // In the current implementation, aliases we add nested tuple names to queries e.g.
-                // SELECT foo from
-                // SELECT x, y FROM (SELECT foo, bar, red, orange FROM baz JOIN colors)
-                // Typically becomes SELECT foo _1foo, _1bar, _2red, _2orange when
-                // this kind of query is the result of an applicative join that looks like this:
-                // query[baz].join(query[colors]).nested
-                // this may need to change based on how distinct appends table names instead of just tuple indexes
-                // into the property path.
+          def concat(alias: Option[String], idx: Int) =
+            Some(s"${alias.getOrElse("")}_${idx + 1}")
 
-                OrderedSelect(o, SelectValue(
-                  // Note: Pass invisible properties to be tokenized by the idiom, they should be excluded there
-                  Property.Opinionated(ast, name, renameable, visible),
-                  // Skip concatonation of invisible properties into the alias e.g. so it will be
-                  Some(s"${nested.getOrElse("")}${expandColumn(name, renameable)}")
-                ))
-            }
-        case pp @ Property(_, TupleIndex(idx)) =>
-          trace"Reference is a tuple index: $idx from $select." andContinue
-            select(idx) match {
-              case OrderedSelect(o, SelectValue(ast, alias, c)) =>
-                OrderedSelect(o, SelectValue(ast, concat(alias, idx), c))
-            }
-        case pp @ Property.Opinionated(_, name, renameable, visible) =>
-          select match {
-            case List(OrderedSelect(o, SelectValue(cc: CaseClass, alias, c))) =>
-              // Currently case class element name is not being appended. Need to change that in order to ensure
-              // path name uniqueness in future.
-              val ((_, ast), index) = cc.values.zipWithIndex.find(_._1._1 == name) match {
-                case Some(v) => v
-                case None    => throw new IllegalArgumentException(s"Cannot find element $name in $cc")
+          val orderedSelect = ref match {
+            case pp @ Property(ast: Property, TupleIndex(idx)) =>
+              trace"Reference is a sub-property of a tuple index: $idx. Walking inside." andReturn
+                expandReference(ast) match {
+                  case OrderedSelect(o, SelectValue(Tuple(elems), alias, c)) =>
+                    trace"Expressing Element $idx of $elems " andReturn
+                    OrderedSelect(o :+ idx, SelectValue(elems(idx), concat(alias, idx), c))
+                  case OrderedSelect(o, SelectValue(ast, alias, c)) =>
+                    trace"Appending $idx to $alias " andReturn
+                    OrderedSelect(o, SelectValue(ast, concat(alias, idx), c))
+                }
+            case pp @ Property.Opinionated(ast: Property, name, renameable, visible) =>
+              trace"Reference is a sub-property. Walking inside." andReturn
+                expandReference(ast) match {
+                  case OrderedSelect(o, SelectValue(ast, nested, c)) =>
+                    // Alias is the name of the column after the naming strategy
+                    // The clauses in `SqlIdiom` that use `Tokenizer[SelectValue]` select the
+                    // alias field when it's value is Some(T).
+                    // Technically the aliases of a column should not be using naming strategies
+                    // but this is an issue to fix at a later date.
+
+                    // In the current implementation, aliases we add nested tuple names to queries e.g.
+                    // SELECT foo from
+                    // SELECT x, y FROM (SELECT foo, bar, red, orange FROM baz JOIN colors)
+                    // Typically becomes SELECT foo _1foo, _1bar, _2red, _2orange when
+                    // this kind of query is the result of an applicative join that looks like this:
+                    // query[baz].join(query[colors]).nested
+                    // this may need to change based on how distinct appends table names instead of just tuple indexes
+                    // into the property path.
+
+                    trace"...inside walk completed, continuing to return: " andReturn
+                    OrderedSelect(o, SelectValue(
+                      // Note: Pass invisible properties to be tokenized by the idiom, they should be excluded there
+                      Property.Opinionated(ast, name, renameable, visible),
+                      // Skip concatonation of invisible properties into the alias e.g. so it will be
+                      Some(s"${nested.getOrElse("")}${expandColumn(name, renameable)}")
+                    ))
+                }
+            case pp @ Property(_, TupleIndex(idx)) =>
+              trace"Reference is a tuple index: $idx from $select." andReturn
+                select(idx) match {
+                  case OrderedSelect(o, SelectValue(ast, alias, c)) =>
+                    OrderedSelect(o, SelectValue(ast, concat(alias, idx), c))
+                }
+            case pp @ Property.Opinionated(_, name, renameable, visible) =>
+              select match {
+                case List(OrderedSelect(o, SelectValue(cc: CaseClass, alias, c))) =>
+                  // Currently case class element name is not being appended. Need to change that in order to ensure
+                  // path name uniqueness in future.
+                  val ((_, ast), index) = cc.values.zipWithIndex.find(_._1._1 == name) match {
+                    case Some(v) => v
+                    case None    => throw new IllegalArgumentException(s"Cannot find element $name in $cc")
+                  }
+                  trace"Reference is a case class member: " andReturn
+                    OrderedSelect(o :+ index, SelectValue(ast, Some(expandColumn(name, renameable)), c))
+                case List(OrderedSelect(o, SelectValue(i: Ident, _, c))) =>
+                  trace"Reference is an identifier: " andReturn
+                    OrderedSelect(o, SelectValue(Property.Opinionated(i, name, renameable, visible), Some(name), c))
+                case other =>
+                  trace"Reference is unidentified: $other returning:" andReturn
+                    OrderedSelect(Integer.MAX_VALUE, SelectValue(Ident.Opinionated(name, visible), Some(expandColumn(name, renameable)), false))
               }
-              trace"Reference is a case class member: " andReturn
-                OrderedSelect(o :+ index, SelectValue(ast, Some(expandColumn(name, renameable)), c))
-            case List(OrderedSelect(o, SelectValue(i: Ident, _, c))) =>
-              trace"Reference is an identifier: " andReturn
-                OrderedSelect(o, SelectValue(Property.Opinionated(i, name, renameable, visible), None, c))
-            case other =>
-              trace"Reference is unidentified: " andReturn
-                OrderedSelect(Integer.MAX_VALUE, SelectValue(Ident(name), Some(expandColumn(name, renameable)), false))
           }
-      }
 
-      trace"Expanded $ref into $orderedSelect"
-      orderedSelect
-    }
+          // For certain very large queries where entities are unwrapped and then re-wrapped into CaseClass/Tuple constructs,
+          // the actual row-types can contain Tuple/CaseClass values. For this reason. They need to be beta-reduced again.
+          val normalizedOrderedSelect = orderedSelect.copy(selectValue =
+            orderedSelect.selectValue.copy(ast =
+              BetaReduction(orderedSelect.selectValue.ast)))
 
-    references.toList match {
-      case Nil => select.map(_.selectValue)
-      case refs => {
-        // elements first need to be sorted by their order in the select clause. Since some may map to multiple
-        // properties when expanded, we want to maintain this order of properties as a secondary value.
-        val mappedRefs = refs.map(expandReference)
-        trace"Mapped Refs: $mappedRefs" andLog ()
-
-        // are there any selects that have infix values which we have not already selected? We need to include
-        // them because they could be doing essential things e.g. RANK ... ORDER BY
-        val remainingSelectsWithInfixes =
-          trace"Searching Selects with Infix:" andReturn
-            new FindUnexpressedInfixes(select)(mappedRefs)
-
-        implicit val ordering: scala.math.Ordering[List[Int]] = new scala.math.Ordering[List[Int]] {
-          override def compare(x: List[Int], y: List[Int]): Int =
-            (x, y) match {
-              case (head1 :: tail1, head2 :: tail2) =>
-                val diff = head1 - head2
-                if (diff != 0) diff
-                else compare(tail1, tail2)
-              case (Nil, Nil)   => 0 // List(1,2,3) == List(1,2,3)
-              case (head1, Nil) => -1 // List(1,2,3) < List(1,2)
-              case (Nil, head2) => 1 // List(1,2) > List(1,2,3)
-            }
+          trace"Expanded $ref into $orderedSelect then Normalized to $normalizedOrderedSelect" andReturn
+            normalizedOrderedSelect
         }
 
-        val sortedRefs =
-          (mappedRefs ++ remainingSelectsWithInfixes).sortBy(ref => ref.order) //(ref.order, ref.secondaryOrder)
+      def deAliasWhenUneeded(os: OrderedSelect) =
+        os match {
+          case OrderedSelect(_, sv @ SelectValue(Property(Ident(_), propName), Some(alias), _)) if (propName == alias) =>
+            trace"Detected select value with un-needed alias: $os removing it:" andReturn
+              os.copy(selectValue = sv.copy(alias = None))
+          case _ => os
+        }
 
-        sortedRefs.map(_.selectValue)
+      references.toList match {
+        case Nil => select.map(_.selectValue)
+        case refs => {
+          // elements first need to be sorted by their order in the select clause. Since some may map to multiple
+          // properties when expanded, we want to maintain this order of properties as a secondary value.
+          val mappedRefs =
+            refs
+              // Expand all the references to properties that we have selected in the super query
+              .map(expandReference)
+              // Once all the recursive calls of expandReference are done, remove the alias if it is not needed.
+              // We cannot do this because during recursive calls, the aliases of outer clauses are used for inner ones.
+              .map(deAliasWhenUneeded(_))
+
+          trace"Mapped Refs: $mappedRefs" andLog ()
+
+          // are there any selects that have infix values which we have not already selected? We need to include
+          // them because they could be doing essential things e.g. RANK ... ORDER BY
+          val remainingSelectsWithInfixes =
+            trace"Searching Selects with Infix:" andReturn
+              new FindUnexpressedInfixes(select)(mappedRefs)
+
+          implicit val ordering: scala.math.Ordering[List[Int]] = new scala.math.Ordering[List[Int]] {
+            override def compare(x: List[Int], y: List[Int]): Int =
+              (x, y) match {
+                case (head1 :: tail1, head2 :: tail2) =>
+                  val diff = head1 - head2
+                  if (diff != 0) diff
+                  else compare(tail1, tail2)
+                case (Nil, Nil)   => 0 // List(1,2,3) == List(1,2,3)
+                case (head1, Nil) => -1 // List(1,2,3) < List(1,2)
+                case (Nil, head2) => 1 // List(1,2) > List(1,2,3)
+              }
+          }
+
+          val sortedRefs =
+            (mappedRefs ++ remainingSelectsWithInfixes).sortBy(ref => ref.order) //(ref.order, ref.secondaryOrder)
+
+          sortedRefs.map(_.selectValue)
+        }
       }
     }
-  }
 }
 
 object ExpandSelect {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/InfixSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/InfixSpec.scala
@@ -20,7 +20,7 @@ class InfixSpec extends Spec {
       val q = quote {
         query[Data].map(e => TwoValue(e.id, infix"RAND()".as[Int])).filter(r => r.value > 10)
       }
-      ctx.run(q).string mustEqual "SELECT e.id, e.value FROM (SELECT e.id AS id, RAND() AS value FROM Data e) AS e WHERE e.value > 10"
+      ctx.run(q).string mustEqual "SELECT e.id, e.value FROM (SELECT e.id, RAND() AS value FROM Data e) AS e WHERE e.value > 10"
     }
 
     "collapse nesting where not needed" in {
@@ -41,7 +41,7 @@ class InfixSpec extends Spec {
       val q = quote {
         query[Data].map(e => TwoValue(e.id, infix"RAND()".as[Int])).nested.filter(r => r.value > 10).map(r => (r.id, r.value + 1))
       }
-      ctx.run(q).string mustEqual "SELECT r.id, r.value + 1 FROM (SELECT e.id AS id, RAND() AS value FROM Data e) AS r WHERE r.value > 10"
+      ctx.run(q).string mustEqual "SELECT r.id, r.value + 1 FROM (SELECT e.id, RAND() AS value FROM Data e) AS r WHERE r.value > 10"
     }
 
     "preserve nesting with single value binary op" in {
@@ -62,14 +62,14 @@ class InfixSpec extends Spec {
       val q = quote {
         query[Data].map(e => TwoValue(e.id, infix"RAND()".as[Int])).filter(r => r.value > 10).map(r => TwoValue(r.id, r.value + 1))
       }
-      ctx.run(q).string mustEqual "SELECT e.id, e.value + 1 FROM (SELECT e.id AS id, RAND() AS value FROM Data e) AS e WHERE e.value > 10"
+      ctx.run(q).string mustEqual "SELECT e.id, e.value + 1 FROM (SELECT e.id, RAND() AS value FROM Data e) AS e WHERE e.value > 10"
     }
 
     "preserve triple nesting with filter in between plus second filter" in {
       val q = quote {
         query[Data].map(e => TwoValue(e.id, infix"RAND()".as[Int])).filter(r => r.value > 10).map(r => TwoValue(r.id, r.value + 1)).filter(_.value > 111)
       }
-      ctx.run(q).string mustEqual "SELECT e.id, e.value + 1 FROM (SELECT e.id AS id, RAND() AS value FROM Data e) AS e WHERE e.value > 10 AND (e.value + 1) > 111"
+      ctx.run(q).string mustEqual "SELECT e.id, e.value + 1 FROM (SELECT e.id, RAND() AS value FROM Data e) AS e WHERE e.value > 10 AND (e.value + 1) > 111"
     }
 
     "preserve nesting of query in query" in {
@@ -87,7 +87,7 @@ class InfixSpec extends Spec {
         } yield ThreeData(r.id, r.value, infix"bar".as[Int])
       }
 
-      ctx.run(q2).string mustEqual "SELECT d.id, d.value, d.secondValue FROM (SELECT d.id AS id, d.value AS value, bar AS secondValue FROM (SELECT d.id AS id, foo AS value FROM Data d) AS d WHERE d.value = 1) AS d"
+      ctx.run(q2).string mustEqual "SELECT d.id, d.value, d.secondValue FROM (SELECT d.id, d.value, bar AS secondValue FROM (SELECT d.id, foo AS value FROM Data d) AS d WHERE d.value = 1) AS d"
     }
 
     "excluded infix values" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/NestedDistinctSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/NestedDistinctSpec.scala
@@ -1,6 +1,7 @@
 package io.getquill.context.sql
 
 import io.getquill.{ Literal, MirrorSqlDialect, Spec, SqlMirrorContext }
+import io.getquill.context.sql.util.StringOps._
 
 class NestedDistinctSpec extends Spec {
 
@@ -23,7 +24,7 @@ class NestedDistinctSpec extends Spec {
           .map(e => SimpleEnt2(e.a + 2, e.b))
           .distinct
       }
-      ctx.run(q).string mustEqual "SELECT e.aa, e.bb FROM (SELECT DISTINCT e.a + 2 AS aa, e.b AS bb FROM (SELECT DISTINCT e.field_a + 1 AS a, e.b AS b FROM CustomEnt e) AS e) AS e"
+      ctx.run(q).string mustEqual "SELECT e.aa, e.bb FROM (SELECT DISTINCT e.a + 2 AS aa, e.b AS bb FROM (SELECT DISTINCT e.field_a + 1 AS a, e.b FROM CustomEnt e) AS e) AS e"
     }
 
     "works with explicitly nested infixes" in {
@@ -59,6 +60,247 @@ class NestedDistinctSpec extends Spec {
       }
 
       ctx.run(q).string mustEqual "SELECT e._1, e._2 FROM (SELECT e._1 + 2 AS _1, bar(e._2) AS _2 FROM (SELECT e.field_a + 1 AS _1, foo(e.b) AS _2 FROM CustomEnt e) AS e) AS e"
+    }
+
+    "embedded entity from parent" - {
+      case class Emb(id: Int, name: String) extends Embedded
+      case class Parent(idP: Int, emb: Emb)
+      implicit val parentMeta = schemaMeta[Parent]("Parent", _.emb.name -> "theName")
+
+      "embedded can be propagated across distinct inside tuple with naming intact" in {
+        val q = quote {
+          query[Parent].map(p => (p.emb, 1)).distinct.map(e => (e._1.name, e._1.id))
+        }
+
+        ctx.run(q).string mustEqual "SELECT p._1theName, p._1id FROM (SELECT DISTINCT p.theName AS _1theName, p.id AS _1id FROM Parent p) AS p"
+      }
+
+      "embedded can be propagated across distinct inside case class with naming intact" in {
+        case class SuperParent(emb: Emb, id: Int)
+
+        val q = quote {
+          query[Parent].map(p => SuperParent(p.emb, 1)).distinct.map(e => (e.emb.name, e.emb.id))
+        }
+
+        ctx.run(q).string mustEqual "SELECT p.embtheName, p.embid FROM (SELECT DISTINCT p.theName AS embtheName, p.id AS embid FROM Parent p) AS p"
+      }
+
+      "can be propagated across query with naming intact" in {
+        val q = quote {
+          query[Parent].map(p => p.emb).nested.map(e => (e.name, e.id))
+        }
+        ctx.run(q).string mustEqual "SELECT p.theName, p.embid FROM (SELECT x.theName, x.id AS embid FROM Parent x) AS p"
+      }
+
+      "can be propogated across query with naming intact and then used further" in {
+        val q = quote {
+          query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id)).distinct.map(tup => (tup._1, tup._2)).distinct
+        }
+        ctx.run(q).string mustEqual "SELECT x._1, x._2 FROM (SELECT DISTINCT e.theName AS _1, e.id AS _2 FROM (SELECT DISTINCT theName AS theName, id AS id FROM Parent p) AS e) AS x"
+      }
+
+      "can be propogated across query with naming intact and then used further - nested" in {
+        val q = quote {
+          query[Parent].map(p => p.emb).nested.map(e => (e.name, e.id)).nested.map(tup => (tup._1, tup._2)).nested
+        }
+        ctx.run(q).string mustEqual "SELECT p.theName, p.embid FROM (SELECT x.theName, x.id AS embid FROM Parent x) AS p"
+      }
+
+      "can be propogated across query with naming intact - returned as single property" in {
+        val q = quote {
+          query[Parent].map(p => p.emb).distinct.map(e => (e.name))
+        }
+        ctx.run(q).string mustEqual "SELECT e.theName FROM (SELECT DISTINCT theName AS theName FROM Parent p) AS e"
+      }
+
+      "can be propogated across query with naming intact - and the immediately returned" in {
+        val q = quote {
+          query[Parent].map(p => p.emb).nested.map(e => e)
+        }
+        ctx.run(q).string mustEqual "SELECT p.embid, p.theName FROM (SELECT x.id AS embid, x.theName FROM Parent x) AS p"
+      }
+
+      "can be propogated across distinct with naming intact - and the immediately returned" in {
+        val q = quote {
+          query[Parent].map(p => p.emb).distinct.map(e => e)
+        }
+        ctx.run(q).string mustEqual "SELECT e.id, e.theName FROM (SELECT DISTINCT id AS id, theName AS theName FROM Parent p) AS e"
+      }
+
+      "can be propogated across query with naming intact and then re-wrapped in case class" in {
+        val q = quote {
+          query[Parent].map(p => p.emb).distinct.map(e => Parent(1, e))
+        }
+        ctx.run(q).string mustEqual "SELECT 1, e.id, e.theName FROM (SELECT DISTINCT id AS id, theName AS theName FROM Parent p) AS e"
+      }
+
+      "can be propogated across query with naming intact and then re-wrapped in tuple" in {
+        val q = quote {
+          query[Parent].map(p => p.emb).nested.map(e => Parent(1, e))
+        }
+        ctx.run(q).string mustEqual "SELECT 1, p.embid, p.theName FROM (SELECT x.id AS embid, x.theName FROM Parent x) AS p"
+      }
+    }
+
+    "double embedded entity from parent" - {
+      case class Emb(id: Int, name: String) extends Embedded
+      case class Parent(id: Int, name: String, emb: Emb) extends Embedded
+      case class GrandParent(id: Int, par: Parent)
+      implicit val parentMeta = schemaMeta[GrandParent]("GrandParent", _.par.emb.name -> "theName", _.par.name -> "theParentName")
+
+      "fully unwrapped name propagates" in {
+        val q = quote {
+          query[GrandParent]
+            .map(g => g.par).distinct
+            .map(p => p.emb).map(p => p.name).distinct
+        }
+        ctx.run(q).string mustEqual "SELECT DISTINCT p.theName FROM (SELECT DISTINCT theName AS theName FROM GrandParent g) AS p"
+      }
+
+      "fully unwrapped name propagates with side property" in {
+        val q = quote {
+          query[GrandParent]
+            .map(g => g.par).distinct
+            .map(p => (p.name, p.emb)).distinct
+            .map(tup => (tup._1, tup._2)).distinct
+        }
+        ctx.run(q).string mustEqual
+          "SELECT x._1, x._2id, x._2theName FROM (SELECT DISTINCT p.theParentName AS _1, p.embid AS _2id, p.embtheName AS _2theName FROM (SELECT DISTINCT theParentName AS theParentName, id AS embid, theName AS embtheName FROM GrandParent g) AS p) AS x"
+      }
+
+      "fully unwrapped name propagates with side property - nested" in {
+        val q = quote {
+          query[GrandParent]
+            .map(g => g.par).nested
+            .map(p => (p.name, p.emb)).nested
+            .map(tup => (tup._1, tup._2)).nested
+        }
+        ctx.run(q).string mustEqual
+          "SELECT g.theParentName, g.parembid, g.theName FROM (SELECT x.theParentName, x.id AS parembid, x.theName FROM GrandParent x) AS g"
+      }
+
+      "fully unwrapped name propagates with un-renamed properties" in {
+        val q = quote {
+          query[GrandParent]
+            .map(g => g.par).distinct
+            .map(p => (p.name, p.emb, p.id, p.emb.id)).distinct
+            .map(tup => (tup._1, tup._2, tup._3, tup._4)).distinct
+        }
+        ctx.run(q).string.collapseSpace mustEqual
+          """SELECT x._1, x._2id, x._2theName, x._3, x._4
+            |FROM (SELECT DISTINCT p.theParentName AS _1,
+            |                      p.embid         AS _2id,
+            |                      p.embtheName    AS _2theName,
+            |                      p.id            AS _3,
+            |                      p.embid         AS _4
+            |      FROM (SELECT DISTINCT theParentName AS theParentName, id AS embid, theName AS embtheName, id AS id
+            |            FROM GrandParent g) AS p) AS x
+          """.stripMargin.collapseSpace
+      }
+
+      "fully unwrapped name propagates with un-renamed properties - with one property renamed" in {
+        implicit val parentMeta = schemaMeta[GrandParent]("GrandParent", _.id -> "gId", _.par.emb.name -> "theName", _.par.name -> "theParentName")
+        val q = quote {
+          query[GrandParent]
+            .map(g => g.par).distinct
+            .map(p => (p.name, p.emb, p.id, p.emb.id)).distinct
+            .map(tup => (tup._1, tup._2, tup._3, tup._4)).distinct
+        }
+        ctx.run(q).string.collapseSpace mustEqual
+          """SELECT x._1, x._2id, x._2theName, x._3, x._4
+            |FROM (SELECT DISTINCT p.theParentName AS _1,
+            |                      p.embid         AS _2id,
+            |                      p.embtheName    AS _2theName,
+            |                      p.id            AS _3,
+            |                      p.embid         AS _4
+            |      FROM (SELECT DISTINCT theParentName AS theParentName, id AS embid, theName AS embtheName, id AS id
+            |            FROM GrandParent g) AS p) AS x
+          """.stripMargin.collapseSpace
+      }
+
+      "fully unwrapped and fully re-wrapped" in {
+        implicit val parentMeta = schemaMeta[GrandParent]("GrandParent", _.par.emb.name -> "theName", _.par.name -> "theParentName")
+        val q = quote {
+          query[GrandParent]
+            .map(g => (g.id, g.par)).distinct
+            .map(p => (p._1, p._2.id, p._2.name, p._2.emb)).distinct
+            .map(tup => (tup._1, tup._2, tup._3, tup._4.id, tup._4.name)).distinct
+            .map(tup => (tup._1, tup._2, tup._3, tup._4, tup._5)).distinct
+            .map(tup => (tup._1, tup._2, tup._3, Emb(tup._4, tup._5))).distinct
+            .map(tup => (tup._1, Parent(tup._2, tup._3, tup._4))).distinct
+            .map(tup => GrandParent(tup._1, tup._2))
+
+        }
+        ctx.run(q).string.collapseSpace mustEqual
+          """SELECT tup._1, tup._2id, tup._2name, tup._2embid, tup._2embname
+            |FROM (SELECT DISTINCT tup._1,
+            |                      tup._2     AS _2id,
+            |                      tup._3     AS _2name,
+            |                      tup._4id   AS _2embid,
+            |                      tup._4name AS _2embname
+            |      FROM (SELECT DISTINCT tup._1, tup._2, tup._3, tup._4 AS _4id, tup._5 AS _4name
+            |            FROM (SELECT DISTINCT tup._1, tup._2, tup._3, tup._4id AS _4, tup._4theName AS _5
+            |                  FROM (SELECT DISTINCT p._1,
+            |                                        p._2id            AS _2,
+            |                                        p._2theParentName AS _3,
+            |                                        p._2embid         AS _4id,
+            |                                        p._2embtheName    AS _4theName
+            |                        FROM (SELECT DISTINCT g.id            AS _1,
+            |                                              g.id            AS _2id,
+            |                                              g.theParentName AS _2theParentName,
+            |                                              g.id            AS _2embid,
+            |                                              g.theName       AS _2embtheName
+            |                              FROM GrandParent g) AS p) AS tup) AS tup) AS tup) AS tup
+          """.stripMargin.collapseSpace
+      }
+
+      "fully unwrapped and fully re-wrapped - nested" in {
+        implicit val parentMeta = schemaMeta[GrandParent]("GrandParent", _.par.emb.name -> "theName", _.par.name -> "theParentName")
+        val q = quote {
+          query[GrandParent]
+            .map(g => (g.id, g.par)).nested
+            .map(p => (p._1, p._2.id, p._2.name, p._2.emb)).nested
+            .map(tup => (tup._1, tup._2, tup._3, tup._4.id, tup._4.name)).nested
+            .map(tup => (tup._1, tup._2, tup._3, tup._4, tup._5)).nested
+            .map(tup => (tup._1, tup._2, tup._3, Emb(tup._4, tup._5))).nested
+            .map(tup => (tup._1, Parent(tup._2, tup._3, tup._4))).nested
+            .map(tup => GrandParent(tup._1, tup._2))
+
+        }
+        ctx.run(q).string.collapseSpace mustEqual
+          """SELECT g.id, g.parid, g.theParentName, g.parembid, g.theName FROM (SELECT x.id, x.id AS parid, x.theParentName, x.id AS parembid, x.theName FROM GrandParent x) AS g""".stripMargin.collapseSpace
+      }
+
+      "fully unwrapped and fully re-wrapped - nested and distinct" in {
+        implicit val parentMeta = schemaMeta[GrandParent]("GrandParent", _.par.emb.name -> "theName", _.par.name -> "theParentName")
+        val q = quote {
+          query[GrandParent]
+            .map(g => (g.id, g.par)).nested
+            .map(p => (p._1, p._2.id, p._2.name, p._2.emb)).distinct
+            .map(tup => (tup._1, tup._2, tup._3, tup._4.id, tup._4.name)).nested
+            .map(tup => (tup._1, tup._2, tup._3, tup._4, tup._5)).distinct
+            .map(tup => (tup._1, tup._2, tup._3, Emb(tup._4, tup._5))).nested
+            .map(tup => (tup._1, Parent(tup._2, tup._3, tup._4))).distinct
+            .map(tup => GrandParent(tup._1, tup._2))
+
+        }
+        ctx.run(q).string.collapseSpace mustEqual
+          """SELECT tup._1, tup._2id, tup._2name, tup._2embid, tup._2embname
+            |FROM (SELECT DISTINCT tup._1, tup._2 AS _2id, tup._3 AS _2name, tup._4 AS _2embid, tup._5 AS _2embname
+            |      FROM (SELECT DISTINCT tup._1, tup._2, tup._3, tup._4id AS _4, tup._4theName AS _5
+            |            FROM (SELECT DISTINCT g.id            AS _1,
+            |                                  g.parid         AS _2,
+            |                                  g.theParentName AS _3,
+            |                                  g.parembid      AS _4id,
+            |                                  g.parembtheName AS _4theName
+            |                  FROM (SELECT x.id,
+            |                               x.id      AS parid,
+            |                               x.theParentName,
+            |                               x.id      AS parembid,
+            |                               x.theName AS parembtheName
+            |                        FROM GrandParent x) AS g) AS tup) AS tup) AS tup
+          """.stripMargin.collapseSpace
+      }
     }
 
     "adversarial tests" - {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -780,7 +780,7 @@ class SqlQuerySpec extends Spec {
           qr1.map(q => TrivialEntitySameField(q.s)) ++ qr1.map(q => TrivialEntitySameField(q.s))
         }
         testContext.run(q).string mustEqual
-          "SELECT x.s FROM ((SELECT q.s AS s FROM TestEntity q) UNION ALL (SELECT q1.s AS s FROM TestEntity q1)) AS x"
+          "SELECT x.s FROM ((SELECT q.s FROM TestEntity q) UNION ALL (SELECT q1.s FROM TestEntity q1)) AS x"
       }
     }
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -131,7 +131,7 @@ class SqlIdiomSpec extends Spec {
             qr1.map(i => new IntLong(i.i, i.l)).distinct
           }
           testContext.run(q).string mustEqual
-            "SELECT i.i, i.l FROM (SELECT DISTINCT i.i AS i, i.l AS l FROM TestEntity i) AS i"
+            "SELECT i.i, i.l FROM (SELECT DISTINCT i.i, i.l FROM TestEntity i) AS i"
         }
         "caseclass companion constructor" in {
           case class IntLong(i: Int, l: Long)
@@ -139,7 +139,7 @@ class SqlIdiomSpec extends Spec {
             qr1.map(i => IntLong(i.i, i.l)).distinct
           }
           testContext.run(q).string mustEqual
-            "SELECT i.i, i.l FROM (SELECT DISTINCT i.i AS i, i.l AS l FROM TestEntity i) AS i"
+            "SELECT i.i, i.l FROM (SELECT DISTINCT i.i, i.l FROM TestEntity i) AS i"
         }
 
         "nesting" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -2,6 +2,7 @@ package io.getquill.context.sql.norm
 
 import io.getquill.{ MirrorSqlDialect, SnakeCase, Spec, SqlMirrorContext }
 import io.getquill.context.sql.testContext
+import io.getquill.context.sql.util.StringOps._
 
 class ExpandNestedQueriesSpec extends Spec {
 
@@ -107,5 +108,131 @@ class ExpandNestedQueriesSpec extends Spec {
 
     testContext.run(q).string mustEqual
       "SELECT both._1s, both._1i, both._1l, both._1o, both._2s, both._2i, both._2l, both._2o FROM (SELECT a.s AS _1s, a.i AS _1i, a.l AS _1l, a.o AS _1o, b.s AS _2s, b.i AS _2i, b.l AS _2l, b.o AS _2o FROM TestEntity a INNER JOIN TestEntity b ON a.i = b.i) AS both"
+  }
+
+  "nested with distinct" - {
+    val ctx = testContext
+    import ctx._
+
+    "embedded, distinct entity in sub-tuple" in {
+      case class Parent(id: Int, emb: Emb)
+      case class Emb(name: String, id: Int) extends Embedded
+
+      val q = quote {
+        query[Parent].map(p => (p.emb, 1)).distinct.map(e => (e._1.name, e._1.id))
+      }
+
+      ctx.run(q).string mustEqual "SELECT p._1name, p._1id FROM (SELECT DISTINCT p.name AS _1name, p.id AS _1id FROM Parent p) AS p"
+    }
+
+    "embedded, distinct entity in case class" in {
+      case class Parent(id: Int, emb: Emb)
+      case class Emb(name: String, id: Int) extends Embedded
+      case class SuperParent(emb: Emb, id: Int)
+
+      val q = quote {
+        query[Parent].map(p => SuperParent(p.emb, 1)).distinct.map(e => (e.emb.name, e.emb.id))
+      }
+
+      ctx.run(q).string mustEqual "SELECT p.embname, p.embid FROM (SELECT DISTINCT p.name AS embname, p.id AS embid FROM Parent p) AS p"
+    }
+
+    "can be propagated across nested query with naming intact" in {
+      case class Parent(id: Int, emb: Emb)
+      case class Emb(name: String, id: Int) extends Embedded
+
+      val q = quote {
+        query[Parent].map(p => p.emb).nested.map(e => (e.name, e.id))
+      }
+      ctx.run(q).string mustEqual "SELECT p.embname, p.embid FROM (SELECT x.name AS embname, x.id AS embid FROM Parent x) AS p"
+    }
+
+    "can be propagated across distinct query with naming intact" in {
+      case class Parent(id: Int, emb: Emb)
+      case class Emb(name: String, id: Int) extends Embedded
+
+      val q = quote {
+        query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id))
+      }
+      ctx.run(q).string mustEqual "SELECT e.name, e.id FROM (SELECT DISTINCT name AS name, id AS id FROM Parent p) AS e"
+    }
+
+    "can be propagated across distinct query with naming intact - double distinct" in {
+      case class Parent(id: Int, emb: Emb)
+      case class Emb(name: String, id: Int) extends Embedded
+
+      val q = quote {
+        query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id)).distinct
+      }
+      ctx.run(q).string mustEqual "SELECT DISTINCT e.name, e.id FROM (SELECT DISTINCT name AS name, id AS id FROM Parent p) AS e"
+    }
+
+    "can be propagated across distinct query with naming intact then re-wrapped into the parent" in {
+      case class Parent(id: Int, emb: Emb)
+      case class Emb(name: String, id: Int) extends Embedded
+
+      val q = quote {
+        query[Parent].map(p => p.emb).distinct.map(e => (e.name, e.id)).distinct.map(tup => Emb(tup._1, tup._2)).distinct
+      }
+      ctx.run(q).string.collapseSpace mustEqual
+        """SELECT tup.name, tup.id
+          |FROM (SELECT DISTINCT tup._1 AS name, tup._2 AS id
+          |      FROM (SELECT DISTINCT e.name AS _1, e.id AS _2
+          |            FROM (SELECT DISTINCT name AS name, id AS id FROM Parent p) AS e) AS tup) AS tup
+        """.stripMargin.collapseSpace
+    }
+  }
+
+  "multiple embedding levels" in {
+    import testContext._
+    case class Emb(id: Int, name: String) extends Embedded
+    case class Parent(id: Int, name: String, emb: Emb) extends Embedded
+    case class GrandParent(id: Int, par: Parent)
+
+    val q = quote {
+      query[GrandParent]
+        .map(g => (g.id, g.par)).distinct
+        .map(p => (p._1, p._2.id, p._2.name, p._2.emb)).distinct
+        .map(tup => (tup._1, tup._2, tup._3, tup._4.id, tup._4.name)).distinct
+        .map(tup => (tup._1, tup._2, tup._3, tup._4, tup._5)).distinct
+        .map(tup => (tup._1, tup._2, tup._3, Emb(tup._4, tup._5))).distinct
+        .map(tup => (tup._1, Parent(tup._2, tup._3, tup._4))).distinct
+        .map(tup => GrandParent(tup._1, tup._2)).distinct
+    }
+
+    testContext.run(q).string.collapseSpace mustEqual
+      """SELECT tup.id, tup.parid, tup.parname, tup.parembid, tup.parembname
+        |FROM (SELECT DISTINCT tup._1        AS id,
+        |                      tup._2id      AS parid,
+        |                      tup._2name    AS parname,
+        |                      tup._2embid   AS parembid,
+        |                      tup._2embname AS parembname
+        |      FROM (SELECT DISTINCT tup._1,
+        |                            tup._2     AS _2id,
+        |                            tup._3     AS _2name,
+        |                            tup._4id   AS _2embid,
+        |                            tup._4name AS _2embname
+        |            FROM (SELECT DISTINCT tup._1,
+        |                                  tup._2,
+        |                                  tup._3,
+        |                                  tup._4 AS _4id,
+        |                                  tup._5 AS _4name
+        |                  FROM (SELECT DISTINCT tup._1,
+        |                                        tup._2,
+        |                                        tup._3,
+        |                                        tup._4id   AS _4,
+        |                                        tup._4name AS _5
+        |                        FROM (SELECT DISTINCT p._1,
+        |                                              p._2id      AS _2,
+        |                                              p._2name    AS _3,
+        |                                              p._2embid   AS _4id,
+        |                                              p._2embname AS _4name
+        |                              FROM (SELECT DISTINCT g.id   AS _1,
+        |                                                    g.id   AS _2id,
+        |                                                    g.name AS _2name,
+        |                                                    g.id   AS _2embid,
+        |                                                    g.name AS _2embname
+        |                                    FROM GrandParent g) AS p) AS tup) AS tup) AS tup) AS tup) AS tup
+      """.collapseSpace
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/util/StringOps.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/util/StringOps.scala
@@ -1,0 +1,8 @@
+package io.getquill.context.sql.util
+
+object StringOps {
+
+  implicit class StringOpsExt(str: String) {
+    def collapseSpace: String = str.stripMargin.replaceAll("\\s+", " ").trim
+  }
+}


### PR DESCRIPTION
Fixes #1627

In many ways, this represents a continuation of #1613. In #1613, schema protraction was introduced in order to solve the situation where a `querySchema` needs to be propagated for an entity that is wrapped into a tuple or case class e.g:
```scala
case class Emb(name:String) extends Embedded
case class Parent(id: Int, emb: Embedded)
implicit val embSchema = schemaMeta[Emb]("EmbTable", _.name -> "theName")
run { query[Emb].map(e => Parent(1, e)).distinct.map(p => (p.id, p.emb.name)) }
```
This PR represents a fix for the opposite case, i.e. where an entity from a super-class is sub-selected:
```scala
implicit val parenttSchema = schemaMeta[Parent]("ParentTable", _.id -> "theParentId", _.emb.name -> "theName")
run { query[Parent].map(p => p.emb).distinct.map(e => (e.name))
```
Several additional changes to Schema Protraction needed to be made for this purpose including:
1. A way to sub-select data out of an `Entity` representing an entity whose embedded element is being extracted. This transformation is roughly:
```scala
`Entity(name, 
      PropertyAlias(List("id"), "theParentId"), 
      PropertyAlias(List("emb", "name"), "theName")...PropertyAlias(List("emb", xyz), "theName"))` ->
  `Entity(name, PropertyAlias(List("name"), "theName"))`
```
Or more sussinctly:
```
Entity(name, _.id -> "theParnetId", _.emb.name -> "theName"... _.emb.xyz) ->     // before .map(p => p.emb)
  Entity(name, _.name -> "theName"... _.xyz) // afterward
```
That is to say, every PropertyAlias path to `emb` inside of the host entity needs to be extracted from te Entity.

An additional change that needed to be made was the introduction of invisible identities. This was specifically needed for certain queries where one embedded entity was mapped into another. For instance:
```scala
case class Emb(id: Int, name: String) extends Embedded
case class Parent(id: Int, name: String, emb: Emb) extends Embedded
case class GrandParent(id: Int, par: Parent)

query[GrandParent]
    .map(g => g.par).distinct
    .map(p => (p.name, p.emb)).distinct
    .map(tup => (tup._1, tup._2)).distinct
}
```
In this kind of situation `p.emb` (in the second map clause) needs to be directly sub-selected and it's properties are then appended to it in the `ExpandNestedQueries` phase. Since the default-case of `ExpandNestedQueries` (in `ExpandSelect`) is to take the selected property directly i.e:
```scala
case other =>
                  trace"Reference is unidentified: $other returning:" andReturn
                    OrderedSelect(Integer.MAX_VALUE, SelectValue(Ident(name), Some(expandColumn(name, renameable)), false))
```
We needed to enhance Ident to be able to be invisible and then propagate this property:
```scala
case other =>
                  trace"Reference is unidentified: $other returning:" andReturn
                    OrderedSelect(Integer.MAX_VALUE, SelectValue(Ident.Opinionated(name, visible), Some(expandColumn(name, renameable)), false))
```
Many tests of this functionality were introduced that unwrap as well as unwrap and rewrap entities.

These kinds of changes are not necessarily the most "savory" form of AST manipulation and a Typed-AST would forego many of these issues. For example, if we knew that the `emb` identity in the query above is a nested entity, we could just expand it into it's component properties on the spot (i.e. inside of `ExpandDistinct` as opposed to having to make the property invisible inside of recursive calls of `ExpandNestedQueries`. 

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
