### PR TITLE
Better error message about lifting for enum types

### DIFF
--- a/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
+++ b/quill-core/src/main/scala/io/getquill/idiom/StatementInterpolator.scala
@@ -53,7 +53,21 @@ object StatementInterpolator {
           s"    run(query[Users].update(\n" +
           s"       _.embeddedCaseClass.a -> lift(someInstance.a),\n" +
           s"       _.embeddedCaseClass.b -> lift(someInstance.b)\n" +
-          s"    ))"
+          s"    ))" +
+          s"\n" +
+          s"* You are trying to insert or update an ADT field, but Scala infers the specific type\n" +
+          s"  instead of the ADT type. For example:\n" +
+          s"    case class User(role: UserRole)\n" +
+          s"    sealed trait UserRole extends Product with Serializable\n" +
+          s"    object UserRole {\n" +
+          s"      case object Writer extends UserRole\n" +
+          s"      case object Reader extends UserRole\n" +
+          s"      implicit val encodeStatus: MappedEncoding[UserRole, String] = ...\n" +
+          s"      implicit val decodeStatus: MappedEncoding[String, UserRole] = ...\n" +
+          s"    }\n" +
+          s"    run(query[User].update(_.role -> lift(UserRole.Writer)))\n" +
+          s"  In that case, make sure you are uplifting to ADT type, for example:\n" +
+          s"    run(query[User].update(_.role -> lift(UserRole.Writer: UserRole)))\n"
       )
     }
 


### PR DESCRIPTION
### Problem

Explain here the context, and why you're making that change.
What is the problem you're trying to solve?

When trying to update enum filed, Scala infers the value type instead of enum type. Minimal reproducible example:
```scala
package example
import io.getquill._

case class User(role: UserRole)
sealed trait UserRole extends Product with Serializable
object UserRole {
  case object Writer extends UserRole
  case object Reader extends UserRole
  implicit val encodeStatus: MappedEncoding[UserRole, String] = MappedEncoding[UserRole, String]{
    case Reader => "Reader" 
    case Writer => "Writer"
  }
  implicit val decodeStatus: MappedEncoding[String, UserRole] = MappedEncoding[String, UserRole]{
    case "Reader" => Reader
    case "Writer" => Writer
  }
}

object Hello extends App {
  val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
  import ctx._
  val updateQuery = quote {
    query[User].update(_.role -> lift(UserRole.Writer))
  }
  run(updateQuery)
}
```

The error message isn't really helpful:
```
sbt:Quill ADT test> run                                                                                   
...
[error] .../Code/personal/quill-adt-test/src/main/scala/example/Hello.scala:31:6: exception during macro expansion: 
[error] java.lang.IllegalStateException: Can't tokenize a non-scalar lifting. Hello.this.updateQuery.UserRole.Writer
[error]                                                                                                   
[error] This might happen because:                                                                        
[error] * You are trying to insert or update an `Option[A]` field, but Scala infers the type
[error]   to `Some[A]` or `None.type`. For example:
[error]     run(query[Users].update(_.optionalField -> lift(Some(value))))  In that case, make sure the type is `Option`:
[error]     run(query[Users].update(_.optionalField -> lift(Some(value): Option[Int])))
[error]   or                                                                                              
[error]     run(query[Users].update(_.optionalField -> lift(Option(value))))
[error]             
[error] * You are trying to insert or update whole Embedded case class. For example:
[error]     run(query[Users].update(_.embeddedCaseClass -> lift(someInstance)))
[error]   In that case, make sure you are updating individual columns, for example:
[error]     run(query[Users].update(
[error]        _.embeddedCaseClass.a -> lift(someInstance.a),
[error]        _.embeddedCaseClass.b -> lift(someInstance.b)
[error]     ))
[error]         at io.getquill.util.Messages$.fail(Messages.scala:43)
```

This issue can be simply worked around by uplifting the type:
```scala
query[User].update(_.role -> lift(UserRole.Writer: UserRole))
```

### Solution

Although the type inference issue is hard to solve here, the error message can be more helpful. This PR introduces updated error message.

Updated message provides following guidance on how to solve the issue:
```
[error] * You are trying to insert or update an enum field, but Scala infers the value
[error]   instead of the enum type. For example:
[error]     case class User(role: UserRole)
[error]     sealed trait UserRole extends Product with Serializable
[error]     object UserRole {                                                                             
[error]       case object Writer extends UserRole                                                         
[error]       case object Reader extends UserRole
[error]       implicit val encodeStatus: MappedEncoding[UserRole, String] = ...
[error]       implicit val decodeStatus: MappedEncoding[String, UserRole] = ...
[error]     }
[error]     run(query[User].update(_.role -> lift(UserRole.Writer)))
[error]   In that case, make sure you are uplifting to enum type, for example:
[error]     run(query[User].update(_.role -> lift(UserRole.Writer: UserRole)))
```

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
