### PR TITLE
Remove use of `Row#getAnyOption` from `FinaglePostgresDecoders`

### DIFF
--- a/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/context/finagle/postgres/FinaglePostgresDecoders.scala
@@ -1,13 +1,16 @@
 package io.getquill.context.finagle.postgres
 
+import java.nio.charset.Charset
 import java.time.{ LocalDate, LocalDateTime, ZoneId }
 import java.util.{ Date, UUID }
 
 import com.twitter.finagle.postgres.values.ValueDecoder
+import com.twitter.util.Return
+import com.twitter.util.Throw
+import com.twitter.util.Try
 import io.getquill.FinaglePostgresContext
 import io.getquill.util.Messages.fail
-
-import scala.reflect.{ ClassTag, classTag }
+import io.netty.buffer.ByteBuf
 
 trait FinaglePostgresDecoders {
   this: FinaglePostgresContext[_] =>
@@ -16,70 +19,62 @@ trait FinaglePostgresDecoders {
 
   type Decoder[T] = FinaglePostgresDecoder[T]
 
-  case class FinaglePostgresDecoder[T](decoder: BaseDecoder[T]) extends BaseDecoder[T] {
+  case class FinaglePostgresDecoder[T](
+    vd:      ValueDecoder[T],
+    default: Throwable => T  = (e: Throwable) => fail(e.getMessage)
+  ) extends BaseDecoder[T] {
     override def apply(index: Index, row: ResultRow): T =
-      decoder(index, row)
+      row.getTry[T](index)(vd) match {
+        case Return(r) => r
+        case Throw(e)  => default(e)
+      }
+
+    def orElse[U](f: U => T)(implicit vdu: ValueDecoder[U]): FinaglePostgresDecoder[T] = {
+      val mappedVd = vdu.map[T](f)
+      FinaglePostgresDecoder[T](
+        new ValueDecoder[T] {
+          def decodeText(recv: String, text: String): Try[T] = {
+            val t = vd.decodeText(recv, text)
+            if (t.isReturn) t
+            else mappedVd.decodeText(recv, text)
+          }
+          def decodeBinary(recv: String, bytes: ByteBuf, charset: Charset): Try[T] = {
+            val t = vd.decodeBinary(recv, bytes, charset)
+            if (t.isReturn) t
+            else mappedVd.decodeBinary(recv, bytes, charset)
+          }
+        }
+      )
+    }
   }
 
-  def decoder[T: ClassTag](f: PartialFunction[Any, T]): Decoder[T] =
-    FinaglePostgresDecoder((index, row) => {
-      row.getAnyOption(index) match {
-        case Some(v: T)                  => v
-        case Some(v) if f.isDefinedAt(v) => f(v)
-        case v                           => fail(s"Cannot decode value $v at index $index to ${classTag[T]}")
-      }
-    })
-
-  implicit def decoderDirectly[T: ClassTag](implicit vd: ValueDecoder[T]): Decoder[T] =
-    FinaglePostgresDecoder((index, row) =>
-      row.get[T](index) match {
-        case v: T => v
-        case v    => fail(s"Cannot decode value $v at index $index to ${classTag[T]}")
-      })
+  implicit def decoderDirectly[T](implicit vd: ValueDecoder[T]): Decoder[T] = FinaglePostgresDecoder(vd)
+  def decoderMapped[U, T](f: U => T)(implicit vd: ValueDecoder[U]): Decoder[T] = FinaglePostgresDecoder(vd.map[T](f))
 
   implicit def optionDecoder[T](implicit d: Decoder[T]): Decoder[Option[T]] =
-    FinaglePostgresDecoder((index, row) => {
-      row.getAnyOption(index).map(_ => d.decoder(index, row))
-    })
+    FinaglePostgresDecoder[Option[T]](
+      new ValueDecoder[Option[T]] {
+        def decodeText(recv: String, text: String): Try[Option[T]] = Return(d.vd.decodeText(recv, text).toOption)
+        def decodeBinary(recv: String, bytes: ByteBuf, charset: Charset): Try[Option[T]] = Return(d.vd.decodeBinary(recv, bytes, charset).toOption)
+      },
+      _ => None
+    )
 
   implicit def mappedDecoder[I, O](implicit mapped: MappedEncoding[I, O], d: Decoder[I]): Decoder[O] =
-    FinaglePostgresDecoder(mappedBaseDecoder(mapped, d.decoder))
+    decoderMapped[I, O](mapped.f)(d.vd)
 
   implicit val stringDecoder: Decoder[String] = decoderDirectly[String]
   implicit val bigDecimalDecoder: Decoder[BigDecimal] = decoderDirectly[BigDecimal]
   implicit val booleanDecoder: Decoder[Boolean] = decoderDirectly[Boolean]
-  implicit val byteDecoder: Decoder[Byte] = decoder[Byte] {
-    case v: Short => v.toByte
-  }
   implicit val shortDecoder: Decoder[Short] = decoderDirectly[Short]
-  implicit val intDecoder: Decoder[Int] =
-    decoder[Int] {
-      case v: Int  => v
-      case v: Long => v.toInt
-    }
-  implicit val longDecoder: Decoder[Long] =
-    decoder[Long] {
-      case v: Int  => v.toLong
-      case v: Long => v
-    }
-  implicit val floatDecoder: Decoder[Float] = decoder[Float] {
-    case v: Double => v.toFloat
-    case v: Float  => v
-  }
+  implicit val byteDecoder: Decoder[Byte] = decoderMapped[Short, Byte](_.toByte)
+  implicit val intDecoder: Decoder[Int] = decoderDirectly[Int].orElse[Long](_.toInt)
+  implicit val longDecoder: Decoder[Long] = decoderDirectly[Long].orElse[Int](_.toLong)
+  implicit val floatDecoder: Decoder[Float] = decoderDirectly[Float].orElse[Double](_.toFloat)
   implicit val doubleDecoder: Decoder[Double] = decoderDirectly[Double]
   implicit val byteArrayDecoder: Decoder[Array[Byte]] = decoderDirectly[Array[Byte]]
-  implicit val dateDecoder: Decoder[Date] =
-    decoder[Date] {
-      case d: LocalDateTime => Date.from(d.atZone(ZoneId.systemDefault()).toInstant);
-    }
-  implicit val localDateDecoder: Decoder[LocalDate] = decoder[LocalDate] {
-    case d: LocalDateTime => d.toLocalDate
-    case d: LocalDate     => d
-  }
-  implicit val localDateTimeDecoder: Decoder[LocalDateTime] = decoder[LocalDateTime] {
-    case d: LocalDateTime => d
-    case d: LocalDate     => d.atStartOfDay()
-  }
-
+  implicit val dateDecoder: Decoder[Date] = decoderMapped[LocalDateTime, Date](d => Date.from(d.atZone(ZoneId.systemDefault()).toInstant))
+  implicit val localDateDecoder: Decoder[LocalDate] = decoderDirectly[LocalDate].orElse[LocalDateTime](_.toLocalDate)
+  implicit val localDateTimeDecoder: Decoder[LocalDateTime] = decoderDirectly[LocalDateTime].orElse[LocalDate](_.atStartOfDay)
   implicit val uuidDecoder: Decoder[UUID] = decoderDirectly[UUID]
 }


### PR DESCRIPTION
Fixes #1844

### Problem

The decoders that are not direct in `FinaglePostgresDecoders` rely on `Row#getAnyOption`. `Row#getAnyOption` relies on custom receiving functions being defined on the `PostgresClient`. postgres-finagle could define these by default (which it probably should), but by default it does not.  When custom receiving functions are not defined, `Row#getAnyOption` always returns `None`.

### Solution

This change introduces an `orElse` method on `FinaglePostgresDecoder` which allows for composition of `ValueDecoder`s that was previous being accomplished by `PartialFunction`s. This solution removes the need for `ClassTag` (although we may want to keep it to keep error messages consistent) as well as the reliance on `Row#getAnyOption`.

### Notes

This removes the definition of `decoder[T]` which I do not see much value in since it requires custom receive functions to be defined for `T` in order to work.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers