### PR TITLE
Do not aggregate on root project when debugMacro enabled

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,12 +109,25 @@ val filteredModules = {
   } else modules
 }
 
-lazy val `quill` =
-  (project in file("."))
-    .settings(commonSettings: _*)
-    .settings(`tut-settings`:_*)
-    .aggregate(filteredModules.map(_.project): _*)
-    .dependsOn(filteredModules: _*)
+lazy val `quill` = {
+  val quill =
+    (project in file("."))
+      .settings(commonSettings: _*)
+      .settings(`tut-settings`:_*)
+
+  // Do not do aggregate project builds when debugging since during that time
+  // typically only individual modules are being build/compiled. This is mostly for convenience with IntelliJ.
+  // Normally it to just exclude `quill` from the build in Intellij instead but then local file change tracking
+  // and search of files from the root level (e.g. in the 'build' directory) is lost.
+  debugMacro match {
+    case true =>
+      quill
+    case false =>
+      quill
+        .aggregate(filteredModules.map(_.project): _*)
+        .dependsOn(filteredModules: _*)
+  }
+}
 
 publishArtifact in `quill` := false
 


### PR DESCRIPTION
When using IntelliJ, it is frequently useful to unload modules that do not need to be re-compiled while you are developing a different part of the system. For example, when changing quill-monix-jdbc, the modules quill-core, quill-sql and most others can all be disabled. For another example, when changing quill-sql, most of the upstream jdbc modules can be disabled (they will eventually need to be recompiled and tested but that is only once your work on quill-sql is complete).
Now in because the quill root-project (i.e. `quill`) relies on all the sub-projects, you need to unload the quill root project to avoid potential compilation errors. This is due to the 'aggregate' setting on the root project.
![image](https://user-images.githubusercontent.com/1369480/94770078-b3f87080-0381-11eb-8a77-f7448d397138.png)

Now the quill root project can quite easily be unloaded and ignored, the problem is that if it is, IntelliJ will stop tracking local file changes of everything under the root directory path and searching for files under the root directory path will also not work.
![image](https://user-images.githubusercontent.com/1369480/94770498-bdcea380-0382-11eb-8e75-db78d32aec95.png)

For this reason, we would like to be able to have a "developement" build setting that disables aggregation on the quill root project so that it can be safely loaded without requiring loading of sub-projects.

The debugMacro setting seems reasonable to use for this feature.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
