### PR TITLE
Change Constant.apply Quat Inference to Constant.auto

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlQuery.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlQuery.scala
@@ -32,7 +32,7 @@ object CqlQuery {
       case Map(q: Query, x, p) =>
         apply(q, select(p), distinct)
       case Aggregation(AggregationOperator.`size`, q: Query) =>
-        apply(q, List(Aggregation(AggregationOperator.`size`, Constant(1))), distinct)
+        apply(q, List(Aggregation(AggregationOperator.`size`, Constant.auto(1))), distinct)
       case other =>
         apply(q, List(), distinct)
     }

--- a/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
@@ -434,7 +434,7 @@ sealed trait Value extends Ast
 case class Constant(v: Any, quat: Quat) extends Value
 
 object Constant {
-  def apply(v: Any) = {
+  def auto(v: Any) = {
     val quat = if (v.isInstanceOf[Boolean]) Quat.BooleanValue else Quat.Value
     new Constant(v, quat)
   }

--- a/quill-core/src/test/scala/io/getquill/ast/AstOpsSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/AstOpsSpec.scala
@@ -9,12 +9,12 @@ class AstOpsSpec extends Spec {
 
   "+||+" - {
     "unapply" in {
-      BinaryOperation(VIdent("a"), BooleanOperator.`||`, Constant(true)) must matchPattern {
+      BinaryOperation(VIdent("a"), BooleanOperator.`||`, Constant.auto(true)) must matchPattern {
         case VIdent(a) +||+ Constant(t, _) if (a == "a" && t == true) =>
       }
     }
     "apply" in {
-      (VIdent("a") +||+ Constant(true)) must matchPattern {
+      (VIdent("a") +||+ Constant.auto(true)) must matchPattern {
         case BinaryOperation(VIdent(a), BooleanOperator.`||`, Constant(t, _)) if (a == "a" && t == true) =>
       }
     }
@@ -22,12 +22,12 @@ class AstOpsSpec extends Spec {
 
   "+&&+" - {
     "unapply" in {
-      BinaryOperation(VIdent("a"), BooleanOperator.`&&`, Constant(true)) must matchPattern {
+      BinaryOperation(VIdent("a"), BooleanOperator.`&&`, Constant.auto(true)) must matchPattern {
         case VIdent(a) +&&+ Constant(t, _) if (a == "a" && t == true) =>
       }
     }
     "apply" in {
-      (VIdent("a") +&&+ Constant(true)) must matchPattern {
+      (VIdent("a") +&&+ Constant.auto(true)) must matchPattern {
         case BinaryOperation(VIdent(a), BooleanOperator.`&&`, Constant(t, _)) if (a == "a" && t == true) =>
       }
     }
@@ -35,12 +35,12 @@ class AstOpsSpec extends Spec {
 
   "+==+" - {
     "unapply" in {
-      BinaryOperation(VIdent("a"), EqualityOperator.`==`, Constant(true)) must matchPattern {
+      BinaryOperation(VIdent("a"), EqualityOperator.`==`, Constant.auto(true)) must matchPattern {
         case VIdent(a) +==+ Constant(t, _) if (a == "a" && t == true) =>
       }
     }
     "apply" in {
-      (VIdent("a") +==+ Constant(true)) must matchPattern {
+      (VIdent("a") +==+ Constant.auto(true)) must matchPattern {
         case BinaryOperation(VIdent(a), EqualityOperator.`==`, Constant(t, _)) if (a == "a" && t == true) =>
       }
     }
@@ -99,7 +99,7 @@ class AstOpsSpec extends Spec {
   }
 
   "returning matcher" - {
-    val insert = Insert(Entity("Ent", List(), Quat.LeafProduct("prop")), List(Assignment(VIdent("p"), Property(VIdent("p"), "prop"), Constant(123))))
+    val insert = Insert(Entity("Ent", List(), Quat.LeafProduct("prop")), List(Assignment(VIdent("p"), Property(VIdent("p"), "prop"), Constant.auto(123))))
     val r = VIdent("r")
     val prop = Property(r, "value")
 

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -160,7 +160,7 @@ class StatefulTransformerSpec extends Spec {
 
     "value" - {
       "constant" in {
-        val ast: Ast = Constant("a")
+        val ast: Ast = Constant.auto("a")
         Subject(Nil)(ast) match {
           case (at, att) =>
             at mustEqual ast

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -109,7 +109,7 @@ class StatelessTransformerSpec extends Spec {
 
     "value" - {
       "constant" in {
-        val ast: Ast = Constant("a")
+        val ast: Ast = Constant.auto("a")
         Subject()(ast) mustEqual ast
       }
       "null" in {

--- a/quill-core/src/test/scala/io/getquill/norm/AttachToEntitySpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/AttachToEntitySpec.scala
@@ -7,7 +7,7 @@ import io.getquill.Query
 
 class AttachToEntitySpec extends Spec {
 
-  val attachToEntity = (AttachToEntity(SortBy(_, _, Constant(1), AscNullsFirst)) _).andThen(replaceTempIdent.apply _)
+  val attachToEntity = (AttachToEntity(SortBy(_, _, Constant.auto(1), AscNullsFirst)) _).andThen(replaceTempIdent.apply _)
 
   "attaches clause to the root of the query (entity)" - {
     "query is the entity" in {

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -54,7 +54,7 @@ class BetaReductionSpec extends Spec {
       val (aE, bE, cE, dE) = (Ident("a", QEP), Ident("b", QEP), Ident("c", QEP), Ident("d", QEP))
       // Value Idents
       val (a, b, c, d) = (Ident("a", QV), Ident("b", QV), Ident("c", QV), Ident("d", QV))
-      val (c1, c2, c3) = (Constant(1), Constant(2), Constant(3))
+      val (c1, c2, c3) = (Constant.auto(1), Constant.auto(2), Constant.auto(3))
 
       "top level block" in {
         val block = Block(List(

--- a/quill-core/src/test/scala/io/getquill/norm/ExpandReturningSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/ExpandReturningSpec.scala
@@ -146,7 +146,7 @@ class ExpandReturningSpec extends Spec {
         Ident("p"),
         Tuple(List(Property.Opinionated(Ident("p"), "name", renameable, Visible), Property.Opinionated(Ident("p"), "age", renameable, Visible)))
       ),
-      List(Assignment(Ident("pp"), Property.Opinionated(Ident("pp"), "name", renameable, Visible), Constant("Joe")))
+      List(Assignment(Ident("pp"), Property.Opinionated(Ident("pp"), "name", renameable, Visible), Constant.auto("Joe")))
     )
     def retMulti =
       Returning(insert, Ident("r"), Tuple(List(Property.Opinionated(Ident("r"), "name", renameable, Visible), Property.Opinionated(Ident("r"), "age", renameable, Visible))))

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -11,10 +11,10 @@ import io.getquill.MoreAstOps._
 class FlattenOptionOperationSpec extends Spec {
 
   def o = Ident("o")
-  def c1 = Constant(1)
-  def cFoo = Constant("foo")
-  def cBar = Constant("bar")
-  def cValue = Constant("value")
+  def c1 = Constant.auto(1)
+  def cFoo = Constant.auto("foo")
+  def cBar = Constant.auto("bar")
+  def cValue = Constant.auto("value")
 
   "transforms option operations into simple properties" - {
     case class Row(id: Int, value: String)
@@ -24,7 +24,7 @@ class FlattenOptionOperationSpec extends Spec {
         (o: Option[Int]) => o.getOrElse(1)
       }
       new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-        If(BinaryOperation(Ident("o"), EqualityOperator.`!=`, NullValue), Ident("o"), Constant(1))
+        If(BinaryOperation(Ident("o"), EqualityOperator.`!=`, NullValue), Ident("o"), Constant.auto(1))
     }
     "flatten" - {
       "regular operation" in {
@@ -41,7 +41,7 @@ class FlattenOptionOperationSpec extends Spec {
           (o: Option[Option[String]]) => o.flatten.map(s => s + "foo")
         }
         new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-          o +++ Constant("foo")
+          o +++ Constant.auto("foo")
         new FlattenOptionOperation(NonAnsiConcat)(q.ast.body: Ast) mustEqual
           IfExistElseNull(o, o +++ cFoo)
       }
@@ -105,7 +105,7 @@ class FlattenOptionOperationSpec extends Spec {
           (o: Option[String]) => o.map(s => s + "foo")
         }
         new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-          o +++ Constant("foo")
+          o +++ Constant.auto("foo")
         new FlattenOptionOperation(NonAnsiConcat)(q.ast.body: Ast) mustEqual
           IfExistElseNull(o, o +++ cFoo)
       }
@@ -131,7 +131,7 @@ class FlattenOptionOperationSpec extends Spec {
       }
       new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
         BinaryOperation(
-          BinaryOperation(Ident("o"), NumericOperator.`<`, Constant(1)),
+          BinaryOperation(Ident("o"), NumericOperator.`<`, Constant.auto(1)),
           BooleanOperator.`||`,
           OptionIsEmpty(Ident("o"))
         )
@@ -142,7 +142,7 @@ class FlattenOptionOperationSpec extends Spec {
       }
       new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
         BinaryOperation(
-          BinaryOperation(Ident("o"), NumericOperator.`<`, Constant(1)),
+          BinaryOperation(Ident("o"), NumericOperator.`<`, Constant.auto(1)),
           BooleanOperator.`||`,
           OptionNonEmpty(Ident("o"))
         )
@@ -171,9 +171,9 @@ class FlattenOptionOperationSpec extends Spec {
           (o: Option[String]) => o.forall(s => if (s + "foo" == "bar") true else false)
         }
         new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-          (IsNullCheck(o) +||+ (IsNotNullCheck(o) +&&+ If((o +++ cFoo) +==+ cBar, Constant(true), Constant(false))))
+          (IsNullCheck(o) +||+ (IsNotNullCheck(o) +&&+ If((o +++ cFoo) +==+ cBar, Constant.auto(true), Constant.auto(false))))
         new FlattenOptionOperation(NonAnsiConcat)(q.ast.body: Ast) mustEqual
-          (IsNullCheck(o) +||+ (IsNotNullCheck(o) +&&+ If((o +++ cFoo) +==+ cBar, Constant(true), Constant(false))))
+          (IsNullCheck(o) +||+ (IsNotNullCheck(o) +&&+ If((o +++ cFoo) +==+ cBar, Constant.auto(true), Constant.auto(false))))
       }
     }
     "map + forall + binop" - {
@@ -182,16 +182,16 @@ class FlattenOptionOperationSpec extends Spec {
           (o: Option[TestEntity]) => o.map(_.i).forall(i => i != 1) && true
         }
         new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-          ((IsNullCheck(Property(o, "i")) +||+ ((Property(o, "i") +!=+ c1))) +&&+ Constant(true))
+          ((IsNullCheck(Property(o, "i")) +||+ ((Property(o, "i") +!=+ c1))) +&&+ Constant.auto(true))
       }
       "possible-fallthrough operation" in {
         val q = quote {
           (o: Option[TestEntity2]) => o.map(_.s).forall(s => s + "foo" == "bar") && true
         }
         new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-          ((IsNullCheck(Property(o, "s")) +||+ ((Property(o, "s") +++ cFoo) +==+ cBar) +&&+ Constant(true)))
+          ((IsNullCheck(Property(o, "s")) +||+ ((Property(o, "s") +++ cFoo) +==+ cBar) +&&+ Constant.auto(true)))
         new FlattenOptionOperation(NonAnsiConcat)(q.ast.body: Ast) mustEqual
-          ((IsNullCheck(Property(o, "s")) +||+ (IsNotNullCheck(Property(o, "s")) +&&+ ((Property(o, "s") +++ cFoo) +==+ cBar))) +&&+ Constant(true))
+          ((IsNullCheck(Property(o, "s")) +||+ (IsNotNullCheck(Property(o, "s")) +&&+ ((Property(o, "s") +++ cFoo) +==+ cBar))) +&&+ Constant.auto(true))
       }
     }
     "exists" - {
@@ -218,9 +218,9 @@ class FlattenOptionOperationSpec extends Spec {
           (o: Option[String]) => o.exists(s => if (s + "foo" == "bar") true else false)
         }
         new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-          (IsNotNullCheck(o) +&&+ If((o +++ cFoo) +==+ cBar, Constant(true), Constant(false)))
+          (IsNotNullCheck(o) +&&+ If((o +++ cFoo) +==+ cBar, Constant.auto(true), Constant.auto(false)))
         new FlattenOptionOperation(NonAnsiConcat)(q.ast.body: Ast) mustEqual
-          (IsNotNullCheck(o) +&&+ If((o +++ cFoo) +==+ cBar, Constant(true), Constant(false)))
+          (IsNotNullCheck(o) +&&+ If((o +++ cFoo) +==+ cBar, Constant.auto(true), Constant.auto(false)))
       }
     }
     "exists row" in {
@@ -234,7 +234,7 @@ class FlattenOptionOperationSpec extends Spec {
         (o: Option[Int]) => o.contains(1)
       }
       new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-        BinaryOperation(Ident("o"), EqualityOperator.`==`, Constant(1))
+        BinaryOperation(Ident("o"), EqualityOperator.`==`, Constant.auto(1))
     }
   }
 }

--- a/quill-core/src/test/scala/io/getquill/norm/QueryGenerator.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/QueryGenerator.scala
@@ -49,10 +49,10 @@ class QueryGenerator(seed: Int) {
   }
 
   private def take(i: Int) =
-    Take(apply(i - 1), Constant(i))
+    Take(apply(i - 1), Constant.auto(i))
 
   private def drop(i: Int) =
-    Drop(apply(i - 1), Constant(i))
+    Drop(apply(i - 1), Constant.auto(i))
 
   private def map(i: Int) = {
     val q = apply(i)
@@ -69,7 +69,7 @@ class QueryGenerator(seed: Int) {
   private def filter(i: Int) = {
     val q = apply(i)
     val id = Ident(char, q.quat)
-    Filter(q, id, BinaryOperation(id.randomProperty, EqualityOperator.`!=`, Constant(1)))
+    Filter(q, id, BinaryOperation(id.randomProperty, EqualityOperator.`!=`, Constant.auto(1)))
   }
 
   private def sortBy(i: Int) = {

--- a/quill-core/src/test/scala/io/getquill/norm/SimplifyNullChecksSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/SimplifyNullChecksSpec.scala
@@ -15,7 +15,7 @@ class SimplifyNullChecksSpec extends Spec {
   val ia = Ident("a")
   val ib = Ident("b")
   val it = Ident("t")
-  val ca = Constant("a")
+  val ca = Constant.auto("a")
 
   val SimplifyNullChecksAnsi = new SimplifyNullChecks(AnsiEquality)
   val SimplifyNullChecksNonAnsi = new SimplifyNullChecks(NonAnsiEquality)
@@ -49,28 +49,28 @@ class SimplifyNullChecksSpec extends Spec {
       val q = quote {
         (a: Option[Int]) => a == Option(1)
       }
-      SimplifyNullChecksNonAnsi(quote(unquote(q)).ast.body) mustEqual (OptionIsDefined(ia) +&&+ (ia +==+ OptionApply(Constant(1))))
+      SimplifyNullChecksNonAnsi(quote(unquote(q)).ast.body) mustEqual (OptionIsDefined(ia) +&&+ (ia +==+ OptionApply(Constant.auto(1))))
     }
 
     "reduces when Option(constant) == Option" in {
       val q = quote {
         (a: Option[Int]) => Option(1) == a
       }
-      SimplifyNullChecksNonAnsi(quote(unquote(q)).ast.body) mustEqual (OptionIsDefined(ia) +&&+ (OptionApply(Constant(1)) +==+ ia))
+      SimplifyNullChecksNonAnsi(quote(unquote(q)).ast.body) mustEqual (OptionIsDefined(ia) +&&+ (OptionApply(Constant.auto(1)) +==+ ia))
     }
 
     "reduces when Option != Option(constant)" in {
       val q = quote {
         (a: Option[Int]) => a != Option(1)
       }
-      SimplifyNullChecksAnsi(quote(unquote(q)).ast.body) mustEqual (OptionIsEmpty(ia) +||+ (ia +!=+ OptionApply(Constant(1))))
+      SimplifyNullChecksAnsi(quote(unquote(q)).ast.body) mustEqual (OptionIsEmpty(ia) +||+ (ia +!=+ OptionApply(Constant.auto(1))))
     }
 
     "reduces when Option(constant) != Option" in {
       val q = quote {
         (a: Option[Int]) => Option(1) != a
       }
-      SimplifyNullChecksAnsi(quote(unquote(q)).ast.body) mustEqual (OptionIsEmpty(ia) +||+ (OptionApply(Constant(1)) +!=+ ia))
+      SimplifyNullChecksAnsi(quote(unquote(q)).ast.body) mustEqual (OptionIsEmpty(ia) +||+ (OptionApply(Constant.auto(1)) +!=+ ia))
     }
 
     "with ansi enabled" - {

--- a/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quotation/QuotationSpec.scala
@@ -98,7 +98,7 @@ class QuotationSpec extends Spec {
           val renamedQuat = TestEntityQuat.renameAtPath(Nil, List("s" -> "theS"))
           quote(unquote(q)).ast mustEqual (
             Filter(Entity.Opinionated("SomeAlias", List(PropertyAlias(List("s"), "theS")), renamedQuat, Fixed), Ident("t", renamedQuat),
-              (Property(Ident("t", renamedQuat), "s") +==+ Constant("s")) +&&+ (Property(Ident("t", renamedQuat), "i") +==+ Constant(1)))
+              (Property(Ident("t", renamedQuat), "s") +==+ Constant.auto("s")) +&&+ (Property(Ident("t", renamedQuat), "i") +==+ Constant.auto(1)))
           )
         }
       }
@@ -106,13 +106,13 @@ class QuotationSpec extends Spec {
         val q = quote {
           qr1.filter(t => t.s == "s")
         }
-        quote(unquote(q)).ast mustEqual Filter(Entity("TestEntity", Nil, TestEntityQuat), Ident("t", TestEntityQuat), BinaryOperation(Property(Ident("t", TestEntityQuat), "s"), EqualityOperator.`==`, Constant("s")))
+        quote(unquote(q)).ast mustEqual Filter(Entity("TestEntity", Nil, TestEntityQuat), Ident("t", TestEntityQuat), BinaryOperation(Property(Ident("t", TestEntityQuat), "s"), EqualityOperator.`==`, Constant.auto("s")))
       }
       "withFilter" in {
         val q = quote {
           qr1.withFilter(t => t.s == "s")
         }
-        quote(unquote(q)).ast mustEqual Filter(Entity("TestEntity", Nil, TestEntityQuat), Ident("t"), BinaryOperation(Property(Ident("t"), "s"), EqualityOperator.`==`, Constant("s")))
+        quote(unquote(q)).ast mustEqual Filter(Entity("TestEntity", Nil, TestEntityQuat), Ident("t"), BinaryOperation(Property(Ident("t"), "s"), EqualityOperator.`==`, Constant.auto("s")))
       }
       "map" in {
         val q = quote {
@@ -130,7 +130,7 @@ class QuotationSpec extends Spec {
         val q = quote {
           qr1.concatMap(t => t.s.split(" "))
         }
-        quote(unquote(q)).ast mustEqual ConcatMap(Entity("TestEntity", Nil, TestEntityQuat), Ident("t"), BinaryOperation(Property(Ident("t", TestEntityQuat), "s"), StringOperator.`split`, Constant(" ")))
+        quote(unquote(q)).ast mustEqual ConcatMap(Entity("TestEntity", Nil, TestEntityQuat), Ident("t"), BinaryOperation(Property(Ident("t", TestEntityQuat), "s"), StringOperator.`split`, Constant.auto(" ")))
       }
       "sortBy" - {
         "default ordering" in {
@@ -260,13 +260,13 @@ class QuotationSpec extends Spec {
         val q = quote {
           qr1.take(10)
         }
-        quote(unquote(q)).ast mustEqual Take(Entity("TestEntity", Nil, TestEntityQuat), Constant(10))
+        quote(unquote(q)).ast mustEqual Take(Entity("TestEntity", Nil, TestEntityQuat), Constant.auto(10))
       }
       "drop" in {
         val q = quote {
           qr1.drop(10)
         }
-        quote(unquote(q)).ast mustEqual Drop(Entity("TestEntity", Nil, TestEntityQuat), Constant(10))
+        quote(unquote(q)).ast mustEqual Drop(Entity("TestEntity", Nil, TestEntityQuat), Constant.auto(10))
       }
       "union" in {
         val q = quote {
@@ -333,13 +333,13 @@ class QuotationSpec extends Spec {
           val q = quote {
             qr1.update(t => t.s -> "s")
           }
-          quote(unquote(q)).ast mustEqual Update(Entity("TestEntity", Nil, TestEntityQuat), List(Assignment(Ident("t"), Property(Ident("t"), "s"), Constant("s"))))
+          quote(unquote(q)).ast mustEqual Update(Entity("TestEntity", Nil, TestEntityQuat), List(Assignment(Ident("t"), Property(Ident("t"), "s"), Constant.auto("s"))))
         }
         "set field using another field" in {
           val q = quote {
             qr1.update(t => t.i -> (t.i + 1))
           }
-          quote(unquote(q)).ast mustEqual Update(Entity("TestEntity", Nil, TestEntityQuat), List(Assignment(Ident("t"), Property(Ident("t"), "i"), BinaryOperation(Property(Ident("t"), "i"), NumericOperator.`+`, Constant(1)))))
+          quote(unquote(q)).ast mustEqual Update(Entity("TestEntity", Nil, TestEntityQuat), List(Assignment(Ident("t"), Property(Ident("t"), "i"), BinaryOperation(Property(Ident("t"), "i"), NumericOperator.`+`, Constant.auto(1)))))
         }
         "case class" in {
           val q = quote {
@@ -361,7 +361,7 @@ class QuotationSpec extends Spec {
           val q = quote {
             qr1.update(t => Predef.ArrowAssoc(t.s).->[String]("s"))
           }
-          quote(unquote(q)).ast mustEqual Update(Entity("TestEntity", Nil, TestEntityQuat), List(Assignment(Ident("t"), Property(Ident("t"), "s"), Constant("s"))))
+          quote(unquote(q)).ast mustEqual Update(Entity("TestEntity", Nil, TestEntityQuat), List(Assignment(Ident("t"), Property(Ident("t"), "s"), Constant.auto("s"))))
         }
         "unicode arrow must compile" in {
           """|quote {
@@ -375,7 +375,7 @@ class QuotationSpec extends Spec {
           val q = quote {
             qr1.insert(t => t.s -> "s")
           }
-          quote(unquote(q)).ast mustEqual Insert(Entity("TestEntity", Nil, TestEntityQuat), List(Assignment(Ident("t"), Property(Ident("t"), "s"), Constant("s"))))
+          quote(unquote(q)).ast mustEqual Insert(Entity("TestEntity", Nil, TestEntityQuat), List(Assignment(Ident("t"), Property(Ident("t"), "s"), Constant.auto("s"))))
         }
         "case class" in {
           val q = quote {
@@ -440,25 +440,25 @@ class QuotationSpec extends Spec {
       }
       "constant" in {
         val q = quote(11L)
-        quote(unquote(q)).ast mustEqual Constant(11L)
+        quote(unquote(q)).ast mustEqual Constant.auto(11L)
       }
       "tuple" - {
         "literal" in {
           val q = quote((1, "a"))
-          quote(unquote(q)).ast mustEqual Tuple(List(Constant(1), Constant("a")))
+          quote(unquote(q)).ast mustEqual Tuple(List(Constant.auto(1), Constant.auto("a")))
         }
         "arrow assoc" - {
           "unicode arrow" in {
             val q = quote(1 → "a")
-            quote(unquote(q)).ast mustEqual Tuple(List(Constant(1), Constant("a")))
+            quote(unquote(q)).ast mustEqual Tuple(List(Constant.auto(1), Constant.auto("a")))
           }
           "normal arrow" in {
             val q = quote(1 -> "a" -> "b")
-            quote(unquote(q)).ast mustEqual Tuple(List(Tuple(List(Constant(1), Constant("a"))), Constant("b")))
+            quote(unquote(q)).ast mustEqual Tuple(List(Tuple(List(Constant.auto(1), Constant.auto("a"))), Constant.auto("b")))
           }
           "explicit `Predef.ArrowAssoc`" in {
             val q = quote(Predef.ArrowAssoc("a").->[String]("b"))
-            quote(unquote(q)).ast mustEqual Tuple(List(Constant("a"), Constant("b")))
+            quote(unquote(q)).ast mustEqual Tuple(List(Constant.auto("a"), Constant.auto("b")))
           }
         }
       }
@@ -535,13 +535,13 @@ class QuotationSpec extends Spec {
         val q = quote {
           f("s")
         }
-        quote(unquote(q)).ast mustEqual Constant("s")
+        quote(unquote(q)).ast mustEqual Constant.auto("s")
       }
       "function reference" in {
         val q = quote {
           (f: String => String) => f("a")
         }
-        quote(unquote(q)).ast.body mustEqual FunctionApply(Ident("f"), List(Constant("a")))
+        quote(unquote(q)).ast.body mustEqual FunctionApply(Ident("f"), List(Constant.auto("a")))
       }
     }
     "binary operation" - {
@@ -994,20 +994,20 @@ class QuotationSpec extends Spec {
               val q = quote {
                 (i: Int) => s"v$i"
               }
-              quote(unquote(q)).ast.body mustEqual BinaryOperation(Constant("v"), StringOperator.`+`, Ident("i"))
+              quote(unquote(q)).ast.body mustEqual BinaryOperation(Constant.auto("v"), StringOperator.`+`, Ident("i"))
             }
             "start" in {
               val q = quote {
                 (i: Int) => s"${i}v"
               }
-              normStrConcat(quote(unquote(q)).ast.body) mustEqual BinaryOperation(Ident("i"), StringOperator.`+`, Constant("v"))
+              normStrConcat(quote(unquote(q)).ast.body) mustEqual BinaryOperation(Ident("i"), StringOperator.`+`, Constant.auto("v"))
             }
           }
           "multiple params" in {
             val q = quote {
               (i: Int, j: Int, h: Int) => s"${i}a${j}b${h}"
             }
-            normStrConcat(quote(unquote(q)).ast.body) mustEqual BinaryOperation(BinaryOperation(BinaryOperation(BinaryOperation(Ident("i"), StringOperator.`+`, Constant("a")), StringOperator.`+`, Ident("j")), StringOperator.`+`, Constant("b")), StringOperator.`+`, Ident("h"))
+            normStrConcat(quote(unquote(q)).ast.body) mustEqual BinaryOperation(BinaryOperation(BinaryOperation(BinaryOperation(Ident("i"), StringOperator.`+`, Constant.auto("a")), StringOperator.`+`, Ident("j")), StringOperator.`+`, Constant.auto("b")), StringOperator.`+`, Ident("h"))
           }
         }
       }
@@ -1085,13 +1085,13 @@ class QuotationSpec extends Spec {
           val q = quote {
             (s: String) => s.split(" ")
           }
-          quote(unquote(q)).ast.body mustEqual BinaryOperation(Ident("s"), StringOperator.`split`, Constant(" "))
+          quote(unquote(q)).ast.body mustEqual BinaryOperation(Ident("s"), StringOperator.`split`, Constant.auto(" "))
         }
         "startsWith" in {
           val q = quote {
             (s: String) => s.startsWith(" ")
           }
-          quote(unquote(q)).ast.body mustEqual BinaryOperation(Ident("s"), StringOperator.`startsWith`, Constant(" "))
+          quote(unquote(q)).ast.body mustEqual BinaryOperation(Ident("s"), StringOperator.`startsWith`, Constant.auto(" "))
         }
       }
     }
@@ -1270,7 +1270,7 @@ class QuotationSpec extends Spec {
         val q = quote {
           (o: Option[Int]) => o.getOrElse(11)
         }
-        quote(unquote(q)).ast.body mustEqual OptionGetOrElse(Ident("o"), Constant(11))
+        quote(unquote(q)).ast.body mustEqual OptionGetOrElse(Ident("o"), Constant.auto(11))
       }
       "map + getOrElse" in {
         val q = quote {
@@ -1278,8 +1278,8 @@ class QuotationSpec extends Spec {
         }
         quote(unquote(q)).ast.body mustEqual
           OptionGetOrElse(
-            OptionMap(Ident("o"), Ident("i"), BinaryOperation(Ident("i"), NumericOperator.`<`, Constant(10))),
-            Constant(true)
+            OptionMap(Ident("o"), Ident("i"), BinaryOperation(Ident("i"), NumericOperator.`<`, Constant.auto(10))),
+            Constant.auto(true)
           )
       }
       "flatten" in {
@@ -1340,7 +1340,7 @@ class QuotationSpec extends Spec {
             (o: Option[Row]) => o.exists(v => v.id == 4)
           }
           quote(unquote(q)).ast.body mustEqual OptionTableExists(Ident("o"), Ident("v"),
-            Property(Ident("v"), "id") +==+ Constant(4))
+            Property(Ident("v"), "id") +==+ Constant.auto(4))
         }
         "embedded" in {
           case class EmbeddedEntity(id: Int) extends Embedded
@@ -1348,7 +1348,7 @@ class QuotationSpec extends Spec {
             (o: Option[EmbeddedEntity]) => o.exists(v => v.id == 1)
           }
           quote(unquote(q)).ast.body mustEqual OptionTableExists(Ident("o"), Ident("v"),
-            Property(Ident("v"), "id") +==+ Constant(1))
+            Property(Ident("v"), "id") +==+ Constant.auto(1))
         }
       }
       "contains" in {
@@ -1457,7 +1457,7 @@ class QuotationSpec extends Spec {
       "quoted dynamic" in {
         val i: Quoted[Int] = quote(1)
         val q: Quoted[Int] = quote(i + 1)
-        quote(unquote(q)).ast mustEqual BinaryOperation(Constant(1), NumericOperator.`+`, Constant(1))
+        quote(unquote(q)).ast mustEqual BinaryOperation(Constant.auto(1), NumericOperator.`+`, Constant.auto(1))
       }
       "abritrary tree" in {
         object test {
@@ -1466,7 +1466,7 @@ class QuotationSpec extends Spec {
         val q = quote {
           test.a
         }
-        quote(unquote(q)).ast mustEqual Constant("a")
+        quote(unquote(q)).ast mustEqual Constant.auto("a")
       }
       "nested" in {
         case class Add(i: Quoted[Int]) {
@@ -1475,7 +1475,7 @@ class QuotationSpec extends Spec {
         val q = quote {
           Add(1).apply()
         }
-        quote(unquote(q)).ast mustEqual BinaryOperation(Constant(1), NumericOperator.`+`, Constant(1))
+        quote(unquote(q)).ast mustEqual BinaryOperation(Constant.auto(1), NumericOperator.`+`, Constant.auto(1))
       }
       "type param" - {
         "simple" in {
@@ -1485,7 +1485,7 @@ class QuotationSpec extends Spec {
         }
         "nested" in {
           def test[T: SchemaMeta] = quote(query[T].map(t => 1))
-          test[TestEntity].ast mustEqual Map(Entity("TestEntity", Nil, TestEntityQuat), Ident("t"), Constant(1))
+          test[TestEntity].ast mustEqual Map(Entity("TestEntity", Nil, TestEntityQuat), Ident("t"), Constant.auto(1))
         }
       }
       "forced" in {
@@ -1498,13 +1498,13 @@ class QuotationSpec extends Spec {
         val q = quote {
           (c: Boolean) => if (c) 1 else 2
         }
-        quote(unquote(q)).ast.body mustEqual If(Ident("c"), Constant(1), Constant(2))
+        quote(unquote(q)).ast.body mustEqual If(Ident("c"), Constant.auto(1), Constant.auto(2))
       }
       "nested" in {
         val q = quote {
           (c1: Boolean, c2: Boolean) => if (c1) 1 else if (c2) 2 else 3
         }
-        quote(unquote(q)).ast.body mustEqual If(Ident("c1"), Constant(1), If(Ident("c2"), Constant(2), Constant(3)))
+        quote(unquote(q)).ast.body mustEqual If(Ident("c1"), Constant.auto(1), If(Ident("c2"), Constant.auto(2), Constant.auto(3)))
       }
     }
     "ord" in {
@@ -1759,7 +1759,7 @@ class QuotationSpec extends Spec {
   "unquotes referenced quotations" in {
     val q = quote(1)
     val q2 = quote(q + 1)
-    quote(unquote(q2)).ast mustEqual BinaryOperation(Constant(1), NumericOperator.`+`, Constant(1))
+    quote(unquote(q2)).ast mustEqual BinaryOperation(Constant.auto(1), NumericOperator.`+`, Constant.auto(1))
   }
 
   "ignores the ifrefutable call" in {

--- a/quill-spark/src/main/scala/io/getquill/context/spark/norm/EscapeQuestionMarks.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/norm/EscapeQuestionMarks.scala
@@ -8,7 +8,7 @@ object EscapeQuestionMarks extends StatelessTransformer {
   override def apply(ast: Ast): Ast =
     ast match {
       case Constant(value, _) =>
-        Constant(if (value.isInstanceOf[String]) escape(value.asInstanceOf[String]) else value)
+        Constant.auto(if (value.isInstanceOf[String]) escape(value.asInstanceOf[String]) else value)
       case Infix(parts, params, pure, quat) =>
         Infix(parts.map(escape(_)), params, pure, quat)
       case other =>

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -228,7 +228,7 @@ trait SqlIdiom extends Idiom {
     case BinaryOperation(NullValue, EqualityOperator.`==`, b) => stmt"${scopedTokenizer(b)} IS NULL"
     case BinaryOperation(a, EqualityOperator.`!=`, NullValue) => stmt"${scopedTokenizer(a)} IS NOT NULL"
     case BinaryOperation(NullValue, EqualityOperator.`!=`, b) => stmt"${scopedTokenizer(b)} IS NOT NULL"
-    case BinaryOperation(a, StringOperator.`startsWith`, b)   => stmt"${scopedTokenizer(a)} LIKE (${(BinaryOperation(b, StringOperator.`+`, Constant("%")): Ast).token})"
+    case BinaryOperation(a, StringOperator.`startsWith`, b)   => stmt"${scopedTokenizer(a)} LIKE (${(BinaryOperation(b, StringOperator.`+`, Constant.auto("%")): Ast).token})"
     case BinaryOperation(a, op @ StringOperator.`split`, b)   => stmt"${op.token}(${scopedTokenizer(a)}, ${scopedTokenizer(b)})"
     case BinaryOperation(a, op @ SetOperator.`contains`, b)   => SetContainsToken(scopedTokenizer(b), op.token, a.token)
     case BinaryOperation(a, op @ `&&`, b) => (a, b) match {

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/norm/AddDropToNestedOrderBy.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/norm/AddDropToNestedOrderBy.scala
@@ -14,7 +14,7 @@ object AddDropToNestedOrderBy {
     q match {
       case q: FlattenSqlQuery =>
         q.copy(
-          offset = if (q.orderBy.nonEmpty) q.offset.orElse(Some(Constant(0))) else q.offset,
+          offset = if (q.orderBy.nonEmpty) q.offset.orElse(Some(Constant.auto(0))) else q.offset,
           from = q.from.map(applyInner(_))
         )(q.quat)
 


### PR DESCRIPTION
Fixes #1963

In certain situations, `Constant` typing was confused by the compiler and the `apply` method was confused. This changes the auto-inferred `apply` of `Constant` to have another name.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
