### PR TITLE
Serialize Quats with Kryo due to 64K JVM limits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -368,12 +368,15 @@ lazy val `quill-ndbc-monix` =
 
 lazy val `quill-spark` =
   (project in file("quill-spark"))
-    .settings(commonSettings: _*)
+    .settings(commonNoLogSettings: _*)
     .settings(mimaSettings: _*)
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
         "org.apache.spark" %% "spark-sql" % "2.4.4"
+      ),
+      excludeDependencies ++= Seq(
+        "ch.qos.logback"  % "logback-classic"
       )
     )
     .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
@@ -696,6 +699,12 @@ val crossVersions = {
   }
 }
 
+lazy val loggingSettings = Seq(
+  libraryDependencies ++= Seq(
+    "ch.qos.logback"  % "logback-classic" % "1.2.3" % Test
+  )
+)
+
 lazy val basicSettings = Seq(
   excludeFilter in unmanagedSources := {
     excludeTests match {
@@ -710,7 +719,6 @@ lazy val basicSettings = Seq(
     "org.scala-lang.modules" %%% "scala-collection-compat" % "2.1.6",
     "com.lihaoyi"     %% "pprint"         % pprintVersion(scalaVersion.value),
     "org.scalatest"   %%% "scalatest"     % "3.2.0"          % Test,
-    "ch.qos.logback"  % "logback-classic" % "1.2.3"          % Test,
     "com.google.code.findbugs" % "jsr305" % "3.0.2"          % Provided // just to avoid warnings during compilation
   ) ++ {
     if (debugMacro) Seq(
@@ -794,7 +802,10 @@ def doOnPush(steps: ReleaseStep*): Seq[ReleaseStep] =
   else
     Seq[ReleaseStep](steps: _*)
 
-lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ basicSettings ++ Seq(
+lazy val commonNoLogSettings = ReleasePlugin.extraReleaseCommands ++ basicSettings ++ releaseSettings
+lazy val commonSettings = ReleasePlugin.extraReleaseCommands ++ basicSettings ++ loggingSettings ++ releaseSettings
+
+lazy val releaseSettings = Seq(
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   publishMavenStyle := true,
   publishTo := {

--- a/build.sbt
+++ b/build.sbt
@@ -121,8 +121,8 @@ publishArtifact in `quill` := false
 lazy val superPure = new sbtcrossproject.CrossType {
   def projectDir(crossBase: File, projectType: String): File =
     projectType match {
-      case "jvm" => crossBase
-      case "js"  => crossBase / s".$projectType"
+      case "jvm" => crossBase / s"$projectType"
+      case "js"  => crossBase / s"$projectType"
     }
 
   def sharedSrcDir(projectBase: File, conf: String): Option[File] =
@@ -130,8 +130,8 @@ lazy val superPure = new sbtcrossproject.CrossType {
 
   override def projectDir(crossBase: File, projectType: sbtcrossproject.Platform): File =
     projectType match {
-      case JVMPlatform => crossBase
-      case JSPlatform  => crossBase / ".js"
+      case JVMPlatform => crossBase / "jvm"
+      case JSPlatform  => crossBase / "js"
     }
 }
 
@@ -146,14 +146,17 @@ lazy val `quill-core-portable` =
     .settings(libraryDependencies ++= Seq(
       "com.typesafe"               %  "config"        % "1.4.0",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
-      "org.scala-lang"             %  "scala-reflect" % scalaVersion.value
+      "org.scala-lang"             %  "scala-reflect" % scalaVersion.value,
+      "com.twitter"                %% "chill"         % "0.9.5",
+      "io.suzaku"                  %% "boopickle"     % "1.3.1"
     ))
     .jsSettings(
       libraryDependencies ++= Seq(
         "com.lihaoyi" %%% "pprint" % pprintVersion(scalaVersion.value),
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
         "com.lihaoyi" %%% "pprint" % "0.5.4",
-        "org.scala-js" %%% "scalajs-java-time" % "0.2.5"
+        "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
+        "io.suzaku" %%% "boopickle" % "1.3.1"
       ),
       coverageExcludedPackages := ".*"
     )
@@ -181,8 +184,9 @@ lazy val `quill-core` =
     )
     .dependsOn(`quill-core-portable` % "compile->compile")
 
-lazy val `quill-core-jvm` = `quill-core`.jvm
-lazy val `quill-core-js` = `quill-core`.js
+// dependsOn in these clauses technically not needed however, intellij does not work properly without them
+lazy val `quill-core-jvm` = `quill-core`.jvm.dependsOn(`quill-core-portable-jvm` % "compile->compile")
+lazy val `quill-core-js` = `quill-core`.js.dependsOn(`quill-core-portable-js` % "compile->compile")
 
 lazy val `quill-sql-portable` =
   crossProject(JVMPlatform, JSPlatform).crossType(superPure)

--- a/quill-core-portable/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
@@ -1,0 +1,49 @@
+package io.getquill.quat
+
+import java.nio.ByteBuffer
+import java.util.Base64
+
+import boopickle.Default._
+
+import scala.collection.mutable.LinkedHashMap
+
+object BooQuatSerializer {
+  case class ProductWithRenames(data: LinkedHashMap[String, Quat], renames: List[(String, String)])
+
+  //  implicit val productPickler: Pickler[Quat.Product] =
+  //    transformPickler(
+  //      (pr: ProductWithRenames) => if (pr.renames.isEmpty) Quat.Product(pr.data) else Quat.Product.WithRenames(pr.data, pr.renames)
+  //    )(
+  //        (p: Quat.Product) => ProductWithRenames(p.fields, p.renames)
+  //      )
+
+  implicit object productPickler extends Pickler[Quat.Product] {
+    override def pickle(value: Quat.Product)(implicit state: PickleState): Unit = {
+      state.pickle(value.fields)
+      state.pickle(value.renames)
+      ()
+    }
+    override def unpickle(implicit state: UnpickleState): Quat.Product = {
+      Quat.Product.WithRenames(
+        state.unpickle[LinkedHashMap[String, Quat]],
+        state.unpickle[List[(String, String)]]
+      )
+    }
+  }
+
+  implicit val quatProductPickler: Pickler[Quat] =
+    compositePickler[Quat]
+      .addConcreteType[Quat.Product](productPickler, scala.reflect.classTag[Quat.Product])
+      .addConcreteType[Quat.Generic.type]
+      .addConcreteType[Quat.Value.type]
+      .addConcreteType[Quat.Null.type]
+
+  def serialize(quat: Quat): String = {
+    Base64.getEncoder.encodeToString(Pickle.intoBytes(quat).array())
+  }
+
+  def deserialize(str: String): Quat = {
+    val bytes = Base64.getDecoder.decode(str)
+    Unpickle[Quat].fromBytes(ByteBuffer.wrap(bytes))
+  }
+}

--- a/quill-core-portable/src/main/scala/io/getquill/quat/KryoQuatSerializer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/KryoQuatSerializer.scala
@@ -4,6 +4,7 @@ import java.util.Base64
 import com.esotericsoftware.kryo.io.{ Input, Output }
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.twitter.chill.{ IKryoRegistrar, KryoPool, ScalaKryoInstantiator }
+import io.getquill.util.Messages
 
 import scala.collection.mutable
 
@@ -47,7 +48,7 @@ object KryoQuatSerializer {
   // Needs to be lazy or will be initialize by ScalaJS and it doesn't exist there.
   lazy val kryo =
     KryoPool.withByteArrayOutputStream(
-      10,
+      Messages.quatKryoPoolSize,
       new ScalaKryoInstantiator().withRegistrar(registrar)
     )
 

--- a/quill-core-portable/src/main/scala/io/getquill/quat/KryoQuatSerializer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/KryoQuatSerializer.scala
@@ -1,0 +1,62 @@
+package io.getquill.quat
+
+import java.util.Base64
+import com.esotericsoftware.kryo.io.{ Input, Output }
+import com.esotericsoftware.kryo.{ Kryo, Serializer }
+import com.twitter.chill.{ IKryoRegistrar, KryoPool, ScalaKryoInstantiator }
+
+import scala.collection.mutable
+
+object KryoQuatSerializer {
+  import scala.collection.mutable.LinkedHashMap
+
+  // Needs to be lazy or will be initialize by ScalaJS and it doesn't exist there.
+  lazy val registrar = new IKryoRegistrar {
+    override def apply(k: Kryo): Unit = {
+      k.register(classOf[Quat])
+      k.register(classOf[Quat.Product])
+      k.register(Quat.Value.getClass)
+      k.register(Quat.Null.getClass)
+      k.register(Quat.Generic.getClass)
+      // Need to make sure LinkedHashMap is converted to a list of key,value tuples before being convered
+      // otherwise very strange things happen after kryo deserialization with the operation of LinkedHashMap.
+      // for example, Quat.zip on LinkedHashMap would cause:
+      // java.lang.ClassCastException: scala.collection.mutable.DefaultEntry cannot be cast to scala.collection.mutable.LinkedEntry
+      // or even SIGSEGV on String.equals in the same place:
+      // Stack: [0x00007f4c681f2000,0x00007f4c682f3000],  sp=0x00007f4c682e36e0,  free space=965k
+      // Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+      // J 15 C2 java.lang.String.equals(Ljava/lang/Object;)Z (81 bytes) @ 0x00007f4c851180da [0x00007f4c851180a0+0x3a]
+      // J 5794 C2 scala.collection.immutable.Map$Map1.get(Ljava/lang/Object;)Lscala/Option; (27 bytes) @ 0x00007f4c8603c1c4 [0x00007f4c8603c040+0x184]
+      // J 5794 C2 scala.collection.immutable.Map$Map1.get(Ljava/lang/Object;)Lscala/Option; (27 bytes) @ 0x00007f4c8603c1c4 [0x00007f4c8603c040+0x184]
+      // J 19573 C2 io.getquill.quat.LinkedHashMapOps$.zipWith(Lscala/collection/mutable/LinkedHashMap;Lscala/collection/mutable/LinkedHashMap;Lscala/PartialFunction;)Lscala/collection/immutable/List; (49 bytes) @ 0x00007f4c860491f8 [0x00007f4c860485e0+0xc18]
+      k.register(
+        classOf[LinkedHashMap[String, Quat]],
+        new Serializer[LinkedHashMap[String, Quat]]() {
+          override def write(kryo: Kryo, output: Output, `object`: mutable.LinkedHashMap[String, Quat]): Unit = {
+            kryo.writeObject(output, `object`.toList)
+          }
+          override def read(kryo: Kryo, input: Input, `type`: Class[mutable.LinkedHashMap[String, Quat]]): mutable.LinkedHashMap[String, Quat] = {
+            val list = kryo.readObject(input, classOf[List[(String, Quat)]])
+            LinkedHashMap(list: _*)
+          }
+        }
+      )
+      ()
+    }
+  }
+  // Needs to be lazy or will be initialize by ScalaJS and it doesn't exist there.
+  lazy val kryo =
+    KryoPool.withByteArrayOutputStream(
+      10,
+      new ScalaKryoInstantiator().withRegistrar(registrar)
+    )
+
+  def serialize(quat: Quat): String = {
+    Base64.getEncoder.encodeToString(kryo.toBytesWithClass(quat))
+  }
+
+  def deserialize(str: String): Quat = {
+    val bytes = Base64.getDecoder.decode(str)
+    kryo.fromBytes(bytes).asInstanceOf[Quat]
+  }
+}

--- a/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
@@ -7,6 +7,7 @@ object Messages {
   private def variable(propName: String, envName: String, default: String) =
     Option(System.getProperty(propName)).orElse(sys.env.get(envName)).getOrElse(default)
 
+  private[getquill] def quatKryoPoolSize = variable("quill.quat.kryoPool", "quill_quat_kryoPool", "10").toInt
   private[util] def prettyPrint = variable("quill.macro.log.pretty", "quill_macro_log", "false").toBoolean
   private[getquill] def alwaysAlias = variable("quill.query.alwaysAlias", "quill_query_alwaysAlias", "false").toBoolean
   private[getquill] def pruneColumns = variable("quill.query.pruneColumns", "quill_query_pruneColumns", "true").toBoolean

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -1,0 +1,28 @@
+package io.getquill.quotation
+
+import scala.reflect.macros.whitebox.Context
+import io.getquill.quat.Quat
+
+import scala.collection.mutable
+
+trait QuatLiftable {
+  val c: Context
+
+  import c.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
+
+  // Liftables are invariant so want to have a separate liftable for Quat.Product since it is used directly inside Entity
+  // which should be lifted/unlifted without the need for casting.
+  implicit val quatProductLiftable: Liftable[Quat.Product] = Liftable[Quat.Product] {
+    // If we are in Java Script, use the JS configured Picker to get around the "Method Too Large" error
+    case quat: Quat => q"io.getquill.quat.Quat.Product.fromSerializedJS(${quat.serializeJS})"
+  }
+
+  implicit val quatLiftable: Liftable[Quat] = Liftable[Quat] {
+    case quat: Quat => q"io.getquill.quat.Quat.fromSerializedJS(${quat.serializeJS})"
+  }
+
+  implicit def linkedHashMapLiftable[K, V](implicit lk: Liftable[K], lv: Liftable[V]): Liftable[mutable.LinkedHashMap[K, V]] = Liftable[mutable.LinkedHashMap[K, V]] {
+    case l: mutable.LinkedHashMap[K, V] =>
+      q"scala.collection.mutable.LinkedHashMap(${l.map { case (k, v) => q"(${lk(k)}, ${lv(v)})" }.toSeq: _*})"
+  }
+}

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -1,0 +1,40 @@
+package io.getquill.quotation
+
+import io.getquill.util.MacroContextExt._
+
+import scala.collection.mutable.LinkedHashMap
+import scala.reflect.macros.whitebox.Context
+import io.getquill.quat.Quat
+
+trait QuatUnliftable {
+  val c: Context
+  import c.universe.{ Constant => _, Function => _, Ident => _, If => _, _ }
+
+  implicit val quatProductUnliftable: Unliftable[Quat.Product] = Unliftable[Quat.Product] {
+    // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
+    case q"$pack.Quat.Product.fromSerializedJS(${ str: String })" => Quat.Product.fromSerializedJS(str)
+  }
+
+  implicit val quatUnliftable: Unliftable[Quat] = Unliftable[Quat] {
+    // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
+    case q"$pack.Quat.fromSerializedJS(${ str: String })" => Quat.fromSerializedJS(str)
+  }
+
+  implicit def linkedHashMapUnliftable[K, V](implicit uk: Unliftable[K], uv: Unliftable[V]): Unliftable[LinkedHashMap[K, V]] = Unliftable[LinkedHashMap[K, V]] {
+    case q"$pack.LinkedHashMap.apply[..$t](..$values)" =>
+      LinkedHashMap[K, V](
+        values.map {
+          case q"($k, $v)" =>
+            (
+              uk.unapply(k).getOrElse(c.fail(s"Can't unlift $k")),
+              uv.unapply(v).getOrElse(c.fail(s"Can't unlift $v"))
+            )
+        }: _*
+      )
+  }
+
+  implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {
+    case q"$pack.Nil"                         => Nil
+    case q"$pack.List.apply[..$t](..$values)" => values.map(v => u.unapply(v).getOrElse(c.fail(s"Can't unlift $v")))
+  }
+}

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -1,0 +1,29 @@
+package io.getquill.quotation
+
+import scala.reflect.macros.whitebox.Context
+import io.getquill.quat.Quat
+
+import scala.collection.mutable
+
+trait QuatLiftable {
+  val c: Context
+
+  import c.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
+
+  // Liftables are invariant so want to have a separate liftable for Quat.Product since it is used directly inside Entity
+  // which should be lifted/unlifted without the need for casting.
+  implicit val quatProductLiftable: Liftable[Quat.Product] = Liftable[Quat.Product] {
+    // If we are in the JVM, use Kryo to serialize our Quat due to JVM 64KB method limit that we will run into of the Quat Constructor
+    // if plainly lifted into the method created by our macro (i.e. the 'ast' method).
+    case quat: Quat => q"io.getquill.quat.Quat.Product.fromSerializedJVM(${quat.serializeJVM})"
+  }
+
+  implicit val quatLiftable: Liftable[Quat] = Liftable[Quat] {
+    case quat: Quat => q"io.getquill.quat.Quat.fromSerializedJVM(${quat.serializeJVM})"
+  }
+
+  implicit def linkedHashMapLiftable[K, V](implicit lk: Liftable[K], lv: Liftable[V]): Liftable[mutable.LinkedHashMap[K, V]] = Liftable[mutable.LinkedHashMap[K, V]] {
+    case l: mutable.LinkedHashMap[K, V] =>
+      q"scala.collection.mutable.LinkedHashMap(${l.map { case (k, v) => q"(${lk(k)}, ${lv(v)})" }.toSeq: _*})"
+  }
+}

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -1,0 +1,40 @@
+package io.getquill.quotation
+
+import io.getquill.util.MacroContextExt._
+
+import scala.collection.mutable.LinkedHashMap
+import scala.reflect.macros.whitebox.Context
+import io.getquill.quat.Quat
+
+trait QuatUnliftable {
+  val c: Context
+  import c.universe.{ Constant => _, Function => _, Ident => _, If => _, _ }
+
+  implicit val quatProductUnliftable: Unliftable[Quat.Product] = Unliftable[Quat.Product] {
+    // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
+    case q"$pack.Quat.Product.fromSerializedJVM(${ str: String })" => Quat.Product.fromSerializedJVM(str)
+  }
+
+  implicit val quatUnliftable: Unliftable[Quat] = Unliftable[Quat] {
+    // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
+    case q"$pack.Quat.fromSerializedJVM(${ str: String })" => Quat.fromSerializedJVM(str)
+  }
+
+  implicit def linkedHashMapUnliftable[K, V](implicit uk: Unliftable[K], uv: Unliftable[V]): Unliftable[LinkedHashMap[K, V]] = Unliftable[LinkedHashMap[K, V]] {
+    case q"$pack.LinkedHashMap.apply[..$t](..$values)" =>
+      LinkedHashMap[K, V](
+        values.map {
+          case q"($k, $v)" =>
+            (
+              uk.unapply(k).getOrElse(c.fail(s"Can't unlift $k")),
+              uv.unapply(v).getOrElse(c.fail(s"Can't unlift $v"))
+            )
+        }: _*
+      )
+  }
+
+  implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {
+    case q"$pack.Nil"                         => Nil
+    case q"$pack.List.apply[..$t](..$values)" => values.map(v => u.unapply(v).getOrElse(c.fail(s"Can't unlift $v")))
+  }
+}

--- a/quill-core/src/test/scala/io/getquill/UnlimitedOptionalEmbeddedSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/UnlimitedOptionalEmbeddedSpec.scala
@@ -55,7 +55,7 @@ class UnlimitedOptionalEmbeddedSpec extends Spec {
         PropertyAlias(List("e2", "e2", "e1", "value"), "value221"),
         PropertyAlias(List("e2", "e2", "e2", "value"), "value222")
       ),
-      quatOf[OptEmd],
+      quatOf[OptEmd].probit,
       Fixed
     )
   }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/LargeQuatSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/LargeQuatSpec.scala
@@ -1,0 +1,76 @@
+package io.getquill.context.sql
+
+import io.getquill.Spec
+
+class LargeQuatSpec extends Spec {
+
+  case class Large(
+    rec1:  String,
+    rec2:  String,
+    rec3:  String,
+    rec4:  String,
+    rec5:  String,
+    rec6:  String,
+    rec7:  String,
+    rec8:  String,
+    rec9:  String,
+    rec10: String,
+    rec11: String,
+    rec12: String,
+    rec13: String,
+    rec14: String,
+    rec15: String,
+    rec16: String,
+    rec17: String,
+    rec18: String,
+    rec19: String,
+    rec20: String,
+    rec21: String,
+    rec22: String,
+    rec23: String,
+    rec24: String,
+    rec25: String,
+    rec26: String,
+    rec27: String,
+    rec28: String,
+    rec29: String,
+    rec30: String,
+    rec31: String,
+    rec32: String,
+    rec33: String,
+    rec34: String,
+    rec35: String,
+    rec36: String,
+    rec37: String,
+    rec38: String,
+    rec39: String,
+    rec40: String,
+    rec41: String,
+    rec42: String,
+    rec43: String,
+    rec44: String,
+    rec45: String,
+    rec46: String,
+    rec47: String,
+    rec48: String,
+    rec49: String,
+    rec50: String
+  )
+
+  "large record size quats compile" in {
+    import testContext._
+
+    val q = quote {
+      for {
+        a <- query[Large]
+        b <- query[Large].join(b => b.rec1 == a.rec1)
+        c <- query[Large].join(c => c.rec1 == b.rec1)
+        d <- query[Large].join(d => d.rec1 == c.rec1)
+      } yield (a, b, c, d)
+    }
+
+    testContext.run(q).string mustEqual
+      "SELECT a.rec1, a.rec2, a.rec3, a.rec4, a.rec5, a.rec6, a.rec7, a.rec8, a.rec9, a.rec10, a.rec11, a.rec12, a.rec13, a.rec14, a.rec15, a.rec16, a.rec17, a.rec18, a.rec19, a.rec20, a.rec21, a.rec22, a.rec23, a.rec24, a.rec25, a.rec26, a.rec27, a.rec28, a.rec29, a.rec30, a.rec31, a.rec32, a.rec33, a.rec34, a.rec35, a.rec36, a.rec37, a.rec38, a.rec39, a.rec40, a.rec41, a.rec42, a.rec43, a.rec44, a.rec45, a.rec46, a.rec47, a.rec48, a.rec49, a.rec50, b.rec1, b.rec2, b.rec3, b.rec4, b.rec5, b.rec6, b.rec7, b.rec8, b.rec9, b.rec10, b.rec11, b.rec12, b.rec13, b.rec14, b.rec15, b.rec16, b.rec17, b.rec18, b.rec19, b.rec20, b.rec21, b.rec22, b.rec23, b.rec24, b.rec25, b.rec26, b.rec27, b.rec28, b.rec29, b.rec30, b.rec31, b.rec32, b.rec33, b.rec34, b.rec35, b.rec36, b.rec37, b.rec38, b.rec39, b.rec40, b.rec41, b.rec42, b.rec43, b.rec44, b.rec45, b.rec46, b.rec47, b.rec48, b.rec49, b.rec50, c.rec1, c.rec2, c.rec3, c.rec4, c.rec5, c.rec6, c.rec7, c.rec8, c.rec9, c.rec10, c.rec11, c.rec12, c.rec13, c.rec14, c.rec15, c.rec16, c.rec17, c.rec18, c.rec19, c.rec20, c.rec21, c.rec22, c.rec23, c.rec24, c.rec25, c.rec26, c.rec27, c.rec28, c.rec29, c.rec30, c.rec31, c.rec32, c.rec33, c.rec34, c.rec35, c.rec36, c.rec37, c.rec38, c.rec39, c.rec40, c.rec41, c.rec42, c.rec43, c.rec44, c.rec45, c.rec46, c.rec47, c.rec48, c.rec49, c.rec50, d.rec1, d.rec2, d.rec3, d.rec4, d.rec5, d.rec6, d.rec7, d.rec8, d.rec9, d.rec10, d.rec11, d.rec12, d.rec13, d.rec14, d.rec15, d.rec16, d.rec17, d.rec18, d.rec19, d.rec20, d.rec21, d.rec22, d.rec23, d.rec24, d.rec25, d.rec26, d.rec27, d.rec28, d.rec29, d.rec30, d.rec31, d.rec32, d.rec33, d.rec34, d.rec35, d.rec36, d.rec37, d.rec38, d.rec39, d.rec40, d.rec41, d.rec42, d.rec43, d.rec44, d.rec45, d.rec46, d.rec47, d.rec48, d.rec49, d.rec50 FROM Large a INNER JOIN Large b ON b.rec1 = a.rec1 INNER JOIN Large c ON c.rec1 = b.rec1 INNER JOIN Large d ON d.rec1 = c.rec1"
+  }
+
+}


### PR DESCRIPTION
Fixes #1929 

### Problem

Quats on large records run into JVM record size limits. Especially in large flat-join that have lots of aliases. For example:
```scala
case class Large(
  rec1:   String,
  rec2:   String,
  rec3:   String,
  rec4:   String,
  rec5:   String,
  rec6:   String,
  rec7:   String,
  rec8:   String,
  rec9:   String,
  rec10:  String,
  rec11:  String,
  rec12:  String,
  rec13:  String,
  rec14:  String,
  rec15:  String,
  rec16:  String,
  rec17:  String,
  rec18:  String,
  rec19:  String,
  rec20:  String,
  rec21:  String,
  rec22:  String,
  rec23:  String,
  rec24:  String,
  rec25:  String,
  rec26:  String,
  rec27:  String,
  rec28:  String,
  rec29:  String,
  rec30:  String
)

val q = quote {
  for {
    a <- query[Large]
    b <- query[Large].join(b => b.rec1 == a.rec1) //hyelloooooooooooooooooo
    c <- query[Large].join(c => c.rec1 == b.rec1)
    d <- query[Large].join(d => d.rec1 == c.rec1)
  } yield (a, b, c, d)
}
println(run(q).string)
```
The following happens:
```
[error] Error while emitting io/getquill/MySqlTest4$$anon$2$$anon$3
[error] Method too large: io/getquill/MySqlTest4$$anon$2$$anon$3.ast ()Lio/getquill/ast/Function;
[error] one error found
```

### Solution

Serialize the Quats using Kryo in Liftables and Deserialize them in Unliftables.


- [X] Unit test all changes
- [ ] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
