### PR TITLE
Update cassandra version in dockerfile setup

### DIFF
--- a/build/Dockerfile-setup
+++ b/build/Dockerfile-setup
@@ -26,8 +26,8 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     update-locale LANG=en_US.UTF-8
 
 RUN  cd /opt ; \
-     curl http://apache.volia.net/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz | tar zx
+     curl http://apache.volia.net/cassandra/3.11.5/apache-cassandra-3.11.5-bin.tar.gz | tar zx
 
-ENV PATH /opt/apache-cassandra-3.11.4/bin:$PATH
+ENV PATH /opt/apache-cassandra-3.11.5/bin:$PATH
 
 WORKDIR /app


### PR DESCRIPTION
### Problem

Running the `setup` docker container fails as the artefact for cassandra 3.11.4 no longer exist at the
location we're fetching it from.

### Solution

Update cassandra from version 3.11.4 to 3.11.5

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
