### PR TITLE
breakdown caseclasses in groupBy clause

### DIFF
--- a/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
@@ -8,16 +8,16 @@ object Messages {
     Option(System.getProperty(propName)).orElse(sys.env.get(envName)).getOrElse(default)
 
   private[getquill] def quatKryoPoolSize = variable("quill.quat.kryoPool", "quill_quat_kryoPool", "10").toInt
-  private[util] def prettyPrint = variable("quill.macro.log.pretty", "quill_macro_log", "false").toBoolean
+  private[util] def prettyPrint = variable("quill.macro.log.pretty", "quill_macro_log", "true").toBoolean
   private[getquill] def alwaysAlias = variable("quill.query.alwaysAlias", "quill_query_alwaysAlias", "false").toBoolean
   private[getquill] def pruneColumns = variable("quill.query.pruneColumns", "quill_query_pruneColumns", "true").toBoolean
   private[util] def debugEnabled = variable("quill.macro.log", "quill_macro_log", "true").toBoolean
-  private[util] def traceEnabled = variable("quill.trace.enabled", "quill_trace_enabled", "false").toBoolean
+  private[util] def traceEnabled = variable("quill.trace.enabled", "quill_trace_enabled", "true").toBoolean
   private[util] def traceColors = variable("quill.trace.color", "quill_trace_color,", "false").toBoolean
   private[util] def traceOpinions = variable("quill.trace.opinion", "quill_trace_opinion", "false").toBoolean
   private[util] def traceAstSimple = variable("quill.trace.ast.simple", "quill_trace_ast_simple", "false").toBoolean
   private[util] def traces: List[TraceType] =
-    variable("quill.trace.types", "quill_trace_types", "standard")
+    variable("quill.trace.types", "quill_trace_types", "sql")
       .split(",")
       .toList
       .map(_.trim)

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/SqlQuery.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/SqlQuery.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.sql
 
 import io.getquill.ast._
-import io.getquill.context.sql.norm.FlattenGroupByAggregation
+import io.getquill.context.sql.norm.{ ExpandSelection, FlattenGroupByAggregation }
 import io.getquill.norm.BetaReduction
 import io.getquill.quat.Quat
 import io.getquill.util.Messages.fail
@@ -151,9 +151,14 @@ object SqlQuery {
 
       case Map(GroupBy(q, x @ Ident(alias, _), g), a, p) =>
         val b = base(q, alias)
+        val flatGroupByAsts = new ExpandSelection(b.from).apply(List(SelectValue(g))).map(_.ast)
+        val groupByClause =
+          if (flatGroupByAsts.length > 1) Tuple(flatGroupByAsts)
+          else flatGroupByAsts.head
+
         val select = BetaReduction(p, a -> Tuple(List(g, x)))
         val flattenSelect = FlattenGroupByAggregation(x)(select)
-        b.copy(groupBy = Some(g), select = this.selectValues(flattenSelect))(quat)
+        b.copy(groupBy = Some(groupByClause), select = this.selectValues(flattenSelect))(quat)
 
       case GroupBy(q, Ident(alias, _), p) =>
         fail("A `groupBy` clause must be followed by `map`.")
@@ -271,6 +276,17 @@ object SqlQuery {
       case JoinContext(_, a, b, _)     => collectAliases(List(a)) ++ collectAliases(List(b))
       case FlatJoinContext(_, from, _) => collectAliases(List(from))
     }
-
   }
+
+  private def collectTableAliases(contexts: List[FromContext]): List[String] = {
+    contexts.flatMap {
+      case c: TableContext             => List(c.alias)
+      case c: QueryContext             => List()
+      case c: InfixContext             => List()
+      case JoinContext(_, a, b, _)     => collectAliases(List(a)) ++ collectAliases(List(b))
+      case FlatJoinContext(_, from, _) => collectAliases(List(from))
+    }
+  }
+
 }
+

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/norm/SelectPropertyProtractor.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/norm/SelectPropertyProtractor.scala
@@ -2,7 +2,7 @@ package io.getquill.sql.norm
 
 import io.getquill.ast.{ Ast, Ident, Property, Renameable }
 import io.getquill.ast.Visibility.{ Hidden, Visible }
