### PR TITLE
Update returning

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ val returnedIds = ctx.run(q) //: List[(Int, Long)]
 
 In certain situations, we might want to return fields that are not auto generated as well. In this case we do not want 
 the fields to be automatically excluded from the insertion. The `returning` method is used for that.
- 
+
 ```scala
 val q = quote {
   query[Product].insert(lift(Product(0, "My Product", 1011L))).returning(r => (id, description))
@@ -272,7 +272,7 @@ val q = quote {
 val returnedIds = ctx.run(q) //: List[(Int, String)]
 // INSERT INTO Product (description, sku) VALUES (?, ?) RETURNING id, description
 ```
- 
+
  We can also fix this situation by using an insert-meta.
 
 ```scala
@@ -283,6 +283,19 @@ val q = quote {
 
 val returnedIds = ctx.run(q) //: List[(Int, String)]
 // INSERT INTO Product (description, sku) VALUES (?, ?) RETURNING id, description
+```
+
+##### update returning
+
+`returning` can also be used after `update`:
+
+```scala
+val q = quote {
+  query[Product].update(lift(Product(42, "Updated Product", 2022L))).returning(r => (r.id, r.description))
+}
+
+val updated = ctx.run(q) //: List[(Int, String)]
+// UPDATE Product SET id = ?, description = ?, sku = ? RETURNING id, description
 ```
 
 #### Customization
@@ -355,6 +368,16 @@ Add 100 to the value of `id`:
 ```scala
 ctx.run(q.returning(r => id + 100)) //: List[Int]
 // INSERT INTO Product (description, sku) OUTPUT INSERTED.id + 100 VALUES (?, ?)
+```
+
+Update returning:
+```scala
+val q = quote {
+  query[Product].update(_.description -> "Updated Product", _.sku -> 2022L).returning(r => (r.id, r.description))
+}
+
+val updated = ctx.run(q)
+// UPDATE Product SET description = 'Updated Product', sku = 2022 OUTPUT INSERTED.id, INSERTED.description
 ```
 
 ### Embedded case classes

--- a/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
+++ b/quill-core/src/main/scala/io/getquill/dsl/QueryDsl.scala
@@ -167,8 +167,12 @@ private[getquill] trait QueryDsl {
     def onConflictUpdate(target: E => Any, targets: (E => Any)*)(assign: ((E, E) => (Any, Any)), assigns: ((E, E) => (Any, Any))*): Insert[E] = NonQuotedException()
   }
 
+  sealed trait Update[E] extends Action[E] {
+    @compileTimeOnly(NonQuotedException.message)
+    def returning[R](f: E => R): ActionReturning[E, R] = NonQuotedException()
+  }
+
   sealed trait ActionReturning[E, Output] extends Action[E]
