### PR TITLE
Smart serialization based on number of Quat fields

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -798,14 +798,13 @@ lazy val basicSettings = Seq(
   EclipseKeys.eclipseOutput := Some("bin"),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
-    "-Xfatal-warnings",
     "-encoding", "UTF-8",
     "-feature",
     "-deprecation",
     "-unchecked",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard",
+    "-Ywarn-value-discard"
 
   ),
   scalacOptions ++= {
@@ -822,7 +821,9 @@ lazy val basicSettings = Seq(
           "-Xsource:2.12" // needed so existential types work correctly
         )
       case Some((2, 12)) =>
-        Seq("-Xlint:-unused,_",
+        Seq(
+          "-Xfatal-warnings",
+          "-Xlint:-unused,_",
           "-Xfuture",
           "-deprecation",
           "-Yno-adapted-args",

--- a/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
@@ -9,6 +9,17 @@ sealed trait Ast {
 
   def quat: Quat
 
+  def countQuatFields: Int =
+    CollectAst(this) {
+      case c: Constant           => c.quat.countFields
+      case a: Ident              => a.quat.countFields
+      case o: OptionNone         => o.quat.countFields
+      case l: ScalarValueLift    => l.quat.countFields
+      case l: ScalarQueryLift    => l.quat.countFields
+      case l: CaseClassValueLift => l.quat.countFields
+      case l: CaseClassQueryLift => l.quat.countFields
+    }.sum
+
   override def toString = {
     import io.getquill.MirrorIdiom._
     import io.getquill.idiom.StatementInterpolator._

--- a/quill-core-portable/src/main/scala/io/getquill/quat/Quat.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/Quat.scala
@@ -46,6 +46,13 @@ sealed trait Quat {
   def serializeJVM = KryoQuatSerializer.serialize(this)
   def serializeJS = BooQuatSerializer.serialize(this)
 
+  /** Recursively count the fields of the Quat */
+  def countFields: Int =
+    this match {
+      case p: Quat.Product => p.fields.map(kv => kv._2.countFields).sum + 1
+      case _               => 1
+    }
+
   def renames: List[(String, String)] = List()
 
   /** Either convert to a Product or make the Quat into an error if it is anything else. */

--- a/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
@@ -8,6 +8,7 @@ object Messages {
     Option(System.getProperty(propName)).orElse(sys.env.get(envName)).getOrElse(default)
 
   private[getquill] def quatKryoPoolSize = variable("quill.quat.kryoPool", "quill_quat_kryoPool", "10").toInt
+  private[getquill] def maxQuatFields = variable("quill.quat.tooManyFields", "quill_quat_tooManyFields", "100").toInt
   private[util] def prettyPrint = variable("quill.macro.log.pretty", "quill_macro_log", "false").toBoolean
   private[getquill] def alwaysAlias = variable("quill.query.alwaysAlias", "quill_query_alwaysAlias", "false").toBoolean
   private[getquill] def pruneColumns = variable("quill.query.pruneColumns", "quill_query_pruneColumns", "true").toBoolean

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -6,19 +6,28 @@ import io.getquill.quat.Quat
 import scala.collection.mutable
 
 trait QuatLiftable {
-  val c: Context
+  val mctx: Context
+  def serializeQuats: Boolean
 
-  import c.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
+  import mctx.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
 
   // Liftables are invariant so want to have a separate liftable for Quat.Product since it is used directly inside Entity
   // which should be lifted/unlifted without the need for casting.
   implicit val quatProductLiftable: Liftable[Quat.Product] = Liftable[Quat.Product] {
-    // If we are in Java Script, use the JS configured Picker to get around the "Method Too Large" error
-    case quat: Quat => q"io.getquill.quat.Quat.Product.fromSerializedJS(${quat.serializeJS})"
+    // If we are in the JS, use Kryo to serialize our Quat due to JS 64KB method limit that we will run into of the Quat Constructor
+    // if plainly lifted into the method created by our macro (i.e. the 'ast' method).
+    case quat: Quat.Product if (serializeQuats)    => q"io.getquill.quat.Quat.Product.fromSerializedJS(${quat.serializeJS})"
+    case Quat.Product.WithRenames(fields, renames) => q"io.getquill.quat.Quat.Product.WithRenames($fields, $renames)"
   }
 
   implicit val quatLiftable: Liftable[Quat] = Liftable[Quat] {
-    case quat: Quat => q"io.getquill.quat.Quat.fromSerializedJS(${quat.serializeJS})"
+    case quat: Quat.Product if (serializeQuats)    => q"io.getquill.quat.Quat.fromSerializedJS(${quat.serializeJS})"
+    case Quat.Product.WithRenames(fields, renames) => q"io.getquill.quat.Quat.Product.WithRenames($fields, $renames)"
+    case Quat.Value                                => q"io.getquill.quat.Quat.Value"
+    case Quat.Null                                 => q"io.getquill.quat.Quat.Null"
+    case Quat.Generic                              => q"io.getquill.quat.Quat.Generic"
+    case Quat.BooleanValue                         => q"io.getquill.quat.Quat.BooleanValue"
+    case Quat.BooleanExpression                    => q"io.getquill.quat.Quat.BooleanExpression"
   }
 
   implicit def linkedHashMapLiftable[K, V](implicit lk: Liftable[K], lv: Liftable[V]): Liftable[mutable.LinkedHashMap[K, V]] = Liftable[mutable.LinkedHashMap[K, V]] {

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -7,17 +7,25 @@ import scala.reflect.macros.whitebox.Context
 import io.getquill.quat.Quat
 
 trait QuatUnliftable {
-  val c: Context
-  import c.universe.{ Constant => _, Function => _, Ident => _, If => _, _ }
+  val mctx: Context
+  import mctx.universe.{ Constant => _, Function => _, Ident => _, If => _, _ }
 
   implicit val quatProductUnliftable: Unliftable[Quat.Product] = Unliftable[Quat.Product] {
-    // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
+    // On JS, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JS (due to 64KB method limit)
     case q"$pack.Quat.Product.fromSerializedJS(${ str: String })" => Quat.Product.fromSerializedJS(str)
+    case q"$pack.Quat.Product.WithRenames.apply(${ fields: LinkedHashMap[String, Quat] }, ${ renames: List[(String, String)] })" => Quat.Product.WithRenames(fields, renames)
   }
 
   implicit val quatUnliftable: Unliftable[Quat] = Unliftable[Quat] {
-    // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
+    // On JS, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JS (due to 64KB method limit)
     case q"$pack.Quat.fromSerializedJS(${ str: String })" => Quat.fromSerializedJS(str)
+    case q"$pack.Quat.Product.WithRenames.apply(${ fields: LinkedHashMap[String, Quat] }, ${ renames: List[(String, String)] })" => Quat.Product.WithRenames(fields, renames)
+    case q"$pack.Quat.Product.apply(${ fields: List[(String, Quat)] })" => Quat.Product(fields)
+    case q"$pack.Quat.Value" => Quat.Value
+    case q"$pack.Quat.Null" => Quat.Null
+    case q"$pack.Quat.Generic" => Quat.Generic
+    case q"$pack.Quat.BooleanValue" => Quat.BooleanValue
+    case q"$pack.Quat.BooleanExpression" => Quat.BooleanExpression
   }
 
   implicit def linkedHashMapUnliftable[K, V](implicit uk: Unliftable[K], uv: Unliftable[V]): Unliftable[LinkedHashMap[K, V]] = Unliftable[LinkedHashMap[K, V]] {
@@ -26,8 +34,8 @@ trait QuatUnliftable {
         values.map {
           case q"($k, $v)" =>
             (
-              uk.unapply(k).getOrElse(c.fail(s"Can't unlift $k")),
-              uv.unapply(v).getOrElse(c.fail(s"Can't unlift $v"))
+              uk.unapply(k).getOrElse(mctx.fail(s"Can't unlift $k")),
+              uv.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v"))
             )
         }: _*
       )
@@ -35,6 +43,6 @@ trait QuatUnliftable {
 
   implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {
     case q"$pack.Nil"                         => Nil
-    case q"$pack.List.apply[..$t](..$values)" => values.map(v => u.unapply(v).getOrElse(c.fail(s"Can't unlift $v")))
+    case q"$pack.List.apply[..$t](..$values)" => values.map(v => u.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v")))
   }
 }

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -6,20 +6,28 @@ import io.getquill.quat.Quat
 import scala.collection.mutable
 
 trait QuatLiftable {
-  val c: Context
+  val mctx: Context
+  val serializeQuats: Boolean
 
-  import c.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
+  import mctx.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
 
   // Liftables are invariant so want to have a separate liftable for Quat.Product since it is used directly inside Entity
   // which should be lifted/unlifted without the need for casting.
   implicit val quatProductLiftable: Liftable[Quat.Product] = Liftable[Quat.Product] {
     // If we are in the JVM, use Kryo to serialize our Quat due to JVM 64KB method limit that we will run into of the Quat Constructor
     // if plainly lifted into the method created by our macro (i.e. the 'ast' method).
-    case quat: Quat => q"io.getquill.quat.Quat.Product.fromSerializedJVM(${quat.serializeJVM})"
+    case quat: Quat.Product if (serializeQuats)    => q"io.getquill.quat.Quat.Product.fromSerializedJVM(${quat.serializeJVM})"
+    case Quat.Product.WithRenames(fields, renames) => q"io.getquill.quat.Quat.Product.WithRenames($fields, $renames)"
   }
 
   implicit val quatLiftable: Liftable[Quat] = Liftable[Quat] {
-    case quat: Quat => q"io.getquill.quat.Quat.fromSerializedJVM(${quat.serializeJVM})"
+    case quat: Quat.Product if (serializeQuats)    => q"io.getquill.quat.Quat.fromSerializedJVM(${quat.serializeJVM})"
+    case Quat.Product.WithRenames(fields, renames) => q"io.getquill.quat.Quat.Product.WithRenames($fields, $renames)"
+    case Quat.Value                                => q"io.getquill.quat.Quat.Value"
+    case Quat.Null                                 => q"io.getquill.quat.Quat.Null"
+    case Quat.Generic                              => q"io.getquill.quat.Quat.Generic"
+    case Quat.BooleanValue                         => q"io.getquill.quat.Quat.BooleanValue"
+    case Quat.BooleanExpression                    => q"io.getquill.quat.Quat.BooleanExpression"
   }
 
   implicit def linkedHashMapLiftable[K, V](implicit lk: Liftable[K], lv: Liftable[V]): Liftable[mutable.LinkedHashMap[K, V]] = Liftable[mutable.LinkedHashMap[K, V]] {

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -7,17 +7,25 @@ import scala.reflect.macros.whitebox.Context
 import io.getquill.quat.Quat
 
 trait QuatUnliftable {
-  val c: Context
-  import c.universe.{ Constant => _, Function => _, Ident => _, If => _, _ }
+  val mctx: Context
+  import mctx.universe.{ Constant => _, Function => _, Ident => _, If => _, _ }
 
   implicit val quatProductUnliftable: Unliftable[Quat.Product] = Unliftable[Quat.Product] {
     // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
     case q"$pack.Quat.Product.fromSerializedJVM(${ str: String })" => Quat.Product.fromSerializedJVM(str)
+    case q"$pack.Quat.Product.WithRenames.apply(${ fields: LinkedHashMap[String, Quat] }, ${ renames: List[(String, String)] })" => Quat.Product.WithRenames(fields, renames)
   }
 
   implicit val quatUnliftable: Unliftable[Quat] = Unliftable[Quat] {
     // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
     case q"$pack.Quat.fromSerializedJVM(${ str: String })" => Quat.fromSerializedJVM(str)
+    case q"$pack.Quat.Product.WithRenames.apply(${ fields: LinkedHashMap[String, Quat] }, ${ renames: List[(String, String)] })" => Quat.Product.WithRenames(fields, renames)
+    case q"$pack.Quat.Product.apply(${ fields: List[(String, Quat)] })" => Quat.Product(fields)
+    case q"$pack.Quat.Value" => Quat.Value
+    case q"$pack.Quat.Null" => Quat.Null
+    case q"$pack.Quat.Generic" => Quat.Generic
+    case q"$pack.Quat.BooleanValue" => Quat.BooleanValue
+    case q"$pack.Quat.BooleanExpression" => Quat.BooleanExpression
   }
 
   implicit def linkedHashMapUnliftable[K, V](implicit uk: Unliftable[K], uv: Unliftable[V]): Unliftable[LinkedHashMap[K, V]] = Unliftable[LinkedHashMap[K, V]] {
@@ -26,8 +34,8 @@ trait QuatUnliftable {
         values.map {
           case q"($k, $v)" =>
             (
-              uk.unapply(k).getOrElse(c.fail(s"Can't unlift $k")),
-              uv.unapply(v).getOrElse(c.fail(s"Can't unlift $v"))
+              uk.unapply(k).getOrElse(mctx.fail(s"Can't unlift $k")),
+              uv.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v"))
             )
         }: _*
       )
@@ -35,6 +43,6 @@ trait QuatUnliftable {
 
   implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {
     case q"$pack.Nil"                         => Nil
-    case q"$pack.List.apply[..$t](..$values)" => values.map(v => u.unapply(v).getOrElse(c.fail(s"Can't unlift $v")))
+    case q"$pack.List.apply[..$t](..$values)" => values.map(v => u.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v")))
   }
 }

--- a/quill-core/src/main/scala/io/getquill/context/ContextMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ContextMacro.scala
@@ -2,10 +2,9 @@ package io.getquill.context
 
 import scala.reflect.macros.whitebox.{ Context => MacroContext }
 import io.getquill.ast.{ Ast, Dynamic, Lift, Tag }
-import io.getquill.quotation.Quotation
+import io.getquill.quotation.{ IsDynamic, LiftUnlift, Quotation }
 import io.getquill.util.LoadObject
 import io.getquill.util.MacroContextExt._
-import io.getquill.quotation.IsDynamic
 import io.getquill.NamingStrategy
 import io.getquill.idiom._
 
@@ -36,16 +35,23 @@ trait ContextMacro extends Quotation {
       case true  => translateDynamic(ast)
     }
 
-  private implicit val tokenLiftable: Liftable[Token] = Liftable[Token] {
-    case ScalarTagToken(lift)       => q"io.getquill.idiom.ScalarTagToken(${lift: Tag})"
-    case QuotationTagToken(lift)    => q"io.getquill.idiom.QuotationTagToken(${lift: Tag})"
-    case StringToken(string)        => q"io.getquill.idiom.StringToken($string)"
-    case ScalarLiftToken(lift)      => q"io.getquill.idiom.ScalarLiftToken(${lift: Lift})"
-    case Statement(tokens)          => q"io.getquill.idiom.Statement(scala.List(..$tokens))"
-    case SetContainsToken(a, op, b) => q"io.getquill.idiom.SetContainsToken($a, $op, $b)"
+  abstract class TokenLift(numQuatFields: Int) extends LiftUnlift(numQuatFields) {
+    import mctx.universe.{ Ident => _, Constant => _, Function => _, If => _, _ }
+
+    implicit val tokenLiftable: Liftable[Token] = Liftable[Token] {
+      case ScalarTagToken(lift)       => q"io.getquill.idiom.ScalarTagToken(${lift: Tag})"
+      case QuotationTagToken(lift)    => q"io.getquill.idiom.QuotationTagToken(${lift: Tag})"
+      case StringToken(string)        => q"io.getquill.idiom.StringToken($string)"
+      case ScalarLiftToken(lift)      => q"io.getquill.idiom.ScalarLiftToken(${lift: Lift})"
+      case Statement(tokens)          => q"io.getquill.idiom.Statement(scala.List(..$tokens))"
+      case SetContainsToken(a, op, b) => q"io.getquill.idiom.SetContainsToken($a, $op, $b)"
+    }
   }
 
   private def translateStatic(ast: Ast): Tree = {
+    val liftUnlift = new { override val mctx: c.type = c } with TokenLift(ast.countQuatFields)
+    import liftUnlift._
+
     idiomAndNamingStatic match {
       case Success((idiom, naming)) =>
         val (normalizedAst, statement) = idiom.translate(ast)(naming)
@@ -70,6 +76,8 @@ trait ContextMacro extends Quotation {
   }
 
   private def translateDynamic(ast: Ast): Tree = {
+    val liftUnlift = new { override val mctx: c.type = c } with TokenLift(ast.countQuatFields)
+    import liftUnlift._
     c.info("Dynamic query")
     q"""
       val (idiom, naming) = ${idiomAndNamingDynamic}

--- a/quill-core/src/main/scala/io/getquill/quat/QuatMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/quat/QuatMacro.scala
@@ -1,11 +1,16 @@
 package io.getquill.quat
 
-import io.getquill.quotation.Liftables
+import io.getquill.quotation.LiftUnlift
 
 import scala.reflect.macros.whitebox.{ Context => MacroContext }
 
-class QuatMacro(val c: MacroContext) extends QuatMaking with Liftables {
+class QuatMacro(val c: MacroContext) extends QuatMaking {
   import c.universe._
 
-  def makeQuat[T: c.WeakTypeTag]: c.Tree = q"${inferQuat(implicitly[c.WeakTypeTag[T]].tpe)}"
+  def makeQuat[T: c.WeakTypeTag]: c.Tree = {
+    val quat = inferQuat(implicitly[c.WeakTypeTag[T]].tpe)
+    val liftUnlift = new { override val mctx: c.type = c } with LiftUnlift(quat.countFields)
+    val quatExpr: c.Tree = liftUnlift.quatLiftable(quat)
+    q"${quatExpr}"
+  }
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -6,8 +6,8 @@ import io.getquill.dsl.CoreDsl
 import io.getquill.quat.Quat
 
 trait Liftables extends QuatLiftable {
-  val c: Context
-  import c.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
+  val mctx: Context
+  import mctx.universe.{ Ident => _, Constant => _, Function => _, If => _, Block => _, _ }
 
   private val pack = q"io.getquill.ast"
 
@@ -31,7 +31,7 @@ trait Liftables extends QuatLiftable {
     case UnaryOperation(a, b) => q"$pack.UnaryOperation($a, $b)"
     case Infix(a, b, pure, quat) => q"$pack.Infix($a, $b, $pure, $quat)"
     case If(a, b, c) => q"$pack.If($a, $b, $c)"
-    case Dynamic(tree: Tree, _) if (tree.tpe <:< c.weakTypeOf[CoreDsl#Quoted[Any]]) => q"$tree.ast"
+    case Dynamic(tree: Tree, _) if (tree.tpe <:< mctx.weakTypeOf[CoreDsl#Quoted[Any]]) => q"$tree.ast"
     case Dynamic(tree: Tree, quat) => q"$pack.Constant($tree, $quat)"
     case QuotedReference(tree: Tree, ast) => q"$ast"
     case OnConflict.Excluded(a) => q"$pack.OnConflict.Excluded($a)"
@@ -185,7 +185,7 @@ trait Liftables extends QuatLiftable {
 
   implicit val valueLiftable: Liftable[Value] = Liftable[Value] {
     case NullValue         => q"$pack.NullValue"
-    case Constant(a, quat) => q"$pack.Constant(${Literal(c.universe.Constant(a))}, $quat)"
+    case Constant(a, quat) => q"$pack.Constant(${Literal(mctx.universe.Constant(a))}, $quat)"
     case Tuple(a)          => q"$pack.Tuple($a)"
     case CaseClass(a)      => q"$pack.CaseClass($a)"
   }

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -367,6 +367,10 @@ trait Parsing extends ValueComputation with QuatMaking {
           fused.collect {
             case Right(a) => astParser(a)
           }
+
+        val liftUnlift = new { override val mctx: c.type = c } with LiftUnlift(newParams.foldLeft(0)((num, ast) => num + ast.countQuatFields))
+        import liftUnlift._
+
         Dynamic {
           c.typecheck(q"""
             new ${c.prefix}.Quoted[Any] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Quotation.scala
@@ -7,26 +7,33 @@ import io.getquill.ast._
 import io.getquill.util.MacroContextExt._
 import io.getquill.norm.BetaReduction
 import io.getquill.util.Messages.TraceType
-import io.getquill.util.{ EnableReflectiveCalls, Interpolator }
+import io.getquill.util.{ EnableReflectiveCalls, Interpolator, Messages }
 
 case class QuotedAst(ast: Ast) extends StaticAnnotation
 
-trait Quotation extends Liftables with Unliftables with Parsing with ReifyLiftings {
+abstract class LiftUnlift(numQuatFields: Int) extends Liftables with Unliftables {
+  lazy val serializeQuats: Boolean = numQuatFields > Messages.maxQuatFields
+}
+
+trait Quotation extends Parsing with ReifyLiftings {
   val c: Context
   import c.universe._
 
   private val quoted = TermName("quoted")
 
   def quote[T](body: Tree)(implicit t: WeakTypeTag[T]) = {
-
     val interp = new Interpolator(TraceType.Quotation, 1)
     import interp._
 
     val ast = BetaReduction(trace"Parsing Quotation Body" andReturn (astParser(body)))
 
     val id = TermName(s"id${ast.hashCode.abs}")
-
     val (reifiedAst, liftings) = reifyLiftings(ast)
+
+    val liftUnlift = new { override val mctx: c.type = c } with LiftUnlift(reifiedAst.countQuatFields)
+
+    // Technically can just put reifiedAst into the quasi-quote directly but this is more comprehensible
+    val liftedAst: c.Tree = liftUnlift.astLiftable(reifiedAst)
 
     val quotation =
       c.untypecheck {
@@ -35,10 +42,10 @@ trait Quotation extends Liftables with Unliftables with Parsing with ReifyLiftin
 
             ..${EnableReflectiveCalls(c)}
 
-            @${c.weakTypeOf[QuotedAst]}($reifiedAst)
+            @${c.weakTypeOf[QuotedAst]}($liftedAst)
             def $quoted = ast
 
-            override def ast = $reifiedAst
+            override def ast = $liftedAst
 
             def $id() = ()
 
@@ -65,10 +72,13 @@ trait Quotation extends Liftables with Unliftables with Parsing with ReifyLiftin
       case q"(..$p) => $b" => q"${c.prefix}.quote((..$p) => ${c.prefix}.unquote($b))"
     }
 
-  protected def unquote[T](tree: Tree)(implicit ct: ClassTag[T]) =
+  protected def unquote[T](tree: Tree)(implicit ct: ClassTag[T]) = {
+    val unlift = new { override val mctx: c.type = c } with Unliftables
+    import unlift._
     astTree(tree).flatMap(astUnliftable.unapply).map {
       case ast: T => ast
     }
+  }
 
   private def astTree(tree: Tree) =
     for {

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -5,8 +5,8 @@ import io.getquill.ast._
 import io.getquill.quat.Quat
 
 trait Unliftables extends QuatUnliftable {
-  val c: Context
-  import c.universe.{ Ident => _, Constant => _, Function => _, If => _, _ }
+  val mctx: Context
+  import mctx.universe.{ Ident => _, Constant => _, Function => _, If => _, _ }
 
   implicit val astUnliftable: Unliftable[Ast] = Unliftable[Ast] {
     case liftUnliftable(ast) => ast
@@ -185,7 +185,7 @@ trait Unliftables extends QuatUnliftable {
 
   implicit val valueUnliftable: Unliftable[Value] = Unliftable[Value] {
     case q"$pack.NullValue" => NullValue
-    case q"$pack.Constant.apply(${ Literal(c.universe.Constant(a)) }, ${ quat: Quat })" => Constant(a, quat)
+    case q"$pack.Constant.apply(${ Literal(mctx.universe.Constant(a)) }, ${ quat: Quat })" => Constant(a, quat)
     case q"$pack.Tuple.apply(${ a: List[Ast] })" => Tuple(a)
     case q"$pack.CaseClass.apply(${ values: List[(String, Ast)] })" => CaseClass(values)
   }


### PR DESCRIPTION
Fixes #1996

In order to fix issues that Quats had with JVM 64kb limits, we introduced Quat serialization in #1928. However as #1996 demonstrates, serialization with even something as fast as Kryo can incur significant performance penalties (why this is actually the case should also be investigated in TBD). We can do the following things to mitigate the problem:
1) Do not serialize leaf level entities (e.g. Quat.Value, Quat.BooleanValue, etc...)
2) Only serialize trees where the number of lifted Quat fields (i.e. how many times we're declaring a Quat product and how many things and sub-things, and sub-sub-things we are passing into it) of the Ast that we are lifting is larger then some number (determined by `-Dquill.quats.tooManyFields`). This generally means that smaller queries should not be serialized at all. This should be a reasonble fix since small queries are usually the ones that need to be the speediest in terms of delivery.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
