### PR TITLE
Apply NamingStrategy after applying prefix

### DIFF
--- a/quill-sql-portable/src/main/scala/io/getquill/sql/norm/nested/ExpandSelect.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/norm/nested/ExpandSelect.scala
@@ -113,7 +113,7 @@ private class ExpandSelect(selectValues: List[SelectValue], references: LinkedHa
                       // Note: Pass invisible properties to be tokenized by the idiom, they should be excluded there
                       Property.Opinionated(ast, name, renameable, visible),
                       // Skip concatonation of invisible properties into the alias e.g. so it will be
-                      Some(s"${nested.getOrElse("")}${expandColumn(name, renameable)}")
+                      Some(expandColumn(s"${nested.getOrElse("")}$name", renameable))
                     ))
                 }
             case pp @ Property(_, TupleIndex(idx)) =>

--- a/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/TestContext.scala
@@ -34,6 +34,7 @@ object UpperCaseNonDefault extends getquill.UpperCaseNonDefault
 
 object testContext extends TestContextTemplate[MirrorSqlDialect, Literal](MirrorSqlDialect, Literal)
 object testContextUpper extends TestContextTemplate[MirrorSqlDialect, getquill.UpperCaseNonDefault](MirrorSqlDialect, UpperCaseNonDefault)
+object testContextEscape extends TestContextTemplate[MirrorSqlDialect, Escape](MirrorSqlDialect, Escape)
 
 trait NonAnsiMirrorSqlDialect extends MirrorSqlDialect {
   override def equalityBehavior: EqualityBehavior = NonAnsiEquality

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/NestedQueryNamingStrategySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/NestedQueryNamingStrategySpec.scala
@@ -1,85 +1,104 @@
 package io.getquill.context.sql.idiom
 
 import io.getquill.Spec
-import io.getquill.context.sql.testContextUpper
-import io.getquill.context.sql.testContextUpper._
 
 class NestedQueryNamingStrategySpec extends Spec {
 
   case class Person(id: Int, name: String)
+
   case class Address(ownerFk: Int, street: String)
 
-  "inner aliases should use naming strategy" in {
-    val q = quote {
-      query[Person].map {
-        p => (p, infix"foobar".as[Int])
-      }.filter(_._1.id == 1)
+  "with escape naming strategy" - {
+    import io.getquill.context.sql.testContextEscape
+    import io.getquill.context.sql.testContextEscape._
+
+    "inner aliases should use naming strategy" in {
+      val q = quote {
+        query[Person].map {
+          p => (p, infix"foobar".as[Int])
+        }.filter(_._1.id == 1)
+      }
+      testContextEscape.run(q).string mustEqual
+        """SELECT "p"."_1id", "p"."_1name", "p"."_2" FROM (SELECT "p"."id" AS "_1id", "p"."name" AS "_1name", foobar AS _2 FROM "Person" "p") AS "p" WHERE "p"."_1id" = 1"""
     }
-    testContextUpper.run(q).string mustEqual
-      "SELECT p._1ID, p._1NAME, p._2 FROM (SELECT p.ID AS _1ID, p.NAME AS _1NAME, foobar AS _2 FROM PERSON p) AS p WHERE p._1ID = 1"
   }
 
-  "inner aliases should use naming strategy with override" in {
-    val qs = quote {
-      querySchema[Person]("ThePerson", _.id -> "theId", _.name -> "theName") //helloooooo
+  "with upper naming strategy" - {
+    import io.getquill.context.sql.testContextUpper
+    import io.getquill.context.sql.testContextUpper._
+
+    "inner aliases should use naming strategy" in {
+      val q = quote {
+        query[Person].map {
+          p => (p, infix"foobar".as[Int])
+        }.filter(_._1.id == 1)
+      }
+      testContextUpper.run(q).string mustEqual
+        "SELECT p._1ID, p._1NAME, p._2 FROM (SELECT p.ID AS _1ID, p.NAME AS _1NAME, foobar AS _2 FROM PERSON p) AS p WHERE p._1ID = 1"
     }
 
-    val q = quote {
-      qs.map {
-        p => (p, infix"foobar".as[Int])
-      }.filter(_._1.id == 1)
-    }
-    testContextUpper.run(q).string mustEqual
-      "SELECT p._1theId, p._1theName, p._2 FROM (SELECT p.theId AS _1theId, p.theName AS _1theName, foobar AS _2 FROM ThePerson p) AS p WHERE p._1theId = 1"
-  }
+    "inner aliases should use naming strategy with override" in {
+      val qs = quote {
+        querySchema[Person]("ThePerson", _.id -> "theId", _.name -> "theName") //helloooooo
+      }
 
-  "inner aliases should use naming strategy with override - two tables" in {
-    val qs = quote {
-      querySchema[Person]("ThePerson", _.id -> "theId", _.name -> "theName")
-    }
-
-    val joined = quote {
-      qs.join(query[Person]).on((a, b) => a.name == b.name)
+      val q = quote {
+        qs.map {
+          p => (p, infix"foobar".as[Int])
+        }.filter(_._1.id == 1)
+      }
+      testContextUpper.run(q).string mustEqual
+        "SELECT p._1theId, p._1theName, p._2 FROM (SELECT p.theId AS _1theId, p.theName AS _1theName, foobar AS _2 FROM ThePerson p) AS p WHERE p._1theId = 1"
     }
 
-    val q = quote {
-      joined.map { (ab) =>
-        val (a, b) = ab
-        (a, b, infix"foobar".as[Int])
-      }.filter(_._1.id == 1)
-    }
-    testContextUpper.run(q).string mustEqual
-      "SELECT ab._1theId, ab._1theName, ab._2ID, ab._2NAME, ab._3 FROM (SELECT a.theId AS _1theId, a.theName AS _1theName, b.ID AS _2ID, b.NAME AS _2NAME, foobar AS _3 FROM ThePerson a INNER JOIN PERSON b ON a.theName = b.NAME) AS ab WHERE ab._1theId = 1"
-  }
+    "inner aliases should use naming strategy with override - two tables" in {
+      val qs = quote {
+        querySchema[Person]("ThePerson", _.id -> "theId", _.name -> "theName")
+      }
 
-  "inner alias should nest properly in multiple levels" in {
-    val q = quote {
-      query[Person].map {
-        p => (p, infix"foobar".as[Int])
-      }.filter(_._1.id == 1).map {
-        pp => (pp, infix"barbaz".as[Int])
-      }.filter(_._1._1.id == 2)
-    }
+      val joined = quote {
+        qs.join(query[Person]).on((a, b) => a.name == b.name)
+      }
 
-    testContextUpper.run(q).string mustEqual
-      "SELECT p._1_1ID, p._1_1NAME, p._1_2, p._2 FROM (SELECT p._1ID AS _1_1ID, p._1NAME AS _1_1NAME, p._2 AS _1_2, barbaz AS _2 FROM (SELECT p.ID AS _1ID, p.NAME AS _1NAME, foobar AS _2 FROM PERSON p) AS p WHERE p._1ID = 1) AS p WHERE p._1_1ID = 2"
-  }
-
-  "inner alias should nest properly in multiple levels - with query schema" in {
-
-    val qs = quote {
-      querySchema[Person]("ThePerson", _.id -> "theId", _.name -> "theName")
+      val q = quote {
+        joined.map { (ab) =>
+          val (a, b) = ab
+          (a, b, infix"foobar".as[Int])
+        }.filter(_._1.id == 1)
+      }
+      testContextUpper.run(q).string mustEqual
+        "SELECT ab._1theId, ab._1theName, ab._2ID, ab._2NAME, ab._3 FROM (SELECT a.theId AS _1theId, a.theName AS _1theName, b.ID AS _2ID, b.NAME AS _2NAME, foobar AS _3 FROM ThePerson a INNER JOIN PERSON b ON a.theName = b.NAME) AS ab WHERE ab._1theId = 1"
     }
 
-    val q = quote {
-      qs.map {
-        p => (p, infix"foobar".as[Int])
-      }.filter(_._1.id == 1).map {
-        pp => (pp, infix"barbaz".as[Int])
-      }.filter(_._1._1.id == 2)
+    "inner alias should nest properly in multiple levels" in {
+      val q = quote {
+        query[Person].map {
+          p => (p, infix"foobar".as[Int])
+        }.filter(_._1.id == 1).map {
+          pp => (pp, infix"barbaz".as[Int])
+        }.filter(_._1._1.id == 2)
+      }
+
+      testContextUpper.run(q).string mustEqual
+        "SELECT p._1_1ID, p._1_1NAME, p._1_2, p._2 FROM (SELECT p._1ID AS _1_1ID, p._1NAME AS _1_1NAME, p._2 AS _1_2, barbaz AS _2 FROM (SELECT p.ID AS _1ID, p.NAME AS _1NAME, foobar AS _2 FROM PERSON p) AS p WHERE p._1ID = 1) AS p WHERE p._1_1ID = 2"
     }
 
-    testContextUpper.run(q).string mustEqual
-      "SELECT p._1_1theId, p._1_1theName, p._1_2, p._2 FROM (SELECT p._1theId AS _1_1theId, p._1theName AS _1_1theName, p._2 AS _1_2, barbaz AS _2 FROM (SELECT p.theId AS _1theId, p.theName AS _1theName, foobar AS _2 FROM ThePerson p) AS p WHERE p._1theId = 1) AS p WHERE p._1_1theId = 2"
+    "inner alias should nest properly in multiple levels - with query schema" in {
+
+      val qs = quote {
+        querySchema[Person]("ThePerson", _.id -> "theId", _.name -> "theName")
+      }
+
+      val q = quote {
+        qs.map {
+          p => (p, infix"foobar".as[Int])
+        }.filter(_._1.id == 1).map {
+          pp => (pp, infix"barbaz".as[Int])
+        }.filter(_._1._1.id == 2)
+      }
+
+      testContextUpper.run(q).string mustEqual
+        "SELECT p._1_1theId, p._1_1theName, p._1_2, p._2 FROM (SELECT p._1theId AS _1_1theId, p._1theName AS _1_1theName, p._2 AS _1_2, barbaz AS _2 FROM (SELECT p.theId AS _1theId, p.theName AS _1theName, foobar AS _2 FROM ThePerson p) AS p WHERE p._1theId = 1) AS p WHERE p._1_1theId = 2"
+    }
   }
 }


### PR DESCRIPTION
Fixes #1806

### Problem

Invalid `SQL`, generated with `Escape` `NamingStrategy`: `AS _1"name"` instead if `AS "_1name"`.

### Solution

Apply `NamingStrategy` after applying order prefix.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable (not applicable)
- [x] Add `[WIP]` to the pull request title if it's work in progress (not WIP AFAIC)
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes (single commit)
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
