### PR TITLE
Fixed bug where alias of filter clause did not match alias of inner query.

### DIFF
--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -710,6 +710,16 @@ class SqlQuerySpec extends Spec {
       }
     }
 
+    "embedded sortBy" in {
+      case class Sim(sid: Int, name: String)
+      val q = quote {
+        query[Sim]
+          .map(sim => (sim.sid, sim.name))
+          .sortBy(sim => sim._1)
+      }
+      SqlQuery(q.ast).toString mustEqual "SELECT sim.sid, sim.name FROM Sim sim ORDER BY sim._1 ASC NULLS FIRST"
+    }
+
     "queries using options" - {
       case class Entity(id: Int, s: String, o: Option[String], fk: Int, io: Option[Int])
       case class EntityA(id: Int, s: String, o: Option[String])


### PR DESCRIPTION
### Problem

An embedded filter where the filter had a different alias than the query, if it was not placed after a .nested, would throw an exception as the filter alias would be different than the alias of the query, and the query was not being wrapped up.

### Solution

Only add the filter clause directly into the existing flattenSqlQuery if the filter alias matched an alias of one of the fromContext's. 
Do so by adding a condition in the filter case to check the alias before adding the clause directly into the base flattenSqlQuery.
Otherwise, nest the inner query just like if there was already an existent filter clause.
Same for SortBy.

@getquill/maintainers
