### PR TITLE
Exclude macro model from coverage. This code is not used directly.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,7 @@ lazy val `quill-core-portable` =
         "com.twitter"                %% "chill"         % "0.9.5",
         "io.suzaku"                  %% "boopickle"     % "1.3.1"
       ),
-      coverageExcludedPackages := "<empty>;.*AstPrinter;.*Using;io\\.getquill\\.Model;io\\.getquill\\.MacroModel"
+      coverageExcludedPackages := "<empty>;.*AstPrinter;.*Using;.*io/getquill/Model;.*io/getquill/MacroModel"
     )
     .jsSettings(
       libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,7 @@ lazy val `quill-core-portable` =
         "com.twitter"                %% "chill"         % "0.9.5",
         "io.suzaku"                  %% "boopickle"     % "1.3.1"
       ),
-      coverageExcludedPackages := "<empty>;.*AstPrinter;.*Using;"
+      coverageExcludedPackages := "<empty>;.*AstPrinter;.*Using;.*/Model;.*/MacroModel"
     )
     .jsSettings(
       libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,7 @@ lazy val `quill-core-portable` =
         "com.twitter"                %% "chill"         % "0.9.5",
         "io.suzaku"                  %% "boopickle"     % "1.3.1"
       ),
-      coverageExcludedPackages := "<empty>;.*AstPrinter;.*Using;.*/Model;.*/MacroModel"
+      coverageExcludedPackages := "<empty>;.*AstPrinter;.*Using;io\\.getquill\\.Model;io\\.getquill\\.MacroModel"
     )
     .jsSettings(
       libraryDependencies ++= Seq(


### PR DESCRIPTION
Macro-model code registers as untested because it is not actually executed code. Rather it is parsed by parser. Therefore it makes sense to exclude.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
