### PR TITLE
Quat Enhancements to Support Needed Spark Use Cases

### DIFF
--- a/quill-core-portable/src/main/scala/io/getquill/AstPrinter.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/AstPrinter.scala
@@ -5,7 +5,6 @@ import io.getquill.ast.Renameable.{ ByStrategy, Fixed }
 import io.getquill.ast.Visibility.{ Hidden, Visible }
 import io.getquill.ast._
 import io.getquill.quat.Quat
-import io.getquill.util.Messages
 import io.getquill.util.Messages.QuatTrace
 import pprint.{ Renderer, Tree, Truncated }
 
@@ -19,7 +18,7 @@ object AstPrinter {
   }
 }
 
-class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean) extends pprint.Walker {
+class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean, traceQuats: QuatTrace) extends pprint.Walker {
   val defaultWidth: Int = 150
   val defaultHeight: Int = Integer.MAX_VALUE
   val defaultIndent: Int = 2
@@ -51,7 +50,7 @@ class AstPrinter(traceOpinions: Boolean, traceAstSimple: Boolean) extends pprint
     private def treeifyList: List[Tree] =
       toContent.list.flatMap {
         case e: treemake.Quat =>
-          Messages.traceQuats match {
+          traceQuats match {
             case QuatTrace.Full  => List(Tree.Literal(e.q.shortString))
             case QuatTrace.Short => List(Tree.Literal(e.q.shortString.take(10)))
             case QuatTrace.None  => List()

--- a/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
@@ -49,7 +49,7 @@ object Terminal {
 object BottomTypedTerminal {
   def unapply(ast: Ast): Option[Terminal] =
     ast match {
-      case t: Terminal if (t.quat == Quat.Null || t.quat == Quat.Generic) =>
+      case t: Terminal if (t.quat == Quat.Null || t.quat == Quat.Generic || t.quat == Quat.Unknown) =>
         Some(t)
       case _ =>
         None

--- a/quill-core-portable/src/main/scala/io/getquill/norm/ApplyMap.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/norm/ApplyMap.scala
@@ -55,6 +55,7 @@ object ApplyMap {
     def unapply(ast: Ast): Option[(Ast, Ident, Ast)] =
       ast match {
         case Map(a: GroupBy, b, c)              => None
+        case Map(a: FlatJoin, b, c)             => None // FlatJoin should always be surrounded by a Map
         case Map(a, b, InfixedTailOperation(c)) => None
         case Map(a, b, c)                       => Some((a, b, c))
         case _                                  => None
@@ -66,6 +67,7 @@ object ApplyMap {
 
       case Map(a: GroupBy, b, c) if (b == c)    => None
       case Map(a: Nested, b, c) if (b == c)     => None
+      case Map(a: FlatJoin, b, c) if (b == c)   => None // FlatJoin should always be surrounded by a Map
       case Nested(DetachableMap(a: Join, b, c)) => None
 
       //  map(i => (i.i, i.l)).distinct.map(x => (x._1, x._2)) =>

--- a/quill-core-portable/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -117,11 +117,11 @@ object SeedRenames extends StatelessTransformer {
                 // Use the Quat from the Infix to do the renames
                 case p: Quat.Product =>
                   p.withRenamesFrom(elem.quat)
-                // If the infix is marked as generic, use the Infix from the single-element to do the renames
+                // If the infix is marked as generic or unknown, use the Infix from the single-element to do the renames
                 // This typically happens with situations where the generic type of an infix needs to be cast
                 // into is not known by the macros yet. See allowFiltering for the cassandra quill-context or
                 // liftQuery(ds: Dataset) in the quill-spark context.
-                case Quat.Generic =>
+                case Quat.Placeholder(_) =>
                   elem.quat
                 case _ =>
                   qu

--- a/quill-core-portable/src/main/scala/io/getquill/norm/RepropagateQuats.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/norm/RepropagateQuats.scala
@@ -2,6 +2,7 @@ package io.getquill.norm
 
 import io.getquill.ast.{ Action, Assignment, Ast, ConcatMap, Filter, FlatJoin, FlatMap, GroupBy, Ident, Insert, Join, Map, OnConflict, Property, Query, Returning, ReturningGenerated, SortBy, StatelessTransformer, Update }
 import io.getquill.quat.Quat
+import io.getquill.quat.Quat.Product
 import io.getquill.util.Interpolator
 import io.getquill.util.Messages.TraceType
 import io.getquill.quotation.QuatExceptionOps._
@@ -40,9 +41,14 @@ object RepropagateQuats extends StatelessTransformer {
           case (key, None, Some(value))               => (key, value)
         }
       val newFields = mutable.LinkedHashMap(newFieldsIter.toList: _*)
+      val newTpe =
+        if (q.tpe == Product.Type.Abstract || other.tpe == Product.Type.Abstract)
+          Product.Type.Abstract
+        else
+          Product.Type.Concrete
       // Note, some extra renames from properties that don't exist could make it here.
       // Need to make sure to ignore extra ones when they are actually applied.
-      Quat.Product(newFields).withRenames(other.renames)
+      Quat.Product(newFields).withRenames(other.renames).withType(newTpe)
     }
   }
 

--- a/quill-core-portable/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
@@ -12,17 +12,24 @@ object BooQuatSerializer {
 
   implicit object productPickler extends Pickler[Quat.Product] {
     override def pickle(value: Quat.Product)(implicit state: PickleState): Unit = {
+      state.pickle(value.tpe)
       state.pickle(value.fields)
       state.pickle(value.renames)
       ()
     }
     override def unpickle(implicit state: UnpickleState): Quat.Product = {
       Quat.Product.WithRenames(
+        state.unpickle[Quat.Product.Type],
         state.unpickle[LinkedHashMap[String, Quat]],
         state.unpickle[LinkedHashMap[String, String]]
       )
     }
   }
+
+  implicit val quatProductTypePickler: Pickler[Quat.Product.Type] =
+    compositePickler[Quat.Product.Type]
+      .addConcreteType[Quat.Product.Type.Concrete.type]
+      .addConcreteType[Quat.Product.Type.Abstract.type]
 
   implicit val quatProductPickler: Pickler[Quat] =
     compositePickler[Quat]

--- a/quill-core-portable/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/BooQuatSerializer.scala
@@ -28,6 +28,7 @@ object BooQuatSerializer {
     compositePickler[Quat]
       .addConcreteType[Quat.Product](productPickler, scala.reflect.classTag[Quat.Product])
       .addConcreteType[Quat.Generic.type]
+      .addConcreteType[Quat.Unknown.type]
       .addConcreteType[Quat.Value.type]
       .addConcreteType[Quat.BooleanValue.type]
       .addConcreteType[Quat.BooleanExpression.type]

--- a/quill-core-portable/src/main/scala/io/getquill/quat/KryoQuatSerializer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/KryoQuatSerializer.scala
@@ -21,6 +21,7 @@ object KryoQuatSerializer {
       k.register(Quat.BooleanExpression.getClass)
       k.register(Quat.Null.getClass)
       k.register(Quat.Generic.getClass)
+      k.register(Quat.Unknown.getClass)
       // Need to make sure LinkedHashMap is converted to a list of key,value tuples before being convered
       // otherwise very strange things happen after kryo deserialization with the operation of LinkedHashMap.
       // for example, Quat.zip on LinkedHashMap would cause:

--- a/quill-core-portable/src/main/scala/io/getquill/quat/KryoQuatSerializer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/KryoQuatSerializer.scala
@@ -16,12 +16,17 @@ object KryoQuatSerializer {
     override def apply(k: Kryo): Unit = {
       k.register(classOf[Quat])
       k.register(classOf[Quat.Product])
+      k.register(classOf[Quat.Product.Id])
       k.register(Quat.Value.getClass)
       k.register(Quat.BooleanValue.getClass)
       k.register(Quat.BooleanExpression.getClass)
       k.register(Quat.Null.getClass)
       k.register(Quat.Generic.getClass)
       k.register(Quat.Unknown.getClass)
+      k.register(classOf[Quat.Product.Type])
+      k.register(Quat.Product.Type.Concrete.getClass)
+      k.register(Quat.Product.Type.Abstract.getClass)
+
       // Need to make sure LinkedHashMap is converted to a list of key,value tuples before being convered
       // otherwise very strange things happen after kryo deserialization with the operation of LinkedHashMap.
       // for example, Quat.zip on LinkedHashMap would cause:

--- a/quill-core-portable/src/main/scala/io/getquill/quat/Quat.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/Quat.scala
@@ -1,6 +1,7 @@
 package io.getquill.quat
 
 import io.getquill.quotation.QuatException
+import io.getquill.util.Messages.TraceType
 
 import scala.collection.mutable
 
@@ -40,6 +41,7 @@ object LinkedHashMapOps {
  * all operations Quats have referential transparency.
  */
 sealed trait Quat {
+  def isPrimitive = false
   def applyRenames: Quat = this
   def withRenames(renames: mutable.LinkedHashMap[String, String]): Quat
   def withRenames(renames: List[(String, String)]): Quat =
@@ -89,7 +91,7 @@ sealed trait Quat {
   override def toString: String = shortString
 
   def shortString: String = this match {
-    case Quat.Product(fields) => s"CC(${
+    case p @ Quat.Product(fields) => s"CC${if (p.tpe == Quat.Product.Type.Abstract) "A" else ""}(${
       fields.map {
         case (k, v) => k + (v match {
           case other => ":" + other.shortString
@@ -123,11 +125,11 @@ sealed trait Quat {
   def lookup(path: String): Quat = (this, path) match {
     case (cc @ Quat.Product(fields), fieldName) =>
       fields.get(fieldName).getOrElse {
-        io.getquill.util.Messages.trace(s"The field '${fieldName}' does not exist in an SQL-level type ${cc}. Assuming it's type is Quat.Unknown.")
+        io.getquill.util.Messages.trace(s"The field '${fieldName}' does not exist in an SQL-level type ${cc}. Assuming it's type is Quat.Unknown.", traceType = TraceType.Warning)
         Quat.Unknown
       }
     case (other, fieldName) =>
-      io.getquill.util.Messages.trace(s"The field '${fieldName}' does not exist in an SQL-level type ${other}. Assuming it's type is Quat.Unknown.")
+      io.getquill.util.Messages.trace(s"The field '${fieldName}' does not exist in an SQL-level type ${other}. Assuming it's type is Quat.Unknown.", traceType = TraceType.Warning)
       Quat.Unknown
   }
   def lookup(list: List[String]): Quat =
@@ -143,19 +145,19 @@ object Quat {
   def fromSerializedJVM(serial: String): Quat = KryoQuatSerializer.deserialize(serial)
   def fromSerializedJS(serial: String): Quat = BooQuatSerializer.deserialize(serial)
 
-  case class Product(fields: mutable.LinkedHashMap[String, Quat]) extends Quat {
-    def this(list: Iterator[(String, Quat)]) = this((mutable.LinkedHashMap[String, Quat]() ++ list): mutable.LinkedHashMap[String, Quat])
+  class Product(val fields: mutable.LinkedHashMap[String, Quat], override val renames: mutable.LinkedHashMap[String, String], val tpe: Quat.Product.Type) extends Quat {
+    private val id = Product.Id(fields)
 
-    // Strictly internal, use WithRenames to construct an instance of a Product with Renames
-    private def this(fields: mutable.LinkedHashMap[String, Quat], newRenames: mutable.LinkedHashMap[String, String]) = {
-      this(fields)
-      _renames = newRenames
-    }
+    override def equals(that: Any) =
+      that match {
+        case e: Quat.Product => this.id == e.id
+        case _               => false
+      }
 
-    // Defining as var but should be effectively static! I.e. changes only possible with WithRename. Need
-    // to make this var because doing "new Product { override def renames = newRenames }" breaks BooPickle serialization
-    var _renames: mutable.LinkedHashMap[String, String] = mutable.LinkedHashMap()
-    override def renames: mutable.LinkedHashMap[String, String] = _renames
+    override def hashCode = id.hashCode()
+
+    def copy(fields: mutable.LinkedHashMap[String, Quat] = this.fields, renames: mutable.LinkedHashMap[String, String] = this.renames, tpe: Quat.Product.Type = this.tpe) =
+      new Product(fields, renames, tpe)
 
     def withRenamesFrom(other: Quat): Quat = {
       other match {
@@ -172,8 +174,13 @@ object Quat {
               // If the value of the other field is not a product, just return the original field/value
               case Right((key, _, to))                      => (key, to)
             }
-          // Pass in the local renames from the other quat product
-          Quat.Product(newFields).withRenames(otherProduct.renames)
+          // Pass in the local renames from the other quat product)
+          val newTpe =
+            if (this.tpe == Product.Type.Abstract || otherProduct.tpe == Product.Type.Abstract)
+              Product.Type.Abstract
+            else
+              Product.Type.Concrete
+          Quat.Product(newFields).withRenames(otherProduct.renames).withType(newTpe)
 
         case _ => this
       }
@@ -187,16 +194,24 @@ object Quat {
           case (key, Some(value)) => (key, value)
         }
       val newFields = mutable.LinkedHashMap(newFieldsIter.toList: _*)
+      val newTpe =
+        if (this.tpe == Product.Type.Abstract || other.tpe == Product.Type.Abstract)
+          Product.Type.Abstract
+        else
+          Product.Type.Concrete
       // Note, some extra renames from properties that don't exist could make it here.
       // Need to make sure to ignore extra ones when they are actually applied.
-      Some(Quat.Product(newFields).withRenames(renames))
+      Some(Quat.Product(newFields).withRenames(renames).withType(newTpe))
     }
 
     override def withRenames(renames: mutable.LinkedHashMap[String, String]): Quat.Product =
-      Product.WithRenames(fields, renames)
+      Product.WithRenames(tpe, fields, renames)
+
+    def withType(tpe: Quat.Product.Type) =
+      this.copy(tpe = tpe)
 
     override def withRenames(renames: List[(String, String)]): Quat.Product =
-      Product.WithRenames(fields, (mutable.LinkedHashMap[String, String]() ++ renames): mutable.LinkedHashMap[String, String])
+      Product.WithRenames(tpe, fields, (mutable.LinkedHashMap[String, String]() ++ renames): mutable.LinkedHashMap[String, String])
 
     /**
      * Rename the properties based on the renames list. Keep this list
@@ -212,20 +227,48 @@ object Quat {
           val newValue = q.applyRenames
           (newKey, newValue)
       }
-      Product.WithRenames(newFields, renames)
+      Product.WithRenames(tpe, newFields, renames)
     }
   }
   def LeafProduct(list: String*) = Quat.Product(list.map(e => (e, Quat.Value)))
   def LeafTuple(numElems: Int) = Quat.Tuple((1 to numElems).map(_ => Quat.Value))
 
   object Product {
+    case class Id(fields: mutable.LinkedHashMap[String, Quat])
+
     def fromSerializedJVM(serial: String): Quat.Product = KryoQuatSerializer.deserialize(serial).probit
     def fromSerializedJS(serial: String): Quat.Product = BooQuatSerializer.deserialize(serial).probit
 
-    def empty = new Quat.Product(mutable.LinkedHashMap[String, Quat]())
-    def apply(fields: (String, Quat)*): Quat.Product = apply(fields.iterator)
-    def apply(fields: Iterable[(String, Quat)]): Quat.Product = new Quat.Product(fields.iterator)
-    def apply(fields: Iterator[(String, Quat)]): Quat.Product = new Quat.Product(fields)
+    def empty = new Quat.Product(mutable.LinkedHashMap(), mutable.LinkedHashMap(), Type.Concrete)
+
+    def apply(fields: (String, Quat)*): Quat.Product = new Quat.Product(mutable.LinkedHashMap[String, Quat]() ++ fields.iterator, mutable.LinkedHashMap(), Type.Concrete)
+    def apply(tpe: Type, fields: (String, Quat)*): Quat.Product = new Quat.Product(mutable.LinkedHashMap[String, Quat]() ++ fields.iterator, mutable.LinkedHashMap(), tpe)
+
+    def apply(fields: Iterable[(String, Quat)]): Quat.Product = new Quat.Product(mutable.LinkedHashMap[String, Quat]() ++ fields.iterator, mutable.LinkedHashMap(), Type.Concrete)
+    def apply(tpe: Type, fields: Iterable[(String, Quat)]): Quat.Product = new Quat.Product(mutable.LinkedHashMap[String, Quat]() ++ fields.iterator, mutable.LinkedHashMap(), tpe)
+
+    def apply(fields: Iterator[(String, Quat)]): Quat.Product = new Quat.Product(mutable.LinkedHashMap[String, Quat]() ++ fields, mutable.LinkedHashMap(), Type.Concrete)
+    def apply(tpe: Type, fields: Iterator[(String, Quat)]): Quat.Product = new Quat.Product(mutable.LinkedHashMap[String, Quat]() ++ fields, mutable.LinkedHashMap(), tpe)
+
+    def apply(fields: mutable.LinkedHashMap[String, Quat]): Quat.Product = new Quat.Product(fields, mutable.LinkedHashMap(), Type.Concrete)
+    def apply(tpe: Type, fields: mutable.LinkedHashMap[String, Quat]): Quat.Product = new Quat.Product(fields, mutable.LinkedHashMap(), tpe)
+
+    def unapply(p: Quat.Product): Option[mutable.LinkedHashMap[String, Quat]] = Some(p.fields)
+
+    /**
+     * Since Product-Quats can be a representation of abstract product types (e.g. abstract classes, traits, etc...)
+     * in some cases we need to keep track of this information in order to know that the present product type does not have all of the needed fields.
+     * Currently, this is only really possible in quill-spark where resolution of T (of Query[T]) can be a different class during compile-time
+     * and run-type while still having a static-query (since dataframes are lifted via the liftQuery construct that has this unique property, I do not
+     * believe that this is currently possible with the standard query[T] method).
+     * As outlined in the TypeMemberJoinSpec, there are certain situations where the contents of an `Ident(a)` are not entirely known and the ident
+     * needs to be expanded as either `struct(a.*)` or just `a.*` depending on the situation.
+     */
+    sealed trait Type
+    object Type {
+      case object Abstract extends Type
+      case object Concrete extends Type
+    }
 
     /**
      * Add staged renames to the Quat. Note that renames should
@@ -234,11 +277,12 @@ object Quat {
      * (see `PropagateRenames` for more detail)
      */
     object WithRenames {
-      def apply(fields: mutable.LinkedHashMap[String, Quat], theRenames: mutable.LinkedHashMap[String, String]) =
-        new Product(fields, theRenames)
+      def apply(tpe: Quat.Product.Type, fields: mutable.LinkedHashMap[String, Quat], theRenames: mutable.LinkedHashMap[String, String]) =
+        new Product(fields, theRenames, tpe)
 
-      def iterated(list: Iterator[(String, Quat)], renames: Iterator[(String, String)]) =
+      def iterated(tpe: Quat.Product.Type, list: Iterator[(String, Quat)], renames: Iterator[(String, String)]) =
         WithRenames.apply(
+          tpe,
           (mutable.LinkedHashMap[String, Quat]() ++ list): mutable.LinkedHashMap[String, Quat],
           (mutable.LinkedHashMap[String, String]() ++ renames): mutable.LinkedHashMap[String, String]
         )
@@ -248,7 +292,7 @@ object Quat {
     }
 
     object WithRenamesCompact {
-      def apply(fields: String*)(values: Quat*)(renamesFrom: String*)(renamesTo: String*) = {
+      def apply(tpe: Quat.Product.Type)(fields: String*)(values: Quat*)(renamesFrom: String*)(renamesTo: String*) = {
         if (fields.length != values.length)
           throw new IllegalArgumentException(
             s"Property Re-creation failed because fields length ${fields.length} was not same as values length ${values.length}." +
@@ -259,19 +303,19 @@ object Quat {
             s"Property Re-creation failed because rename keys length ${renamesFrom.length} was not same as rename values length ${renamesTo.length}." +
               s"\nKeys: [${renamesFrom.mkString(", ")}]" + s"\nValues: [${renamesTo.mkString(", ")}]"
           )
-        Product.WithRenames.iterated(fields.zip(values).iterator, renamesFrom.zip(renamesTo).iterator)
+        Product.WithRenames.iterated(tpe, fields.zip(values).iterator, renamesFrom.zip(renamesTo).iterator)
       }
 
       def unapply(p: Quat.Product) = {
         val (fields, values) = p.fields.unzip
         val (renamesFrom, renamesTo) = p.renames.unzip
-        Some((fields, values, renamesFrom, renamesTo))
+        Some((p.tpe, fields, values, renamesFrom, renamesTo))
       }
     }
   }
   object Tuple {
     def apply(fields: Quat*): Quat.Product = apply(fields)
-    def apply(fields: Iterable[Quat]): Quat.Product = new Quat.Product(fields.zipWithIndex.map { case (f, i) => (s"_${i + 1}", f) }.iterator)
+    def apply(fields: Iterable[Quat]): Quat.Product = Quat.Product(fields.zipWithIndex.map { case (f, i) => (s"_${i + 1}", f) }.iterator)
   }
   case object Null extends Quat {
     override def withRenames(renames: mutable.LinkedHashMap[String, String]) = this
@@ -292,8 +336,14 @@ object Quat {
       }
   }
 
-  case object Value extends Quat with NoRenames
-  sealed trait Boolean extends Quat
+  // A 'primitive' quat represents a value
+  sealed trait Primitive extends Quat {
+    override def isPrimitive = true
+  }
+
+  case object Value extends Primitive with NoRenames
+  sealed trait Boolean extends Primitive
+
   case object BooleanValue extends Boolean with NoRenames
   case object BooleanExpression extends Boolean with NoRenames
 

--- a/quill-core-portable/src/main/scala/io/getquill/quat/QuatOps.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quat/QuatOps.scala
@@ -36,7 +36,7 @@ private[getquill] object QuatOps {
           val newFields = quat.fields.map(kv => if (kv._1 == head) (kv._1, newSubQuat) else kv)
           // Re-create the quat with the new fields. Can't use copy since it would not copy the renames
           // along with the object.
-          Quat.Product.WithRenames(newFields, quat.renames)
+          Quat.Product.WithRenames(quat.tpe, newFields, quat.renames)
       }
 
     renameQuatAtPathRecurse(path, List(), rootQuat)

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -14,13 +14,18 @@ trait QuatLiftable {
   implicit val quatProductLiftable: Liftable[Quat.Product] = Liftable[Quat.Product] {
     // If we are in the JS, use Kryo to serialize our Quat due to JS 64KB method limit that we will run into of the Quat Constructor
     // if plainly lifted into the method created by our macro (i.e. the 'ast' method).
-    case quat: Quat.Product if (serializeQuats)                                  => q"io.getquill.quat.Quat.Product.fromSerializedJS(${quat.serializeJS})"
-    case Quat.Product.WithRenamesCompact(fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+    case quat: Quat.Product if (serializeQuats)                                       => q"io.getquill.quat.Quat.Product.fromSerializedJS(${quat.serializeJS})"
+    case Quat.Product.WithRenamesCompact(tpe, fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply($tpe)(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+  }
+
+  implicit val quatProductTypeLiftable: Liftable[Quat.Product.Type] = Liftable[Quat.Product.Type] {
+    case Quat.Product.Type.Concrete => q"io.getquill.quat.Quat.Product.Type.Concrete"
+    case Quat.Product.Type.Abstract => q"io.getquill.quat.Quat.Product.Type.Abstract"
   }
 
   implicit val quatLiftable: Liftable[Quat] = Liftable[Quat] {
     case quat: Quat.Product if (serializeQuats) => q"io.getquill.quat.Quat.fromSerializedJS(${quat.serializeJS})"
-    case Quat.Product.WithRenamesCompact(fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+    case Quat.Product.WithRenamesCompact(tpe, fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply($tpe)(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
     case Quat.Value => q"io.getquill.quat.Quat.Value"
     case Quat.Null => q"io.getquill.quat.Quat.Null"
     case Quat.Generic => q"io.getquill.quat.Quat.Generic"

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -24,6 +24,7 @@ trait QuatLiftable {
     case Quat.Value => q"io.getquill.quat.Quat.Value"
     case Quat.Null => q"io.getquill.quat.Quat.Null"
     case Quat.Generic => q"io.getquill.quat.Quat.Generic"
+    case Quat.Unknown => q"io.getquill.quat.Quat.Unknown"
     case Quat.BooleanValue => q"io.getquill.quat.Quat.BooleanValue"
     case Quat.BooleanExpression => q"io.getquill.quat.Quat.BooleanExpression"
   }

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -17,13 +17,18 @@ trait QuatUnliftable {
   implicit val quatProductUnliftable: Unliftable[Quat.Product] = Unliftable[Quat.Product] {
     // On JS, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JS (due to 64KB method limit)
     case q"$pack.Quat.Product.fromSerializedJS(${ str: String })" => Quat.Product.fromSerializedJS(str)
-    case q"$pack.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(${ tpe: Quat.Product.Type })(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(tpe)(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
+  }
+
+  implicit val quatProductTypeUnliftable: Unliftable[Quat.Product.Type] = Unliftable[Quat.Product.Type] {
+    case q"$pack.Quat.Product.Type.Concrete" => Quat.Product.Type.Concrete
+    case q"$pack.Quat.Product.Type.Abstract" => Quat.Product.Type.Abstract
   }
 
   implicit val quatUnliftable: Unliftable[Quat] = Unliftable[Quat] {
     // On JS, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JS (due to 64KB method limit)
     case q"$pack.Quat.fromSerializedJS(${ str: String })" => Quat.fromSerializedJS(str)
-    case q"$pack.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(${ tpe: Quat.Product.Type })(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(tpe)(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
     case q"$pack.Quat.Product.apply(${ fields: List[(String, Quat)] })" => Quat.Product(fields)
     case q"$pack.Quat.Value" => Quat.Value
     case q"$pack.Quat.Null" => Quat.Null

--- a/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/js/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -28,6 +28,7 @@ trait QuatUnliftable {
     case q"$pack.Quat.Value" => Quat.Value
     case q"$pack.Quat.Null" => Quat.Null
     case q"$pack.Quat.Generic" => Quat.Generic
+    case q"$pack.Quat.Unknown" => Quat.Unknown
     case q"$pack.Quat.BooleanValue" => Quat.BooleanValue
     case q"$pack.Quat.BooleanExpression" => Quat.BooleanExpression
   }

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -24,6 +24,7 @@ trait QuatLiftable {
     case Quat.Value => q"io.getquill.quat.Quat.Value"
     case Quat.Null => q"io.getquill.quat.Quat.Null"
     case Quat.Generic => q"io.getquill.quat.Quat.Generic"
+    case Quat.Unknown => q"io.getquill.quat.Quat.Unknown"
     case Quat.BooleanValue => q"io.getquill.quat.Quat.BooleanValue"
     case Quat.BooleanExpression => q"io.getquill.quat.Quat.BooleanExpression"
   }

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatLiftable.scala
@@ -14,13 +14,18 @@ trait QuatLiftable {
   implicit val quatProductLiftable: Liftable[Quat.Product] = Liftable[Quat.Product] {
     // If we are in the JVM, use Kryo to serialize our Quat due to JVM 64KB method limit that we will run into of the Quat Constructor
     // if plainly lifted into the method created by our macro (i.e. the 'ast' method).
-    case quat: Quat.Product if (serializeQuats)                                  => q"io.getquill.quat.Quat.Product.fromSerializedJVM(${quat.serializeJVM})"
-    case Quat.Product.WithRenamesCompact(fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+    case quat: Quat.Product if (serializeQuats)                                       => q"io.getquill.quat.Quat.Product.fromSerializedJVM(${quat.serializeJVM})"
+    case Quat.Product.WithRenamesCompact(tpe, fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply($tpe)(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+  }
+
+  implicit val quatProductTypeLiftable: Liftable[Quat.Product.Type] = Liftable[Quat.Product.Type] {
+    case Quat.Product.Type.Concrete => q"io.getquill.quat.Quat.Product.Type.Concrete"
+    case Quat.Product.Type.Abstract => q"io.getquill.quat.Quat.Product.Type.Abstract"
   }
 
   implicit val quatLiftable: Liftable[Quat] = Liftable[Quat] {
     case quat: Quat.Product if (serializeQuats) => q"io.getquill.quat.Quat.fromSerializedJVM(${quat.serializeJVM})"
-    case Quat.Product.WithRenamesCompact(fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
+    case Quat.Product.WithRenamesCompact(tpe, fields, values, renamesFrom, renamesTo) => q"io.getquill.quat.Quat.Product.WithRenamesCompact.apply($tpe)(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)"
     case Quat.Value => q"io.getquill.quat.Quat.Value"
     case Quat.Null => q"io.getquill.quat.Quat.Null"
     case Quat.Generic => q"io.getquill.quat.Quat.Generic"

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -28,6 +28,7 @@ trait QuatUnliftable {
     case q"$pack.Quat.Value" => Quat.Value
     case q"$pack.Quat.Null" => Quat.Null
     case q"$pack.Quat.Generic" => Quat.Generic
+    case q"$pack.Quat.Unknown" => Quat.Unknown
     case q"$pack.Quat.BooleanValue" => Quat.BooleanValue
     case q"$pack.Quat.BooleanExpression" => Quat.BooleanExpression
   }

--- a/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
+++ b/quill-core/jvm/src/main/scala/io/getquill/quotation/QuatUnliftable.scala
@@ -17,13 +17,18 @@ trait QuatUnliftable {
   implicit val quatProductUnliftable: Unliftable[Quat.Product] = Unliftable[Quat.Product] {
     // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
     case q"$pack.Quat.Product.fromSerializedJVM(${ str: String })" => Quat.Product.fromSerializedJVM(str)
-    case q"$pack.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(${ tpe: Quat.Product.Type })(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(tpe)(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
+  }
+
+  implicit val quatProductTypeUnliftable: Unliftable[Quat.Product.Type] = Unliftable[Quat.Product.Type] {
+    case q"$pack.Quat.Product.Type.Concrete" => Quat.Product.Type.Concrete
+    case q"$pack.Quat.Product.Type.Abstract" => Quat.Product.Type.Abstract
   }
 
   implicit val quatUnliftable: Unliftable[Quat] = Unliftable[Quat] {
     // On JVM, a Quat must be serialized and then lifted from the serialized state i.e. as a FromSerialized using JVM (due to 64KB method limit)
     case q"$pack.Quat.fromSerializedJVM(${ str: String })" => Quat.fromSerializedJVM(str)
-    case q"$pack.Quat.Product.WithRenamesCompact.apply(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
+    case q"$pack.Quat.Product.WithRenamesCompact.apply(${ tpe: Quat.Product.Type })(..$fields)(..$values)(..$renamesFrom)(..$renamesTo)" => Quat.Product.WithRenamesCompact(tpe)(unliftStrings(fields): _*)(unliftQuats(values): _*)(unliftStrings(renamesFrom): _*)(unliftStrings(renamesTo): _*)
     case q"$pack.Quat.Product.apply(${ fields: List[(String, Quat)] })" => Quat.Product(fields)
     case q"$pack.Quat.Value" => Quat.Value
     case q"$pack.Quat.Null" => Quat.Null

--- a/quill-core/src/main/scala/io/getquill/quat/QuatMaking.scala
+++ b/quill-core/src/main/scala/io/getquill/quat/QuatMaking.scala
@@ -268,13 +268,16 @@ trait QuatMakingBase {
         // run(is80Proof(query[Gin]))
         // When processing is80Prof, we assume that Spirit is actually a base class to be extended
         case Param(Signature(RealTypeBounds(lower, Deoption(upper)))) if (!upper.typeSymbol.isFinal && !existsEncoderFor(tpe)) =>
-          parseType(upper, true)
+          parseType(upper, true) match {
+            case p: Quat.Product => p.copy(tpe = Quat.Product.Type.Abstract)
+            case other           => other
+          }
 
         case Param(RealTypeBounds(lower, Deoption(upper))) if (!upper.typeSymbol.isFinal && !existsEncoderFor(tpe)) =>
-          parseType(upper, true)
-
-        //case Param(tpe) =>
-        //  Quat.Generic
+          parseType(upper, true) match {
+            case p: Quat.Product => p.copy(tpe = Quat.Product.Type.Abstract)
+            case other           => other
+          }
 
         case other =>
           parseType(other)

--- a/quill-core/src/main/scala/io/getquill/quat/QuatMaking.scala
+++ b/quill-core/src/main/scala/io/getquill/quat/QuatMaking.scala
@@ -198,7 +198,7 @@ trait QuatMakingBase {
 
     object Param {
       def unapply(tpe: Type) =
-        if (tpe.typeSymbol.isParameter)
+        if (tpe.typeSymbol.isParameter || tpe.typeSymbol.isAbstract)
           Some(tpe)
         else
           None
@@ -260,8 +260,8 @@ trait QuatMakingBase {
         case Param(RealTypeBounds(lower, Deoption(upper))) if (!upper.typeSymbol.isFinal && !existsEncoderFor(tpe)) =>
           parseType(upper, true)
 
-        case Param(tpe) =>
-          Quat.Generic
+        //case Param(tpe) =>
+        //  Quat.Generic
 
         case other =>
           parseType(other)
@@ -285,9 +285,6 @@ trait QuatMakingBase {
         case QueryType(tpe) =>
           parseType(tpe)
 
-        case Param(tpe) =>
-          Quat.Generic
-
         // If the type is optional, recurse
         case _ if (isOptionType(tpe)) =>
           val innerParam = innerOptionParam(tpe, None)
@@ -304,6 +301,10 @@ trait QuatMakingBase {
         // If we are already inside a bounded type, treat an arbitrary type as a interface list
         case ArbitraryBaseType(name, fields) if (boundedInterfaceType) =>
           Quat.Product(fields.map { case (fieldName, fieldType) => (fieldName, parseType(fieldType)) })
+
+        // Is it a generic or does it have any generic parameters that have not been filled (e.g. is T not filled in Option[T] ?)
+        case Param(tpe) =>
+          Quat.Generic
 
         // Otherwise it's a terminal value
         case _ =>

--- a/quill-core/src/main/scala/io/getquill/quat/QuatMaking.scala
+++ b/quill-core/src/main/scala/io/getquill/quat/QuatMaking.scala
@@ -188,6 +188,14 @@ trait QuatMakingBase {
         Some(tpe.typeSymbol.typeSignature)
     }
 
+    object OptionType {
+      def unapply(tpe: Type) =
+        if (isOptionType(tpe))
+          Some(innerOptionParam(tpe, None))
+        else
+          None
+    }
+
     object Deoption {
       def unapply(tpe: Type) =
         if (isOptionType(tpe))
@@ -229,6 +237,8 @@ trait QuatMakingBase {
           None
         else if (isType[AnyVal](tpe))
           Some(tpe)
+        else if (existsEncoderFor(tpe))
+          Some(tpe)
         else
           None
       }
@@ -237,6 +247,9 @@ trait QuatMakingBase {
     def parseTopLevelType(tpe: Type): Quat =
       tpe match {
         case BooleanType(tpe) =>
+          Quat.BooleanValue
+
+        case OptionType(BooleanType(innerParam)) =>
           Quat.BooleanValue
 
         case DefiniteValue(tpe) =>
@@ -277,6 +290,9 @@ trait QuatMakingBase {
         case BooleanType(tpe) =>
           Quat.BooleanValue
 
+        case OptionType(BooleanType(_)) =>
+          Quat.BooleanValue
+
         case DefiniteValue(tpe) =>
           Quat.Value
 
@@ -286,8 +302,7 @@ trait QuatMakingBase {
           parseType(tpe)
 
         // If the type is optional, recurse
-        case _ if (isOptionType(tpe)) =>
-          val innerParam = innerOptionParam(tpe, None)
+        case OptionType(innerParam) =>
           parseType(innerParam)
 
         case _ if (isNone(tpe)) =>
@@ -308,8 +323,8 @@ trait QuatMakingBase {
 
         // Otherwise it's a terminal value
         case _ =>
-          Messages.trace(s"Could not infer SQL-type of ${tpe}, assuming it is a value.")
-          Quat.Value
+          Messages.trace(s"Could not infer SQL-type of ${tpe}, assuming it is a Unknown Quat.")
+          Quat.Unknown
       }
 
     parseTopLevelType(tpe)

--- a/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/ReifyLiftings.scala
@@ -107,7 +107,7 @@ trait ReifyLiftings extends QuatMaking {
           // other kinds of constructs.
           val reparsedAst =
             (ref.tpe, refAst) match {
-              case (QuotedType(QueryType(tpe)), i @ Infix(_, _, _, Quat.Generic)) =>
+              case (QuotedType(QueryType(tpe)), i @ Infix(_, _, _, Quat.Placeholder(_))) =>
                 i.copy(quat = inferQuat(tpe))
               case _ => refAst
             }

--- a/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/quat/QuatSpec.scala
@@ -8,6 +8,12 @@ class QuatSpec extends Spec {
   object testContext extends TestMirrorContextTemplate(MirrorIdiom, Literal) with TestEntities
   import testContext._
 
+  "boolean and optional boolean" in {
+    case class MyPerson(name: String, isHuman: Boolean, isRussian: Option[Boolean])
+    val MyPersonQuat = Quat.Product("name" -> Quat.Value, "isHuman" -> Quat.BooleanValue, "isRussian" -> Quat.BooleanValue)
+    quote(query[MyPerson]).ast.quat mustEqual MyPersonQuat
+  }
+
   "should support standard case class" in {
     case class MyPerson(firstName: String, lastName: String, age: Int)
     val MyPersonQuat = Quat.LeafProduct("firstName", "lastName", "age")
@@ -57,17 +63,15 @@ class QuatSpec extends Spec {
     val bar = Quat.Product("baz" -> Quat.Value)
     val foo = Quat.Product("v" -> Quat.Value, "bar" -> bar)
     val example = Quat.Product("v" -> Quat.Value, "foo" -> foo)
-    "path" - {
+    "path" in {
       example.lookup("foo") mustEqual foo
       example.lookup(List("foo", "bar")) mustEqual bar
       example.lookup(List("foo", "bar", "baz")) mustEqual Quat.Value
-      val e = intercept[QuatException] {
-        example.lookup("blah")
-      }
+      example.lookup("blah") mustEqual Quat.Unknown
     }
   }
 
-  "probit" - {
+  "probit" in {
     val p: Quat = Quat.Product("foo" -> Quat.Value)
     val v: Quat = Quat.Value
     p.probit mustEqual p

--- a/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
+++ b/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
@@ -45,7 +45,7 @@ trait QuillSparkContext
 
   def liftQuery[T](ds: Dataset[T]) =
     quote {
-      infix"${lift(ds)}".generic.pure.as[Query[T]]
+      infix"${lift(ds)}".pure.as[Query[T]]
     }
 
   // Helper class for the perculateNullArrays method

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SimpleNestedExpansion.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SimpleNestedExpansion.scala
@@ -27,19 +27,65 @@ object TopLevelExpansion {
           case (name, ast) =>
             SelectValue(ast, Some(name), concat)
         }
-      case SelectValue(Ident(singleFieldName, Quat.Product(fields)), alias, concat) if (length == 1) =>
+
+      // If an ident is the only thing in the select list (and it is not abstract, meaning we know what all of it's fields are),
+      // then expand it directly in the selection clauses. If the ident is abstract however, we do not know all of it's fields
+      // and therefore cannot directly expand it into select-values since there could be fields that we have missed.
+      // The only good option that I have thought of so far, is to expand the Ident in the SparkDialect directly
+      // in the FlattenSqlTokenizer with special handling for length=1 selects
+      case SelectValue(Ident(singleFieldName, q @ Quat.Product(fields)), alias, concat) if (length == 1 && q.tpe == Quat.Product.Type.Concrete) =>
         fields.map {
           case (name, quat) =>
             SelectValue(Property(Ident(singleFieldName, quat), name), Some(name), concat)
         }.toList
+
       // Direct infix select, etc...
-      case other if (length == 1) =>
+      case other @ SelectValue(SingleValuePrimitive(), _, _) if (length == 1) =>
         List(other.copy(alias = Some("single")))
       // Technically this case should not exist, adding it so that the pattern match will have full coverage
       case other =>
         List(other)
     }
   }
+}
+
+/**
+ * In each of these situations, the AST can be expanded with as a single SelectValue (with the 'single' alias)
+ * in a select query. For example, SelectValue(Property(p,name)) would become 'SELECT p.name AS single ...'.
+ * SelectValue(If(foo,bar,baz)) would become 'SELECT CASE WHEN foo THEN bar ELSE baz as single ...',
+ * or SelectValue(NullValue) would become 'SELECT null as single ...'
+ * In each of these cases we can assume the actual selection represents a single value.
+ * The opposite of this if the selection is an Ident. In that case, we can never really assume
+ * that the selection represents a single value (*) so we generally have to do star expansions of various kinds.
+ * This unapplier object is used both here and in the SpartDialect select tokenization.
+ *
+ *  - unless the Ident has a Concrete Quat.Proudct with a single value,
+ * but that has already been expanded into it's composite elements in TopLevelExpanion.apply and the Ident shuold no
+ * longer exist in the select values.
+ *
+ * Technically, all we we need to do here is to check that the ast element is not an ident, however due to previous
+ * issues encountered with surprising use-cases with spark, I have decided to ast least log a warning if a single-value
+ * element in a Spark query SelectValue is not one of the expected use-cases.
+ */
+object SingleValuePrimitive {
+  def unapply(ast: Ast): Boolean =
+    ast match {
+      case _: Constant => true
+      case _: Property => true
+      case NullValue => true
+      case op: OptionOperation if (op.quat.isPrimitive) => true
+      case op: BinaryOperation if (op.quat.isPrimitive) => true
+      case op: UnaryOperation if (op.quat.isPrimitive) => true
+      case op: IterableOperation if (op.quat.isPrimitive) => true
+      case i: Infix if (!i.quat.isInstanceOf[Quat.Product]) => true
+      case l: Lift => true
+      // idents should not be directly tokenized as sql values since they always need to be a start-select in a query
+      case id: Ident => false
+      case _ =>
+        import io.getquill.util.Messages._
+        trace(s"Unaccounted-for primitive SelectValue type: ${qprintCustom(traceQuats = QuatTrace.Full)(ast).plainText}. Assuming it can be used as a value-level placeholder and be aliased as 'single'.", traceType = TraceType.Warning)
+        true
+    }
 }
 
 object SimpleNestedExpansion extends StatelessQueryTransformer {

--- a/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
+++ b/quill-spark/src/main/scala/io/getquill/context/spark/SparkDialect.scala
@@ -3,7 +3,7 @@ package io.getquill.context.spark
 import io.getquill.NamingStrategy
 import io.getquill.ast.{ Ast, BinaryOperation, CaseClass, Constant, ExternalIdent, Ident, Operation, Property, Query, StringOperator, Tuple, Value }
 import io.getquill.context.spark.norm.EscapeQuestionMarks
-import io.getquill.context.sql.{ SqlQuery }
+import io.getquill.context.sql.{ FlattenSqlQuery, SelectValue, SetOperationSqlQuery, SqlQuery, UnaryOperationSqlQuery }
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.context.sql.norm.SqlNormalize
 import io.getquill.idiom.StatementInterpolator._
@@ -37,7 +37,7 @@ trait SparkIdiom extends SqlIdiom with CannotReturn { self =>
           val expanded = SimpleNestedExpansion(sql)
           trace("expanded sql")(expanded)
           val tokenized = expanded.token
-          trace("tokenized sql")(tokenized)
+          trace("tokenized sql")(tokenized.toString)
           tokenized
         case other =>
           other.token
@@ -49,8 +49,10 @@ trait SparkIdiom extends SqlIdiom with CannotReturn { self =>
   override def concatFunction = "explode"
 
   override implicit def identTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Ident] = Tokenizer[Ident] {
-    case id @ Ident(name, Quat.Product(fields)) =>
+    case id @ Ident(name, q @ Quat.Product(fields)) if (q.tpe == Quat.Product.Type.Concrete) =>
       stmt"struct(${fields.map { case (field, subQuat) => (Property(id, field): Ast) }.toList.token})"
+    case id @ Ident(name, q: Quat.Product) if (q.tpe == Quat.Product.Type.Abstract) =>
+      stmt"struct(${name.token}.*)"
     // Situations where a single ident arise with is a Quat.Value typically only happen when an operation yields a single SelectValue
     // e.g. a concatMap (or aggregation?)
     case Ident(name, Quat.Value) =>
@@ -58,6 +60,61 @@ trait SparkIdiom extends SqlIdiom with CannotReturn { self =>
     case Ident(name, _) =>
       stmt"${name.token}"
   }
+
+  class SparkFlattenSqlQueryTokenizerHelper(q: FlattenSqlQuery)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy)
+    extends FlattenSqlQueryTokenizerHelper(q)(astTokenizer, strategy) {
+
+    override def selectTokenizer: Token = {
+      // Note that by the time we have reached this point, all Idents representing case classes/tuples in selection have
+      // already been expanded into their composite properties. This is handled via the select.token which delegates
+      // to the list tokenizer which delegates to the select value tokenizer. The remaining cases that need special handling
+      // are when there is a single select-value which represents an Ident that cannot be expanded
+      // (either because it's quat is a placeholder type, or it's quat is abstract), or a single
+      // value-level entity (either a Ident whose quat is Quat.Value) or is a single-value field
+      // e.g. a Property, Constant, etc... as defined by SingleValuePrimitive.
+      // The logic of these cases is simple. Any Ident which whose type is unknown needs to be star-expanded, there
+      // is no other choice since we don't know anything else about it. Any primitive-valued ident also needs to be
+      // star-expanded since we do not know the alias of the actual primitive field (hopefully it is 'single' as defined
+      // by SimpleNestedExpansion but we cannot know for sure).
+      // For any other kind of entity e.g. a Property, etc... we can safely tokenize the select-value whose alias
+      // should hopefully also be 'single'
+      q.select match {
+        case Nil => stmt"*"
+        // If we have encountered a situation where a abstract ident is on the top level and the only select field, (i.e. select.length == 1)
+        // it is a strange situation that needs special handling.
+        // We cannot expand the fields of the ident because there might be fields that we don't know about. We also can't just pass
+        // the ident along since in the SparkDialect it will be rendered as Ident("a") => struct(a.*) which doesn't work in a top-level select
+        // (i.e. you can't do "select struct(a.*) from ..." since on the top level the fields must be expanded.)
+        // The only good option that I have thought of so far, is to expand the Ident in the SparkDialect directly
+        // in the FlattenSqlTokenizer with special handling for length=1 selects
+        case List(SelectValue(Ident(a, q @ Quat.Product(_)), _, _)) if (q.tpe == Quat.Product.Type.Abstract) =>
+          stmt"${a.token}.*"
+        // it is an ident but somehow it's type is not known
+        case List(SelectValue(Ident(a, Quat.Placeholder(_)), _, _)) =>
+          stmt"${a.token}.*"
+        // It is an ident but actually it repsents a single sql-level value
+        case List(SelectValue(Ident(a, _: Quat.Primitive), _, _)) =>
+          stmt"${a.token}.*"
+        // If the selection is a single value e.g. SelectValue(prop.value), SelectValue(Constant) return it right here as a SingleValuePrimitive
+        case sv @ List(SelectValue(a @ SingleValuePrimitive(), _, _)) =>
+          sv.token
+        // Otherwise it should have multiple values.
+        // TODO Maybe we should even introduce an exception here because all the support single-value selects have already been enumerated
+        case _ => q.select.token
+      }
+    }
+
+  }
+
+  override implicit def sqlQueryTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[SqlQuery] = Tokenizer[SqlQuery] {
+    case q: FlattenSqlQuery =>
+      new SparkFlattenSqlQueryTokenizerHelper(q).apply
+    case SetOperationSqlQuery(a, op, b) =>
+      stmt"(${a.token}) ${op.token} (${b.token})"
+    case UnaryOperationSqlQuery(op, q) =>
+      stmt"SELECT ${op.token} (${q.token})"
+  }
+
   override implicit def propertyTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Property] = {
     def path(ast: Ast): Token =
       ast match {

--- a/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/SparkDialectSpec.scala
@@ -68,7 +68,7 @@ class SparkDialectSpec extends Spec {
     val ast = query[Test].concatMap(t => t.s.split(" ")).filter(s => s == "s").ast
     val (norm, stmt) = SparkDialect.translate(ast)(Literal)
     norm mustEqual ast
-    stmt.toString mustEqual "SELECT s.single AS single FROM (SELECT explode(SPLIT(t.s, ' ')) AS single FROM Test t) AS s WHERE s.single = 's'"
+    stmt.toString mustEqual "SELECT s.* FROM (SELECT explode(SPLIT(t.s, ' ')) AS single FROM Test t) AS s WHERE s.single = 's'"
   }
 
   "concat string" in {

--- a/quill-spark/src/test/scala/io/getquill/context/spark/TypeMemberJoinSpec.scala
+++ b/quill-spark/src/test/scala/io/getquill/context/spark/TypeMemberJoinSpec.scala
@@ -1,0 +1,313 @@
+package io.getquill.context.spark
+
+import io.getquill.Spec
+import org.apache.spark.sql.Dataset
+import scala.language.reflectiveCalls
+
+case class Parent(name: String, childId: Int)
+case class Child(name: String, id: Int)
+case class GrandChild(name: String, parentId: Int)
+
+class TypeMemberJoinSpec extends Spec {
+
+  val context = io.getquill.context.sql.testContext
+
+  import testContext._
+  import sqlContext.implicits._
+
+  sealed trait ChildJoiner {
+    type SomeChild <: { def id: Int }
+    type SomeGrandChild <: { def parentId: Int }
+    def children: Dataset[SomeChild]
+    def grandchildren: Dataset[SomeGrandChild]
+
+    implicit class JoinFromParent[T <: { def childId: Int }](p: T) {
+      def joinChild = quote {
+        for {
+          c <- liftQuery(children).join(c => c.id == p.childId)
+        } yield c
+      }
+      def joinChildAndGrandChild = quote { //hellooooooo
+        for {
+          c <- liftQuery(children).join(c => c.id == p.childId)
+          g <- liftQuery(grandchildren).join(g => g.parentId == c.id)
+        } yield (c, g)
+      }
+    }
+  }
+
+  object Data {
+    val parent = Parent("Joe", 1)
+    val child = Child("Jack", 1)
+    val grandChild = GrandChild("James", 1)
+  }
+  val parents = List(Data.parent).toDS
+  val childrenBase = List(Data.child).toDS
+  val grandChildrenBase = List(Data.grandChild).toDS
+
+  class Extensions extends ChildJoiner {
+    override type SomeChild = Child
+    override type SomeGrandChild = GrandChild
+    override val children: Dataset[Child] = childrenBase
+    override val grandchildren: Dataset[GrandChild] = grandChildrenBase
+  }
+
+  "joins on type member objects" - {
+    import io.getquill.ast.{ Ident => Id, _ }
+    import io.getquill.ast.{ Ast, Infix }
+    import io.getquill.quat.Quat
+    object QStr {
+      def unapply(q: Quat) = Some(q.toString)
+    }
+    object AnyInfix {
+      def unapply(ast: Ast) =
+        ast match {
+          case Infix(_, _, _, _) => true
+          case _                 => false
+        }
+    }
+
+    val ext = new Extensions
+    import ext._
+
+    "should be possible on one object" in {
+      val q = quote {
+        for {
+          p <- liftQuery(parents)
+          c <- p.joinChild
+        } yield (p, c)
+      }
+
+      q.ast match {
+        case FlatMap(
+          AnyInfix(),
+          Id("p", QStr("CC(name:V,childId:V)")),
+          Map(
+            Map(
+              FlatJoin(
+                InnerJoin,
+                AnyInfix(),
+                Id("c", QStr("CCA(id:V)")), // This is important, since macro gets inferred from SomeChild, it only knows about the 'id' property
+                (Property(Id("c", QStr("CCA(id:V)")), "id") +==+ Property(Id("p", QStr("CC(name:V,childId:V)")), "childId"))
+                ),
+              Id("c", QStr("CCA(id:V)")),
+              Id("c", QStr("CCA(id:V)"))
+              ),
+            Id("c", QStr("CCA(name:V,id:V)")),
+            Tuple(List(Id("p", QStr("CC(name:V,childId:V)")), Id("c", QStr("CCA(name:V,id:V)"))))
+            )
+          ) =>
+        case _ =>
+          fail(s"Tree did not match:\n${io.getquill.util.Messages.qprint(q.ast).plainText}")
+      }
+      testContext.run(q).collect().toList mustEqual List((Data.parent, Data.child))
+    }
+
+    "should be possible on one single-return object" - {
+      "abstract" in {
+        val q = quote {
+          for {
+            p <- liftQuery(parents)
+            c <- p.joinChild
+          } yield c
+        }
+        testContext.run(q).collect().toList mustEqual List(Data.child)
+      }
+      "concrete" in {
+        val q = quote {
+          for {
+            p <- liftQuery(parents)
+            c <- p.joinChild
+          } yield p
+        }
+        testContext.run(q).collect().toList mustEqual List(Data.parent)
+      }
+      "abstract nested" in {
+        val q = quote {
+          (for {
+            p <- liftQuery(parents)
+            c <- p.joinChild
+          } yield c).nested
+        }
+        testContext.run(q).collect().toList mustEqual List(Data.child)
+      }
+      "abstract double nested" in {
+        val q = quote {
+          (for {
+            p <- liftQuery(parents)
+            c <- p.joinChild
+          } yield c).nested.nested
+        }
+        testContext.run(q).collect().toList mustEqual List(Data.child)
+      }
+      "concrete nested" in {
+        val q = quote {
+          (for {
+            p <- liftQuery(parents)
+            c <- p.joinChild
+          } yield p).nested
+        }
+        testContext.run(q).collect().toList mustEqual List(Data.parent)
+      }
+    }
+
+    "should be possible on one single-return field" - {
+      "abstract" in {
+        val q = quote {
+          for {
+            p <- liftQuery(parents)
+            c <- p.joinChild
+          } yield c.name
+        }
+        testContext.run(q).collect().toList mustEqual List(Data.child.name)
+      }
+      "concrete" in {
+        val q = quote {
+          for {
+            p <- liftQuery(parents)
+            c <- p.joinChild
+          } yield p.name
+        }
+        testContext.run(q).collect().toList mustEqual List(Data.parent.name)
+      }
+      "abstract nested" in {
+        val q = quote {
+          (for {
+            p <- liftQuery(parents)
+            c <- p.joinChild
+          } yield c.name).nested
+        }
+        testContext.run(q).collect().toList mustEqual List(Data.child.name)
+      }
+      "concrete nested" in {
+        val q = quote {
+          (for {
+            p <- liftQuery(parents)
+            c <- p.joinChild
+          } yield p.name).nested
+        }
+        testContext.run(q).collect().toList mustEqual List(Data.parent.name)
+      }
+    }
+
+    "should be possible on one multiple objects" in {
+      val q = quote {
+        for {
+          p <- liftQuery(parents)
+          (c, g) <- p.joinChildAndGrandChild
+        } yield (p, c, g)
+      }
+      testContext.run(q).collect().toList mustEqual List((Data.parent, Data.child, Data.grandChild))
+      testContext.run(q.nested).collect().toList mustEqual List((Data.parent, Data.child, Data.grandChild))
+      testContext.run(q.nested.nested).collect().toList mustEqual List((Data.parent, Data.child, Data.grandChild))
+    }
+
+    "should be possible on one multiple objects - yielding a field" in {
+      val q = quote {
+        for {
+          p <- liftQuery(parents)
+          (c, g) <- p.joinChildAndGrandChild
+        } yield (p, c.name)
+      }
+
+      q.ast match {
+        case FlatMap(
+          AnyInfix(),
+          Id("p", QStr("CC(name:V,childId:V)")),
+          Map(
+            FlatMap(
+              FlatJoin(
+                InnerJoin,
+                AnyInfix(),
+                Id("c", QStr("CCA(id:V)")),
+                (Property(Id("c", QStr("CCA(id:V)")), "id") +==+ Property(Id("p", QStr("CC(name:V,childId:V)")), "childId"))
+                ),
+              Id("c", QStr("CCA(id:V)")),
+              Map(
+                FlatJoin(
+                  InnerJoin,
+                  AnyInfix(),
+                  Id("g", QStr("CCA(parentId:V)")),
+                  (Property(Id("g", QStr("CCA(parentId:V)")), "parentId") +==+ Property(Id("c", QStr("CCA(id:V)")), "id"))
+                  ),
+                Id("g", QStr("CCA(parentId:V)")),
+                Tuple(List(Id("c", QStr("CCA(id:V)")), Id("g", QStr("CCA(parentId:V)"))))
+                )
+              ),
+            Id("x2", QStr("CC(_1:CCA(name:V,id:V),_2:CCA(name:V,parentId:V))")),
+            Tuple(List(
+              Id("p", QStr("CC(name:V,childId:V)")),
+              // Note how here in the Quat of the inner ident, the _1 property representing 'child' has a 'name' and 'id' property
+              // while Child of the _1 property in the 'c' tuple (in the inner Map) only has an 'id' property. This is because
+              // when the quat of the _1 property above was synthesized, it was actually only the abstract property SomeChild
+              // (i.e. while only has a 'id' property and no others)
+              Property(Property(Id("x2", QStr("CC(_1:CCA(name:V,id:V),_2:CCA(name:V,parentId:V))")), "_1"), "name")
+              ))
+            )
+          ) =>
+        case _ =>
+          fail(s"Tree did not match:\n${io.getquill.util.Messages.qprint(q.ast).plainText}")
+      }
+      testContext.run(q).collect().toList mustEqual List((Data.parent, Data.child.name))
+    }
+
+    "should be possible on one multiple objects" - {
+      "single field - grandchild" in {
+        val q = quote {
+          for {
+            p <- liftQuery(parents)
+            (c, g) <- p.joinChildAndGrandChild
+          } yield g.name
+        }
+        testContext.run(q).collect().toList mustEqual List((Data.grandChild.name))
+      }
+
+      "single field - child" in {
+        val q = quote {
+          for {
+            p <- liftQuery(parents)
+            (c, g) <- p.joinChildAndGrandChild
+          } yield c.name
+        }
+        testContext.run(q).collect().toList mustEqual List((Data.child.name))
+        testContext.run(q.nested).collect().toList mustEqual List((Data.child.name))
+        testContext.run(q.nested.nested).collect().toList mustEqual List((Data.child.name))
+      }
+
+      "child and grandchild fields" in {
+        val q = quote {
+          for {
+            p <- liftQuery(parents)
+            (c, g) <- p.joinChildAndGrandChild
+          } yield (c.name, g.name)
+        }
+        testContext.run(q).collect().toList mustEqual List((Data.child.name, Data.grandChild.name))
+        testContext.run(q.nested).collect().toList mustEqual List((Data.child.name, Data.grandChild.name))
+        testContext.run(q.nested.nested).collect().toList mustEqual List((Data.child.name, Data.grandChild.name))
+      }
+
+      "only parent" in {
+        val q = quote {
+          for {
+            p <- liftQuery(parents)
+            (c, g) <- p.joinChildAndGrandChild
+          } yield p
+        }
+        testContext.run(q).collect().toList mustEqual List((Data.parent))
+      }
+
+      "mixed fields and values" in {
+        val q = quote {
+          for {
+            p <- liftQuery(parents)
+            (c, g) <- p.joinChildAndGrandChild
+          } yield (p, c.name, g.name)
+        }
+        testContext.run(q).collect().toList mustEqual List((Data.parent, Data.child.name, Data.grandChild.name))
+        testContext.run(q.nested).collect().toList mustEqual List((Data.parent, Data.child.name, Data.grandChild.name))
+        testContext.run(q.nested.nested).collect().toList mustEqual List((Data.parent, Data.child.name, Data.grandChild.name))
+      }
+    }
+  }
+
+}

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -116,13 +116,15 @@ trait SqlIdiom extends Idiom {
   protected class FlattenSqlQueryTokenizerHelper(q: FlattenSqlQuery)(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy) {
     import q._
 
+    def selectTokenizer =
+      select match {
+        case Nil => stmt"*"
+        case _   => select.token
+      }
+
     def distinctTokenizer = (if (distinct) "DISTINCT " else "").token
 
-    def withDistinct =
-      select match {
-        case Nil => stmt"$distinctTokenizer*"
-        case _   => stmt"$distinctTokenizer${select.token}"
-      }
+    def withDistinct = stmt"$distinctTokenizer${selectTokenizer}"
 
     def withFrom =
       from match {


### PR DESCRIPTION
Spark has a use case that allows Quats on abstract types even for static queries. Here is a pattern in which I have discovered this possibility:

```scala
  // import the quill spark context
  import QuillSparkContext._

  // create a trait that defines types and then returns the based on a query
    sealed trait ChildJoiner {
    type SomeChild <: { def id: Int }
    type SomeGrandChild <: { def parentId: Int }
    def children: Dataset[SomeChild]
    def grandchildren: Dataset[SomeGrandChild]

    implicit class JoinFromParent[T <: { def childId: Int }](p: T) {
      def joinChild = quote {
        for {
          c <- liftQuery(children).join(c => c.id == p.childId)
        } yield c
      }
      def joinChildAndGrandChild = quote { //hellooooooo
        for {
          c <- liftQuery(children).join(c => c.id == p.childId)
          g <- liftQuery(grandchildren).join(g => g.parentId == c.id)
        } yield (c, g)
      }
    }

  // Create types representing concrete impelementations
  // (actually this is spark so it needs to be done in a top-level area)
  case class Parent(name: String, childId: Int)
  case class Child(name: String, id: Int)

  //create a set of types that represent the concrete implementations
  object Data {
    val parent = Parent("Joe", 1)
    val child = Child("Jack", 1)
  }
  val parents = List(Data.parent).toDS
  val childrenBase = List(Data.child).toDS

  // instantiate the data
  class Extensions extends ChildJoiner {
    override type SomeChild = Child
    override val children: Dataset[Child] = childrenBase
  }
```
Now attempt the following query:
```scala
        // val q: Quoted[Query[SomeChild]] = ...
        val q = quote {
          for {
            p <- liftQuery(parents)
            c <- p.joinChild
          } yield c
        }
```
Firstly, this will not be expanded correctly since the ApplyMap phase incorrectly removes the Map element around the FlatJoin of this query. Once that minor issues is fixed however, there is a larger one. Namely that outer nested field of the `c` member 'child' only knows about the `id` field.
```scala
[info]   | SELECT
[info]   |   c.id
[info]   | FROM
[info]   |   (?) AS p
[info]   |   INNER JOIN (?) AS c ON c.id = p.childId
```
This is problematic since the Child object needs both a name and id field for spark to be able to encode the type back (notice how the actual return type is `Quoted[Query[SomeChild]]`).

The above behavior happens because when the quats of this query are introspected, they infer the quat from the `SomeChild` type as opposed to the `Child` type. This can be surmised based on the Quat of the query being create:
```scala
  Map(
    FlatMap(
      infix"${?}",
      Id("p", CC(name:V,childId:V)), // Parent
      Map(
        Map(
          FlatJoin(
            InnerJoin,
            infix"${?}",
            Id("c", CC(id:V)),  // Child
            BinaryOperation(Property(Id("c", CC(id:V)) /* Child */, "id"), ==, Property(Id("p", CC(name:V,childId:V)) /* Parent */, "childId"))
          ),
          Id("c", CC(id:V)), // Child
          Id("c", CC(id:V))  // Child
        ),
        Id("c", CC(name:V,id:V)),  // Child (both fields are known only here since this is synthesized in the 'run' function)
        Id("c", CC(name:V,id:V))   // Child (both fields are known only here since this is synthesized in the 'run' function)
      )
    ),
    Id("x", CC(name:V,id:V)), // Same here
    Id("x", CC(name:V,id:V))  // Same here
  )
```

In order to fix this issue, we need to identify which child quats are abstract and which are not. The `Quat.Product.Type.Concreate` and `Quat.Product.Type.Abstract` fields have been created for this purpose. Using this logic, the AST has been changed to this (i.e. CCA represents an abstract case class).
```scala
  Map(
    FlatMap(
      infix"${?}",
      Id("p", CC(name:V,childId:V)), // Parent
      Map(
        Map(
          FlatJoin(
            InnerJoin,
            infix"${?}",
            Id("c", CCA(id:V)),  // Child
            BinaryOperation(Property(Id("c", CCA(id:V)) /* Child */, "id"), ==, Property(Id("p", CC(name:V,childId:V)) /* Parent */, "childId"))
          ),
          Id("c", CCA(id:V)), // Child
          Id("c", CCA(id:V))  // Child
        ),
        Id("c", CCA(name:V,id:V)),  // Child (technically should be concrete but we do not know for sure since it's parsed from a type-member i.e. SomeChild when it is set to Child)
        Id("c", CCA(name:V,id:V))   // Child (same here)
      )
    ),
    Id("x", CCA(name:V,id:V)), // Child (same here)
    Id("x", CCA(name:V,id:V))  // Child (same here)
  )
```
Furthermore, we a check in the SimpleNestedExpansion to not expand identifiers whose type is abstract, even they are the only field in a selection.
Also, since these kinds of idents (i.e. with a abstract Quat.Product) now need to be expanded with a star in both a struct (e.g. `Ident(a)` => `struct(a.*)`) as well as just start selects if the are on the top level of a FlattenSqlQuery (e.g. `Ident(a)` => `a.*`), modifications need to be made of the sqlQueryTokenizer in SparkDialect.

Finally, it is important to note that since quats can now be abstract, it is perfectly possible to select a property from a quat that does not actually exist. For this reason, we have changed the Property AST element to not throw an exception when a field is looked up that does not exist on the quat inside. Instead it returns Quat.Unknown. This type of Quat is also useful to identify situations where `inferQuat` has received a field is does not know anything about. 