### PR TITLE
breakdown Case Classes in orderBy clause, fix ident verification

### DIFF
--- a/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/VerifySqlQuery.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/VerifySqlQuery.scala
@@ -1,9 +1,8 @@
 package io.getquill.context.sql.idiom
 
 import io.getquill.ast._
-import io.getquill.ast.Implicits._
 import io.getquill.context.sql._
-import io.getquill.quotation.{ FreeVariables }
+import io.getquill.quotation.FreeVariables
 import io.getquill.quat.Quat
 
 case class Error(free: List[Ident], ast: Ast)
@@ -57,13 +56,8 @@ object VerifySqlQuery {
     def verifyAst(ast: Ast) = {
       val freeVariables =
         (FreeVariables(ast) -- aliases).toList
-      val freeIdents =
-        (CollectAst(ast) {
-          case ast: Property            => None
-          case Aggregation(_, _: Ident) => None
-          case ast: Ident               => Some(ast)
-        }).flatten
-      (freeVariables ++ freeIdents.map(_.idName)) match {
+      checkIllegalIdents(ast)
+      freeVariables match {
         case Nil  => None
         case free => Some(Error(free.map(f => Ident(f.name, Quat.Value)), ast)) // Quat is not actually needed here here just for the sake of the Error Ident
       }
@@ -111,4 +105,24 @@ object VerifySqlQuery {
       case s: JoinContext     => aliases(s.a) ++ aliases(s.b)
       case s: FlatJoinContext => aliases(s.a)
     }
+
+  private def checkIllegalIdents(ast: Ast): Unit = {
+    val freeIdents =
+      (CollectAst(ast) {
+        case op: OptionExists if op.quat.isInstanceOf[Quat.Product] => throw new IllegalArgumentException("Cannot use Option.exists on a table or embedded case class")
+        case op: OptionForall if op.quat.isInstanceOf[Quat.Product] => throw new IllegalArgumentException("Cannot use Option.forAll on a table or embedded case class")
+        case op: OptionGetOrElse if op.quat.isInstanceOf[Quat.Product] => throw new IllegalArgumentException("Cannot use Option.getOrElse on a table or embedded case class")
+        case op: OptionIsEmpty if op.quat.isInstanceOf[Quat.Product] => throw new IllegalArgumentException("Cannot use Option.isEmpty on a table or embedded case class")
+        case op: OptionNonEmpty if op.quat.isInstanceOf[Quat.Product] => throw new IllegalArgumentException("Cannot use Option.nonEmpty on a table or embedded case class")
+        case op: OptionIsDefined if op.quat.isInstanceOf[Quat.Product] => throw new IllegalArgumentException("Cannot use Option.isDefined on a table or embedded case class")
+        case op: OptionTableForall if op.quat.isInstanceOf[Quat.Product] => throw new IllegalArgumentException("Cannot use Option.tableForAll on a table or embedded case class")
+        case op: OptionTableExists if op.quat.isInstanceOf[Quat.Product] => throw new IllegalArgumentException("Cannot use Option.tableExists on a table or embedded case class")
+
+        case cond: If if cond.`then`.isInstanceOf[Quat.Product] => throw throw new IllegalArgumentException("Cannot use table or embedded case class as a result of a condition")
+        case cond: If if cond.`else`.isInstanceOf[Quat.Product] => throw throw new IllegalArgumentException("Cannot use table or embedded case class as a result of a condition")
+
+        case cond: If => checkIllegalIdents(cond.condition)
+        case other => None
+      })
+  }
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/GroupBySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/GroupBySpec.scala
@@ -127,4 +127,19 @@ class GroupBySpec extends Spec {
     }
   }
 
+  "after join" in {
+    case class CountryLanguage(countryCode: String, language: String)
+    case class City(id: Int, name: String, countryCode: String)
+
+    val q = quote(
+      query[City]
+        .join(query[CountryLanguage])
+        .on { case (city, cl) => city.countryCode == cl.countryCode }
+        .groupBy { case (city, language) => language }
+        .map { case (language, cityLanguages) => (language, cityLanguages.size) }
+    )
+    testContext.run(q.dynamic).string mustEqual
+      "SELECT x19.countryCode, x19.language, COUNT(*) FROM City x029 INNER JOIN CountryLanguage x19 ON x029.countryCode = x19.countryCode GROUP BY x19.countryCode, x19.language"
+  }
+
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/OrderBySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/OrderBySpec.scala
@@ -1,0 +1,38 @@
+package io.getquill.context.sql
+import io.getquill.Spec
+import io.getquill.context.sql.testContext._
+import io.getquill.Literal
+
+class OrderBySpec extends Spec {
+
+  implicit val naming = new Literal {}
+
+  case class Country(id: Int, name: String)
+  case class City(name: String, countryId: Int)
+
+  "order by case class" in {
+    val q = quote(
+      query[City]
+        .join(query[Country])
+        .on { case (city, country) => city.countryId == country.id }
+        .sortBy { case (city, country) => city }
+    )
+    testContext.run(q.dynamic).string mustEqual
+      "SELECT x01.name, x01.countryId, x11.id, x11.name FROM City x01 INNER JOIN Country x11 ON x01.countryId = x11.id ORDER BY x01.name ASC NULLS FIRST, x01.countryId ASC NULLS FIRST"
+  }
+
+  "order by case class with rename" in {
+    implicit val citySchema = schemaMeta[City]("theCity", _.countryId -> "theCityCode")
+    implicit val countrySchema = schemaMeta[Country]("theCountry", _.id -> "theCountryCode")
+
+    val q = quote(
+      query[City]
+        .join(query[Country])
+        .on { case (city, country) => city.countryId == country.id }
+        .sortBy { case (city, country) => city }
+    )
+    testContext.run(q.dynamic).string mustEqual
+      "SELECT x03.name, x03.theCityCode, x12.theCountryCode, x12.name FROM theCity x03 INNER JOIN theCountry x12 ON x03.theCityCode = x12.theCountryCode ORDER BY x03.name ASC NULLS FIRST, x03.theCityCode ASC NULLS FIRST"
+  }
+
+}

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/VerifySqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/VerifySqlQuerySpec.scala
@@ -32,17 +32,17 @@ class VerifySqlQuerySpec extends Spec {
             case (a, b) => b.isDefined
           }
         }
-        VerifySqlQuery(SqlQuery(SqlNormalize(q.ast))).toString mustEqual
-          "Some(The monad composition can't be expressed using applicative joins. Faulty expression: 'b.isDefined'. Free variables: 'List(b)'.)"
+
+        an[IllegalArgumentException] should be thrownBy VerifySqlQuery(SqlQuery(SqlNormalize(q.ast)))
       }
