### PR TITLE
Remove redundant null checks

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
@@ -44,13 +44,8 @@ trait Decoders {
 
   implicit val stringDecoder: Decoder[String] = decoder(_.getString)
   implicit val bigDecimalDecoder: Decoder[BigDecimal] =
-    decoder((index, row) => {
-      val v = row.getBigDecimal(index)
-      if (v == null)
-        BigDecimal(0)
-      else
-        v
-    })
+    decoder((index, row) =>
+      row.getBigDecimal(index))
   implicit val byteDecoder: Decoder[Byte] = decoder(_.getByte)
   implicit val shortDecoder: Decoder[Short] = decoder(_.getShort)
   implicit val intDecoder: Decoder[Int] = decoder(_.getInt)
@@ -59,27 +54,12 @@ trait Decoders {
   implicit val doubleDecoder: Decoder[Double] = decoder(_.getDouble)
   implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoder(_.getBytes)
   implicit val dateDecoder: Decoder[util.Date] =
-    decoder((index, row) => {
-      val v = row.getTimestamp(index, Calendar.getInstance(dateTimeZone))
-      if (v == null)
-        new util.Date(0)
-      else
-        new util.Date(v.getTime)
-    })
+    decoder((index, row) =>
+      new util.Date(row.getTimestamp(index, Calendar.getInstance(dateTimeZone)).getTime))
   implicit val localDateDecoder: Decoder[LocalDate] =
-    decoder((index, row) => {
-      val v = row.getDate(index, Calendar.getInstance(dateTimeZone))
-      if (v == null)
-        LocalDate.ofEpochDay(0)
-      else
-        v.toLocalDate
-    })
+    decoder((index, row) =>
+      row.getDate(index, Calendar.getInstance(dateTimeZone)).toLocalDate)
   implicit val localDateTimeDecoder: Decoder[LocalDateTime] =
-    decoder((index, row) => {
-      val v = row.getTimestamp(index, Calendar.getInstance(dateTimeZone))
-      if (v == null)
-        LocalDate.ofEpochDay(0).atStartOfDay()
-      else
-        v.toLocalDateTime
-    })
+    decoder((index, row) =>
+      row.getTimestamp(index, Calendar.getInstance(dateTimeZone)).toLocalDateTime)
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcEncodingSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcEncodingSpec.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.jdbc.postgres
 
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.LocalDateTime
 
 import io.getquill.context.sql.EncodingSpec
 
@@ -33,17 +33,21 @@ class JdbcEncodingSpec extends EncodingSpec {
   }
 
   "LocalDateTime" in {
-    case class EncodingTestEntity(v11: LocalDateTime)
-    case class E(v11: Option[LocalDateTime])
-    val e = EncodingTestEntity(LocalDateTime.now())
-    val res: List[EncodingTestEntity] = performIO {
+    case class EncodingTestEntity(v11: Option[LocalDateTime])
+    val now = LocalDateTime.now()
+    val e1 = EncodingTestEntity(Some(now))
+    val e2 = EncodingTestEntity(None)
+    val res: (List[EncodingTestEntity], List[EncodingTestEntity]) = performIO {
       for {
         _ <- testContext.runIO(query[EncodingTestEntity].delete)
-        _ <- testContext.runIO(query[EncodingTestEntity].insert(lift(e)))
-        _ <- testContext.runIO(querySchema[E]("EncodingTestEntity").insert(lift(E(None))))
-        r <- testContext.runIO(query[EncodingTestEntity])
-      } yield r
+        _ <- testContext.runIO(query[EncodingTestEntity].insert(lift(e1)))
+        withoutNull <- testContext.runIO(query[EncodingTestEntity])
+        _ <- testContext.runIO(query[EncodingTestEntity].delete)
+        _ <- testContext.runIO(query[EncodingTestEntity].insert(lift(e2)))
+        withNull <- testContext.runIO(query[EncodingTestEntity])
+      } yield (withoutNull, withNull)
     }
-    res must contain theSameElementsAs List(e, EncodingTestEntity(LocalDate.ofEpochDay(0).atStartOfDay()))
+    res._1 must contain theSameElementsAs List(EncodingTestEntity(Some(now)))
+    res._2 must contain theSameElementsAs List(EncodingTestEntity(None))
   }
 }


### PR DESCRIPTION
### Problem
Historically quill-jdbc has had issues in dealing with null values. Due to the way the `Decoder`'s were designed, they would run even if the value in the database is `null` (ideally you should short-circuit your `Decoder` once you immediately recognize the value was null).  Due to this limitation a lot of `Decoder`'s had to do manual null checks and insert "zero like values" (for the value to then immediately to be discarded). One example of such is this 

```scala
    decoder((index, row) => {
      val v = row.getTimestamp(index, Calendar.getInstance(dateTimeZone))
      if (v == null)
        new util.Date(0)
      else
        new util.Date(v.getTime)
    })
```

In this case, we would see if the row happened to contain a `null` value. If it did then we would just return `new util.Date(0)` for it to be then immediately discarded (otherwise we would proceed as normal).

### Solution

The original issue (i.e. have to manually check for `null` values in decoders because decoders would execute completely even in presence of `null` values) was fixed in https://github.com/getquill/quill/pull/1514. This PR is just removing the redundant null checks, as well adjusting a now invalid test.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