-import io.getquill.context.sql.{ FromContext, TableContext }
+import io.getquill.context.sql.{ FlatJoinContext, FromContext, InfixContext, JoinContext, QueryContext, TableContext }
 import io.getquill.norm.PropertyMatroshka
 import io.getquill.quat.Quat
 import io.getquill.ast.Core
@@ -10,11 +10,21 @@ import io.getquill.ast.Core
 case class SelectPropertyProtractor(from: List[FromContext]) {
 
   private def refersToEntity(ast: Ast) = {
-    val tables = from.collect { case TableContext(entity, alias) => alias }
+    val tables = collectTableAliases(from)
     ast match {
       case Ident(v, _)                       => tables.contains(v)
       case PropertyMatroshka(Ident(v, _), _) => tables.contains(v)
       case _                                 => false
+    }
+  }
+
+  private def collectTableAliases(contexts: List[FromContext]): List[String] = {
+    contexts.flatMap {
+      case c: TableContext             => List(c.alias)
+      case c: QueryContext             => List()
+      case c: InfixContext             => List()
+      case JoinContext(_, a, b, _)     => collectTableAliases(List(a)) ++ collectTableAliases(List(b))
+      case FlatJoinContext(_, from, _) => collectTableAliases(List(from))
     }
   }
 
@@ -57,68 +67,68 @@ case class SelectPropertyProtractor(from: List[FromContext]) {
       case other => List(other).map(p => (p, List.empty))
     }
   }
+}
 
