### PR TITLE
Trigger Release Version 3.6.0-RC3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# 3.6-RC2
+# 3.6.0-RC3
+
+ - [Change all Quat fields to Lazy](https://github.com/getquill/quill/pull/2004)
+ - [Smart serialization based on number of Quat fields](https://github.com/getquill/quill/pull/1997)
+
+# 3.6.0-RC2
 
 - [Fix incorrect Quat.Value parsing issues](https://github.com/getquill/quill/pull/1987)
 

--- a/build.sbt
+++ b/build.sbt
@@ -871,6 +871,7 @@ lazy val releaseSettings = Seq(
   },
   pgpSecretRing := file("local.secring.gpg"),
   pgpPublicRing := file("local.pubring.gpg"),
+  releaseVersionBump := sbtrelease.Version.Bump.Nano,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseProcess := {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.6.0-RC3-SNAPSHOT"
+version in ThisBuild := "3.6.0-RC3"


### PR DESCRIPTION
Release Version 3.6.0-RC3 to address Quat-related performance issues.

@getquill/maintainers
