### PR TITLE
Bump scalatest to 3.1.0; update deprecated api

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -565,7 +565,7 @@ lazy val basicSettings = Seq(
   libraryDependencies ++= Seq(
     "org.scala-lang.modules" %%% "scala-collection-compat" % "2.1.3",
     "com.lihaoyi"     %% "pprint"         % pprintVersion(scalaVersion.value),
-    "org.scalatest"   %%% "scalatest"     % "3.0.8"          % Test,
+    "org.scalatest"   %%% "scalatest"     % "3.1.0"          % Test,
     "ch.qos.logback"  % "logback-classic" % "1.2.3"          % Test,
     "com.google.code.findbugs" % "jsr305" % "3.0.2"          % Provided // just to avoid warnings during compilation
   ) ++ {

--- a/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/CaseClassQueryAsyncSpec.scala
+++ b/quill-async-mysql/src/test/scala/io/getquill/context/async/mysql/CaseClassQueryAsyncSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.async.mysql
 
 import scala.concurrent.ExecutionContext.Implicits.{ global => ec }
 import io.getquill.context.sql.CaseClassQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryAsyncSpec extends CaseClassQuerySpec {
 

--- a/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/CaseClassQueryAsyncSpec.scala
+++ b/quill-async-postgres/src/test/scala/io/getquill/context/async/postgres/CaseClassQueryAsyncSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.async.postgres
 
 import scala.concurrent.ExecutionContext.Implicits.{ global => ec }
 import io.getquill.context.sql.CaseClassQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryAsyncSpec extends CaseClassQuerySpec {
 

--- a/quill-codegen-jdbc/src/test/scala/io/getquill/codegen/DagTest.scala
+++ b/quill-codegen-jdbc/src/test/scala/io/getquill/codegen/DagTest.scala
@@ -2,16 +2,17 @@ package io.getquill.codegen
 
 import java.time.LocalDateTime
 
-import org.scalatest._
-import Matchers._
 import io.getquill.codegen.dag.CatalogBasedAncestry
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers._
 
 import scala.reflect.{ ClassTag, classTag }
 
 // I.e. something the type-ancestry does not know about
 class UnknownClass
 
-class CodeGeneratorRunnerDagTest extends FunSuite with BeforeAndAfter {
+class CodeGeneratorRunnerDagTest extends AnyFunSuite with BeforeAndAfter {
 
   case class TestCase[O](one: ClassTag[_], twos: Seq[ClassTag[_]], result: ClassTag[_])
 

--- a/quill-codegen-jdbc/src/test/scala/io/getquill/codegen/SimpleCodegenSpec.scala
+++ b/quill-codegen-jdbc/src/test/scala/io/getquill/codegen/SimpleCodegenSpec.scala
@@ -1,12 +1,13 @@
 package io.getquill.codegen.codegen
 
 import io.getquill.codegen.util.StringUtil._
-import org.scalatest.{ FreeSpec, Matchers }
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.reflect.runtime.universe._
 import scala.tools.reflect.ToolBox
 
-class SimpleCodegenSpec extends FreeSpec with Matchers {
+class SimpleCodegenSpec extends AnyFreeSpec with Matchers {
 
   case class FieldData(fieldName: String, dataType: String, columnName: String)
   case class FieldDataGroup(data: FieldData*) {

--- a/quill-codegen-jdbc/src/test/scala/io/getquill/codegen/util/SchemaMaker.scala
+++ b/quill-codegen-jdbc/src/test/scala/io/getquill/codegen/util/SchemaMaker.scala
@@ -5,11 +5,11 @@ import java.io.Closeable
 import io.getquill._
 import io.getquill.codegen.integration.DbHelper
 import javax.sql.DataSource
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 import scala.language.implicitConversions
 
-abstract class CodegenSpec extends FreeSpec with SchemaMaker {
+abstract class CodegenSpec extends AnyFreeSpec with SchemaMaker {
   type Prefix <: ConfigPrefix
   val prefix: Prefix
 

--- a/quill-codegen-tests/src/test/scala/io/getquill/codegen/H2CodegenTestCases.scala
+++ b/quill-codegen-tests/src/test/scala/io/getquill/codegen/H2CodegenTestCases.scala
@@ -3,7 +3,7 @@ package io.getquill.codegen
 import io.getquill.codegen.integration.CodegenTestCases._
 import io.getquill.codegen.util.ConfigPrefix.TestH2DB
 import io.getquill.codegen.util._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class H2CodegenTestCases extends CodegenSpec {
   import io.getquill.codegen.generated.h2._

--- a/quill-codegen-tests/src/test/scala/io/getquill/codegen/MysqlCodegenTestCases.scala
+++ b/quill-codegen-tests/src/test/scala/io/getquill/codegen/MysqlCodegenTestCases.scala
@@ -3,7 +3,7 @@ package io.getquill.codegen
 import io.getquill.codegen.integration.CodegenTestCases._
 import io.getquill.codegen.util.ConfigPrefix.TestMysqlDB
 import io.getquill.codegen.util._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class MysqlCodegenTestCases extends CodegenSpec {
   import io.getquill.codegen.generated.mysql._

--- a/quill-codegen-tests/src/test/scala/io/getquill/codegen/OracleCodegenTestCases.scala
+++ b/quill-codegen-tests/src/test/scala/io/getquill/codegen/OracleCodegenTestCases.scala
@@ -4,7 +4,7 @@ import io.getquill.codegen.integration.CodegenTestCases._
 import io.getquill.codegen.util.ConfigPrefix.TestOracleDB
 import io.getquill.codegen.util.{ WithOracleContextStandalone => WithContext, _ }
 import WithContext._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class OracleCodegenTestCases extends CodegenSpec {
   import io.getquill.codegen.generated.oracle._

--- a/quill-codegen-tests/src/test/scala/io/getquill/codegen/PostgresCodegenTestCases.scala
+++ b/quill-codegen-tests/src/test/scala/io/getquill/codegen/PostgresCodegenTestCases.scala
@@ -3,7 +3,7 @@ package io.getquill.codegen
 import io.getquill.codegen.integration.CodegenTestCases._
 import io.getquill.codegen.util.ConfigPrefix.TestPostgresDB
 import io.getquill.codegen.util._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class PostgresCodegenTestCases extends CodegenSpec {
   import io.getquill.codegen.generated.postgres._

--- a/quill-codegen-tests/src/test/scala/io/getquill/codegen/SqlServerCodegenTestCases.scala
+++ b/quill-codegen-tests/src/test/scala/io/getquill/codegen/SqlServerCodegenTestCases.scala
@@ -3,7 +3,7 @@ package io.getquill.codegen
 import io.getquill.codegen.integration.CodegenTestCases._
 import io.getquill.codegen.util.ConfigPrefix.TestSqlServerDB
 import io.getquill.codegen.util._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class SqlServerCodegenTestCases extends CodegenSpec {
   import io.getquill.codegen.generated.postgres._

--- a/quill-codegen-tests/src/test/scala/io/getquill/codegen/SqliteCodegenTestCases.scala
+++ b/quill-codegen-tests/src/test/scala/io/getquill/codegen/SqliteCodegenTestCases.scala
@@ -3,7 +3,7 @@ package io.getquill.codegen
 import io.getquill.codegen.integration.CodegenTestCases._
 import io.getquill.codegen.util.ConfigPrefix.TestSqliteDB
 import io.getquill.codegen.util._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class SqliteCodegenTestCases extends CodegenSpec {
   import io.getquill.codegen.generated.postgres._

--- a/quill-core/src/test/scala/io/getquill/Spec.scala
+++ b/quill-core/src/test/scala/io/getquill/Spec.scala
@@ -1,12 +1,12 @@
 package io.getquill
 
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.FreeSpec
-import org.scalatest.MustMatchers
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
 
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future }
 
-abstract class Spec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
+abstract class Spec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   def await[T](f: Future[T]): T = Await.result(f, Duration.Inf)
 }

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/CaseClassQueryFinagleSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/CaseClassQueryFinagleSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.finagle.mysql
 
 import com.twitter.util.{ Await, Future }
 import io.getquill.context.sql.CaseClassQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryFinagleSpec extends CaseClassQuerySpec {
 

--- a/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/CaseClassQueryFinagleSpec.scala
+++ b/quill-finagle-postgres/src/test/scala/io/getquill/context/finagle/postgres/CaseClassQueryFinagleSpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.finagle.postgres
 
 import com.twitter.util.{ Await, Future }
 import io.getquill.context.sql.CaseClassQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryFinagleSpec extends CaseClassQuerySpec {
 

--- a/quill-jdbc-monix/src/test/scala/io/getquill/ResultSetIteratorSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/ResultSetIteratorSpec.scala
@@ -4,12 +4,14 @@ import io.getquill.context.monix.Runner
 import io.getquill.util.LoadConfig
 import monix.eval.Task
 import monix.execution.Scheduler
-import org.scalatest.Matchers._
-import org.scalatest.{ BeforeAndAfterAll, FreeSpec, MustMatchers }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers._
 
 import scala.collection.mutable.ArrayBuffer
 
-class ResultSetIteratorSpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
+class ResultSetIteratorSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
 
   val ds = JdbcContextConfig(LoadConfig("testPostgresDB")).dataSource
   implicit val scheduler = Scheduler.global

--- a/quill-jdbc-monix/src/test/scala/io/getquill/h2/PeopleMonixJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/h2/PeopleMonixJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.h2
 
 import io.getquill.PeopleMonixSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class PeopleMonixJdbcSpec extends PeopleMonixSpec {
 

--- a/quill-jdbc-monix/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
@@ -2,11 +2,11 @@ package io.getquill.integration
 
 import java.sql.{ Connection, ResultSet }
 
-import org.scalatest.Matchers._
-import io.getquill.context.monix.Runner
 import io.getquill._
+import io.getquill.context.monix.Runner
 import monix.execution.Scheduler
 import monix.execution.schedulers.CanBlock
+import org.scalatest.matchers.should.Matchers._
 
 import scala.concurrent.duration.Duration
 

--- a/quill-jdbc-monix/src/test/scala/io/getquill/mock/MockTests.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/mock/MockTests.scala
@@ -9,7 +9,7 @@ import io.getquill.{ Literal, PostgresMonixJdbcContext, Spec }
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.mockito.scalatest.AsyncMockitoSugar
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 import scala.reflect.ClassTag
 import scala.util.Try

--- a/quill-jdbc-monix/src/test/scala/io/getquill/mysql/PeopleMonixJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/mysql/PeopleMonixJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.mysql
 
 import io.getquill.PeopleMonixSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class PeopleMonixJdbcSpec extends PeopleMonixSpec {
 

--- a/quill-jdbc-monix/src/test/scala/io/getquill/oracle/PeopleMonixJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/oracle/PeopleMonixJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.oracle
 
 import io.getquill.PeopleMonixSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class PeopleMonixJdbcSpec extends PeopleMonixSpec {
 

--- a/quill-jdbc-monix/src/test/scala/io/getquill/postgres/PeopleMonixJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/postgres/PeopleMonixJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.postgres
 
 import io.getquill.PeopleMonixSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class PeopleMonixJdbcSpec extends PeopleMonixSpec {
 

--- a/quill-jdbc-monix/src/test/scala/io/getquill/sqlite/PeopleMonixJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/sqlite/PeopleMonixJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.sqlite
 
 import io.getquill.PeopleMonixSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class PeopleMonixJdbcSpec extends PeopleMonixSpec {
 

--- a/quill-jdbc-monix/src/test/scala/io/getquill/sqlserver/PeopleMonixJdbcSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/sqlserver/PeopleMonixJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.sqlserver
 
 import io.getquill.PeopleMonixSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class PeopleMonixJdbcSpec extends PeopleMonixSpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/CaseClassQueryJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.h2
 
 import io.getquill.context.sql.CaseClassQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/DistinctJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.h2
 
 import io.getquill.context.sql.DistinctSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class DistinctJdbcSpec extends DistinctSpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/h2/OptionJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.h2
 
 import io.getquill.context.sql.OptionQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class OptionJdbcSpec extends OptionQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/CaseClassQueryJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.mysql
 
 import io.getquill.context.sql.CaseClassQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/DistinctJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.mysql
 
 import io.getquill.context.sql.DistinctSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class DistinctJdbcSpec extends DistinctSpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/mysql/OptionJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.mysql
 
 import io.getquill.context.sql.OptionQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class OptionJdbcSpec extends OptionQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/CaseClassQueryJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.oracle
 
 import io.getquill.context.sql.CaseClassQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/DepartmentsJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/DepartmentsJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.oracle
 
 import io.getquill.context.sql.DepartmentsSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class DepartmentsJdbcSpec extends DepartmentsSpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/DistinctJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.oracle
 
 import io.getquill.context.sql.DistinctSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class DistinctJdbcSpec extends DistinctSpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/oracle/OptionJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.oracle
 
 import io.getquill.context.sql.OptionQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class OptionJdbcSpec extends OptionQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/CaseClassQueryJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.postgres
 
 import io.getquill.context.sql.CaseClassQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/DistinctJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.postgres
 
 import io.getquill.context.sql.DistinctSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class DistinctJdbcSpec extends DistinctSpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/postgres/OptionJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.postgres
 
 import io.getquill.context.sql.OptionQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class OptionJdbcSpec extends OptionQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/CaseClassQueryJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/CaseClassQueryJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.sqlite
 
 import io.getquill.context.sql.CaseClassQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class CaseClassQueryJdbcSpec extends CaseClassQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/DistinctJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.sqlite
 
 import io.getquill.context.sql.DistinctSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class DistinctJdbcSpec extends DistinctSpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlite/OptionJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.sqlite
 
 import io.getquill.context.sql.OptionQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class OptionJdbcSpec extends OptionQuerySpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/DistinctJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/DistinctJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.sqlserver
 
 import io.getquill.context.sql.DistinctSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class DistinctJdbcSpec extends DistinctSpec {
 

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/OptionJdbcSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/OptionJdbcSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc.sqlserver
 
 import io.getquill.context.sql.OptionQuerySpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class OptionJdbcSpec extends OptionQuerySpec {
 

--- a/quill-monix/src/test/scala/io/getquill/context/monix/RunnerSpec.scala
+++ b/quill-monix/src/test/scala/io/getquill/context/monix/RunnerSpec.scala
@@ -4,7 +4,7 @@ import io.getquill.Spec
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.execution.schedulers.CanBlock
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 import scala.util.Failure
 

--- a/quill-spark/src/test/scala/io/getquill/context/spark/CaseClassQuerySpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/CaseClassQuerySpec.scala
@@ -2,7 +2,7 @@ package io.getquill.context.spark
 
 import io.getquill.Spec
 import org.apache.spark.sql.Dataset
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 case class Contact(firstName: String, lastName: String, age: Int, addressFk: Int, extraInfo: String)
 case class Address(id: Int, street: String, zip: Int, otherExtraInfo: String)

--- a/quill-spark/src/test/scala/io/getquill/context/spark/QuestionMarkSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/QuestionMarkSpec.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.spark
 
 import io.getquill.Spec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 class QuestionMarkSpec extends Spec {
   val context = io.getquill.context.sql.testContext


### PR DESCRIPTION
### Problem

Scalatest 3.1.0 has a new api, deprecating parts of the previous one.

### Solution

Bump scalatest, updating tests to use the new api.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