-  sealed trait Update[E] extends Action[E]
   sealed trait Delete[E] extends Action[E]
 
   sealed trait BatchAction[+A <: Action[_]]

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -921,7 +921,7 @@ trait Parsing extends ValueComputation {
 
     (ident == originalBody, actionType.tpe) match {
       // Note, tuples are also case classes so this also matches for tuples
-      case (true, ClassTypeRefMatch(cls, List(arg))) if (cls == asClass[QueryDsl#Insert[_]] && isTypeCaseClass(arg)) =>
+      case (true, ClassTypeRefMatch(cls, List(arg))) if (cls == asClass[QueryDsl#Insert[_]] || cls == asClass[QueryDsl#Update[_]]) && isTypeCaseClass(arg) =>
 
         val elements = flatten(q"${TermName(ident.name)}", value("Decoder", arg))
         if (elements.size == 0) c.fail("Case class in the 'returning' clause has no values")

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/JdbcContextSpec.scala
@@ -55,27 +55,61 @@ class JdbcContextSpec extends Spec {
     }
   }
 
-  "Insert with returning with single column table" in {
-    val inserted = testContext.run {
-      qr4.insert(lift(TestEntity4(0))).returning(_.i)
+  "insert returning" - {
+    "with single column table" in {
+      val inserted = testContext.run {
+        qr4.insert(lift(TestEntity4(0))).returning(_.i)
+      }
+      testContext.run(qr4.filter(_.i == lift(inserted))).head.i mustBe inserted
     }
-    testContext.run(qr4.filter(_.i == lift(inserted))).head.i mustBe inserted
+
+    "with multiple columns" in {
+      testContext.run(qr1.delete)
+      val inserted = testContext.run {
+        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i, r.s, r.o))
+      }
+      (1, "foo", Some(123)) mustBe inserted
+    }
+
+    "with multiple columns - case class" in {
+      case class Return(id: Int, str: String, opt: Option[Int])
+      testContext.run(qr1.delete)
+      val inserted = testContext.run {
+        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => Return(r.i, r.s, r.o))
+      }
+      Return(1, "foo", Some(123)) mustBe inserted
+    }
   }
 
-  "Insert with returning with multiple columns" in {
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i, r.s, r.o))
-    }
-    (1, "foo", Some(123)) mustBe inserted
-  }
+  "update returning" - {
+    "with single column table" in {
+      testContext.run(qr4.insert(lift(TestEntity4(8))))
 
-  "Insert with returning with multiple columns - case class" in {
-    case class Return(id: Int, str: String, opt: Option[Int])
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => Return(r.i, r.s, r.o))
+      val updated = testContext.run {
+        qr4.update(lift(TestEntity4(0))).returning(_.i)
+      }
+      testContext.run(qr4.filter(_.i == lift(updated))).head.i mustBe updated
     }
-    Return(1, "foo", Some(123)) mustBe inserted
+
+    "with multiple columns" in {
+      testContext.run(qr1.delete)
+      testContext.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456)))))
+
+      val updated = testContext.run {
+        qr1.update(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i, r.s, r.o))
+      }
+      (1, "foo", Some(123)) mustBe updated
+    }
+
+    "with multiple columns - case class" in {
+      case class Return(id: Int, str: String, opt: Option[Int])
+      testContext.run(qr1.delete)
+      testContext.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456)))))
+
+      val updated = testContext.run {
+        qr1.update(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => Return(r.i, r.s, r.o))
+      }
+      Return(1, "foo", Some(123)) mustBe updated
+    }
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/JdbcContextSpec.scala
@@ -4,146 +4,231 @@ import io.getquill.Spec
 
 class JdbcContextSpec extends Spec {
 
-  val context = testContext
-  import testContext._
+  val ctx = testContext
+  import ctx._
 
   "probes sqls" in {
-    val p = testContext.probe("DELETE FROM TestEntity")
+    val p = ctx.probe("DELETE FROM TestEntity")
   }
 
   "run non-batched action" in {
     val insert = quote {
       qr1.insert(_.i -> lift(1))
     }
-    testContext.run(insert) mustEqual 1
+    ctx.run(insert) mustEqual 1
   }
 
   "provides transaction support" - {
     "success" in {
-      testContext.run(qr1.delete)
-      testContext.transaction {
-        testContext.run(qr1.insert(_.i -> 33))
+      ctx.run(qr1.delete)
+      ctx.transaction {
+        ctx.run(qr1.insert(_.i -> 33))
       }
-      testContext.run(qr1).map(_.i) mustEqual List(33)
+      ctx.run(qr1).map(_.i) mustEqual List(33)
     }
     "failure" in {
-      testContext.run(qr1.delete)
+      ctx.run(qr1.delete)
       intercept[IllegalStateException] {
-        testContext.transaction {
-          testContext.run(qr1.insert(_.i -> 33))
+        ctx.transaction {
+          ctx.run(qr1.insert(_.i -> 33))
           throw new IllegalStateException
         }
       }
-      testContext.run(qr1).isEmpty mustEqual true
+      ctx.run(qr1).isEmpty mustEqual true
     }
     "nested" in {
-      testContext.run(qr1.delete)
-      testContext.transaction {
-        testContext.transaction {
-          testContext.run(qr1.insert(_.i -> 33))
+      ctx.run(qr1.delete)
+      ctx.transaction {
+        ctx.transaction {
+          ctx.run(qr1.insert(_.i -> 33))
         }
       }
-      testContext.run(qr1).map(_.i) mustEqual List(33)
+      ctx.run(qr1).map(_.i) mustEqual List(33)
     }
     "prepare" in {
-      testContext.prepareParams(
+      ctx.prepareParams(
         "select * from Person where name=? and age > ?", ps => (List("Sarah", 127), ps)
       ) mustEqual List("127", "'Sarah'")
     }
   }
 
   "Insert with returning generated with single column table" in {
-    testContext.run(qr4.delete)
+    ctx.run(qr4.delete)
     val insert = quote {
       qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
     }
 
-    val inserted1 = testContext.run(insert)
-    testContext.run(qr4.filter(_.i == lift(inserted1))).head.i mustBe inserted1
+    val inserted1 = ctx.run(insert)
+    ctx.run(qr4.filter(_.i == lift(inserted1))).head.i mustBe inserted1
 
-    val inserted2 = testContext.run(insert)
-    testContext.run(qr4.filter(_.i == lift(inserted2))).head.i mustBe inserted2
+    val inserted2 = ctx.run(insert)
+    ctx.run(qr4.filter(_.i == lift(inserted2))).head.i mustBe inserted2
 
-    val inserted3 = testContext.run(insert)
-    testContext.run(qr4.filter(_.i == lift(inserted3))).head.i mustBe inserted3
+    val inserted3 = ctx.run(insert)
+    ctx.run(qr4.filter(_.i == lift(inserted3))).head.i mustBe inserted3
   }
 
   "Insert with returning generated with single column table using query" in {
-    testContext.run(qr5.delete)
-    val id = testContext.run(qr5.insert(lift(TestEntity5(0, "foo"))).returningGenerated(_.i))
-    val id2 = testContext.run {
+    ctx.run(qr5.delete)
+    val id = ctx.run(qr5.insert(lift(TestEntity5(0, "foo"))).returningGenerated(_.i))
+    val id2 = ctx.run {
       qr5.insert(_.s -> "bar").returningGenerated(r => query[TestEntity5].filter(_.s == "foo").map(_.i).max)
     }.get
     id mustBe id2
   }
 
-  "Insert with returning with multiple columns" in {
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i, r.s, r.o))
+  "insert returning" - {
+    "with multiple columns" in {
+      ctx.run(qr1.delete)
+      val inserted = ctx.run {
+        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i, r.s, r.o))
+      }
+      (1, "foo", Some(123)) mustBe inserted
     }
-    (1, "foo", Some(123)) mustBe inserted
+
+    "with multiple columns and operations" in {
+      ctx.run(qr1.delete)
+      val inserted = ctx.run {
+        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
+      }
+      (1 + 100, "foo", Some(123 + 100)) mustBe inserted
+    }
+
+    "with multiple columns and query" in {
+      ctx.run(qr2.delete)
+      ctx.run(qr2.insert(_.i -> 36, _.l -> 0L, _.s -> "foobar"))
+
+      ctx.run(qr1.delete)
+      val inserted = ctx.run {
+        qr1.insert(lift(TestEntity("two", 36, 18L, Some(123)))).returning(r =>
+          (r.i, r.s + "_s", qr2.filter(rr => rr.i == r.i).map(_.s).max))
+      }
+      (36, "two_s", Some("foobar")) mustBe inserted
+    }
+
+    "with multiple columns and query - with lifting" in {
+      ctx.run(qr2.delete)
+      ctx.run(qr2.insert(_.i -> 36, _.l -> 0L, _.s -> "foobar"))
+
+      val value = "foobar"
+      ctx.run(qr1.delete)
+      val inserted = ctx.run {
+        qr1.insert(lift(TestEntity("two", 36, 18L, Some(123)))).returning(r =>
+          (r.i, r.s + "_s", qr2.filter(rr => rr.i == r.i && rr.s == lift(value)).map(_.s).max))
+      }
+      (36, "two_s", Some("foobar")) mustBe inserted
+    }
+
+    "with multiple columns and query - same table" in {
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("one", 1, 18L, Some(1)))))
+      val inserted = ctx.run {
+        qr1.insert(lift(TestEntity("two", 2, 18L, Some(123)))).returning(r =>
+          (r.i, r.s + "_s", qr1.filter(rr => rr.o.exists(_ == r.i - 1)).map(_.s).max))
+      }
+      (2, "two_s", Some("one")) mustBe inserted
+    }
+
+    "with multiple columns and query embedded" in {
+      ctx.run(qr1Emb.delete)
+      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
+      val inserted = ctx.run {
+        qr1Emb.insert(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r =>
+          (r.emb.i, r.o))
+      }
+      (2, Some(123)) mustBe inserted
+    }
+
+    "with multiple columns - case class" in {
+      case class Return(id: Int, str: String, opt: Option[Int])
+      ctx.run(qr1.delete)
+      val inserted = ctx.run {
+        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => Return(r.i, r.s, r.o))
+      }
+      Return(1, "foo", Some(123)) mustBe inserted
+    }
   }
 
