### PR TITLE
[WIP] Pretty Print SQL Queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,6 +113,8 @@ lazy val `quill-core` =
     .jsSettings(
       libraryDependencies ++= Seq(
         "com.lihaoyi" %%% "pprint" % pprintVersion(scalaVersion.value),
+        "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
+        "com.lihaoyi" %%% "pprint" % "0.5.4",
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5"
       ),
       coverageExcludedPackages := ".*"
@@ -125,7 +127,14 @@ lazy val `quill-sql` =
   crossProject(JVMPlatform, JSPlatform).crossType(superPure)
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
+    .settings(libraryDependencies ++= Seq(
+      "com.github.vertical-blank"  %% "scala-sql-formatter" % "1.0.0"
+    ))
     .jsSettings(
+      libraryDependencies ++= Seq(
+        "com.github.vertical-blank" %%% "scala-sql-formatter" % "1.0.0"
+      ),
+      scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
       coverageExcludedPackages := ".*"
     )
     .dependsOn(`quill-core` % "compile->compile;test->test")

--- a/quill-core/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorContext.scala
@@ -47,7 +47,13 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom: Idi
 
   case class BatchActionReturningMirror[T](groups: List[(String, ReturnAction, List[PrepareRow])], extractor: Extractor[T])
 
-  case class QueryMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T])
+  case class QueryMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T]) {
+    def string(pretty: Boolean): String =
+      if (pretty)
+        idiom.format(string)
+      else
+        string
+  }
 
   def executeQuery[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor) =
     QueryMirror(string, prepare(Row())._2, extractor)

--- a/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
@@ -15,18 +15,25 @@ class ActionMacro(val c: MacroContext)
   import c.universe.{ Function => _, Ident => _, _ }
 
   def translateQuery(quoted: Tree): Tree =
+    translateQueryPrettyPrint(quoted, q"false")
+
+  def translateQueryPrettyPrint(quoted: Tree, prettyPrint: Tree): Tree =
     c.untypecheck {
       q"""
         ..${EnableReflectiveCalls(c)}
         val expanded = ${expand(extractAst(quoted))}
         ${c.prefix}.translateQuery(
           expanded.string,
-          expanded.prepare
+          expanded.prepare,
+          prettyPrint = ${prettyPrint}
         )
       """
     }
 
   def translateBatchQuery(quoted: Tree): Tree =
+    translateBatchQueryPrettyPrint(quoted, q"false")
+
+  def translateBatchQueryPrettyPrint(quoted: Tree, prettyPrint: Tree): Tree =
     expandBatchAction(quoted) {
       case (batch, param, expanded) =>
         q"""
@@ -38,7 +45,8 @@ class ActionMacro(val c: MacroContext)
             }.groupBy(_._1).map {
               case (string, items) =>
                 ${c.prefix}.BatchGroup(string, items.map(_._2).toList)
-            }.toList
+            }.toList,
+            ${prettyPrint}
           )
         """
     }

--- a/quill-core/src/main/scala/io/getquill/context/ContextMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextMacro.scala
@@ -1,7 +1,6 @@
 package io.getquill.context
 
 import scala.reflect.macros.whitebox.{ Context => MacroContext }
-
 import io.getquill.ast.Ast
 import io.getquill.ast.Dynamic
 import io.getquill.quotation.Quotation
@@ -11,6 +10,7 @@ import io.getquill.quotation.IsDynamic
 import io.getquill.ast.Lift
 import io.getquill.NamingStrategy
 import io.getquill.idiom._
+
 import scala.util.Success
 import scala.util.Failure
 
