### PR TITLE
Better PPrinting for Quats in AST Traces

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,12 +135,29 @@ lazy val superPure = new sbtcrossproject.CrossType {
     }
 }
 
+lazy val ultraPure = new sbtcrossproject.CrossType {
+  def projectDir(crossBase: File, projectType: String): File =
+    projectType match {
+      case "jvm" => crossBase
+      case "js"  => crossBase / s".$projectType"
+    }
+
+  def sharedSrcDir(projectBase: File, conf: String): Option[File] =
+    Some(projectBase.getParentFile / "src" / conf / "scala")
+
+  override def projectDir(crossBase: File, projectType: sbtcrossproject.Platform): File =
+    projectType match {
+      case JVMPlatform => crossBase
+      case JSPlatform  => crossBase / ".js"
+    }
+}
+
 def pprintVersion(v: String) = {
   if(v.startsWith("2.11")) "0.5.4" else "0.5.5"
 }
 
 lazy val `quill-core-portable` =
-  crossProject(JVMPlatform, JSPlatform).crossType(superPure)
+  crossProject(JVMPlatform, JSPlatform).crossType(ultraPure)
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(libraryDependencies ++= Seq(
@@ -189,7 +206,7 @@ lazy val `quill-core-jvm` = `quill-core`.jvm.dependsOn(`quill-core-portable-jvm`
 lazy val `quill-core-js` = `quill-core`.js.dependsOn(`quill-core-portable-js` % "compile->compile")
 
 lazy val `quill-sql-portable` =
-  crossProject(JVMPlatform, JSPlatform).crossType(superPure)
+  crossProject(JVMPlatform, JSPlatform).crossType(ultraPure)
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(libraryDependencies ++= Seq(
@@ -211,7 +228,7 @@ lazy val `quill-sql-portable-js` = `quill-sql-portable`.js
 
 
 lazy val `quill-sql` =
-  crossProject(JVMPlatform, JSPlatform).crossType(superPure)
+  crossProject(JVMPlatform, JSPlatform).crossType(ultraPure)
     .settings(commonSettings: _*)
     .settings(mimaSettings: _*)
     .settings(libraryDependencies ++= Seq(

--- a/quill-core-portable/src/main/scala/io/getquill/AstPrinter.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/AstPrinter.scala
@@ -5,6 +5,8 @@ import io.getquill.ast.Renameable.{ ByStrategy, Fixed }
 import io.getquill.ast.Visibility.{ Hidden, Visible }
 import io.getquill.ast._
 import io.getquill.quat.Quat
+import io.getquill.util.Messages
+import io.getquill.util.Messages.QuatTrace
 import pprint.{ Renderer, Tree, Truncated }
 
 object AstPrinter {
@@ -36,6 +38,45 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean) extends pprint
       case Hidden  => Tree.Literal("Hide")
     }
 
+  private trait treemake {
+    private def toContent =
+      this match {
+        case q: treemake.Quat    => treemake.Content(List(q))
+        case e: treemake.Elem    => treemake.Content(List(e))
+        case e: treemake.Tree    => treemake.Content(List(e))
+        case c: treemake.Content => c
+      }
+    def withQuat(q: Quat): treemake = toContent.andWith(treemake.Quat(q))
+    def withTree(t: pprint.Tree): treemake = toContent.andWith(treemake.Tree(t))
+    private def treeifyList: List[Tree] =
+      toContent.list.flatMap {
+        case e: treemake.Quat =>
+          Messages.traceQuats match {
+            case QuatTrace.Full  => List(Tree.Literal(e.q.shortString))
+            case QuatTrace.Short => List(Tree.Literal(e.q.shortString.take(10)))
+            case QuatTrace.None  => List()
+          }
+        case treemake.Elem(value)   => List(pprint.treeify(value))
+        case treemake.Tree(value)   => List(value)
+        case treemake.Content(list) => list.flatMap(_.treeifyList)
+      }
+    def treeify: Iterator[Tree] = treeifyList.iterator
+  }
+  private object treemake {
+    private case class Quat(q: io.getquill.quat.Quat) extends treemake
+    private case class Elem(any: Any) extends treemake
+    private case class Tree(any: pprint.Tree) extends treemake
+    private case class Content(list: List[treemake]) extends treemake {
+      def andWith(elem: treemake) =
+        elem match {
+          case c: Content => Content(list ++ c.list)
+          case other      => Content(list :+ other)
+        }
+    }
+
+    def apply(list: Any*): treemake = Content(list.toList.map(Elem(_)))
+  }
+
   override def additionalHandlers: PartialFunction[Any, Tree] = {
     case ast: Ast if (traceAstSimple) =>
       Tree.Literal("" + ast) // Do not blow up if it is null
@@ -44,20 +85,20 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean) extends pprint
       Tree.Literal("" + past) // Do not blow up if it is null
 
     case i: Ident =>
-      Tree.Apply("Id", List[Tree](treeify(i.name), Tree.Literal(i.quat.shortString)).iterator)
+      Tree.Apply("Id", treemake(i.name).withQuat(i.quat).treeify)
 
     case e: Entity if (!traceOpinions) =>
-      Tree.Apply("Entity", List[Tree](treeify(e.name), treeify(e.properties), Tree.Literal(e.quat.shortString)).iterator)
+      Tree.Apply("Entity", treemake(e.name, e.properties).withQuat(e.quat).treeify)
 
     case q: Quat            => Tree.Literal(q.shortString)
 
-    case s: ScalarValueLift => Tree.Apply("ScalarValueLift", List(treeify("..." + s.name.reverse.take(15).reverse), Tree.Literal(s.quat.shortString)).iterator)
+    case s: ScalarValueLift => Tree.Apply("ScalarValueLift", treemake("..." + s.name.reverse.take(15).reverse).withQuat(s.quat).treeify)
 
     case p: Property if (traceOpinions) =>
       Tree.Apply("Property", List[Tree](treeify(p.ast), treeify(p.name), printRenameable(p.renameable), printVisibility(p.visibility)).iterator)
 
     case e: Entity if (traceOpinions) =>
-      Tree.Apply("Entity", List[Tree](treeify(e.name), treeify(e.properties), printRenameable(e.renameable)).iterator)
+      Tree.Apply("Entity", treemake(e.name, e.properties).withTree(printRenameable(e.renameable)).treeify)
   }
 
   def apply(x: Any): fansi.Str = {

--- a/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
@@ -16,6 +16,18 @@ object Messages {
   private[util] def traceColors = variable("quill.trace.color", "quill_trace_color,", "false").toBoolean
   private[util] def traceOpinions = variable("quill.trace.opinion", "quill_trace_opinion", "false").toBoolean
   private[util] def traceAstSimple = variable("quill.trace.ast.simple", "quill_trace_ast_simple", "false").toBoolean
+  private[getquill] def traceQuats = QuatTrace(variable("quill.trace.quat", "quill_trace_quat", QuatTrace.None.value))
+
+  sealed trait QuatTrace { def value: String }
+  object QuatTrace {
+    case object Short extends QuatTrace { val value = "short" }
+    case object Full extends QuatTrace { val value = "short" }
+    case object None extends QuatTrace { val value = "none" }
+    val values = List(Short, Full, None)
+    def apply(str: String): QuatTrace =
+      values.find(_.value == str).getOrElse(throw new IllegalArgumentException(s"The value ${str} is an invalid quat trace setting. Value values are: ${values.map(_.value).mkString(",")}"))
+  }
+
   private[util] def traces: List[TraceType] =
     variable("quill.trace.types", "quill_trace_types", "standard")
       .split(",")


### PR DESCRIPTION
Printing of Quats in AST elements should be more customize-able, particularly in trees where Quats are large since it can make pprinted ASTs incomprehensible.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
