### PR TITLE
Fixes + Enhancements to Boolean Optional APIs

### DIFF
--- a/quill-core-portable/src/main/scala/io/getquill/quat/Quat.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/Quat.scala
@@ -234,8 +234,9 @@ object Quat {
   }
 
   case object Value extends Quat with NoRenames
-  case object BooleanValue extends Quat with NoRenames
-  case object BooleanExpression extends Quat with NoRenames
+  sealed trait Boolean extends Quat
+  case object BooleanValue extends Boolean with NoRenames
+  case object BooleanExpression extends Boolean with NoRenames
 
   protected trait NoRenames {
     this: Quat =>

--- a/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/FlattenOptionOperationSpec.scala
@@ -3,7 +3,6 @@ package io.getquill.norm
 import io.getquill.Spec
 import io.getquill.ast._
 import io.getquill.testContext._
-import io.getquill.ast.NumericOperator
 import io.getquill.ast.Implicits._
 import io.getquill.norm.ConcatBehavior.{ AnsiConcat, NonAnsiConcat }
 import io.getquill.MoreAstOps._
@@ -129,23 +128,13 @@ class FlattenOptionOperationSpec extends Spec {
       val q = quote {
         (o: Option[Int]) => o.map(_ < 1).getOrElse(true)
       }
-      new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-        BinaryOperation(
-          BinaryOperation(Ident("o"), NumericOperator.`<`, Constant.auto(1)),
-          BooleanOperator.`||`,
-          OptionIsEmpty(Ident("o"))
-        )
+      new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast).toString mustEqual "(((o < 1) != null) && (o < 1)) || true"
     }
     "map + getOrElse(false)" in {
       val q = quote {
         (o: Option[Int]) => o.map(_ < 1).getOrElse(false)
       }
-      new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast) mustEqual
-        BinaryOperation(
-          BinaryOperation(Ident("o"), NumericOperator.`<`, Constant.auto(1)),
-          BooleanOperator.`||`,
-          OptionNonEmpty(Ident("o"))
-        )
+      new FlattenOptionOperation(AnsiConcat)(q.ast.body: Ast).toString mustEqual "(((o < 1) != null) && (o < 1)) || false"
     }
     "forall" - {
       "regular operation" in {

--- a/quill-sql/src/test/scala/io/getquill/context/sql/OptionSqlSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/OptionSqlSpec.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.sql
 
-import io.getquill.Spec
+import io.getquill.{ MirrorSqlDialectWithBooleanLiterals, Spec }
 
 class OptionSqlSpec extends Spec {
   import testContext._
@@ -8,25 +8,37 @@ class OptionSqlSpec extends Spec {
 
   "Should correctly express optional rows to SQL" - {
     "forAll" in {
-      testContext.run { query[Someone].filter(s => s.name.forall(n => n == "Joe")) }.string mustEqual
+      testContext.run {
+        query[Someone].filter(s => s.name.forall(n => n == "Joe"))
+      }.string mustEqual
         "SELECT s.name FROM Someone s WHERE s.name IS NULL OR s.name = 'Joe'"
     }
     "exists" in {
-      testContext.run { query[Someone].filter(s => s.name.exists(n => n == "Joe")) }.string mustEqual
+      testContext.run {
+        query[Someone].filter(s => s.name.exists(n => n == "Joe"))
+      }.string mustEqual
         "SELECT s.name FROM Someone s WHERE s.name = 'Joe'"
     }
     "map" in {
-      testContext.run { query[Someone].map(s => s.name.map(n => n + " Bloggs")) }.string mustEqual
+      testContext.run {
+        query[Someone].map(s => s.name.map(n => n + " Bloggs"))
+      }.string mustEqual
         "SELECT s.name || ' Bloggs' FROM Someone s"
     }
     "flatten" in {
-      testContext.run { query[Someone].map(q => Some(q)).map(os => os.map(s => s.name.map(n => n + " Bloggs")).flatten) }.string mustEqual
+      testContext.run {
+        query[Someone].map(q => Some(q)).map(os => os.map(s => s.name.map(n => n + " Bloggs")).flatten)
+      }.string mustEqual
         "SELECT q.name || ' Bloggs' FROM Someone q"
     }
     "flatMap" in {
-      testContext.run { query[Someone].map(q => Some(q)).map(os => os.flatMap(s => s.name.map(n => n + " Bloggs"))) }.string mustEqual
+      testContext.run {
+        query[Someone].map(q => Some(q)).map(os => os.flatMap(s => s.name.map(n => n + " Bloggs")))
+      }.string mustEqual
         "SELECT q.name || ' Bloggs' FROM Someone q"
     }
+  }
+  "Should correctly express optional tables to SQL" - {
     "table flatMap" in {
       testContext.run { query[Someone].map(q => Some(q)).flatMap(os => query[Someone].join(s1 => s1.name == os.flatMap(oss => oss.name))) }.string mustEqual
         "SELECT s1.name FROM Someone q INNER JOIN Someone s1 ON s1.name IS NULL AND q.name IS NULL OR s1.name = q.name"
@@ -44,4 +56,159 @@ class OptionSqlSpec extends Spec {
         "SELECT n.uptime > 123 FROM Node n"
     }
   }
+
+  case class Node(name: String, isUp: Option[Boolean])
+
+  "getOrElse with Booleans" - {
+    "constant" - {
+      "in map clause" - {
+        "normally" in {
+          testContext.run { query[Node].map(s => s.isUp.map(n => n == true).getOrElse(false)) }.string mustEqual
+            "SELECT (s.isUp = true) IS NOT NULL AND s.isUp = true OR false FROM Node s"
+        }
+        "map to self" in {
+          testContext.run { query[Node].map(s => s.isUp.map(n => n).getOrElse(false)) }.string mustEqual
+            "SELECT s.isUp IS NOT NULL AND s.isUp OR false FROM Node s"
+        }
+        "simple" in {
+          testContext.run { query[Node].map(s => s.isUp.getOrElse(false)) }.string mustEqual
+            "SELECT s.isUp IS NOT NULL AND s.isUp OR false FROM Node s"
+        }
+      }
+      "in filter clause" - {
+        "normally" in {
+          testContext.run { query[Node].filter(s => s.isUp.map(n => n == true).getOrElse(false)) }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE (s.isUp = true) IS NOT NULL AND s.isUp = true OR false"
+        }
+        "map to self" in {
+          testContext.run { query[Node].filter(s => s.isUp.map(n => n).getOrElse(false)) }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE s.isUp IS NOT NULL AND s.isUp OR false"
+        }
+        "simple" in {
+          testContext.run { query[Node].filter(s => s.isUp.getOrElse(false)) }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE s.isUp IS NOT NULL AND s.isUp OR false"
+        }
+      }
+    }
+    "liftable" - {
+      "in map clause" - {
+        "normally" in {
+          testContext.run { query[Node].map(s => s.isUp.map(n => n == true).getOrElse(lift(false))) }.string mustEqual //hello
+            "SELECT (s.isUp = true) IS NOT NULL AND s.isUp = true OR ? FROM Node s"
+        }
+        "map to self" in {
+          testContext.run { query[Node].map(s => s.isUp.map(n => n).getOrElse(lift(false))) }.string mustEqual
+            "SELECT s.isUp IS NOT NULL AND s.isUp OR ? FROM Node s"
+        }
+        "simple" in {
+          testContext.run { query[Node].map(s => s.isUp.getOrElse(lift(false))) }.string mustEqual
+            "SELECT s.isUp IS NOT NULL AND s.isUp OR ? FROM Node s"
+        }
+      }
+      "in filter clause" - {
+        "normally" in {
+          testContext.run { query[Node].filter(s => s.isUp.map(n => n == true).getOrElse(lift(false))) }.string mustEqual //hello
+            "SELECT s.name, s.isUp FROM Node s WHERE (s.isUp = true) IS NOT NULL AND s.isUp = true OR ?"
+        }
+        "map to self" in {
+          testContext.run { query[Node].filter(s => s.isUp.map(n => n).getOrElse(lift(false))) }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE s.isUp IS NOT NULL AND s.isUp OR ?"
+        }
+        "simple" in {
+          testContext.run { query[Node].filter(s => s.isUp.getOrElse(lift(false))) }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE s.isUp IS NOT NULL AND s.isUp OR ?"
+        }
+      }
+    }
+  }
+
+  "getOrElse with Booleans Literal Expansion" - testContext.withDialect(MirrorSqlDialectWithBooleanLiterals) { testContext =>
+    import testContext._
+
+    "constant" - {
+      "in map clause" - {
+        "normally" in {
+          testContext.run {
+            query[Node].map(s => s.isUp.map(n => n == true).getOrElse(false))
+          }.string mustEqual
+            "SELECT CASE WHEN CASE WHEN s.isUp = 1 THEN 1 ELSE 0 END IS NOT NULL AND s.isUp = 1 OR 1 = 0 THEN 1 ELSE 0 END FROM Node s"
+        }
+        "map to self" in {
+          testContext.run {
+            query[Node].map(s => s.isUp.map(n => n).getOrElse(false))
+          }.string mustEqual
+            "SELECT CASE WHEN s.isUp IS NOT NULL AND 1 = s.isUp OR 1 = 0 THEN 1 ELSE 0 END FROM Node s"
+        }
+        "simple" in {
+          testContext.run {
+            query[Node].map(s => s.isUp.getOrElse(false))
+          }.string mustEqual
+            "SELECT CASE WHEN s.isUp IS NOT NULL AND 1 = s.isUp OR 1 = 0 THEN 1 ELSE 0 END FROM Node s"
+        }
+      }
+      "in filter clause" - {
+        "normally" in {
+          testContext.run {
+            query[Node].filter(s => s.isUp.map(n => n == true).getOrElse(false))
+          }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE CASE WHEN s.isUp = 1 THEN 1 ELSE 0 END IS NOT NULL AND s.isUp = 1 OR 1 = 0"
+        }
+        "map to self" in {
+          testContext.run {
+            query[Node].filter(s => s.isUp.map(n => n).getOrElse(false))
+          }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE s.isUp IS NOT NULL AND 1 = s.isUp OR 1 = 0"
+        }
+        "simple" in {
+          testContext.run {
+            query[Node].filter(s => s.isUp.getOrElse(false))
+          }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE s.isUp IS NOT NULL AND 1 = s.isUp OR 1 = 0"
+        }
+      }
+    }
+    "liftable" - {
+      "in map clause" - {
+        "normally" in {
+          testContext.run {
+            query[Node].map(s => s.isUp.map(n => n == true).getOrElse(lift(false)))
+          }.string mustEqual
+            "SELECT CASE WHEN CASE WHEN s.isUp = 1 THEN 1 ELSE 0 END IS NOT NULL AND s.isUp = 1 OR 1 = ? THEN 1 ELSE 0 END FROM Node s"
+        }
+        "map to self" in {
+          testContext.run {
+            query[Node].map(s => s.isUp.map(n => n).getOrElse(lift(false)))
+          }.string mustEqual
+            "SELECT CASE WHEN s.isUp IS NOT NULL AND 1 = s.isUp OR 1 = ? THEN 1 ELSE 0 END FROM Node s"
+        }
+        "simple" in {
+          testContext.run {
+            query[Node].map(s => s.isUp.getOrElse(lift(false)))
+          }.string mustEqual
+            "SELECT CASE WHEN s.isUp IS NOT NULL AND 1 = s.isUp OR 1 = ? THEN 1 ELSE 0 END FROM Node s"
+        }
+      }
+      "in filter clause" - {
+        "normally" in {
+          testContext.run {
+            query[Node].filter(s => s.isUp.map(n => n == true).getOrElse(lift(false)))
+          }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE CASE WHEN s.isUp = 1 THEN 1 ELSE 0 END IS NOT NULL AND s.isUp = 1 OR 1 = ?"
+        }
+        "map to self" in {
+          testContext.run {
+            query[Node].filter(s => s.isUp.map(n => n).getOrElse(lift(false)))
+          }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE s.isUp IS NOT NULL AND 1 = s.isUp OR 1 = ?"
+        }
+        "simple" in {
+          testContext.run {
+            query[Node].filter(s => s.isUp.getOrElse(lift(false)))
+          }.string mustEqual
+            "SELECT s.name, s.isUp FROM Node s WHERE s.isUp IS NOT NULL AND 1 = s.isUp OR 1 = ?"
+        }
+      }
+    }
+  }
+
 }

--- a/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -1053,14 +1053,14 @@ class SqlIdiomSpec extends Spec {
             qr1.filter { t => t.o.map(_ < 10).getOrElse(true) }.map(t => t.i)
           }
           testContext.run(q).string mustEqual
-            "SELECT t.i FROM TestEntity t WHERE t.o < 10 OR t.o IS NULL"
+            "SELECT t.i FROM TestEntity t WHERE (t.o < 10) IS NOT NULL AND t.o < 10 OR true"
         }
         "is not null" in {
           val q = quote {
             qr1.filter { t => t.o.map(_ < 10).getOrElse(false) }.map(t => t.i)
           }
           testContext.run(q).string mustEqual
-            "SELECT t.i FROM TestEntity t WHERE t.o < 10 OR t.o IS NOT NULL"
+            "SELECT t.i FROM TestEntity t WHERE (t.o < 10) IS NOT NULL AND t.o < 10 OR false"
         }
       }
     }


### PR DESCRIPTION
Fixes for #1971 and #1972

Changing boolean expression to explicitly check for nulls. Conversions are the following:
```scala
val q = quote {
  (o: Option[Int]) => o.map(_ < 1).getOrElse(true)
}
// Becomes: (((o < 1) != null) && (o < 1)) || true
```
and...
```scala
val q = quote {
  (o: Option[Int]) => o.map(_ < 1).getOrElse(false)
}
// Becomes: (((o < 1) != null) && (o < 1)) || false
```
Now we can also use a similar kind of logic for statements that do not have explicit boolean constants. 
For example:
```scala
val q = quote {
  (o: Option[Int]) => o.map(_ < 1).getOrElse(lift(true)) // Quat of this lift will be Quat.BooleanValue
}
// Therefore we know we can do this: (((o < 1) != null) && (o < 1)) || ?
```

