### PR TITLE
Fix Cassandra and Node Install

### DIFF
--- a/build/Dockerfile-sbt
+++ b/build/Dockerfile-sbt
@@ -1,6 +1,7 @@
 FROM hseeberger/scala-sbt:8u222_1.3.2_2.13.1
 MAINTAINER mdedetrich@gmail.com
 
+RUN apt-get update
 RUN apt-get install -y --no-install-recommends nodejs
 ENV JAVA_OPTS "-Dquill.macro.log=false -Xmx3G"
 

--- a/build/Dockerfile-setup
+++ b/build/Dockerfile-setup
@@ -25,7 +25,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV CASSANDRA_VERSION 3.11.8
+ENV CASSANDRA_VERSION 3.11.9
 
 RUN  cd /opt ; \
      curl http://apache.volia.net/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz | tar zx


### PR DESCRIPTION
Various issues occur for new users who need to setup the Cassandra and node containers.
The Cassandra container in particular points to artifacts that no longer exists.
The node container needs to be updated before an apt-get install will work.