### PR TITLE
Use quats to expand nested queries

### DIFF
--- a/quill-spark/src/main/scala/io/getquill/context/spark/SimpleNestedExpansion.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SimpleNestedExpansion.scala
@@ -2,6 +2,7 @@ package io.getquill.context.spark
 
 import io.getquill.ast._
 import io.getquill.context.sql._
+import io.getquill.quat.Quat
 import io.getquill.sql.norm.StatelessQueryTransformer
 
 object TopLevelExpansion {
@@ -11,23 +12,32 @@ object TopLevelExpansion {
       alias.orElse(Some("")).map(v => s"${v}${str}")
   }
 
-  def apply(values: List[SelectValue]): List[SelectValue] =
-    values.flatMap(apply(_))
+  def apply(values: List[SelectValue], length: Int): List[SelectValue] =
+    values.flatMap(apply(_, length))
 
-  private def apply(value: SelectValue): List[SelectValue] = {
+  private def apply(value: SelectValue, length: Int): List[SelectValue] = {
     value match {
       case SelectValue(Tuple(values), alias, concat) =>
         values.zipWithIndex.map {
           case (ast, i) =>
-            SelectValue(ast, alias.concatWith(s"_${i + 1}"), concat)
+            SelectValue(ast, Some(s"_${i + 1}"), concat)
         }
-      //      case SelectValue(CaseClass(fields), alias, concat) =>
-      //        fields.flatMap {
-      //          case (name, ast) =>
-      //            apply(SelectValue(ast, alias.concatWith(name), concat))
-      //        }
+      case SelectValue(CaseClass(fields), alias, concat) =>
+        fields.map {
+          case (name, ast) =>
+            SelectValue(ast, Some(name), concat)
+        }
+      case SelectValue(Ident(singleFieldName, Quat.Product(fields)), alias, concat) if (length == 1) =>
+        fields.map {
+          case (name, quat) =>
+            SelectValue(Property(Ident(singleFieldName, quat), name), Some(name), concat)
+        }.toList
       // Direct infix select, etc...
-      case other => List(other)
+      case other if (length == 1) =>
+        List(other.copy(alias = Some("single")))
+      // Technically this case should not exist, adding it so that the pattern match will have full coverage
+      case other =>
+        List(other)
     }
   }
 }
@@ -36,8 +46,8 @@ object SimpleNestedExpansion extends StatelessQueryTransformer {
 
   protected override def apply(q: SqlQuery, isTopLevel: Boolean = false): SqlQuery =
     q match {
-      case q: FlattenSqlQuery =>
-        expandNested(q.copy(select = TopLevelExpansion(q.select))(q.quat), isTopLevel)
+      case q: FlattenSqlQuery => //if (isTopLevel) =>  //needs to be for all levels
+        expandNested(q.copy(select = TopLevelExpansion(q.select, q.select.length))(q.quat), isTopLevel)
       case other =>
         super.apply(q, isTopLevel)
     }

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -1,87 +1,28 @@
 package io.getquill.context.spark
 
 import io.getquill.NamingStrategy
-import io.getquill.ast.Ast
-import io.getquill.ast.BinaryOperation
-import io.getquill.ast.Ident
-import io.getquill.ast.Operation
-import io.getquill.ast.Property
-import io.getquill.ast.Query
-import io.getquill.ast.StringOperator
-import io.getquill.ast.Tuple
-import io.getquill.ast.Value
-import io.getquill.ast.CaseClass
+import io.getquill.ast.{ Ast, BinaryOperation, CaseClass, Constant, ExternalIdent, Ident, Operation, Property, Query, StringOperator, Tuple, Value }
 import io.getquill.context.spark.norm.EscapeQuestionMarks
-import io.getquill.context.sql.{ FlattenSqlQuery, SelectValue, SqlQuery }
+import io.getquill.context.sql.{ SqlQuery }
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.norm.SqlNormalize
 import io.getquill.idiom.StatementInterpolator._
 import io.getquill.idiom.Token
 import io.getquill.util.Messages.trace
-import io.getquill.ast.Constant
 import io.getquill.context.CannotReturn
+import io.getquill.quat.Quat
 
 class SparkDialect extends SparkIdiom
-
-/**
- * This helper object is needed to instantiate SparkDialect instances that have multipleSelect enabled.
- * This is a simple alternative to query re-writing that allows Quill table aliases to be selected
- * in a away that Spark can understand them.
- *
- * Quill will represent table variable returns as identifiers e.g.
- * <br/><code>Query[Foo.join(Query[Bar]).on({case (f,b) => f.id == b.fk})</code>
- * <br/>will become:
- * <br/><code>select f.*, b.* from Foo f join Bar b on f.id == b.fk</code>
- * In order for this to work properly all we have to do is change the query to:
- * <br/><code>select struct(f.*), struct(b.*) from Foo f join Bar b on f.id == b.fk</code>
- *
- * Since the expression of the <code>f</code> and <code>b</code> identifiers in the query happens inside a tokenizer,
- * all that is needed for a tokenizer to be able the add the <code>struct</code> part is to introduce a <code>multipleSelect</code>
- * variable that will guide the expansion. The <code>SparkDialectRecursor</code> has been introduced specifically for this reason.
- * I.e. so that SparkDialect contexts can be recursively declared with a new <code>multipleSelect</code> value.
- *
- * Multiple selection enabling typically needs to happen in two instances:
- * <ol>
- * <li> Multiple table aliases are selected as multiple SelectValues. This typically happens when the output of a query is a single tuple with
- * multiple case classes in it (as is the case with the example above). Or a true nested entity (as these are supported in Spark).
- * The <code>runSuperAstParser</code> method covers this case.
- * <li> Multiple table aliases are inside of a single case-class SelectValue. This typically happens when a Ad-Hoc case class is used.
- * The <code>runCaseClassWithMultipleSelect</code> method covers this case.
- * </ol>
- *
- */
-object SparkDialectRecursor {
-  def runSuperAstParser(sparkIdiom: SparkIdiom, q: SqlQuery)(implicit strategy: NamingStrategy) = {
-    import sparkIdiom._
-    implicit val stableTokenizer = sparkIdiom.astTokenizer(new Tokenizer[Ast] {
-      override def token(v: Ast): Token = astTokenizer(this, strategy).token(v)
-    }, strategy)
-
-    parentTokenizer.token(AliasNestedQueryColumns(q))
-  }
-
-  def runCaseClassWithMultipleSelect(values: List[(String, Ast)], sparkIdiom: SparkIdiom, prevContextMultipleSelect: Boolean)(implicit strategy: NamingStrategy) = {
-    import sparkIdiom._
-    implicit val stableTokenizer = sparkIdiom.astTokenizer(new Tokenizer[Ast] {
-      override def token(v: Ast): Token = astTokenizer(this, strategy).token(v)
-    }, strategy)
-
-    if (prevContextMultipleSelect) // && values.length > 1) // comes from sparkIdiom
-      stmt"(${values.map({ case (prop, value) => stmt"${TokenImplicit(value)(astTokenizer).token} AS ${prop.token}".token }).token})"
-    else
-      stmt"${values.map({ case (prop, value) => stmt"${TokenImplicit(value)(astTokenizer).token} AS ${prop.token}".token }).token}"
-  }
-}
 
 trait SparkIdiom extends SqlIdiom with CannotReturn { self =>
 
   def parentTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy) = super.sqlQueryTokenizer
 
-  def multipleSelect = false
-
   def liftingPlaceholder(index: Int): String = "?"
 
   override def prepareForProbing(string: String) = string
+
+  override implicit def externalIdentTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[ExternalIdent] = super.externalIdentTokenizer
 
   override def translate(ast: Ast)(implicit naming: NamingStrategy) = {
     val normalizedAst = EscapeQuestionMarks(SqlNormalize(ast))
@@ -108,39 +49,15 @@ trait SparkIdiom extends SqlIdiom with CannotReturn { self =>
   override def concatFunction = "explode"
 
   override implicit def identTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Ident] = Tokenizer[Ident] {
+    case id @ Ident(name, Quat.Product(fields)) =>
+      stmt"struct(${fields.map { case (field, subQuat) => (Property(id, field): Ast) }.toList.token})"
+    // Situations where a single ident arise with is a Quat.Value typically only happen when an operation yields a single SelectValue
+    // e.g. a concatMap (or aggregation?)
+    case Ident(name, Quat.Value) =>
+      stmt"${name.token}.single"
     case Ident(name, _) =>
-      if (multipleSelect)
-        stmt"struct(${name.token}.*)"
-      else
-        stmt"${name.token}._1"
+      stmt"${name.token}"
   }
-
-  override implicit def sqlQueryTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[SqlQuery] =
-    Tokenizer[SqlQuery] {
-      case q => {
-        val nextMultipleSelect = q match {
-          case f: FlattenSqlQuery => f.select.length > 1
-          case _                  => false
-        }
-        val nextTokenizer = new SparkIdiom {
-          override def multipleSelect: Boolean = nextMultipleSelect
-        }
-        SparkDialectRecursor.runSuperAstParser(nextTokenizer, q)
-      }
-    }
-
-  override implicit def selectValueTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[SelectValue] = Tokenizer[SelectValue] {
-    case SelectValue(Ident(name, _), Some(alias), _) if (multipleSelect) =>
-      stmt"struct(${strategy.default(name).token}.*) AS ${alias.token}"
-    case SelectValue(Ident(name, _), _, _) =>
-      if (multipleSelect)
-        stmt"struct(${strategy.default(name).token}.*)"
-      else
-        stmt"${strategy.default(name).token}.*"
-    case other =>
-      super.selectValueTokenizer.token(other)
-  }
-
   override implicit def propertyTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Property] = {
     def path(ast: Ast): Token =
       ast match {
@@ -162,15 +79,9 @@ trait SparkIdiom extends SqlIdiom with CannotReturn { self =>
 
   override implicit def valueTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Value] = Tokenizer[Value] {
     case Constant(v: String) => stmt"'${v.replaceAll("""[\\']""", """\\$0""").token}'"
-    case Tuple(values)       => stmt"(${values.token})"
-    case CaseClass(values) => {
-      val nextTokenizer = new SparkIdiom {
-        override def multipleSelect: Boolean = values.length > 1
-      }
-      val keyValues = values.map { case (k, v) => (k, v) }
-      SparkDialectRecursor.runCaseClassWithMultipleSelect(keyValues, nextTokenizer, self.multipleSelect)
-    }
-    case other => super.valueTokenizer.token(other)
+    case Tuple(values)       => stmt"struct(${values.zipWithIndex.map { case (value, index) => stmt"${value.token} AS _${(index + 1 + "").token}" }.token})"
+    case CaseClass(values)   => stmt"struct(${values.map { case (name, value) => stmt"${value.token} AS ${name.token}" }.token})"
+    case other               => super.valueTokenizer.token(other)
   }
 
   override protected def tokenizeGroupBy(values: Ast)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Token =

--- a/quill-spark/src/test/scala/io/getquill/context/spark/MiscQueriesSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/MiscQueriesSpec.scala
@@ -1,0 +1,97 @@
+package io.getquill.context.spark
+
+import io.getquill.Spec
+
+case class Inner(i: Int)
+case class Outer(inner: Inner)
+case class Original(id: Long, name: String, age: Long, numeric: Long)
+case class MapTo(id: Long, name: String, numeric: Long)
+
+class MiscQueriesSpec extends Spec {
+
+  val context = io.getquill.context.sql.testContext
+
+  import testContext._
+  import sqlContext.implicits._
+
+  val tests = liftQuery {
+    Seq(
+      Test(1, 2, "Th r ee"),
+      Test(4, 5, "s"),
+      Test(6, 7, "N s in s e")
+    ).toDS
+  }
+
+  // Also tested in SparkDialectSpec
+  "nested structures" - {
+    "nested property" in {
+      val outers = liftQuery {
+        Seq(
+          Outer(Inner(1)),
+          Outer(Inner(2)),
+          Outer(Inner(1))
+        ).toDS
+      }
+      val q = quote(outers.filter(t => t.inner.i == 1))
+      testContext.run(q).collect.toList mustEqual
+        List(Outer(Inner(1)), Outer(Inner(1)))
+    }
+    "nested tuple" in {
+      val q = quote(tests.map(t => ((t.i, t.j), t.i + 1)))
+      testContext.run(q).collect.toList mustEqual
+        List(((1, 2), 2), ((4, 5), 5), ((6, 7), 7))
+    }
+  }
+
+  // Also tested in SparkDialectSpec
+  "concatMap with filter" - {
+    "single select with filter" in {
+      val q = quote(tests.concatMap(t => t.s.split(" ")).filter(s => s == "s"))
+      testContext.run(q).collect.toList mustEqual
+        List("s", "s", "s")
+    }
+    "nested select" in {
+      val testsR = liftQuery {
+        Seq(
+          Test(1, 2, "r"),
+        ).toDS
+      }
+      val q = quote(
+        tests
+          .concatMap(t => t.s.split(" "))
+          .join(testsR.concatMap(t => t.s.split(" ")))
+          .on { case (a, b) => a == b }
+      )
+      testContext.run(q).collect.toList mustEqual
+        List(("r", "r"))
+    }
+  }
+  "map to CC after GroupBy" in {
+    val originals = liftQuery {
+      Seq(
+        Original(1, "Joe", 0, 10),
+        Original(1, "Joe", 0, 20),
+        Original(2, "Sam", 2, 6),
+        Original(3, "Hanna", 4, 8)
+      ).toDS
+    }
+    val q = quote(
+      originals
+        .groupBy(p => (p.id, p.name))
+        .map {
+          case ((id, name), items) =>
+            MapTo(
+              id,
+              name,
+              items.map(_.numeric).sum.getOrElse(0L)
+            )
+        }
+    )
+    testContext.run(q).collect.toList mustEqual
+      List(
+        MapTo(1, "Joe", 30),
+        MapTo(2, "Sam", 6),
+        MapTo(3, "Hanna", 8)
+      )
+  }
+}

--- a/quill-spark/src/test/scala/io/getquill/context/spark/PeopleSparkSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/PeopleSparkSpec.scala
@@ -46,6 +46,21 @@ class PeopleJdbcSpec extends Spec {
       List(("Alex", 5), ("Cora", 2))
   }
 
+  "Example 1 - differences with explicit join" in {
+    val q =
+      quote {
+        for {
+          c <- couples
+          w <- people.join(w => c.her == w.name)
+          m <- people.join(m => c.him == m.name) if (w.age > m.age)
+        } yield {
+          (w.name, w.age - m.age)
+        }
+      }
+    testContext.run(q).collect.toList mustEqual
+      List(("Alex", 5), ("Cora", 2))
+  }
+
   "Example 2 - range simple" in {
     val rangeSimple = quote {
       (a: Int, b: Int) =>
@@ -112,4 +127,15 @@ class PeopleJdbcSpec extends Spec {
     testContext.run(q("Drew", "Bert")).collect.toList mustEqual
       List(Person("Cora", 33), Person("Drew", 31))
   }
+  /*
+  //blows up
+  "simple distinct" in {
+    val q =
+      quote {
+        couples.distinct
+      }
+    testContext.run(q.dynamic).collect.toList mustEqual
+      List(Couple("Alex", "Bert"), Couple("Cora", "Drew"), Couple("Edna", "Fred"))
+  }
+   */
 }

--- a/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
@@ -21,7 +21,7 @@ class SparkDialectSpec extends Spec {
       val ast = query[Test].ast
       val (norm, stmt) = SparkDialect.translate(ast)(Literal)
       norm mustEqual ast
-      stmt.toString mustEqual "SELECT x.* FROM Test x"
+      stmt.toString mustEqual "SELECT x.i AS i, x.j AS j, x.s AS s FROM Test x"
     }
     "non  -query" in {
       val ast = infix"SELECT 1".ast
@@ -35,50 +35,53 @@ class SparkDialectSpec extends Spec {
     val ast = query[Test].map(t => "test'").ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT 'test\\'' FROM Test t"
+    stmt.toString mustEqual "SELECT 'test\\'' AS single FROM Test t"
   }
 
+  // More comprehensive test in MiscQueriesSpec
   "nested property" in {
     case class Inner(i: Int)
     case class Outer(inner: Inner)
     val ast = query[Outer].filter(t => t.inner.i == 1).ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT t.* FROM Outer t WHERE t.inner.i = 1"
+    stmt.toString mustEqual "SELECT t.inner AS inner FROM Outer t WHERE t.inner.i = 1"
   }
 
+  // More comprehensive test in MiscQueriesSpec
   "nested tuple" in {
     val ast = query[Test].map(t => ((t.i, t.j), t.i + 1)).ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT (t.i, t.j) AS _1, t.i + 1 AS _2 FROM Test t"
+    stmt.toString mustEqual "SELECT struct(t.i AS _1, t.j AS _2) AS _1, t.i + 1 AS _2 FROM Test t"
   }
 
   "concatMap" in {
     val ast = query[Test].concatMap(t => t.s.split(" ")).ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT explode(SPLIT(t.s, ' ')) FROM Test t"
+    stmt.toString mustEqual "SELECT explode(SPLIT(t.s, ' ')) AS single FROM Test t"
   }
 
-  "non-tuple select" in {
+  // More comprehensive test in MiscQueriesSpec
+  "concatMap with filter" in {
     val ast = query[Test].concatMap(t => t.s.split(" ")).filter(s => s == "s").ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT s.* FROM (SELECT explode(SPLIT(t.s, ' ')) FROM Test t) AS s WHERE s._1 = 's'"
+    stmt.toString mustEqual "SELECT s.single AS single FROM (SELECT explode(SPLIT(t.s, ' ')) AS single FROM Test t) AS s WHERE s.single = 's'"
   }
 
   "concat string" in {
     val ast = query[Test].map(t => t.s + " ").ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT concat(t.s, ' ') FROM Test t"
+    stmt.toString mustEqual "SELECT concat(t.s, ' ') AS single FROM Test t"
   }
 
   "groupBy with multiple columns" in {
     val ast = query[Test].groupBy(t => (t.i, t.j)).map(t => t._2).ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT t.* FROM Test t GROUP BY t.i, t.j"
+    stmt.toString mustEqual "SELECT t.i AS i, t.j AS j, t.s AS s FROM Test t GROUP BY t.i, t.j"
   }
 }

--- a/quill-spark/src/test/scala/io/getquill/context/spark/norm/ExpandEntityIdsSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/norm/ExpandEntityIdsSpec.scala
@@ -225,7 +225,7 @@ class ExpandEntityIdsSpec extends Spec {
           b <- qr2 if (a.i + 1) == b.j
         } yield TestHolder(a, b)
       }
-      testContext.run(q.dynamic).collect.toList mustEqual entities.map(e => TestHolder(e, e))
+      testContext.run(q).collect.toList mustEqual entities.map(e => TestHolder(e, e))
     }
     "regular entities and entities inside ad-hoc case classes" in {
       val q = quote {


### PR DESCRIPTION
Fixes #1811 

### Problem

Mapping to a case class after doing a groupBy in spark was causing a SOE.

### Solution

Removed multipleSelect behavior in spark tokenization. Instead of using multiple select to know if the select value needs to be expanded, use the quat of the select value to determine expansion. 

### Notes

Now, all tuples and caseclasses get expanded into "struct( )" in all but the top level selectValue. SimpleNestedExpansion opens up topLevel CCs and Tuples and SparkDialect does all other nesting. Use of quats allows for simplifaction of tokenization behavior and removal of multipleSelect. 

@getquill/maintainers
