### PR TITLE
Change all Quat fields to Lazy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ services:
   - docker
   - postgresql
   - mysql
+before_install:
+  - |
+    wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v1.2.0/travis-wait-enhanced_1.2.0_linux_x86_64.tar.gz" | tar -zxvf - travis-wait-enhanced
+    mv travis-wait-enhanced /home/travis/bin/
+    travis-wait-enhanced --version
 addons:
   postgresql: "9.6"
 branches:

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ enablePlugins(TutPlugin)
 
 val CodegenTag = Tags.Tag("CodegenTag")
 (concurrentRestrictions in Global) += Tags.exclusive(CodegenTag)
+(concurrentRestrictions in Global) += Tags.limit(ScalaJSTags.Link, 1)
 
 lazy val jsModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
   `quill-core-portable-js`, `quill-core-js`,
@@ -192,7 +193,9 @@ lazy val `quill-core-portable` =
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
         "io.suzaku" %%% "boopickle" % "1.3.1"
       ),
-      coverageExcludedPackages := ".*"
+      coverageExcludedPackages := ".*",
+      // 2.12 Build seems to take forever without this option
+      scalaJSOptimizerOptions in fastOptJS in Test ~= { _.withDisableOptimizer(true) }
     )
 
 lazy val `quill-core-portable-jvm` = `quill-core-portable`.jvm
@@ -217,7 +220,9 @@ lazy val `quill-core` =
         "org.scala-js" %%% "scalajs-java-time" % "0.2.5"
       ),
       excludeFilter in unmanagedSources := new SimpleFileFilter(file => file.getName == "DynamicQuerySpec.scala"),
-      coverageExcludedPackages := ".*"
+      coverageExcludedPackages := ".*",
+      // 2.12 Build seems to take forever without this option
+      scalaJSOptimizerOptions in fastOptJS in Test ~= { _.withDisableOptimizer(true) }
     )
     .dependsOn(`quill-core-portable` % "compile->compile")
 
@@ -237,7 +242,9 @@ lazy val `quill-sql-portable` =
         "com.github.vertical-blank" %%% "scala-sql-formatter" % "1.0.0"
       ),
       scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
-      coverageExcludedPackages := ".*"//,
+      coverageExcludedPackages := ".*",
+      // 2.12 Build seems to take forever without this option
+      scalaJSOptimizerOptions in fastOptJS in Test ~= { _.withDisableOptimizer(true) }
       //jsEnv := NodeJSEnv(args = Seq("--max_old_space_size=1024")).value
     )
     .dependsOn(`quill-core-portable` % "compile->compile")
@@ -259,7 +266,9 @@ lazy val `quill-sql` =
         "com.github.vertical-blank" %%% "scala-sql-formatter" % "1.0.1"
       ),
       scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
