### PR TITLE
Dynamic query DSL updated

### DIFF
--- a/quill-core/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/DynamicQueryDSL.scala
@@ -88,6 +88,12 @@ trait DynamicQueryDsl {
       case Some(v) => setValue(property, v)
       case None    => DynamicSetEmpty()
     }
+  
+  def setOpt[T, U](property: String, value: Option[U])(implicit enc: Encoder[U]): DynamicSet[T, U] =
+    value match {
+      case Some(v) => setValue(property, v)
+      case None    => DynamicSetEmpty()
+    }
 
   def set[T, U](property: String, value: Quoted[U]): DynamicSet[T, U] =
     set((f: Quoted[T]) => splice(Property(f.ast, property)), value)


### PR DESCRIPTION
Added an extra method to support `String` properties.

Fixes #1678 

### Problem

`setOpt` method currently doesn't support `String` properties. This leads to forced use of properties during `update` / `insert`

### Solution

Since `set` and `setValue` already supports `String` as property. It is enough to just overload the `setOpt`. 

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
