### PR TITLE
Delete returning

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,6 @@ val returnedIds = ctx.run(q) //: List[(Int, String)]
 // INSERT INTO Product (description, sku) VALUES (?, ?) RETURNING id, description
 ```
 
-##### update returning
-
 `returning` can also be used after `update`:
 
 ```scala
@@ -296,6 +294,17 @@ val q = quote {
 
 val updated = ctx.run(q) //: List[(Int, String)]
 // UPDATE Product SET id = ?, description = ?, sku = ? RETURNING id, description
+```
+
+or even after `delete`:
+
+```scala
+val q = quote {
+  query[Product].delete.returning(r => (r.id, r.description))
+}
+
+val deleted = ctx.run(q) //: List[(Int, String)]
+// DELETE FROM Product RETURNING id, description
 ```
 
 #### Customization
@@ -355,7 +364,7 @@ In the case that this is impossible (e.g. when using Postgres booleans), you can
 ##### SQL Server
 
 The `returning` and `returningGenerated` methods are more restricted when using SQL Server; they only support 
-arithmetic operations. These are inserted directly into the SQL `OUTPUT INSERTED.*` clause.
+arithmetic operations. These are inserted directly into the SQL `OUTPUT INSERTED.*` or `OUTPUT DELETED.*` clauses.
 
 Assuming the query:
 ```scala
@@ -378,6 +387,16 @@ val q = quote {
 
 val updated = ctx.run(q)
 // UPDATE Product SET description = 'Updated Product', sku = 2022 OUTPUT INSERTED.id, INSERTED.description
+```
+
+Delete returning:
+```scala
+val q = quote {
+  query[Product].delete.returning(r => (r.id, r.description))
+}
+
+val updated = ctx.run(q)
+// DELETE FROM Product OUTPUT DELETED.id, DELETED.description
 ```
 
 ### Embedded case classes

--- a/quill-core-portable/src/main/scala/io/getquill/Model.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/Model.scala
@@ -117,12 +117,16 @@ sealed trait Insert[E] extends Action[E] {
   def onConflictUpdate(target: E => Any, targets: (E => Any)*)(assign: ((E, E) => (Any, Any)), assigns: ((E, E) => (Any, Any))*): Insert[E] = NonQuotedException()
 }
 
+sealed trait ActionReturning[E, Output] extends Action[E]
+
 sealed trait Update[E] extends Action[E] {
   @compileTimeOnly(NonQuotedException.message)
   def returning[R](f: E => R): ActionReturning[E, R] = NonQuotedException()
 }
 
-sealed trait ActionReturning[E, Output] extends Action[E]
-sealed trait Delete[E] extends Action[E]
+sealed trait Delete[E] extends Action[E] {
+  @compileTimeOnly(NonQuotedException.message)
+  def returning[R](f: E => R): ActionReturning[E, R] = NonQuotedException()
+}
 
 sealed trait BatchAction[+A <: Action[_]]

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -17,7 +17,7 @@ import io.getquill.ast.Implicits._
 import io.getquill.ast.Renameable.Fixed
 import io.getquill.ast.Visibility.{ Hidden, Visible }
 import io.getquill.util.Interleave
-import io.getquill.{ Query => DslQuery, Update => DslUpdate, Insert => DslInsert }
+import io.getquill.{ Query => DslQuery, Update => DslUpdate, Insert => DslInsert, Delete => DslDelete }
 
 trait Parsing extends ValueComputation {
   this: Quotation =>
@@ -922,7 +922,7 @@ trait Parsing extends ValueComputation {
 
     (ident == originalBody, actionType.tpe) match {
       // Note, tuples are also case classes so this also matches for tuples
-      case (true, ClassTypeRefMatch(cls, List(arg))) if (cls == asClass[DslInsert[_]] || cls == asClass[DslUpdate[_]]) && isTypeCaseClass(arg) =>
+      case (true, ClassTypeRefMatch(cls, List(arg))) if (cls == asClass[DslInsert[_]] || cls == asClass[DslUpdate[_]] || cls == asClass[DslDelete[_]]) && isTypeCaseClass(arg) =>
 
         val elements = flatten(q"${TermName(ident.name)}", value("Decoder", arg))
         if (elements.size == 0) c.fail("Case class in the 'returning' clause has no values")

--- a/quill-core/src/test/scala/io/getquill/context/ActionMacroSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/context/ActionMacroSpec.scala
@@ -207,6 +207,31 @@ class ActionMacroSpec extends Spec {
         r.returningBehavior mustEqual ReturnRecord
       }
     }
+
+    "delete returning" - {
+      "returning value" in {
+        val q = quote {
+          qr1.delete.returning(t => t.l)
+        }
+        val r = testContext.run(q)
+        r.string mustEqual """querySchema("TestEntity").delete.returning((t) => t.l)"""
+        r.prepareRow mustEqual Row()
+        r.returningBehavior mustEqual ReturnRecord
+      }
+      "returning value - with single - should not compile" in testContext.withDialect(MirrorIdiomReturningSingle) { ctx =>
+        "import ctx._; ctx.delete.returning(t => t.l))" mustNot compile
+      }
+      "returning value - with multi" in testContext.withDialect(MirrorIdiomReturningMulti) { ctx =>
+        import ctx._
+        val q = quote {
+          qr1.delete.returning(t => t.l)
+        }
+        val r = ctx.run(q)
+        r.string mustEqual """querySchema("TestEntity").delete.returning((t) => t.l)"""
+        r.prepareRow mustEqual Row()
+        r.returningBehavior mustEqual ReturnColumns(List("l"))
+      }
+    }
   }
 
   "runs batched action" - {

--- a/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcContextSpec.scala
+++ b/quill-jdbc/src/test/scala/io/getquill/context/jdbc/sqlserver/JdbcContextSpec.scala
@@ -145,6 +145,49 @@ class JdbcContextSpec extends Spec {
       Return(1, "foo", Some(123)) mustBe updated
     }
   }
+
+  "delete returning" - {
+    "with multiple columns" in {
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 42L, Some(123)))))
+
+      val deleted = ctx.run {
+        qr1.delete.returning(r => (r.i, r.s, r.o))
+      }
+      (1, "foo", Some(123)) mustBe deleted
+    }
+
+    "with multiple columns and operations" in {
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("foo", 1, 42L, Some(123)))))
+
+      val deleted = ctx.run {
+        qr1.delete.returning(r => (r.i + 100, r.s, r.o.map(_ + 100)))
+      }
+      (1 + 100, "foo", Some(123 + 100)) mustBe deleted
+    }
+
+    "with multiple columns and query embedded" in {
+      ctx.run(qr1Emb.delete)
+      ctx.run(qr1Emb.insert(lift(TestEntityEmb(Emb("one", 1), 42L, Some(333)))))
+
+      val deleted = ctx.run {
+        qr1Emb.delete.returning(r => (r.emb.i, r.o))
+      }
+      (1, Some(333)) mustBe deleted
+    }
+
+    "with multiple columns - case class" in {
+      case class Return(id: Int, str: String, opt: Option[Int])
+      ctx.run(qr1.delete)
+      ctx.run(qr1.insert(lift(TestEntity("foo", 2, 42L, Some(222)))))
+
+      val deleted = ctx.run {
+        qr1.delete.returning(r => Return(r.i, r.s, r.o))
+      }
+      Return(2, "foo", Some(222)) mustBe deleted
+    }
+  }
 }
 
 class PendingUntilFixed extends Spec {

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -469,6 +469,8 @@ trait SqlIdiom extends Idiom {
               stmt"INSERT $table${actionAlias.map(alias => stmt" AS ${alias.token}").getOrElse(stmt"")} (${columns.mkStmt(",")}) OUTPUT ${returnListTokenizer.token(ExpandReturning(r, Some("INSERTED"))(this, strategy).map(_._1))} VALUES (${values.map(scopedTokenizer(_)).mkStmt(", ")})"
             case Update(entity: Entity, assignments) =>
               stmt"UPDATE ${entity.token}${actionAlias.map(alias => stmt" AS ${alias.token}").getOrElse(stmt"")} SET ${assignments.token} OUTPUT ${returnListTokenizer.token(ExpandReturning(r, Some("INSERTED"))(this, strategy).map(_._1))}"
+            case Delete(_) =>
+              stmt"${action.token} OUTPUT ${returnListTokenizer.token(ExpandReturning(r, Some("DELETED"))(this, strategy).map(_._1))}"
             case other =>
               fail(s"Action ast can't be translated to sql: '$other'")
           }

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -467,8 +467,8 @@ trait SqlIdiom extends Idiom {
             case Insert(entity: Entity, assignments) =>
               val (table, columns, values) = insertInfo(insertEntityTokenizer, entity, assignments)
               stmt"INSERT $table${actionAlias.map(alias => stmt" AS ${alias.token}").getOrElse(stmt"")} (${columns.mkStmt(",")}) OUTPUT ${returnListTokenizer.token(ExpandReturning(r, Some("INSERTED"))(this, strategy).map(_._1))} VALUES (${values.map(scopedTokenizer(_)).mkStmt(", ")})"
-            case Update(entity: Entity, assignments) =>
-              stmt"UPDATE ${entity.token}${actionAlias.map(alias => stmt" AS ${alias.token}").getOrElse(stmt"")} SET ${assignments.token} OUTPUT ${returnListTokenizer.token(ExpandReturning(r, Some("INSERTED"))(this, strategy).map(_._1))}"
+            case Update(_, _) =>
+              stmt"${action.token} OUTPUT ${returnListTokenizer.token(ExpandReturning(r, Some("INSERTED"))(this, strategy).map(_._1))}"
             case Delete(_) =>
               stmt"${action.token} OUTPUT ${returnListTokenizer.token(ExpandReturning(r, Some("DELETED"))(this, strategy).map(_._1))}"
             case other =>

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -436,10 +436,10 @@ trait SqlIdiom extends Idiom {
         stmt"UPDATE ${table.token}${actionAlias.map(alias => stmt" AS ${alias.token}").getOrElse(stmt"")} SET ${assignments.token} WHERE ${where.token}"
 
       case Delete(Filter(table: Entity, x, where)) =>
-        stmt"DELETE FROM ${table.token} WHERE ${where.token}"
+        stmt"DELETE FROM ${table.token}${actionAlias.map(alias => stmt" AS ${alias.token}").getOrElse(stmt"")} WHERE ${where.token}"
 
       case Delete(table: Entity) =>
-        stmt"DELETE FROM ${table.token}"
+        stmt"DELETE FROM ${table.token}${actionAlias.map(alias => stmt" AS ${alias.token}").getOrElse(stmt"")}"
 
       case r @ ReturningAction(Insert(table: Entity, Nil), alias, prop) =>
         idiomReturningCapability match {


### PR DESCRIPTION
Fixes #1863 

### Problem

Quill doesn't support `DELETE ... RETURNING`

### Solution

Implemented `delete.returning` for `RETURNING` and `OUTPUT DELETED.fieldName` clauses

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
