### PR TITLE
Fix Cassandra and Node Install 2

### DIFF
--- a/build/Dockerfile-sbt
+++ b/build/Dockerfile-sbt
@@ -1,6 +1,7 @@
 FROM hseeberger/scala-sbt:8u222_1.3.2_2.13.1
 MAINTAINER mdedetrich@gmail.com
 
+RUN apt-get update
 RUN apt-get install -y --no-install-recommends nodejs
 ENV JAVA_OPTS "-Dquill.macro.log=false -Xmx3G"
 

--- a/build/Dockerfile-setup
+++ b/build/Dockerfile-setup
@@ -25,7 +25,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV CASSANDRA_VERSION 3.11.8
+ENV CASSANDRA_VERSION 3.11.9
 
 RUN  cd /opt ; \
      curl http://apache.volia.net/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz | tar zx

--- a/build/build.sh
+++ b/build/build.sh
@@ -189,14 +189,10 @@ function full_build() {
     sbt $SBT_ARGS test tut doc
 }
 
-if [[ $TRAVIS_EVENT_TYPE != "pull_request" ]]; then
+if [[ (! -z "$DOCKER_USERNAME") && (! -z "$DOCKER_USERNAME") ]]; then
   echo "Logging into Docker via $DOCKER_USERNAME for $TRAVIS_EVENT_TYPE"
   echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-else
-  echo "Not Logging into Docker for $TRAVIS_EVENT_TYPE build"
-fi
 
-if [[ (! -z "$DOCKER_USERNAME") && (! -z "$DOCKER_USERNAME") ]]; then
   echo "Getting Per-Account Statistics for Docker Pull Limits"
   TOKEN=$(curl --user "$DOCKER_USERNAME:$DOCKER_PASSWORD" "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
   curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
@@ -204,6 +200,8 @@ else
   echo "Getting Anonymous-Account Statistics for Docker Pull Limits"
   TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
   curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
+
+  echo "Not Logging into Docker for $TRAVIS_EVENT_TYPE build, restarting Docker using GCR mirror"
 fi
 
 if [[ $modules == "db" ]]; then


### PR DESCRIPTION
Various issues occur for new users who need to setup the Cassandra and node containers.
The Cassandra container in particular points to artifacts that no longer exists.
The node container needs to be updated before an apt-get install will work.