+
       "with map" in {
         val q = quote {
           qr1.leftJoin(qr2).on((a, b) => a.i == b.i)
             .map(pcTup => if (pcTup._2.isDefined) "bar" else "baz")
         }
 
-        VerifySqlQuery(SqlQuery(SqlNormalize(q.ast))).toString mustEqual
-          "Some(The monad composition can't be expressed using applicative joins. Faulty expression: 'if(b.isDefined) \"bar\" else \"baz\"'. Free variables: 'List(b)'.)"
+        an[IllegalArgumentException] should be thrownBy VerifySqlQuery(SqlQuery(SqlNormalize(q.ast)))
       }
     }
 


### PR DESCRIPTION
Legalize grouping by a quat product

Fixes #1864

### Problem

VerifySqlQuery was checking for idents which represented tables or case classes in order to make it illegal to sort by an entire table or to do certain filter operations, such as table.exists. Unfortunately, this was also making it illegal to group by an entire table. This is a common scenario where you have a join followed by a group by: in the map following the group by, you may want to simply select one of the tables, not specifying all the fields. This was causing an error.

### Solution

First - in OrderBy, expand anything that has a quat product, making it legal to order by an entire table. For example. in a query of 2 tables, if you order by Table1, then that will internally be expanded to ORDER BY Table1.foo, Table1.bar...
Second - refactor the ident checking. Instead of just looking for any free ident, look for OptionOperations on idents with quat products. Also check the if and else parts of conditions to make sure those are not quat products.

### Notes

In the expansion of an OrderBy criteria, the ordering type gets applied to all the fields expanded out from that criteria.
Since you can have an OptionOperation inside the condition of a cond, run the identChecker on the ast of cond.condition.

@getquill/maintainers
