### PR TITLE
Trigger Release 3.6-RC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.6-RC2
+
+- [Fix incorrect Quat.Value parsing issues](https://github.com/getquill/quill/pull/1987)
+
 # 3.6.0-RC1
 
 - [Fix Query in Nested Operation and Infix](https://github.com/getquill/quill/pull/1980)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.6.0-SNAPSHOT"
+version in ThisBuild := "3.6-RC2"


### PR DESCRIPTION
Trigger Release 3.6-RC2 to fix first batch of Quats issues: #1986, #1984.