### PR TITLE
Fix like to be used as condition to generate valid sql

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/sql/dsl/SqlDsl.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/sql/dsl/SqlDsl.scala
@@ -6,6 +6,6 @@ trait SqlDsl {
   this: SqlContext[_, _] =>
 
   implicit class Like(s1: String) {
-    def like(s2: String) = quote(infix"$s1 like $s2".as[Boolean])
+    def like(s2: String) = quote(infix"$s1 like $s2".asCondition)
   }
 }


### PR DESCRIPTION
Fixes #issue_number

### Problem

Currently when using "like" there's an error: Incorrect syntax near the keyword 'like'
It generates: "...WHERE 1 = name like %?..." which causes the error on sql syntax
### Solution

Changed boolean to asConditon to make comparison with correct types, so sql would be valid

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