-  "Insert with returning with multiple columns and operations" in {
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
+  "update returning" - {
+    "with multiple columns" in {
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))))
+
+      val updated = ctx.run {
+        qr1.update(lift(TestEntity("bar", 2, 42L, Some(321)))).returning(r => (r.i, r.s, r.o))
+      }
+      (2, "bar", Some(321)) mustBe updated
     }
-    (1 + 100, "foo", Some(123 + 100)) mustBe inserted
-  }
 
-  "Insert with returning with multiple columns and query" in {
-    testContext.run(qr2.delete)
-    testContext.run(qr2.insert(_.i -> 36, _.l -> 0L, _.s -> "foobar"))
+    "with multiple columns and operations" in {
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))))
 
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("two", 36, 18L, Some(123)))).returning(r =>
-        (r.i, r.s + "_s", qr2.filter(rr => rr.i == r.i).map(_.s).max))
+      val updated = ctx.run {
+        qr1.update(lift(TestEntity("bar", 2, 42L, Some(321)))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
+      }
+      (2 + 100, "bar", Some(321 + 100)) mustBe updated
     }
-    (36, "two_s", Some("foobar")) mustBe inserted
-  }
 
-  "Insert with returning with multiple columns and query - with lifting" in {
-    testContext.run(qr2.delete)
-    testContext.run(qr2.insert(_.i -> 36, _.l -> 0L, _.s -> "foobar"))
+    "with multiple columns and query" in {
+      ctx.run(qr2.delete)
+      ctx.run(qr2.insert(_.i -> 36, _.l -> 0L, _.s -> "foobar"))
 
-    val value = "foobar"
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("two", 36, 18L, Some(123)))).returning(r =>
-        (r.i, r.s + "_s", qr2.filter(rr => rr.i == r.i && rr.s == lift(value)).map(_.s).max))
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))))
+
+      val updated = ctx.run {
+        qr1.update(lift(TestEntity("bar", 36, 42L, Some(321)))).returning(r =>
+          (r.i, r.s + "_s", qr2.filter(rr => rr.i == r.i).map(_.s).max))
+      }
+      (36, "bar_s", Some("foobar")) mustBe updated
     }
