### PR TITLE
Investigate: Why is Quat Serialization Slowing Down Static Queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,6 @@ env:
 jobs:
   include:
     - stage: build
-      if: type != pull_request
-      script: ./build/build.sh db
-      scala: 2.11.12
-      name: "Databases 2.11 - MySQL, Postgres, Sqlite, H2, SQL Server, Oracle"
-    - stage: build
       script: ./build/build.sh db
       scala: 2.12.10
       name: "Databases 2.12 - MySQL, Postgres, Sqlite, H2, SQL Server, Oracle"
@@ -41,11 +36,6 @@ jobs:
       name: "Databases 2.13 - MySQL, Postgres, Sqlite, H2, SQL Server, Oracle"
 
     - stage: build
-      if: type != pull_request
-      script: ./build/build.sh js
-      scala: 2.11.12
-      name: "Databases 2.11 - JavaScript"
-    - stage: build
       script: ./build/build.sh js
       scala: 2.12.10
       name: "Databases 2.12 - JavaScript"
@@ -54,11 +44,6 @@ jobs:
       scala: 2.13.1
       name: "Databases 2.13 - JavaScript"
 
-    - stage: build
-      if: type != pull_request
-      script: ./build/build.sh async
-      scala: 2.11.12
-      name: "Async, Finagle, NDBC 2.11 - MySQL, Postgres, Sqlite, H2, SQL Server, Oracle"
     - stage: build
       script: ./build/build.sh async
       scala: 2.12.10
@@ -71,11 +56,6 @@ jobs:
     - stage: build
       if: type != pull_request
       script: ./build/build.sh codegen
-      scala: 2.11.12
-      name: "Code Generator 2.11 - MySQL, Postgres, Sqlite, H2, SQL Server, Oracle"
-    - stage: build
-      if: type != pull_request
-      script: ./build/build.sh codegen
       scala: 2.12.10
       name: "Code Generator 2.12 - MySQL, Postgres, Sqlite, H2, SQL Server, Oracle"
     - stage: build
@@ -85,11 +65,6 @@ jobs:
       name: "Code Generator 2.13 - MySQL, Postgres, Sqlite, H2, SQL Server, Oracle"
 
     - stage: build
-      if: type != pull_request
-      script: ./build/build.sh bigdata
-      scala: 2.11.12
-      name: "BigData Databases 2.11 - Cassandra, OrientDB, Spark"
-    - stage: build
       script: ./build/build.sh bigdata
       scala: 2.12.10
       name: "BigData Databases 2.12 - Cassandra, OrientDB, Spark"
@@ -97,43 +72,6 @@ jobs:
       script: ./build/build.sh bigdata
       scala: 2.13.1
       name: "BigData Databases 2.13 - Cassandra, OrientDB, Spark"
-
-    - stage: release
-      if: type != pull_request
-      scala: 2.12.6
-      name: "Release 2.11 base"
-      script:
-        - ./build/release.sh 211 base
-    - stage: release
-      if: type != pull_request
-      scala: 2.12.6
-      name: "Release 2.11 db"
-      script:
-        - ./build/release.sh 211 db
-    - stage: release
-      if: type != pull_request
-      scala: 2.12.6
-      name: "Release 2.11 js"
-      script:
-        - ./build/release.sh 211 js
-    - stage: release
-      if: type != pull_request
-      scala: 2.12.6
-      name: "Release 2.11 async"
-      script:
-        - ./build/release.sh 211 async
-    - stage: release
-      if: type != pull_request
-      scala: 2.12.6
-      name: "Release 2.11 codegen"
-      script:
-        - ./build/release.sh 211 codegen
-    - stage: release
-      if: type != pull_request
-      scala: 2.12.6
-      name: "Release 2.11 bigdata"
-      script:
-        - ./build/release.sh 211 bigdata
 
     - stage: release
       if: type != pull_request

--- a/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
@@ -147,12 +147,12 @@ trait ReifyLiftings extends QuatMaking {
               for ((name, Reified(value, encoder)) <- transformer.state) yield {
                 encoder match {
                   case Some(encoder) =>
-                    q"def $name = io.getquill.quotation.ScalarValueLifting($value, $encoder)"
+                    q"lazy val $name = io.getquill.quotation.ScalarValueLifting($value, $encoder)"
                   case None =>
-                    q"def $name = io.getquill.quotation.CaseClassValueLifting($value)"
+                    q"lazy val $name = io.getquill.quotation.CaseClassValueLifting($value)"
                 }
               }
-            (ast, q"def $liftings = new { ..$trees }")
+            (ast, q"lazy val $liftings = new { ..$trees }")
         }
     }
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
@@ -147,12 +147,12 @@ trait ReifyLiftings extends QuatMaking {
               for ((name, Reified(value, encoder)) <- transformer.state) yield {
                 encoder match {
                   case Some(encoder) =>
-                    q"val $name = io.getquill.quotation.ScalarValueLifting($value, $encoder)"
+                    q"def $name = io.getquill.quotation.ScalarValueLifting($value, $encoder)"
                   case None =>
-                    q"val $name = io.getquill.quotation.CaseClassValueLifting($value)"
+                    q"def $name = io.getquill.quotation.CaseClassValueLifting($value)"
                 }
               }
-            (ast, q"val $liftings = new { ..$trees }")
+            (ast, q"def $liftings = new { ..$trees }")
         }
     }
 }


### PR DESCRIPTION
Fixes #1996

We learned in #1996 that serialization can significantly slow down static queries, the question is why? Since static queries are computed during compile time, why is the lifted/unlifted `serializeJVM` function executed at all?

One possible theory is that since lifting variables (i.e. variables containing the re-lifted AST) are evaluated eagerly when a Quote is declared, the serialization effectively runs during runtime as merely a side-effect of creation of the quotation. Perhaps this could be fixed if lifting variables are converted to lazy vals. Unfortunately this approach does not work with Scala 2.11 (as can be seen here: https://github.com/propensive/magnolia/issues/142) so we will need a different approach for 2.11 (or maybe skip this functionality anyway for it), I cannot deprecate 2.11 yet but will try to soon.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