-      coverageExcludedPackages := ".*"
+      coverageExcludedPackages := ".*",
+      // 2.12 Build seems to take forever without this option
+      scalaJSOptimizerOptions in fastOptJS in Test ~= { _.withDisableOptimizer(true) }
     )
     .dependsOn(
       `quill-sql-portable` % "compile->compile",

--- a/build/build.sh
+++ b/build/build.sh
@@ -163,8 +163,9 @@ function db_build() {
 }
 
 function js_build() {
-    export JVM_OPTS="-Dquill.macro.log=false -Dquill.scala.version=$TRAVIS_SCALA_VERSION -Xms1024m -Xmx5g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
-    sbt -Dmodules=js $SBT_ARGS test doc
+    show_mem
+    export JVM_OPTS="-Dquill.macro.log=false -Dquill.scala.version=$TRAVIS_SCALA_VERSION -Xms1024m -Xmx4g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+    travis-wait-enhanced --interval=1m --timeout=50m -- sbt -Dmodules=js $SBT_ARGS test doc
 }
 
 function async_build() {

--- a/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
@@ -35,7 +35,7 @@ sealed trait Ast {
 sealed trait Query extends Ast
 
 sealed trait Terminal extends Ast {
-  def withQuat(newQuat: Quat): Terminal
+  def withQuat(quat: => Quat): Terminal
 }
 
 object Terminal {
@@ -56,8 +56,6 @@ object BottomTypedTerminal {
     }
 }
 
-case class EntityId(name: String, properties: List[PropertyAlias])
-
 /**
  * Entities represent the actual tables/views being selected.
  * Typically, something like:
@@ -73,8 +71,9 @@ case class EntityId(name: String, properties: List[PropertyAlias])
  * That means that even if the `NamingSchema` is `UpperCase`, the resulting query will select `t_person` as opposed
  * to `T_PERSON` or `Person`.
  */
-case class Entity(name: String, properties: List[PropertyAlias], quat: Quat.Product) extends Query {
-  def id = EntityId(name, properties)
+class Entity(val name: String, val properties: List[PropertyAlias])(theQuat: => Quat.Product) extends Query {
+  def quat: Quat.Product = theQuat
+  private def id = Entity.Id(name, properties)
   // Technically this should be part of the Entity case class but due to the limitations of how
   // scala creates companion objects, the apply/unapply wouldn't be able to work correctly.
   def renameable: Renameable = Renameable.neutral
@@ -106,31 +105,35 @@ case class Entity(name: String, properties: List[PropertyAlias], quat: Quat.Prod
     //   => (name -> (first -> theFirst, last -> theLast))
     val groupedTailPaths = tailPaths.groupBy(_._1).map(kv => (kv._1, kv._2.map(r => r._2))).toList
 
-    val newQuat: Quat.Product =
+    lazy val quat: Quat.Product =
       groupedTailPaths.foldLeft(this.quat) {
         case (quat, (renamePath, renames)) =>
           quat.renameAtPath(renamePath, renames)
       }
 
-    Entity.Opinionated(name, properties, newQuat, renameable)
+    Entity.Opinionated(name, properties, quat, renameable)
   }
 }
 
 object Entity {
-  def apply(name: String, properties: List[PropertyAlias], quat: Quat.Product) =
-    new Entity(name, properties, quat)
+  private case class Id(name: String, properties: List[PropertyAlias])
+
+  def apply(name: String, properties: List[PropertyAlias], quat: => Quat.Product): Entity =
+    new Entity(name, properties)(quat)
+
   def unapply(e: Entity) = Some((e.name, e.properties, e.quat))
 
   object Opinionated {
     def apply(
       name:          String,
       properties:    List[PropertyAlias],
-      quat:          Quat.Product,
+      quat:          => Quat.Product,
       renameableNew: Renameable
-    ) =
-      new Entity(name, properties, quat) {
+    ): Entity =
+      new Entity(name, properties)(quat) {
         override def renameable: Renameable = renameableNew
       }
+
     def unapply(e: Entity) =
       Some((e.name, e.properties, e.quat, e.renameable))
   }
@@ -190,14 +193,34 @@ case class Nested(a: Ast) extends Query { def quat = a.quat }
 
 //************************************************************
 
-case class Infix(parts: List[String], params: List[Ast], pure: Boolean, quat: Quat) extends Ast
+class Infix(val parts: List[String], val params: List[Ast], val pure: Boolean)(theQuat: => Quat) extends Ast {
+  def quat: Quat = theQuat
+  private def id = Infix.Id(parts, params, pure)
+
+  override def equals(that: Any) =
+    that match {
+      case p: Infix => this.id == p.id
+      case _        => false
+    }
+
+  override def hashCode = id.hashCode()
+  def copy(parts: List[String] = this.parts, params: List[Ast] = this.params, pure: Boolean = this.pure, quat: Quat = this.quat) =
+    Infix(parts, params, pure, quat)
+}
+object Infix {
+  private case class Id(val parts: List[String], val params: List[Ast], val pure: Boolean)
+
+  def apply(parts: List[String], params: List[Ast], pure: Boolean, quat: => Quat) =
+    new Infix(parts, params, pure)(quat)
+
+  def unapply(i: Infix) = Some((i.parts, i.params, i.pure, i.quat))
+}
 
 case class Function(params: List[Ident], body: Ast) extends Ast { def quat = body.quat }
 
-case class IdentId(name: String)
-
-case class Ident(name: String, quat: Quat) extends Terminal with Ast {
-  def id = IdentId(name)
+class Ident(val name: String)(theQuat: => Quat) extends Terminal with Ast {
+  def quat: Quat = theQuat
+  private val id = Ident.Id(name)
   def visibility: Visibility = Visibility.Visible
 
   override def equals(that: Any) =
@@ -208,12 +231,12 @@ case class Ident(name: String, quat: Quat) extends Terminal with Ast {
 
   override def hashCode = id.hashCode()
 
-  override def withQuat(newQuat: Quat) = {
-    Ident.Opinionated(this.name, newQuat, this.visibility)
+  override def withQuat(quat: => Quat): Ident = {
+    Ident.Opinionated(this.name, quat, this.visibility)
   }
 
   // need to define a copy which will propogate current value of visibility into the copy
-  def copy(name: String = this.name, quat: Quat = this.quat): Ident =
+  def copy(name: String = this.name, quat: => Quat = this.quat): Ident =
     Ident.Opinionated(name, quat, this.visibility)
 }
 
@@ -237,12 +260,13 @@ case class Ident(name: String, quat: Quat) extends Terminal with Ast {
  * needs to be marked invisible.
  */
 object Ident {
-  def apply(name: String, quat: Quat = Quat.Value) = new Ident(name, quat)
+  private case class Id(name: String)
+  def apply(name: String, quat: => Quat = Quat.Value) = new Ident(name)(quat)
   def unapply(p: Ident) = Some((p.name, p.quat))
 
   object Opinionated {
-    def apply(name: String, quat: Quat, visibilityNew: Visibility) =
-      new Ident(name, quat) {
+    def apply(name: String, quatNew: => Quat, visibilityNew: Visibility) =
+      new Ident(name)(quatNew) {
         override def visibility: Visibility = visibilityNew
       }
     def unapply(p: Ident) =
@@ -250,12 +274,11 @@ object Ident {
   }
 }
 
-case class ExternalIdentId(name: String)
-
 // Like identity but is but defined in a clause external to the query. Currently this is used
 // for 'returning' clauses to define properties being returned.
-case class ExternalIdent(name: String, quat: Quat) extends Ast {
-  def id = ExternalIdentId(name)
+class ExternalIdent(val name: String)(theQuat: => Quat) extends Ast {
+  def quat: Quat = theQuat
+  private def id = ExternalIdent.Id(name)
   def renameable: Renameable = Renameable.neutral
 
   override def equals(that: Any) =
@@ -267,17 +290,19 @@ case class ExternalIdent(name: String, quat: Quat) extends Ast {
   override def hashCode = id.hashCode()
 
   // need to define a copy which will propogate current value of visibility into the copy
-  def copy(name: String = this.name, quat: Quat = this.quat): ExternalIdent =
+  def copy(name: String = this.name, quat: => Quat = this.quat): ExternalIdent =
     ExternalIdent.Opinionated(name, quat, this.renameable)
 }
 
 object ExternalIdent {
-  def apply(name: String, quat: Quat) = new ExternalIdent(name, quat)
+  private case class Id(name: String)
+
+  def apply(name: String, quat: => Quat) = new ExternalIdent(name)(quat)
   def unapply(e: ExternalIdent) = Some((e.name, e.quat))
 
   object Opinionated {
-    def apply(name: String, quat: Quat, rename: Renameable) =
-      new ExternalIdent(name, quat) {
+    def apply(name: String, quat: => Quat, rename: Renameable) =
+      new ExternalIdent(name)(quat) {
         override def renameable: Renameable = rename
       }
 
@@ -390,15 +415,22 @@ case class OptionTableExists(ast: Ast, alias: Ident, body: Ast)
 case class OptionTableForall(ast: Ast, alias: Ident, body: Ast)
   extends OptionOperation { def quat = body.quat }
 case object OptionNoneId
-case class OptionNone(quat: Quat) extends OptionOperation with Terminal {
-  override def withQuat(newQuat: Quat) = this.copy(quat = newQuat)
+class OptionNone(theQuat: => Quat) extends OptionOperation with Terminal {
+  def quat: Quat = theQuat
+  override def withQuat(quat: => Quat) = this.copy(quat = quat)
   override def equals(obj: Any): Boolean =
     obj match {
       case e: OptionNone => true
       case _             => false
     }
   override def hashCode(): Int = OptionNoneId.hashCode()
+  def copy(quat: => Quat = this.quat) = OptionNone(quat)
 }
+object OptionNone {
+  def apply(quat: => Quat): OptionNone = new OptionNone(quat)
+  def unapply(on: OptionNone) = Some(on.quat)
+}
+
 case class OptionSome(ast: Ast) extends OptionOperation { def quat = ast.quat }
 case class OptionApply(ast: Ast) extends OptionOperation { def quat = ast.quat }
 case class OptionOrNull(ast: Ast) extends OptionOperation { def quat = ast.quat }
@@ -442,12 +474,26 @@ case class FunctionApply(function: Ast, values: List[Ast]) extends Operation { d
 
 sealed trait Value extends Ast
 
-case class Constant(v: Any, quat: Quat) extends Value
+class Constant(val v: Any)(theQuat: => Quat) extends Value {
+  def quat: Quat = theQuat
+  private val id = Constant.Id(v)
+  override def hashCode(): Int = id.hashCode()
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case e: Constant => e.id == this.id
+      case _           => false
+    }
+}
 
 object Constant {
-  def auto(v: Any) = {
-    val quat = if (v.isInstanceOf[Boolean]) Quat.BooleanValue else Quat.Value
-    new Constant(v, quat)
+  private case class Id(v: Any)
+
+  def apply(v: Any, quat: => Quat): Constant = new Constant(v)(quat)
+  def unapply(const: Constant) = Some((const.v, const.quat))
+
+  def auto(v: Any): Constant = {
+    lazy val theQuat = if (v.isInstanceOf[Boolean]) Quat.BooleanValue else Quat.Value
+    new Constant(v)(theQuat)
   }
 }
 
@@ -534,12 +580,17 @@ object OnConflict {
 }
 //************************************************************
 
-case class Dynamic(tree: Any, quat: Quat) extends Ast
+class Dynamic(val tree: Any)(theQuat: => Quat) extends Ast {
+  def quat = theQuat
+}
 
 object Dynamic {
-  def apply(v: Any) = {
-    val quat = if (v.isInstanceOf[Boolean]) Quat.BooleanValue else Quat.Value
-    new Dynamic(v, quat)
+  def apply(tree: Any, quat: => Quat): Dynamic = new Dynamic(tree)(quat)
+  def unapply(d: Dynamic) = Some((d.tree, d.quat))
+
+  def apply(v: Any): Dynamic = {
+    lazy val theQuat = if (v.isInstanceOf[Boolean]) Quat.BooleanValue else Quat.Value
+    new Dynamic(v)(theQuat)
   }
 }
 
@@ -560,61 +611,91 @@ sealed trait ScalarLift extends Lift with Terminal {
   val encoder: Any
 }
 
-case class ScalarValueLiftId(name: String, value: Any, encoder: Any)
-case class ScalarValueLift(name: String, value: Any, encoder: Any, quat: Quat)
+class ScalarValueLift(val name: String, val value: Any, val encoder: Any)(theQuat: => Quat)
   extends ScalarLift {
-  override def withQuat(newQuat: Quat) = this.copy(quat = newQuat)
+  def quat: Quat = theQuat
+  override def withQuat(quat: => Quat) = this.copy(quat = quat)
 
-  def id = ScalarValueLiftId(name, value, encoder)
+  private val id = ScalarValueLift.Id(name, value, encoder)
   override def hashCode(): Int = id.hashCode()
   override def equals(obj: Any): Boolean =
     obj match {
       case e: ScalarValueLift => e.id == this.id
       case _                  => false
     }
-
+  def copy(name: String = this.name, value: Any = this.value, encoder: Any = this.encoder, quat: => Quat = this.quat) =
+    ScalarValueLift(name, value, encoder, quat)
+}
+object ScalarValueLift {
+  private case class Id(name: String, value: Any, encoder: Any)
+  def apply(name: String, value: Any, encoder: Any, quat: => Quat): ScalarValueLift = new ScalarValueLift(name, value, encoder)(quat)
+  def unapply(svl: ScalarValueLift) = Some((svl.name, svl.value, svl.encoder, svl.quat))
 }
 
-case class ScalarQueryLiftId(name: String, value: Any, encoder: Any)
-case class ScalarQueryLift(name: String, value: Any, encoder: Any, quat: Quat)
+class ScalarQueryLift(val name: String, val value: Any, val encoder: Any)(theQuat: => Quat)
   extends ScalarLift {
-  override def withQuat(newQuat: Quat) = this.copy(quat = newQuat)
+  def quat: Quat = theQuat
+  override def withQuat(quat: => Quat) = this.copy(quat = quat)
 
-  def id = ScalarQueryLiftId(name, value, encoder)
+  private val id = ScalarQueryLift.Id(name, value, encoder)
   override def hashCode(): Int = id.hashCode()
   override def equals(obj: Any): Boolean =
     obj match {
       case e: ScalarQueryLift => e.id == this.id
       case _                  => false
     }
+
+  def copy(name: String = this.name, value: Any = this.value, encoder: Any = this.encoder, quat: => Quat = this.quat) =
+    ScalarQueryLift(name, value, encoder, quat)
+}
+object ScalarQueryLift {
+  private case class Id(name: String, value: Any, encoder: Any)
+  def apply(name: String, value: Any, encoder: Any, quat: => Quat): ScalarQueryLift = new ScalarQueryLift(name, value, encoder)(quat)
+  def unapply(l: ScalarQueryLift) = Some((l.name, l.value, l.encoder, l.quat))
 }
 
 sealed trait CaseClassLift extends Lift
 
-case class CaseClassValueLiftId(name: String, value: Any)
-case class CaseClassValueLift(name: String, value: Any, quat: Quat) extends CaseClassLift {
-  override def withQuat(newQuat: Quat) = this.copy(quat = newQuat)
+class CaseClassValueLift(val name: String, val value: Any)(theQuat: => Quat) extends CaseClassLift {
+  def quat: Quat = theQuat
+  override def withQuat(quat: => Quat) = this.copy(quat = quat)
 
-  def id = CaseClassValueLiftId(name, value)
+  private val id = CaseClassValueLift.Id(name, value)
   override def hashCode(): Int = id.hashCode()
   override def equals(obj: Any): Boolean =
     obj match {
       case e: CaseClassValueLift => e.id == this.id
       case _                     => false
     }
+  def copy(name: String = this.name, value: Any = this.value, quat: => Quat = this.quat) =
+    CaseClassValueLift(name, value, quat)
+}
+object CaseClassValueLift {
+  private case class Id(name: String, value: Any)
+  def apply(name: String, value: Any, quat: => Quat): CaseClassValueLift = new CaseClassValueLift(name, value)(quat)
+  def unapply(l: CaseClassValueLift) = Some((l.name, l.value, l.quat))
 }
 
-case class CaseClassQueryLiftId(name: String, value: Any)
-case class CaseClassQueryLift(name: String, value: Any, quat: Quat) extends CaseClassLift {
-  override def withQuat(newQuat: Quat) = this.copy(quat = newQuat)
+class CaseClassQueryLift(val name: String, val value: Any)(theQuat: => Quat) extends CaseClassLift {
+  def quat: Quat = theQuat
+  override def withQuat(quat: => Quat) = this.copy(quat = quat)
 
-  def id = CaseClassQueryLiftId(name, value)
+  private val id = CaseClassQueryLift.Id(name, value)
   override def hashCode(): Int = id.hashCode()
   override def equals(obj: Any): Boolean =
     obj match {
       case e: CaseClassQueryLift => e.id == this.id
       case _                     => false
     }
+
+  def copy(name: String = this.name, value: Any = this.value, quat: => Quat = this.quat) =
+    CaseClassQueryLift(name, value, quat)
+}
+
+object CaseClassQueryLift {
+  private case class Id(name: String, value: Any)
+  def apply(name: String, value: Any, quat: => Quat): CaseClassQueryLift = new CaseClassQueryLift(name, value)(quat)
+  def unapply(l: CaseClassQueryLift) = Some((l.name, l.value, l.quat))
 }
 
 /***********************************************************************/
@@ -629,7 +710,7 @@ case class ScalarTagId(uid: String)
 case class ScalarTag(uid: String) extends Tag {
   def quat = Quat.Value
 
-  def id = ScalarTagId(uid)
+  private val id = ScalarTagId(uid)
   override def hashCode(): Int = id.hashCode()
   override def equals(obj: Any): Boolean =
     obj match {
@@ -642,7 +723,7 @@ case class QuotationTagId(uid: String)
 case class QuotationTag(uid: String) extends Tag {
   def quat = Quat.Value
 
-  def id = QuotationTagId(uid)
+  private val id = QuotationTagId(uid)
   override def hashCode(): Int = id.hashCode()
   override def equals(obj: Any): Boolean =
     obj match {

--- a/quill-core-portable/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -79,8 +79,8 @@ object ApplyRenamesToProps extends StatelessTransformer {
         trace"Checking Property: ${p} for possible rename".andLog()
         val newAst = apply(ast)
         // Check the quat if it is renaming this property if so rename it. Otherwise property is the same
-        newAst.quat.renames.find(_._1 == name) match {
-          case Some((_, newName)) =>
+        newAst.quat.renames.get(name) match {
+          case Some(newName) =>
             trace"Applying Rename on Property:" andReturn
               Property.Opinionated(newAst, newName, Renameable.Fixed, visibility)
           case None => p

--- a/quill-core-portable/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
@@ -19,7 +19,7 @@ object BooQuatSerializer {
     override def unpickle(implicit state: UnpickleState): Quat.Product = {
       Quat.Product.WithRenames(
         state.unpickle[LinkedHashMap[String, Quat]],
-        state.unpickle[List[(String, String)]]
+        state.unpickle[LinkedHashMap[String, String]]
       )
     }
   }

--- a/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
@@ -8,7 +8,7 @@ object Messages {
     Option(System.getProperty(propName)).orElse(sys.env.get(envName)).getOrElse(default)
 
   private[getquill] def quatKryoPoolSize = variable("quill.quat.kryoPool", "quill_quat_kryoPool", "10").toInt
-  private[getquill] def maxQuatFields = variable("quill.quat.tooManyFields", "quill_quat_tooManyFields", "100").toInt
+  private[getquill] def maxQuatFields = variable("quill.quat.tooManyFields", "quill_quat_tooManyFields", "500").toInt
   private[util] def prettyPrint = variable("quill.macro.log.pretty", "quill_macro_log", "false").toBoolean
   private[getquill] def alwaysAlias = variable("quill.query.alwaysAlias", "quill_query_alwaysAlias", "false").toBoolean
   private[getquill] def pruneColumns = variable("quill.query.pruneColumns", "quill_query_pruneColumns", "true").toBoolean

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -3,8 +3,6 @@ package io.getquill.quotation
 import scala.reflect.macros.whitebox.Context
 import io.getquill.quat.Quat
 
-import scala.collection.mutable
-
 trait QuatLiftable {
   val mctx: Context
   def serializeQuats: Boolean
@@ -16,22 +14,17 @@ trait QuatLiftable {
   implicit val quatProductLiftable: Liftable[Quat.Product] = Liftable[Quat.Product] {
     // If we are in the JS, use Kryo to serialize our Quat due to JS 64KB method limit that we will run into of the Quat Constructor
     // if plainly lifted into the method created by our macro (i.e. the 'ast' method).
-    case quat: Quat.Product if (serializeQuats)    => q"io.getquill.quat.Quat.Product.fromSerializedJS(${quat.serializeJS})"
-    case Quat.Product.WithRenames(fields, renames) => q"io.getquill.quat.Quat.Product.WithRenames($fields, $renames)"
+    case quat: Quat.Product if (serializeQuats)                                  => q"io.getquill.quat.Quat.Product.fromSerializedJS(${quat.serializeJS})"
+    case Quat.Product.WithRenamesCompact(fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
   }
 
   implicit val quatLiftable: Liftable[Quat] = Liftable[Quat] {
-    case quat: Quat.Product if (serializeQuats)    => q"io.getquill.quat.Quat.fromSerializedJS(${quat.serializeJS})"
-    case Quat.Product.WithRenames(fields, renames) => q"io.getquill.quat.Quat.Product.WithRenames($fields, $renames)"
-    case Quat.Value                                => q"io.getquill.quat.Quat.Value"
-    case Quat.Null                                 => q"io.getquill.quat.Quat.Null"
-    case Quat.Generic                              => q"io.getquill.quat.Quat.Generic"
-    case Quat.BooleanValue                         => q"io.getquill.quat.Quat.BooleanValue"
-    case Quat.BooleanExpression                    => q"io.getquill.quat.Quat.BooleanExpression"
-  }
-
-  implicit def linkedHashMapLiftable[K, V](implicit lk: Liftable[K], lv: Liftable[V]): Liftable[mutable.LinkedHashMap[K, V]] = Liftable[mutable.LinkedHashMap[K, V]] {
-    case l: mutable.LinkedHashMap[K, V] =>
-      q"scala.collection.mutable.LinkedHashMap(${l.map { case (k, v) => q"(${lk(k)}, ${lv(v)})" }.toSeq: _*})"
+    case quat: Quat.Product if (serializeQuats) => q"io.getquill.quat.Quat.fromSerializedJS(${quat.serializeJS})"
+    case Quat.Product.WithRenamesCompact(fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+    case Quat.Value => q"io.getquill.quat.Quat.Value"
+    case Quat.Null => q"io.getquill.quat.Quat.Null"
+    case Quat.Generic => q"io.getquill.quat.Quat.Generic"
+    case Quat.BooleanValue => q"io.getquill.quat.Quat.BooleanValue"
+    case Quat.BooleanExpression => q"io.getquill.quat.Quat.BooleanExpression"
   }
 }

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -2,7 +2,6 @@ package io.getquill.quotation
 
 import io.getquill.util.MacroContextExt._
 
-import scala.collection.mutable.LinkedHashMap
 import scala.reflect.macros.whitebox.Context
 import io.getquill.quat.Quat
 
@@ -10,35 +9,27 @@ trait QuatUnliftable {
   val mctx: Context
   import mctx.universe.{ Constant => _, Function => _, Ident => _, If => _, _ }
 
+  def unliftQuat(v: Tree) = quatUnliftable.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v"))
+  def unliftQuats(v: Seq[Tree]) = v.map(unliftQuat(_))
+  def unliftString(v: Tree)(implicit u: Unliftable[String]) = u.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v"))
+  def unliftStrings(v: Seq[Tree])(implicit u: Unliftable[String]) = v.map(unliftString(_))
+
   implicit val quatProductUnliftable: Unliftable[Quat.Product] = Unliftable[Quat.Product] {
     // On JS, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JS (due to 64KB method limit)
     case q"$pack.Quat.Product.fromSerializedJS(${ str: String })" => Quat.Product.fromSerializedJS(str)
-    case q"$pack.Quat.Product.WithRenames.apply(${ fields: LinkedHashMap[String, Quat] }, ${ renames: List[(String, String)] })" => Quat.Product.WithRenames(fields, renames)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
   }
 
   implicit val quatUnliftable: Unliftable[Quat] = Unliftable[Quat] {
     // On JS, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JS (due to 64KB method limit)
     case q"$pack.Quat.fromSerializedJS(${ str: String })" => Quat.fromSerializedJS(str)
-    case q"$pack.Quat.Product.WithRenames.apply(${ fields: LinkedHashMap[String, Quat] }, ${ renames: List[(String, String)] })" => Quat.Product.WithRenames(fields, renames)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
     case q"$pack.Quat.Product.apply(${ fields: List[(String, Quat)] })" => Quat.Product(fields)
     case q"$pack.Quat.Value" => Quat.Value
     case q"$pack.Quat.Null" => Quat.Null
     case q"$pack.Quat.Generic" => Quat.Generic
     case q"$pack.Quat.BooleanValue" => Quat.BooleanValue
     case q"$pack.Quat.BooleanExpression" => Quat.BooleanExpression
-  }
-
-  implicit def linkedHashMapUnliftable[K, V](implicit uk: Unliftable[K], uv: Unliftable[V]): Unliftable[LinkedHashMap[K, V]] = Unliftable[LinkedHashMap[K, V]] {
-    case q"$pack.LinkedHashMap.apply[..$t](..$values)" =>
-      LinkedHashMap[K, V](
-        values.map {
-          case q"($k, $v)" =>
-            (
-              uk.unapply(k).getOrElse(mctx.fail(s"Can't unlift $k")),
-              uv.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v"))
-            )
-        }: _*
-      )
   }
 
   implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -3,8 +3,6 @@ package io.getquill.quotation
 import scala.reflect.macros.whitebox.Context
 import io.getquill.quat.Quat
 
-import scala.collection.mutable
-
 trait QuatLiftable {
   val mctx: Context
   val serializeQuats: Boolean
@@ -16,22 +14,17 @@ trait QuatLiftable {
   implicit val quatProductLiftable: Liftable[Quat.Product] = Liftable[Quat.Product] {
     // If we are in the JVM, use Kryo to serialize our Quat due to JVM 64KB method limit that we will run into of the Quat Constructor
     // if plainly lifted into the method created by our macro (i.e. the 'ast' method).
-    case quat: Quat.Product if (serializeQuats)    => q"io.getquill.quat.Quat.Product.fromSerializedJVM(${quat.serializeJVM})"
-    case Quat.Product.WithRenames(fields, renames) => q"io.getquill.quat.Quat.Product.WithRenames($fields, $renames)"
+    case quat: Quat.Product if (serializeQuats)                                  => q"io.getquill.quat.Quat.Product.fromSerializedJVM(${quat.serializeJVM})"
+    case Quat.Product.WithRenamesCompact(fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
   }
 
   implicit val quatLiftable: Liftable[Quat] = Liftable[Quat] {
-    case quat: Quat.Product if (serializeQuats)    => q"io.getquill.quat.Quat.fromSerializedJVM(${quat.serializeJVM})"
-    case Quat.Product.WithRenames(fields, renames) => q"io.getquill.quat.Quat.Product.WithRenames($fields, $renames)"
-    case Quat.Value                                => q"io.getquill.quat.Quat.Value"
-    case Quat.Null                                 => q"io.getquill.quat.Quat.Null"
-    case Quat.Generic                              => q"io.getquill.quat.Quat.Generic"
-    case Quat.BooleanValue                         => q"io.getquill.quat.Quat.BooleanValue"
-    case Quat.BooleanExpression                    => q"io.getquill.quat.Quat.BooleanExpression"
-  }
-
-  implicit def linkedHashMapLiftable[K, V](implicit lk: Liftable[K], lv: Liftable[V]): Liftable[mutable.LinkedHashMap[K, V]] = Liftable[mutable.LinkedHashMap[K, V]] {
-    case l: mutable.LinkedHashMap[K, V] =>
-      q"scala.collection.mutable.LinkedHashMap(${l.map { case (k, v) => q"(${lk(k)}, ${lv(v)})" }.toSeq: _*})"
+    case quat: Quat.Product if (serializeQuats) => q"io.getquill.quat.Quat.fromSerializedJVM(${quat.serializeJVM})"
+    case Quat.Product.WithRenamesCompact(fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+    case Quat.Value => q"io.getquill.quat.Quat.Value"
+    case Quat.Null => q"io.getquill.quat.Quat.Null"
+    case Quat.Generic => q"io.getquill.quat.Quat.Generic"
+    case Quat.BooleanValue => q"io.getquill.quat.Quat.BooleanValue"
+    case Quat.BooleanExpression => q"io.getquill.quat.Quat.BooleanExpression"
   }
 }

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -2,7 +2,6 @@ package io.getquill.quotation
 
 import io.getquill.util.MacroContextExt._
 
-import scala.collection.mutable.LinkedHashMap
 import scala.reflect.macros.whitebox.Context
 import io.getquill.quat.Quat
 
@@ -10,35 +9,27 @@ trait QuatUnliftable {
   val mctx: Context
   import mctx.universe.{ Constant => _, Function => _, Ident => _, If => _, _ }
 
+  def unliftQuat(v: Tree) = quatUnliftable.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v"))
+  def unliftQuats(v: Seq[Tree]) = v.map(unliftQuat(_))
+  def unliftString(v: Tree)(implicit u: Unliftable[String]) = u.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v"))
+  def unliftStrings(v: Seq[Tree])(implicit u: Unliftable[String]) = v.map(unliftString(_))
+
   implicit val quatProductUnliftable: Unliftable[Quat.Product] = Unliftable[Quat.Product] {
     // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
     case q"$pack.Quat.Product.fromSerializedJVM(${ str: String })" => Quat.Product.fromSerializedJVM(str)
-    case q"$pack.Quat.Product.WithRenames.apply(${ fields: LinkedHashMap[String, Quat] }, ${ renames: List[(String, String)] })" => Quat.Product.WithRenames(fields, renames)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
   }
 
   implicit val quatUnliftable: Unliftable[Quat] = Unliftable[Quat] {
     // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
     case q"$pack.Quat.fromSerializedJVM(${ str: String })" => Quat.fromSerializedJVM(str)
-    case q"$pack.Quat.Product.WithRenames.apply(${ fields: LinkedHashMap[String, Quat] }, ${ renames: List[(String, String)] })" => Quat.Product.WithRenames(fields, renames)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
     case q"$pack.Quat.Product.apply(${ fields: List[(String, Quat)] })" => Quat.Product(fields)
     case q"$pack.Quat.Value" => Quat.Value
     case q"$pack.Quat.Null" => Quat.Null
     case q"$pack.Quat.Generic" => Quat.Generic
     case q"$pack.Quat.BooleanValue" => Quat.BooleanValue
     case q"$pack.Quat.BooleanExpression" => Quat.BooleanExpression
-  }
-
-  implicit def linkedHashMapUnliftable[K, V](implicit uk: Unliftable[K], uv: Unliftable[V]): Unliftable[LinkedHashMap[K, V]] = Unliftable[LinkedHashMap[K, V]] {
-    case q"$pack.LinkedHashMap.apply[..$t](..$values)" =>
-      LinkedHashMap[K, V](
-        values.map {
-          case q"($k, $v)" =>
-            (
-              uk.unapply(k).getOrElse(mctx.fail(s"Can't unlift $k")),
-              uv.unapply(v).getOrElse(mctx.fail(s"Can't unlift $v"))
-            )
-        }: _*
-      )
   }
 
   implicit def listUnliftable[T](implicit u: Unliftable[T]): Unliftable[List[T]] = Unliftable[List[T]] {


### PR DESCRIPTION
Fixes #1996 

The Quat.Product liftable creates significant work for a processor in even small Queries. Make the quat field lazy so it will not be forced to evaluate in static queries.