-    (36, "two_s", Some("foobar")) mustBe inserted
-  }
 
-  "Insert with returning with multiple columns and query - same table" in {
-    testContext.run(qr1.delete)
-    testContext.run(qr1.insert(lift(TestEntity("one", 1, 18L, Some(1)))))
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("two", 2, 18L, Some(123)))).returning(r =>
-        (r.i, r.s + "_s", qr1.filter(rr => rr.o.exists(_ == r.i - 1)).map(_.s).max))
-    }
-    (2, "two_s", Some("one")) mustBe inserted
-  }
+    "with multiple columns and query - with lifting" in {
+      ctx.run(qr2.delete)
+      ctx.run(qr2.insert(_.i -> 36, _.l -> 0L, _.s -> "foobar"))
 
-  "Insert with returning with multiple columns and query embedded" in {
-    testContext.run(qr1Emb.delete)
-    testContext.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
-    val inserted = testContext.run {
-      qr1Emb.insert(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r =>
-        (r.emb.i, r.o))
-    }
-    (2, Some(123)) mustBe inserted
-  }
+      val value = "foobar"
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))))
 
-  "Insert with returning with multiple columns - case class" in {
-    case class Return(id: Int, str: String, opt: Option[Int])
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => Return(r.i, r.s, r.o))
+      val updated = ctx.run {
+        qr1.update(lift(TestEntity("bar", 36, 42L, Some(321)))).returning(r =>
+          (r.i, r.s + "_s", qr2.filter(rr => rr.i == r.i && rr.s == lift(value)).map(_.s).max))
+      }
+      (36, "bar_s", Some("foobar")) mustBe updated
     }
