### PR TITLE
[Deps] Fix pprint dependency duplication

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,6 @@ lazy val `quill-core` =
       libraryDependencies ++= Seq(
         "com.lihaoyi" %%% "pprint" % pprintVersion(scalaVersion.value),
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
-        "com.lihaoyi" %%% "pprint" % "0.5.4",
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5"
       ),
       coverageExcludedPackages := ".*"


### PR DESCRIPTION
### Problem

The pprint dependency was duplicated, which causes some strangeness downstream for projects running on 2.13 (tries to resolve a 0.5.4).

For example, see https://mvnrepository.com/artifact/io.getquill/quill-core_sjs0.6_2.13/3.5.0

<img width="841" alt="Screenshot 2019-12-01 at 13 40 11" src="https://user-images.githubusercontent.com/914805/69909574-1d48e380-1440-11ea-814e-973fc7a195ca.png">

FWIW, I think this should be "fixed" by making this impossible in SBT/ScalaJs packaging/dep resolution, but this is the more tactical fix.

### Solution

Removes the duplicated pprint dependency line.

### Notes

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
