### PR TITLE
Fix Query in Nested Operation and Infix

### DIFF
--- a/quill-sql-portable/src/main/scala/io/getquill/sql/norm/ExpandNestedQueries.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/norm/ExpandNestedQueries.scala
@@ -72,7 +72,7 @@ object ExpandNestedQueries extends StatelessQueryTransformer {
     def apply(p: Ast): Ast = {
       p match {
         case p @ PropertyMatroshka(inner, path) =>
-          val isSubselect = !inContext.refersToEntity(p)
+          val isSubselect = inContext.isSubselect(p)
           val renameable =
             if (p.prevName.isDefined || isSubselect)
               Renameable.Fixed

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/norm/SelectPropertyProtractor.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/norm/SelectPropertyProtractor.scala
@@ -6,29 +6,71 @@ import io.getquill.context.sql.{ FlatJoinContext, FromContext, InfixContext, Joi
 import io.getquill.norm.PropertyMatroshka
 import io.getquill.quat.Quat
 import io.getquill.ast.Core
+import io.getquill.sql.norm.InContext.{ InContextType, InInfixContext, InQueryContext, InTableContext }
 
 /**
- * Simple utility that checks if if an AST entity refers to a entity
+ * Simple utility that checks if if an AST entity refers to a entity. It traverses
+ * through the context types to find out what kind of context a variable refers to.
+ * For example, in a query like:
+ * {{{ query[Pair].map(p => Pair(p.a, p.b)).distinct.map(p => (p.b, p.a)) }}}
+ *
+ * Yielding SQL like this:
+ * {{{ SELECT p.b, p.a FROM (SELECT DISTINCT p.a, p.b FROM pair p) AS p }}}
+ *
+ * the inner p.a and p.b will have a TableContext while the outer p.b and p.a will have a QueryContext.
+ *
+ * Note that there are some cases where the id of a field is not in a FromContext at all. For example,
+ * in a query like this:
+ * {{{ query[Human].filter(h => query[Robot].filter(r => r.friend == h.id).nonEmpty) }}}
+ *
+ * Where the sql produced is something like this:
+ * {{{ SELECT h.id FROM human h WHERE EXISTS (SELECT r.* FROM robot r WHERE r.friend = h.id) }}}
+ *
+ * the field `r.friend`` is selected from a sub-query of an SQL operation (i.e. `EXISTS (...)`)
+ * so a from-context of it will not exist at all.
+ * When deciding which properties to treat as sub-select properties (e.g. if we want to make sure NOT
+ * to apply a naming-schema on them) we need to take care to understand that we may not know the
+ * FromContext that a property comes from since it may not exist.
  */
 case class InContext(from: List[FromContext]) {
-  def refersToEntity(ast: Ast) = {
-    val tables = collectTableAliases(from)
+  // Are we sure it is a subselect
+  def isSubselect(ast: Ast) =
+    contextReferenceType(ast) match {
+      case Some(InQueryContext) => true
+      case _                    => false
+    }
+
+  // Are we sure it is a table reference
+  def isEntityReference(ast: Ast) =
+    contextReferenceType(ast) match {
+      case Some(InTableContext) => true
+      case _                    => false
+    }
+
+  def contextReferenceType(ast: Ast) = {
+    val references = collectTableAliases(from)
     ast match {
-      case Ident(v, _)                       => tables.contains(v)
-      case PropertyMatroshka(Ident(v, _), _) => tables.contains(v)
-      case _                                 => false
+      case Ident(v, _)                       => references.get(v)
+      case PropertyMatroshka(Ident(v, _), _) => references.get(v)
+      case _                                 => None
     }
   }
 
-  private def collectTableAliases(contexts: List[FromContext]): List[String] = {
-    contexts.flatMap {
-      case c: TableContext             => List(c.alias)
-      case c: QueryContext             => List()
-      case c: InfixContext             => List()
+  private def collectTableAliases(contexts: List[FromContext]): Map[String, InContextType] = {
+    contexts.map {
+      case c: TableContext             => Map(c.alias -> InTableContext)
+      case c: QueryContext             => Map(c.alias -> InQueryContext)
+      case c: InfixContext             => Map(c.alias -> InInfixContext)
       case JoinContext(_, a, b, _)     => collectTableAliases(List(a)) ++ collectTableAliases(List(b))
       case FlatJoinContext(_, from, _) => collectTableAliases(List(from))
-    }
+    }.foldLeft(Map[String, InContextType]())(_ ++ _)
   }
+}
+object InContext {
+  sealed trait InContextType
+  case object InTableContext extends InContextType
+  case object InQueryContext extends InContextType
+  case object InInfixContext extends InContextType
 }
 
 case class SelectPropertyProtractor(from: List[FromContext]) {
@@ -53,7 +95,7 @@ case class SelectPropertyProtractor(from: List[FromContext]) {
   def apply(ast: Ast): List[(Ast, List[String])] = {
     ast match {
       case id @ Core() =>
-        val isEntity = inContext.refersToEntity(id)
+        val isEntity = inContext.isEntityReference(id)
         id.quat match {
           case p: Quat.Product =>
             ProtractQuat(isEntity)(p, id).map { case (prop, path) => (freezeNonEntityProps(prop, isEntity), path) }
@@ -63,7 +105,7 @@ case class SelectPropertyProtractor(from: List[FromContext]) {
       // Assuming a property contains only an Ident, Infix or Constant at this point
       // and all situations where there is a case-class, tuple, etc... inside have already been beta-reduced
       case prop @ PropertyMatroshka(id @ Core(), _) =>
-        val isEntity = inContext.refersToEntity(id)
+        val isEntity = inContext.isEntityReference(id)
         prop.quat match {
           case p: Quat.Product =>
             ProtractQuat(isEntity)(p, prop).map { case (prop, path) => (freezeNonEntityProps(prop, isEntity), path) }


### PR DESCRIPTION
Fixes #1976, #1978

### Problem

In ExpandNestedQueries, an assumption was made when using the InContext (currently in SelectPropertyProtractor.scala) that any `FromContext` reference that is not a TableReference, must be a sub-select context hence require 'freezing' properties to not apply naming schemas the way normal nested queries do not *.
The solution to this is to keep track of which references are actual found in TableContext and which are found in QueryContext in the `collectTableAliases` method.

* For example:
```scala
val ctx = new SqlMirrorContext(PostgresContext, SnakeCase)
import ctx._
case class Person(firstName:String, lastName:String)
run( query[Person].nested.map(p => p.firstName)
```
This will be:
```
SELECT p.firstName FROM (SELECT p.first_name AS firstName from Person)
```
Note how the outer property is `firstName` instead of `first_name` i.e. it's name is "frozen" and will not be renamed as per the query schema. That is because the `FlattenNestedProperty.apply` method in `ExpandNestedQueries.scala` changes the 'opinion' to Renameable.Fixed.

### Solution

Only "freeze" properties whose FromContext is a QueryContext as opposed to everywhere where they are not a TableContext.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