-    Return(1, "foo", Some(123)) mustBe inserted
+
+    "with multiple columns and query - same table" in {
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("one", 1, 18L, Some(1)))))
+
+      val updated = ctx.run {
+        qr1.update(lift(TestEntity("two", 2, 18L, Some(123)))).returning(r =>
+          (r.i, r.s + "_s", qr1.filter(rr => rr.o.exists(_ == r.i - 1)).map(_.s).max))
+      }
+      (2, "two_s", Some("one")) mustBe updated
+    }
+
+    "with multiple columns and query embedded" in {
+      ctx.run(qr1Emb.delete)
+      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
+
+      val updated = ctx.run {
+        qr1Emb.update(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r => (r.emb.i, r.o))
+      }
+      (2, Some(123)) mustBe updated
+    }
+
+    "with multiple columns - case class" in {
+      case class Return(id: Int, str: String, opt: Option[Int])
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("one", 1, 18L, Some(1)))))
+
+      val updated = ctx.run {
+        qr1.update(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => Return(r.i, r.s, r.o))
+      }
+      Return(1, "foo", Some(123)) mustBe updated
+    }
   }
 }

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcContextSpec.scala
@@ -4,101 +4,146 @@ import io.getquill.{ Literal, Spec, SqlServerJdbcContext }
 
 class JdbcContextSpec extends Spec {
 
-  val context = testContext
-  import testContext._
+  val ctx = testContext
+  import ctx._
 
   "probes sqls" in {
-    val p = testContext.probe("DELETE FROM TestEntity")
+    val p = ctx.probe("DELETE FROM TestEntity")
   }
 
   "run non-batched action" in {
     val insert = quote {
       qr1.insert(_.i -> lift(1))
     }
-    testContext.run(insert) mustEqual 1
+    ctx.run(insert) mustEqual 1
   }
 
   "provides transaction support" - {
     "success" in {
-      testContext.run(qr1.delete)
-      testContext.transaction {
-        testContext.run(qr1.insert(_.i -> 33))
+      ctx.run(qr1.delete)
+      ctx.transaction {
+        ctx.run(qr1.insert(_.i -> 33))
       }
-      testContext.run(qr1).map(_.i) mustEqual List(33)
+      ctx.run(qr1).map(_.i) mustEqual List(33)
     }
     "failure" in {
-      testContext.run(qr1.delete)
+      ctx.run(qr1.delete)
       intercept[IllegalStateException] {
-        testContext.transaction {
-          testContext.run(qr1.insert(_.i -> 33))
+        ctx.transaction {
+          ctx.run(qr1.insert(_.i -> 33))
           throw new IllegalStateException
         }
       }
-      testContext.run(qr1).isEmpty mustEqual true
+      ctx.run(qr1).isEmpty mustEqual true
     }
     "nested" in {
-      testContext.run(qr1.delete)
-      testContext.transaction {
-        testContext.transaction {
-          testContext.run(qr1.insert(_.i -> 33))
+      ctx.run(qr1.delete)
+      ctx.transaction {
+        ctx.transaction {
+          ctx.run(qr1.insert(_.i -> 33))
         }
       }
-      testContext.run(qr1).map(_.i) mustEqual List(33)
+      ctx.run(qr1).map(_.i) mustEqual List(33)
     }
     "prepare" in {
-      testContext.prepareParams(
+      ctx.prepareParams(
         "select * from Person where name=? and age > ?", ps => (List("Sarah", 127), ps)
       ) mustEqual List("127", "'Sarah'")
     }
   }
 
   "Insert with returning generated with single column table" in {
-    val inserted = testContext.run {
+    val inserted = ctx.run {
       qr4.insert(lift(TestEntity4(0))).returningGenerated(_.i)
     }
-    testContext.run(qr4.filter(_.i == lift(inserted))).head.i mustBe inserted
+    ctx.run(qr4.filter(_.i == lift(inserted))).head.i mustBe inserted
   }
 
   "Insert with returning generated with multiple columns and query embedded" in {
-    val inserted = testContext.run {
+    val inserted = ctx.run {
       qr4Emb.insert(lift(TestEntity4Emb(EmbSingle(0)))).returningGenerated(_.emb.i)
     }
-    testContext.run(qr4Emb.filter(_.emb.i == lift(inserted))).head.emb.i mustBe inserted
+    ctx.run(qr4Emb.filter(_.emb.i == lift(inserted))).head.emb.i mustBe inserted
   }
 
-  "Insert with returning with multiple columns" in {
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i, r.s, r.o))
+  "insert returning" - {
+    "with multiple columns" in {
+      ctx.run(qr1.delete)
+      val inserted = ctx.run {
+        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i, r.s, r.o))
+      }
+      (1, "foo", Some(123)) mustBe inserted
     }
-    (1, "foo", Some(123)) mustBe inserted
+
+    "with multiple columns and operations" in {
+      ctx.run(qr1.delete)
+      val inserted = ctx.run {
+        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
+      }
+      (1 + 100, "foo", Some(123 + 100)) mustBe inserted
+    }
+
+    "with multiple columns and query embedded" in {
+      ctx.run(qr1Emb.delete)
+      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
+      val inserted = ctx.run {
+        qr1Emb.insert(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r =>
+          (r.emb.i, r.o))
+      }
+      (2, Some(123)) mustBe inserted
+    }
+
+    "with multiple columns - case class" in {
+      case class Return(id: Int, str: String, opt: Option[Int])
+      ctx.run(qr1.delete)
+      val inserted = ctx.run {
+        qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => Return(r.i, r.s, r.o))
+      }
+      Return(1, "foo", Some(123)) mustBe inserted
+    }
   }
 
-  "Insert with returning with multiple columns and operations" in {
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
-    }
-    (1 + 100, "foo", Some(123 + 100)) mustBe inserted
-  }
+  "update returning" - {
+    "with multiple columns" in {
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456)))))
 
