### PR TITLE
Added support for onConflictIgnore to H2 (v1.4.200 in PostgreSQL mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,7 +1175,7 @@ Since you cannot use `Option[Table].isDefined`, if you want to null-check a whol
 val q = quote {
   query[Company].leftJoin(query[Address])
     .on((c, a) => c.zip == a.zip)         // Row type is (Company, Option[Address])
-    .filter({case(c,a) => a.isDefined})   // You cannot null-check a whole table
+    .filter({case(c,a) => a.isDefined})   // You cannot null-check a whole table!
 }
 ```
  
@@ -1298,7 +1298,7 @@ Database actions are defined using quotations as well. These actions don't have 
 ```scala
 val a = quote(query[Contact].insert(lift(Contact(999, "+1510488988"))))
 
-ctx.run(a)
+ctx.run(a) // = 1 if the row was inserted 0 otherwise
 // INSERT INTO Contact (personId,phone) VALUES (?, ?)
 ```
 
@@ -1316,10 +1316,10 @@ ctx.run(a)
 ### batch insert
 ```scala
 val a = quote {
-  liftQuery(List(Person(0, "John", 31))).foreach(e => query[Person].insert(e))
+  liftQuery(List(Person(0, "John", 31),Person(2, "name2", 32))).foreach(e => query[Person].insert(e))
 }
 
-ctx.run(a)
+ctx.run(a) //: List[Long] size = 2. Contains 1 @ positions, where row was inserted E.g List(1,1)
 // INSERT INTO Person (id,name,age) VALUES (?, ?, ?)
 ```
 
@@ -1329,7 +1329,7 @@ val a = quote {
   query[Person].filter(_.id == 999).update(lift(Person(999, "John", 22)))
 }
 
-ctx.run(a)
+ctx.run(a) // = Long number of rows updated
 // UPDATE Person SET id = ?, name = ?, age = ? WHERE id = 999
 ```
 
@@ -1359,12 +1359,12 @@ ctx.run(a)
 
 ```scala
 val a = quote {
-  liftQuery(List(Person(1, "name", 31))).foreach { person =>
+  liftQuery(List(Person(1, "name", 31),Person(2, "name2", 32))).foreach { person =>
      query[Person].filter(_.id == person.id).update(_.name -> person.name, _.age -> person.age)
   }
 }
 
-ctx.run(a)
+ctx.run(a) // : List[Long] size = 2. Contains 1 @ positions, where row was inserted E.g List(1,0)
 // UPDATE Person SET name = ?, age = ? WHERE id = ?
 ```
 
@@ -1374,13 +1374,13 @@ val a = quote {
   query[Person].filter(p => p.name == "").delete
 }
 
-ctx.run(a)
+ctx.run(a) // = Long the number of rows deleted
 // DELETE FROM Person WHERE name = ''
 ```
 
 ### insert or update (upsert, conflict)
 
-Upsert is supported by Postgres, SQLite, and MySQL
+Upsert is supported by Postgres, SQLite, MySQL and H2 `onConflictIgnore` only (since v1.4.200 in PostgreSQL compatibility mode)
 
 #### Postgres and SQLite
 

--- a/quill-sql/src/main/scala/io/getquill/H2Dialect.scala
+++ b/quill-sql/src/main/scala/io/getquill/H2Dialect.scala
@@ -3,10 +3,12 @@ package io.getquill
 import io.getquill.idiom.StatementInterpolator._
 import java.util.concurrent.atomic.AtomicInteger
 
+import io.getquill.ast.{ Ast, OnConflict }
 import io.getquill.context.CanReturnField
 import io.getquill.context.sql.idiom.PositionalBindVariables
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.idiom.ConcatSupport
+import io.getquill.util.Messages.fail
 
 trait H2Dialect
   extends SqlIdiom
@@ -18,6 +20,23 @@ trait H2Dialect
 
   override def prepareForProbing(string: String) =
     s"PREPARE p${preparedStatementId.incrementAndGet.toString.token} AS $string}"
+
+  override def astTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Ast] =
+    Tokenizer[Ast] {
+      case c: OnConflict => c.token
+      case ast           => super.astTokenizer.token(ast)
+    }
+
+  implicit def conflictTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[OnConflict] = {
+    import OnConflict._
+    def tokenizer(implicit astTokenizer: Tokenizer[Ast]) =
+      Tokenizer[OnConflict] {
+        case OnConflict(i, NoTarget, Ignore) => stmt"${astTokenizer.token(i)} ON CONFLICT DO NOTHING"
+        case _                               => fail("Only onConflictIgnore upsert is supported in H2 (v1.4.200+).")
+      }
+
+    tokenizer(super.astTokenizer)
+  }
 }
 
 object H2Dialect extends H2Dialect

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/H2DialectSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/H2DialectSpec.scala
@@ -1,0 +1,20 @@
+package io.getquill.context.sql.idiom
+
+import io.getquill.{ H2Dialect, Literal, SqlMirrorContext, TestEntities }
+
+class H2DialectSpec extends OnConflictSpec {
+  val ctx = new SqlMirrorContext(H2Dialect, Literal) with TestEntities
+  import ctx._
+  "OnConflict" - {
+    "no target - ignore" in {
+      ctx.run(`no target - ignore`).string mustEqual
+        "INSERT INTO TestEntity (s,i,l,o) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING"
+    }
+    "no target - ignore batch" in {
+      ctx.run(`no target - ignore batch`).groups.foreach {
+        _._1 mustEqual
+          "INSERT INTO TestEntity (s,i,l,o) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING"
+      }
+    }
+  }
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OnConflictSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/OnConflictSpec.scala
@@ -24,4 +24,9 @@ trait OnConflictSpec extends Spec {
   def `cols target - update` = quote {
     ins.onConflictUpdate(_.i, _.s)((t, e) => t.l -> (t.l + e.l) / 2, _.s -> _.s)
   }
+  def insBatch = quote(liftQuery(Seq(e, TestEntity("s2", 1, 2L, Some(1)))))
+
+  def `no target - ignore batch` = quote {
+    insBatch.foreach(query[TestEntity].insert(_).onConflictIgnore)
+  }
 }


### PR DESCRIPTION
- Added support for onConflictIgnore to H2 (v1.4.200 in PostgreSQL mode)
- Doc updated with database actions return values

Fixes #1730

### Problem

H2 (v1.4.200 in PostgreSQL mode) supports `INSERT ... ON CONFLICT DO NOTHING`
quill does not

### Solution

Similarly to MySQL I've extended the H2Dialect with the onConflictIgnore

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
