### PR TITLE
Update cassandra driver and fix tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -548,7 +548,7 @@ lazy val `quill-cassandra` =
     .settings(
       fork in Test := true,
       libraryDependencies ++= Seq(
-        "com.datastax.cassandra" %  "cassandra-driver-core" % "3.7.2"
+        "com.datastax.cassandra" %  "cassandra-driver-core" % "3.10.2"
       )
     )
     .dependsOn(`quill-core-jvm` % "compile->compile;test->test")

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/cluster/ClusterBuilderSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/cluster/ClusterBuilderSpec.scala
@@ -16,19 +16,19 @@ class ClusterBuilderSpec extends Spec {
     "with a single host" in {
       val cfgString = s"contactPoint = ${hosts.head}"
       val clusterBuilder: Builder = ClusterBuilder(ConfigFactory.parseString(cfgString))
-      clusterBuilder.getContactPoints must contain theSameElementsAs (contactPoints.take(1))
+      clusterBuilder.getContactPoints === contactPoints.take(1)
     }
 
     "with a single host in an array" in {
       val cfgString = s"contactPoints = [${hosts.head}]"
       val clusterBuilder: Builder = ClusterBuilder(ConfigFactory.parseString(cfgString))
-      clusterBuilder.getContactPoints must contain theSameElementsAs (contactPoints.take(1))
+      clusterBuilder.getContactPoints === contactPoints.take(1)
     }
 
     "with multiple hosts" in {
       val cfgString = s"""contactPoints = [${hosts.mkString(",")}] """
       val clusterBuilder: Builder = ClusterBuilder(ConfigFactory.parseString(cfgString))
-      clusterBuilder.getContactPoints must contain theSameElementsAs (contactPoints)
+      clusterBuilder.getContactPoints === contactPoints
     }
   }
 }


### PR DESCRIPTION
The automatic prs for cassandra drivers have been failing for a while.

### Solution

Fix the tests so these prs are usefull again.

@getquill/maintainers