-  "Insert with returning with multiple columns and query embedded" in {
-    testContext.run(qr1Emb.delete)
-    testContext.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 18L, Some(123)))))
-    val inserted = testContext.run {
-      qr1Emb.insert(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r =>
-        (r.emb.i, r.o))
+      val updated = ctx.run {
+        qr1.update(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i, r.s, r.o))
+      }
+      (1, "foo", Some(123)) mustBe updated
     }
-    (2, Some(123)) mustBe inserted
-  }
 
-  "Insert with returning with multiple columns - case class" in {
-    case class Return(id: Int, str: String, opt: Option[Int])
-    testContext.run(qr1.delete)
-    val inserted = testContext.run {
-      qr1.insert(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => Return(r.i, r.s, r.o))
+    "with multiple columns and operations" in {
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456)))))
+
+      val updated = ctx.run {
+        qr1.update(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
+      }
+      (1 + 100, "foo", Some(123 + 100)) mustBe updated
     }
-    Return(1, "foo", Some(123)) mustBe inserted
+
+    "with multiple columns and query embedded" in {
+      ctx.run(qr1Emb.delete)
+      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 42L, Some(456)))))
+
+      val updated = ctx.run {
+        qr1Emb.update(lift(TestEntityEmb(Emb("two", 2), 18L, Some(123)))).returning(r => (r.emb.i, r.o))
+      }
+      (2, Some(123)) mustBe updated
+    }
+
+    "with multiple columns - case class" in {
+      case class Return(id: Int, str: String, opt: Option[Int])
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("baz", 6, 42L, Some(456)))))
+
+      val updated = ctx.run {
+        qr1.update(lift(TestEntity("foo", 1, 18L, Some(123)))).returning(r => Return(r.i, r.s, r.o))
+      }
+      Return(1, "foo", Some(123)) mustBe updated
+    }
   }
 }
 

--- a/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/idiom/SqlIdiom.scala
@@ -467,6 +467,8 @@ trait SqlIdiom extends Idiom {
             case Insert(entity: Entity, assignments) =>
               val (table, columns, values) = insertInfo(insertEntityTokenizer, entity, assignments)
               stmt"INSERT $table${actionAlias.map(alias => stmt" AS ${alias.token}").getOrElse(stmt"")} (${columns.mkStmt(",")}) OUTPUT ${returnListTokenizer.token(ExpandReturning(r, Some("INSERTED"))(this, strategy).map(_._1))} VALUES (${values.map(scopedTokenizer(_)).mkStmt(", ")})"
+            case Update(entity: Entity, assignments) =>
+              stmt"UPDATE ${entity.token}${actionAlias.map(alias => stmt" AS ${alias.token}").getOrElse(stmt"")} SET ${assignments.token} OUTPUT ${returnListTokenizer.token(ExpandReturning(r, Some("INSERTED"))(this, strategy).map(_._1))}"
             case other =>
               fail(s"Action ast can't be translated to sql: '$other'")
           }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlActionMacroSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.sql
 
-import io.getquill._
 import io.getquill.ReturnAction.{ ReturnColumns, ReturnRecord }