-  /* Take a quat and project it out as nested properties with some core ast inside.
- * quat: CC(foo,bar:Quat(a,b)) with core id:Ident(x) =>
- *   List( Prop(id,foo) [foo], Prop(Prop(id,bar),a) [bar.a], Prop(Prop(id,bar),b) [bar.b] )
- */
-  case class ProtractQuat(refersToEntity: Boolean) {
-    def apply(quat: Quat.Product, core: Ast): List[(Property, List[String])] =
-      applyInner(quat, core)
+/* Take a quat and project it out as nested properties with some core ast inside.
+* quat: CC(foo,bar:Quat(a,b)) with core id:Ident(x) =>
+*   List( Prop(id,foo) [foo], Prop(Prop(id,bar),a) [bar.a], Prop(Prop(id,bar),b) [bar.b] )
+*/
+case class ProtractQuat(refersToEntity: Boolean) {
+  def apply(quat: Quat.Product, core: Ast): List[(Property, List[String])] =
+    applyInner(quat, core)
 
-    def applyInner(quat: Quat.Product, core: Ast): List[(Property, List[String])] = {
-      // Property (and alias path) should be visible unless we are referring directly to a TableContext
-      // with an Entity that has embedded fields. In that case, only top levels should show since
-      // we're selecting from an actual table and in that case, the embedded paths don't actually exist.
-      val wholePathVisible = !refersToEntity
+  def applyInner(quat: Quat.Product, core: Ast): List[(Property, List[String])] = {
+    // Property (and alias path) should be visible unless we are referring directly to a TableContext
+    // with an Entity that has embedded fields. In that case, only top levels should show since
+    // we're selecting from an actual table and in that case, the embedded paths don't actually exist.
+    val wholePathVisible = !refersToEntity
 
-      // Assuming renames have been applied so the value of a renamed field will be the 2nd element
-      def isPropertyRenameable(name: String) =
-        if (quat.renames.find(_._2 == name).isDefined)
-          Renameable.Fixed
-        else
-          Renameable.ByStrategy
+    // Assuming renames have been applied so the value of a renamed field will be the 2nd element
+    def isPropertyRenameable(name: String) =
+      if (quat.renames.find(_._2 == name).isDefined)
+        Renameable.Fixed
+      else
+        Renameable.ByStrategy
 
-      quat.fields.flatMap {
-        case (name, child: Quat.Product) =>
-          // Should not need this
-          //val fieldName = quat.renames.find(_._1 == name).map(_._2).getOrElse(name)
-          // TODO Quat once renames changed to LinkedHashSet change the lookup here to lookup from the hash for better perf
-          applyInner(
-            child,
-            Property.Opinionated(
-              core,
-              // If the quat is renamed, create a property representing the renamed field, otherwise use the quat field for the property
-              name,
-              // Property is renameable if it is being directly selected from a table and there is no naming strategy selecting from it
-              isPropertyRenameable(name),
-              /* If the property represents a property of a Entity (i.e. we're selecting from an actual table,
-               * then the entire projection of the Quat should be visible (since subsequent aliases will
-               * be using the entire path.
-               * Take: Bim(bid:Int, mam:Mam), Mam(mid:Int, mood:Int) extends Embedded
-               * Here is an example:
-               * SELECT g.mam FROM
-               *    SELECT gim.bim: CC(bid:Int,mam:CC(mid:Int,mood:Int)) FROM g
-               *
-               * This needs to be projected into:
-               * SELECT g.mammid, g.mammood FROM                         -- (2) so their selection of sub-properties from here is correct
-               *    SELECT gim.mid AS mammid, gim.mood as mammood FROM g -- (1) for mamid and mammood need full quat path here...
-               *
-               * (See examples of this in ExpandNestedQueries multiple embedding levels series of tests. Also note that since sub-selection
-               * is typically done from tuples, paths typically start with _1,_2 etc...)
-               */
-              if (wholePathVisible) Visible else Hidden
-            )
-          ).map {
-              case (prop, path) =>
-                (prop, name +: path)
-            }
-        case (name, _) =>
-          // If the quat is renamed, create a property representing the renamed field, otherwise use the quat field for the property
-          //val fieldName = quat.renames.find(_._1 == name).map(_._2).getOrElse(name)
-          // The innermost entity of the quat. This is always visible since it is the actual column of the table
-          List((Property.Opinionated(core, name, isPropertyRenameable(name), Visible), List(name)))
-      }.toList
-    }
+    quat.fields.flatMap {
+      case (name, child: Quat.Product) =>
+        // Should not need this
+        //val fieldName = quat.renames.find(_._1 == name).map(_._2).getOrElse(name)
+        // TODO Quat once renames changed to LinkedHashSet change the lookup here to lookup from the hash for better perf
+        applyInner(
+          child,
+          Property.Opinionated(
+            core,
+            // If the quat is renamed, create a property representing the renamed field, otherwise use the quat field for the property
+            name,
+            // Property is renameable if it is being directly selected from a table and there is no naming strategy selecting from it
+            isPropertyRenameable(name),
+            /* If the property represents a property of a Entity (i.e. we're selecting from an actual table,
+             * then the entire projection of the Quat should be visible (since subsequent aliases will
+             * be using the entire path.
+             * Take: Bim(bid:Int, mam:Mam), Mam(mid:Int, mood:Int) extends Embedded
+             * Here is an example:
+             * SELECT g.mam FROM
+             *    SELECT gim.bim: CC(bid:Int,mam:CC(mid:Int,mood:Int)) FROM g
+             *
+             * This needs to be projected into:
+             * SELECT g.mammid, g.mammood FROM                         -- (2) so their selection of sub-properties from here is correct
+             *    SELECT gim.mid AS mammid, gim.mood as mammood FROM g -- (1) for mamid and mammood need full quat path here...
+             *
+             * (See examples of this in ExpandNestedQueries multiple embedding levels series of tests. Also note that since sub-selection
+             * is typically done from tuples, paths typically start with _1,_2 etc...)
+             */
+            if (wholePathVisible) Visible else Hidden
+          )
+        ).map {
+            case (prop, path) =>
+              (prop, name +: path)
+          }
+      case (name, _) =>
+        // If the quat is renamed, create a property representing the renamed field, otherwise use the quat field for the property
+        //val fieldName = quat.renames.find(_._1 == name).map(_._2).getOrElse(name)
+        // The innermost entity of the quat. This is always visible since it is the actual column of the table
+        List((Property.Opinionated(core, name, isPropertyRenameable(name), Visible), List(name)))
+    }.toList
   }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/GroupBySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/GroupBySpec.scala
@@ -1,0 +1,130 @@
+package io.getquill.context.sql
+
+import io.getquill.Spec
+import io.getquill.context.sql.testContext._
+import io.getquill.Literal
+
+class GroupBySpec extends Spec {
+  implicit val naming = new Literal {}
+
+  "groupBy table expansion" - {
+    case class Country(id: Int, name: String)
+    case class City(name: String, countryId: Int)
+
+    "basic" in {
+      val q = quote(
+        query[City]
+          .join(query[Country])
+          .on { case (city, country) => city.countryId == country.id }
+          .groupBy { case (city, country) => country }
+          .map { case (country, citysInCountry) => (country.name, citysInCountry.map(cICn => cICn._1)) }
+          .map { case (country, citiesInCountry) => (country, citiesInCountry.size) }
+      )
+      testContext.run(q.dynamic).string mustEqual
+        "SELECT x11.name, COUNT(*) FROM City x01 INNER JOIN Country x11 ON x01.countryId = x11.id GROUP BY x11.id, x11.name"
+    }
+    "with QuerySchema" in {
+      implicit val citySchema = schemaMeta[City]("theCity", _.name -> "theCityName")
+      implicit val countrySchema = schemaMeta[Country]("theCountry", _.name -> "theCountryName")
+      val q = quote(
+        query[City]
+          .join(query[Country])
+          .on { case (city, country) => city.countryId == country.id }
+          .groupBy { case (city, country) => country }
+          .map { case (country, citysInCountry) => (country.name, citysInCountry.map(cICn => cICn._1)) }
+          .map { case (country, citiesInCountry) => (country, citiesInCountry.size) }
+      )
+      testContext.run(q.dynamic).string mustEqual
+        "SELECT x12.theCountryName, COUNT(*) FROM theCity x05 INNER JOIN theCountry x12 ON x05.countryId = x12.id GROUP BY x12.id, x12.theCountryName"
+    }
+    "nested" in {
+      val q = quote(
+        query[City]
+          .join(query[Country])
+          .on { case (city, country) => city.countryId == country.id }
+          .nested
+          .groupBy { case (city, country) => country }
+          .map { case (country, citiesInCountry) => (country, citiesInCountry.size) }
+      )
+      testContext.run(q.dynamic).string mustEqual
+        "SELECT x010._2id, x010._2name, COUNT(*) FROM (SELECT x13.id AS _2id, x13.name AS _2name FROM City x09 INNER JOIN Country x13 ON x09.countryId = x13.id) AS x010 GROUP BY x010._2id, x010._2name"
+    }
+    "with QuerySchema nested" in {
+      implicit val citySchema = schemaMeta[City]("theCity", _.name -> "theCityName")
+      implicit val countrySchema = schemaMeta[Country]("theCountry", _.name -> "theCountryName")
+      val q = quote(
+        query[City]
+          .join(query[Country])
+          .on { case (city, country) => city.countryId == country.id }
+          .nested
+          .groupBy { case (city, country) => country }
+          .map { case (country, citiesInCountry) => (country, citiesInCountry.size) }
+      )
+      testContext.run(q.dynamic).string mustEqual
+        "SELECT x013._2id, x013._2theCountryName, COUNT(*) FROM (SELECT x14.id AS _2id, x14.theCountryName AS _2theCountryName FROM theCity x012 INNER JOIN theCountry x14 ON x012.countryId = x14.id) AS x013 GROUP BY x013._2id, x013._2theCountryName"
+    }
+
+  }
+
+  "Embedded entity expansion" - {
+    case class Language(name: String, dialect: String) extends Embedded
+    case class Country(countryCode: String, language: Language)
+    case class City(countryCode: String, name: String)
+
+    "simple" in {
+      val q = quote(
+        query[City]
+          .join(query[Country])
+          .on { case (city, country) => city.countryCode == country.countryCode }
+          .groupBy { case (city, country) => country }
+          .map { case (country, citysInCountry) => ((country.countryCode, country.language), citysInCountry.map(cICn => cICn._1)) }
+          .map { case (country, cityCountries) => (country, cityCountries.size) }
+      )
+      testContext.run(q.dynamic).string mustEqual
+        "SELECT x15.countryCode, x15.languagename, x15.languagedialect, COUNT(*) FROM City x015 INNER JOIN Country x15 ON x015.countryCode = x15.countryCode GROUP BY x15.countryCode, x15.languagename, x15.languagedialect"
+    }
+    "nested" in {
+      val q = quote(
+        query[City]
+          .join(query[Country])
+          .on { case (city, country) => city.countryCode == country.countryCode }
+          .nested
+          .groupBy { case (city, country) => country }
+          .map { case (country, cityCountries) => (country, cityCountries.size) }
+      )
+      testContext.run(q.dynamic).string mustEqual
+        "SELECT x020._2countryCode, x020._2languagename, x020._2languagedialect, COUNT(*) FROM (SELECT x16.countryCode AS _2countryCode, x16.languagename AS _2languagename, x16.languagedialect AS _2languagedialect FROM City x019 INNER JOIN Country x16 ON x019.countryCode = x16.countryCode) AS x020 GROUP BY x020._2countryCode, x020._2languagename, x020._2languagedialect"
+    }
+    "with schema" in {
+      implicit val countrySchema =
+        schemaMeta[Country]("theCountry", _.countryCode -> "theCountryCode", _.language.name -> "TheLanguageName")
+
+      val q = quote(
+        query[City]
+          .join(query[Country])
+          .on { case (city, country) => city.countryCode == country.countryCode }
+          .groupBy { case (city, country) => country }
+          .map { case (country, citysInCountry) => ((country.countryCode, country.language), citysInCountry.map(cICn => cICn._1)) }
+          .map { case (country, cityCountries) => (country, cityCountries.size) }
+      )
+      testContext.run(q.dynamic).string mustEqual
+        "SELECT x17.theCountryCode, x17.languageTheLanguageName, x17.languagedialect, COUNT(*) FROM City x022 INNER JOIN theCountry x17 ON x022.countryCode = x17.theCountryCode GROUP BY x17.theCountryCode, x17.languageTheLanguageName, x17.languagedialect"
+    }
+    "with schema nested" in {
+      implicit val languageSchema =
+        schemaMeta[Country]("theCountry", _.countryCode -> "theCountryCode", _.language.name -> "TheLanguageName")
+
+      val q = quote(
+        query[City]
+          .join(query[Country])
+          .on { case (city, country) => city.countryCode == country.countryCode }
+          .nested
+          .groupBy { case (city, country) => country }
+          .map { case (country, cityCountries) => (country, cityCountries.size) }
+      )
+      testContext.run(q.dynamic).string mustEqual
+        "SELECT x027._2theCountryCode, x027._2languageTheLanguageName, x027._2languagedialect, COUNT(*) FROM (SELECT x18.theCountryCode AS _2theCountryCode, x18.languageTheLanguageName AS _2languageTheLanguageName, x18.languagedialect AS _2languagedialect FROM City x026 INNER JOIN theCountry x18 ON x026.countryCode = x18.theCountryCode) AS x027 GROUP BY x027._2theCountryCode, x027._2languageTheLanguageName, x027._2languagedialect"
+    }
+  }
+
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -10,7 +10,7 @@ class SqlQuerySpec extends Spec {
 
   implicit val naming = new Literal {}
 
-  "transforms the ast into a flatten sql-like structure" - { //hello
+  "transforms the ast into a flatten sql-like structure" - {
 
     "inner join query" in {
       val q = quote {


### PR DESCRIPTION
Fixes #1936

### Problem

When you group by a case class, the groupBy clause is not broken up into the fields of the case class, but tries to group by the whole class.

### Solution

In the case groupBy in SqlQuery,, use the ExpandSelection class and logic to break down all fields in the groupBy clause into their components, just as ExpandSelection already does for selectValues. 

### Notes

ExpandSelection has all the logic for renaming fields based on scemas... We're using that same logic to break down the groupBy clause.

@getquill/maintainers
