### PR TITLE
Fix Context Checking for ExpandNestedQueries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,11 @@ import scala.sys.process.Process
 import sbtcrossproject.crossProject
 import java.io.{File => JFile}
 
+// one
+// two
+// three
+// four
+
 enablePlugins(TutPlugin)
 
 val CodegenTag = Tags.Tag("CodegenTag")

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/NestedQueryNamingStrategySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/NestedQueryNamingStrategySpec.scala
@@ -79,7 +79,7 @@ class NestedQueryNamingStrategySpec extends Spec { //hello
         }.filter(_._1.id == 1)
       }
       testContextUpper.run(q).string mustEqual
-        "SELECT ab._1theId, ab._1theName, ab._2id, ab._2name, ab._3 FROM (SELECT a.theId AS _1theId, a.theName AS _1theName, b.id AS _2id, b.name AS _2name, foobar AS _3 FROM ThePerson a INNER JOIN PERSON b ON a.theName = b.NAME) AS ab WHERE ab._1theId = 1"
+        "SELECT ab._1theId, ab._1theName, ab._2id, ab._2name, ab._3 FROM (SELECT a.theId AS _1theId, a.theName AS _1theName, b.ID AS _2id, b.NAME AS _2name, foobar AS _3 FROM ThePerson a INNER JOIN PERSON b ON a.theName = b.NAME) AS ab WHERE ab._1theId = 1"
     }
 
     "inner alias should nest properly in multiple levels" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/norm/RenamePropertiesOverrideSpec.scala
@@ -261,21 +261,21 @@ class RenamePropertiesOverrideSpec extends Spec {
           e.join(f).on((a, b) => a.s == b.s).map(t => t._1.s)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT a.field_s FROM test_entity a INNER JOIN (SELECT t.S AS s FROM TESTENTITY t WHERE t.I = 1) AS t ON a.field_s = t.S"
+          "SELECT a.field_s FROM test_entity a INNER JOIN (SELECT t.S AS s FROM TESTENTITY t WHERE t.I = 1) AS t ON a.field_s = t.s"
       }
       "left" in {
         val q = quote {
           e.leftJoin(f).on((a, b) => a.s == b.s).map(t => t._1.s)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT a.field_s FROM test_entity a LEFT JOIN (SELECT t.S AS s FROM TESTENTITY t WHERE t.I = 1) AS t ON a.field_s = t.S"
+          "SELECT a.field_s FROM test_entity a LEFT JOIN (SELECT t.S AS s FROM TESTENTITY t WHERE t.I = 1) AS t ON a.field_s = t.s"
       }
       "right" in {
         val q = quote {
           f.rightJoin(e).on((a, b) => a.s == b.s).map(t => t._2.s)
         }
         testContextUpper.run(q).string mustEqual
-          "SELECT b.field_s FROM (SELECT t.S AS s FROM TESTENTITY t WHERE t.I = 1) AS t RIGHT JOIN test_entity b ON t.S = b.field_s"
+          "SELECT b.field_s FROM (SELECT t.S AS s FROM TESTENTITY t WHERE t.I = 1) AS t RIGHT JOIN test_entity b ON t.s = b.field_s"
       }
       "flat inner" in {
         val q = quote {


### PR DESCRIPTION
ExpandNestedQueries does applies naming schema to on-clauses in certain cases where it should not. It also applies naming schema to columns of from-clause tables where it should not.

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