+import io.getquill._
 import io.getquill.context.mirror.Row
 
 class SqlActionMacroSpec extends Spec {
@@ -52,7 +52,7 @@ class SqlActionMacroSpec extends Spec {
       }
     }
 
-    "returning generated" - {
+    "insert returning generated" - {
       "single with returning generated" in {
         val q = quote {
           qr1.insert(lift(TestEntity("s", 0, 1L, None))).returningGenerated(_.l)
@@ -478,7 +478,7 @@ class SqlActionMacroSpec extends Spec {
       }
     }
 
-    "returning" - {
+    "insert returning" - {
       "multi" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
         import ctx._
         val q = quote {
@@ -694,6 +694,222 @@ class SqlActionMacroSpec extends Spec {
       }
     }
 
+    "update returning" - {
+      "multi" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
+        import ctx._
+        val q = quote {
+          qr1.update(lift(TestEntity("s", 0, 1L, None))).returning(_.l)
+        }
+
+        val mirror = ctx.run(q)
+        mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ?"
+        mirror.returningBehavior mustEqual ReturnColumns(List("l"))
+      }
+      "multi - should fail on operation" in testContext.withDialect(MirrorSqlDialectWithReturnMulti) { ctx =>
+        """import ctx._; quote { qr1.update(lift(TestEntity("s", 0, 1L, None))).returning(r => (r.i, r.l + 1)) }""" mustNot compile
+      }
+      "no return - should fail on property" in testContext.withDialect(MirrorSqlDialectWithNoReturn) { ctx =>
+        """import ctx._; quote { qr1.update(lift(TestEntity("s", 0, 1L, None))).returning(r => r.i) }""" mustNot compile
+      }
+
+      "returning clause - single" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+        import ctx._
+        val q = quote {
+          qr1.update(_.s -> "s").returning(_.l)
+        }
+
+        val mirror = ctx.run(q)
+        mirror.string mustEqual "UPDATE TestEntity SET s = 's' RETURNING l"
+        mirror.returningBehavior mustEqual ReturnRecord
+      }
+      "returning clause - multi" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+        import ctx._
+        val q = quote {
+          qr1.update(lift(TestEntity("s", 0, 1L, None))).returning(r => (r.i, r.l))
+        }
+        val mirror = ctx.run(q)
+        mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? RETURNING i, l"
+        mirror.returningBehavior mustEqual ReturnRecord
+      }
+      "returning clause - operation" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+        import ctx._
+        val q = quote {
+          qr1.update(lift(TestEntity("s", 0, 1L, None))).returning(r => (r.i, r.l + 1))
+        }
+        val mirror = ctx.run(q)
+        mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? RETURNING i, l + 1"
+        mirror.returningBehavior mustEqual ReturnRecord
+      }
+      "returning clause - embedded" - {
+        case class Dummy(i: Int)
+
+        "embedded property" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1Emb.update(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(_.emb.i)
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? RETURNING i"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+        "two embedded properties" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1Emb.update(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(r => (r.emb.i, r.emb.s))
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? RETURNING i, s"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+        "query with filter using id - id should be excluded" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1Emb.update(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(r => query[Dummy].filter(d => d.i == r.emb.i).max)
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity AS r SET s = ?, i = ?, l = ?, o = ? RETURNING (SELECT MAX(*) FROM Dummy d WHERE d.i = r.i)"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+      }
+      "with returning clause - query" - {
+        case class Dummy(i: Int)
+
+        "simple not using id - id not excluded" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1
+              .update(lift(TestEntity("s", 0, 1L, None)))
+              .returning(r => query[Dummy].map(d => d.i).max)
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity AS r SET s = ?, i = ?, l = ?, o = ? RETURNING (SELECT MAX(d.i) FROM Dummy d)"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+        "simple with id - id would be excluded (if was returningGenerated)" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1
+              .update(lift(TestEntity("s", 0, 1L, None)))
+              .returning(r => (r.i, query[Dummy].map(d => d.i).max))
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity AS r SET s = ?, i = ?, l = ?, o = ? RETURNING r.i, (SELECT MAX(d.i) FROM Dummy d)"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+        "simple with filter using id - id would be excluded (if was returningGenerated)" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1
+              .update(lift(TestEntity("s", 0, 1L, None)))
+              .returning(r => query[Dummy].filter(d => d.i == r.i).max)
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity AS r SET s = ?, i = ?, l = ?, o = ? RETURNING (SELECT MAX(*) FROM Dummy d WHERE d.i = r.i)"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+        "shadow variable - id not excluded (same as returningGenerated)" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1
+              .update(lift(TestEntity("s", 0, 1L, None)))
+              .returning(r => query[Dummy].map(r => r.i).max)
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity AS r SET s = ?, i = ?, l = ?, o = ? RETURNING (SELECT MAX(r1.i) FROM Dummy r1)"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+        "shadow variable in multiple clauses - id not excluded (same as returningGenerated)" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1
+              .update(lift(TestEntity("s", 0, 1L, None)))
+              .returning(
+                r =>
+                  (query[Dummy]
+                    .filter(
+                      r => r.i == r.i /* always true since r overridden! */
+                    )
+                    .map(r => r.i)
+                    .max)
+              )
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity AS r SET s = ?, i = ?, l = ?, o = ? RETURNING (SELECT MAX(r1.i) FROM Dummy r1 WHERE r1.i = r1.i)"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+        "shadow variable in one of multiple clauses - id excluded" in testContext.withDialect(MirrorSqlDialectWithReturnClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1
+              .update(lift(TestEntity("s", 0, 1L, None)))
+              .returning(
+                r => query[Dummy].filter(d => d.i == r.i).map(r => r.i).max
+              )
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity AS r SET s = ?, i = ?, l = ?, o = ? RETURNING (SELECT MAX(d.i) FROM Dummy d WHERE d.i = r.i)"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+      }
+      "output clause - single" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
+        import ctx._
+        val q = quote {
+          qr1.update(lift(TestEntity("s", 0, 1L, None))).returning(_.l)
+        }
+
+        val mirror = ctx.run(q)
+        mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? OUTPUT INSERTED.l"
+        mirror.returningBehavior mustEqual ReturnRecord
+      }
+      "output clause - multi" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
+        import ctx._
+        val q = quote {
+          qr1.update(lift(TestEntity("s", 0, 1L, None))).returning(r => (r.i, r.l))
+        }
+        val mirror = ctx.run(q)
+        mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? OUTPUT INSERTED.i, INSERTED.l"
+        mirror.returningBehavior mustEqual ReturnRecord
+      }
+      "output clause - operation" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
+        import ctx._
+        val q = quote { qr1.update(lift(TestEntity("s", 0, 1L, None))).returning(r => (r.i, r.l + 1)) }
+        val mirror = ctx.run(q)
+
+        mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? OUTPUT INSERTED.i, INSERTED.l + 1"
+      }
+      "output clause - record" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
+        import ctx._
+        val q = quote {
+          qr1.update(lift(TestEntity("s", 0, 1L, None))).returning(r => r)
+        }
+        val mirror = ctx.run(q)
+        mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? OUTPUT INSERTED.s, INSERTED.i, INSERTED.l, INSERTED.o"
+        mirror.returningBehavior mustEqual ReturnRecord
+      }
+      "output clause - embedded" - {
+        "embedded property" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1Emb.update(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(_.emb.i)
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? OUTPUT INSERTED.i"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+        "two embedded properties" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
+          import ctx._
+          val q = quote {
+            qr1Emb.update(lift(TestEntityEmb(Emb("s", 0), 1L, None))).returning(r => (r.emb.i, r.emb.s))
+          }
+          val mirror = ctx.run(q)
+          mirror.string mustEqual "UPDATE TestEntity SET s = ?, i = ?, l = ?, o = ? OUTPUT INSERTED.i, INSERTED.s"
+          mirror.returningBehavior mustEqual ReturnRecord
+        }
+      }
+      "output clause - should fail on query" in testContext.withDialect(MirrorSqlDialectWithOutputClause) { ctx =>
+        """import ctx._; quote { qr4.update(lift(TestEntity4(1L))).returning(r => query[TestEntity4].filter(t => t.i == r.i)) }""" mustNot compile
+      }
+    }
   }
   "apply naming strategy to returning action" in testContext.withNaming(SnakeCase) { ctx =>
     import ctx._


### PR DESCRIPTION
Fixes #572 

### Problem

We don't have support to UPDATE ... RETURNING

### Solution

Implemented `update.returning` for Postgres, Sql Server and Oracle

### Notes

Additional notes.

### Checklist

- [X] Unit test all changes
- [x] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