@@ -60,7 +60,7 @@ trait ContextMacro extends Quotation {
 
         ProbeStatement(idiom.prepareForProbing(string), c)
 
-        c.info(string)
+        c.query(string, idiom)
 
         q"($normalizedAst, ${statement: Token})"
       case Failure(ex) =>

--- a/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
@@ -8,60 +8,100 @@ import io.getquill.util.EnableReflectiveCalls
 class QueryMacro(val c: MacroContext) extends ContextMacro {
   import c.universe.{ Ident => _, _ }
 
-  sealed trait FetchSizeBehavior
-  case class UsesExplicitFetch(tree: Tree) extends FetchSizeBehavior
-  case object UsesDefaultFetch extends FetchSizeBehavior
-  case object DoesNotUseFetch extends FetchSizeBehavior
+  sealed trait FetchSizeArg
+  case class UsesExplicitFetch(tree: Tree) extends FetchSizeArg
+  case object UsesDefaultFetch extends FetchSizeArg
+  case object DoesNotUseFetch extends FetchSizeArg
+
+  sealed trait PrettyPrintingArg
+  case class ExplicitPrettyPrint(tree: Tree) extends PrettyPrintingArg
+  case object DefaultPrint extends PrettyPrintingArg
+
+  sealed trait ContextMethod { def name: String }
+  case class StreamQuery(fetchSizeBehavior: FetchSizeArg) extends ContextMethod { val name = "streamQuery" }
+  case object ExecuteQuery extends ContextMethod { val name = "executeQuery" }
+  case object ExecuteQuerySingle extends ContextMethod { val name = "executeQuerySingle" }
+  case class TranslateQuery(prettyPrintingArg: PrettyPrintingArg) extends ContextMethod { val name = "translateQuery" }
+  case object PrepareQuery extends ContextMethod { val name = "prepareQuery" }
 
   def streamQuery[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
-    expandQuery[T](quoted, "streamQuery", UsesDefaultFetch)
+    expandQuery[T](quoted, StreamQuery(UsesDefaultFetch))
 
   def streamQueryFetch[T](quoted: Tree, fetchSize: Tree)(implicit t: WeakTypeTag[T]): Tree =
-    expandQuery[T](quoted, "streamQuery", UsesExplicitFetch(fetchSize))
+    expandQuery[T](quoted, StreamQuery(UsesExplicitFetch(fetchSize)))
 
   def runQuery[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
-    expandQuery[T](quoted, "executeQuery", DoesNotUseFetch)
+    expandQuery[T](quoted, ExecuteQuery)
 
   def runQuerySingle[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
-    expandQuery[T](quoted, "executeQuerySingle", DoesNotUseFetch)
+    expandQuery[T](quoted, ExecuteQuerySingle)
 
   def translateQuery[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
-    expandQuery[T](quoted, "translateQuery", DoesNotUseFetch)
+    expandQuery[T](quoted, TranslateQuery(DefaultPrint))
+
+  def translateQueryPrettyPrint[T](quoted: Tree, prettyPrint: Tree)(implicit t: WeakTypeTag[T]): Tree =
+    expandQuery[T](quoted, TranslateQuery(ExplicitPrettyPrint(prettyPrint)))
 
   def prepareQuery[T](quoted: Tree)(implicit t: WeakTypeTag[T]): Tree =
-    expandQuery[T](quoted, "prepareQuery", DoesNotUseFetch)
+    expandQuery[T](quoted, PrepareQuery)
 
-  private def expandQuery[T](quoted: Tree, method: String, fetchBehavior: FetchSizeBehavior)(implicit t: WeakTypeTag[T]) =
+  private def expandQuery[T](quoted: Tree, method: ContextMethod)(implicit t: WeakTypeTag[T]) =
     OptionalTypecheck(c)(q"implicitly[${c.prefix}.Decoder[$t]]") match {
-      case Some(decoder) => expandQueryWithDecoder(quoted, method, decoder, fetchBehavior)
-      case None          => expandQueryWithMeta[T](quoted, method, fetchBehavior)
+      case Some(decoder) => expandQueryWithDecoder(quoted, method, decoder)
+      case None          => expandQueryWithMeta[T](quoted, method)
     }
 
-  private def expandQueryWithDecoder(quoted: Tree, method: String, decoder: Tree, fetchBehavior: FetchSizeBehavior) = {
+  private def expandQueryWithDecoder(quoted: Tree, method: ContextMethod, decoder: Tree) = {
     val ast = Map(extractAst(quoted), Ident("x"), Ident("x"))
     val invocation =
-      fetchBehavior match {
-        case UsesExplicitFetch(size) =>
+      method match {
+        case StreamQuery(UsesExplicitFetch(size)) =>
           q"""
-            ${c.prefix}.${TermName(method)}(
+            ${c.prefix}.${TermName(method.name)}(
               Some(${size}),
               expanded.string,
               expanded.prepare,
               row => $decoder(0, row)
             )
            """
-        case UsesDefaultFetch =>
+        case StreamQuery(UsesDefaultFetch) =>
           q"""
-            ${c.prefix}.${TermName(method)}(
+            ${c.prefix}.${TermName(method.name)}(
               None,
               expanded.string,
               expanded.prepare,
               row => $decoder(0, row)
             )
            """
-        case DoesNotUseFetch =>
+        case StreamQuery(DoesNotUseFetch) =>
           q"""
-            ${c.prefix}.${TermName(method)}(
+            ${c.prefix}.${TermName(method.name)}(
+              expanded.string,
+              expanded.prepare,
+              row => $decoder(0, row)
+            )
+           """
+        case TranslateQuery(ExplicitPrettyPrint(argValue)) =>
+          q"""
+            ${c.prefix}.${TermName(method.name)}(
+              expanded.string,
+              expanded.prepare,
+              row => $decoder(0, row),
+              prettyPrint = ${argValue}
+            )
+           """
+        case TranslateQuery(DefaultPrint) =>
+          q"""
+            ${c.prefix}.${TermName(method.name)}(
+              expanded.string,
+              expanded.prepare,
+              row => $decoder(0, row),
+              prettyPrint = false
+            )
+           """
+        case _ =>
+          q"""
+            ${c.prefix}.${TermName(method.name)}(
               expanded.string,
               expanded.prepare,
               row => $decoder(0, row)
@@ -78,33 +118,59 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
     }
   }
 
-  private def expandQueryWithMeta[T](quoted: Tree, method: String, fetch: FetchSizeBehavior)(implicit t: WeakTypeTag[T]) = {
+  private def expandQueryWithMeta[T](quoted: Tree, method: ContextMethod)(implicit t: WeakTypeTag[T]) = {
     val metaTpe = c.typecheck(tq"${c.prefix}.QueryMeta[$t]", c.TYPEmode).tpe
     val meta = c.inferImplicitValue(metaTpe).orElse(q"${c.prefix}.materializeQueryMeta[$t]")
     val ast = extractAst(c.typecheck(q"${c.prefix}.quote($meta.expand($quoted))"))
     val invocation =
-      fetch match {
-        case UsesExplicitFetch(size) =>
+      method match {
+        case StreamQuery(UsesExplicitFetch(size)) =>
           q"""
-            ${c.prefix}.${TermName(method)}(
+            ${c.prefix}.${TermName(method.name)}(
               Some(${size}),
               expanded.string,
               expanded.prepare,
               $meta.extract
             )
            """
-        case UsesDefaultFetch =>
+        case StreamQuery(UsesDefaultFetch) =>
           q"""
-            ${c.prefix}.${TermName(method)}(
+            ${c.prefix}.${TermName(method.name)}(
               None,
               expanded.string,
               expanded.prepare,
               $meta.extract
             )
            """
-        case DoesNotUseFetch =>
+        case StreamQuery(DoesNotUseFetch) =>
           q"""
-            ${c.prefix}.${TermName(method)}(
+            ${c.prefix}.${TermName(method.name)}(
+              expanded.string,
+              expanded.prepare,
+              $meta.extract
+            )
+           """
+        case TranslateQuery(ExplicitPrettyPrint(argValue)) =>
+          q"""
+            ${c.prefix}.${TermName(method.name)}(
+              expanded.string,
+              expanded.prepare,
+              $meta.extract,
+              prettyPrint = ${argValue}
+            )
+           """
+        case TranslateQuery(DefaultPrint) =>
+          q"""
+            ${c.prefix}.${TermName(method.name)}(
+              expanded.string,
+              expanded.prepare,
+              $meta.extract,
+              prettyPrint = false
+            )
+           """
+        case _ =>
+          q"""
+            ${c.prefix}.${TermName(method.name)}(
               expanded.string,
               expanded.prepare,
               $meta.extract

--- a/quill-core/src/main/scala/io/getquill/idiom/Idiom.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/Idiom.scala
@@ -14,5 +14,7 @@ trait Idiom extends Capabilities {
 
   def translate(ast: Ast)(implicit naming: NamingStrategy): (Ast, Statement)
 
+  def format(queryString: String): String = queryString
+
   def prepareForProbing(string: String): String
 }

--- a/quill-core/src/main/scala/io/getquill/util/IndentUtil.scala
+++ b/quill-core/src/main/scala/io/getquill/util/IndentUtil.scala
@@ -1,0 +1,16 @@
+package io.getquill.util
+
+object IndentUtil {
+  implicit class StringOpsExt(str: String) {
+    def fitsOnOneLine: Boolean = !str.contains("\n")
+    def multiline(indent: Int, prefix: String): String =
+      str.split("\n").map(elem => indent.prefix + prefix + elem).mkString("\n")
+  }
+
+  implicit class IndentOps(i: Int) {
+    def prefix = indentOf(i)
+  }
+
+  private def indentOf(num: Int) =
+    (0 to num).map(_ => "").mkString("  ")
+}

--- a/quill-core/src/main/scala/io/getquill/util/Interpolator.scala
+++ b/quill-core/src/main/scala/io/getquill/util/Interpolator.scala
@@ -5,6 +5,7 @@ import java.io.PrintStream
 import io.getquill.AstPrinter
 import io.getquill.AstPrinter.Implicits._
 import io.getquill.util.Messages.TraceType
+import io.getquill.util.IndentUtil._
 
 import scala.collection.mutable
 import scala.util.matching.Regex
@@ -20,16 +21,6 @@ class Interpolator(
   implicit class InterpolatorExt(sc: StringContext) {
     def trace(elements: Any*) = new Traceable(sc, elements)
   }
-  implicit class StringOps(str: String) {
-    def fitsOnOneLine: Boolean = !str.contains("\n")
-    def multiline(indent: Int, prefix: String): String =
-      str.split("\n").map(elem => indent.prefix + prefix + elem).mkString("\n")
-  }
-  implicit class IndentOps(i: Int) {
-    def prefix = indentOf(i)
-  }
-  private def indentOf(num: Int) =
-    (0 to num).map(_ => "").mkString("  ")
 
   class Traceable(sc: StringContext, elementsSeq: Seq[Any]) {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/PrettyPrintingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/PrettyPrintingSpec.scala
@@ -1,0 +1,26 @@
+package io.getquill.context.jdbc.postgres
+
+import io.getquill.Spec
+
+class PrettyPrintingSpec extends Spec {
+
+  val context = testContext
+  import testContext._
+
+  case class Person(name: String, age: Int)
+
+  "pretty prints query when enabled" in {
+    val q = quote { query[Person] }
+    translate(q, true) mustEqual
+      """SELECT
+        |  x.name,
+        |  x.age
+        |FROM
+        |  Person x""".stripMargin
+  }
+
+  "regular print when not enabled" in {
+    val q = quote { query[Person] }
+    translate(q) mustEqual "SELECT x.name, x.age FROM Person x"
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -1,5 +1,6 @@
 package io.getquill.context.sql.idiom
 
+import com.github.vertical_blank.sqlformatter.scala.SqlFormatter
 import io.getquill.ast._
 import io.getquill.ast.BooleanOperator._
 import io.getquill.ast.Lift
@@ -28,6 +29,8 @@ trait SqlIdiom extends Idiom {
   protected def equalityBehavior: EqualityBehavior = AnsiEquality
 
   protected def actionAlias: Option[Ident] = None
+
+  override def format(queryString: String): String = SqlFormatter.format(queryString)
 
   def querifyAst(ast: Ast) = SqlQuery(ast)
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/PrettyPrintingSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/PrettyPrintingSpec.scala
@@ -1,0 +1,25 @@
+package io.getquill.context.sql
+
+import io.getquill.Spec
+
+class PrettyPrintingSpec extends Spec {
+
+  import testContext._
+
+  case class Person(name: String, age: Int)
+
+  "pretty print query when enabled" in {
+    val prettyString = testContext.run(query[Person]).string(true)
+    prettyString mustEqual
+      """SELECT
+        |  x.name,
+        |  x.age
+        |FROM
+        |  Person x""".stripMargin
+  }
+
+  "regular print query when not enabled" in {
+    val prettyString = testContext.run(query[Person]).string(false)
+    prettyString mustEqual "SELECT x.name, x.age FROM Person x"
+  }
+}


### PR DESCRIPTION
Pretty printing via:
- `translateContext(query/action/batchAction, true/false)`
- Query log `-Dquill.macro.log.pretty=true` (default is `false`)
- MirrorContext's `string(true/false)` (TBD)

Using SQL Formatter by vertical-blank.
https://github.com/vertical-blank/sql-formatter

Example output if `quill.macro.log.pretty` is enabled.
```
[info] /home/me/work/quill/quill-sql/src/main/scala/io/getquill/MySqlTest.scala:36:16: 
[info]   | SELECT
[info]   |   x2.myEmbname
[info]   | FROM
[info]   |   (
[info]   |     SELECT
[info]   |       DISTINCT x1.name AS myEmbname
[info]   |     FROM
[info]   |       MyParent x1
[info]   |     WHERE
[info]   |       x1.name = 'firstTest'
[info]   |   ) AS x2
[info]   | WHERE
[info]   |   x2.myEmbname = 'test'
[info] 
[info]     println(run(q).string)
```

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
