### PR TITLE
ZIO Cassandra

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val codegenModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
 )
 
 lazy val bigdataModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
-  `quill-cassandra`, `quill-cassandra-lagom`, `quill-cassandra-monix`, `quill-orientdb`, `quill-spark`
+  `quill-cassandra`, `quill-cassandra-lagom`, `quill-cassandra-monix`, `quill-cassandra-zio`, `quill-orientdb`, `quill-spark`
 )
 
 lazy val allModules =
@@ -610,6 +610,20 @@ lazy val `quill-cassandra-monix` =
     .dependsOn(`quill-cassandra` % "compile->compile;test->test")
     .dependsOn(`quill-monix` % "compile->compile;test->test")
 
+lazy val `quill-cassandra-zio` =
+  (project in file("quill-cassandra-zio"))
+    .settings(commonSettings: _*)
+    .settings(mimaSettings: _*)
+    .settings(
+      fork in Test := true,
+      libraryDependencies ++= Seq(
+        "dev.zio" %% "zio" % "1.0.5",
+        "dev.zio" %% "zio-streams" % "1.0.5",
+        "dev.zio" %% "zio-interop-guava" % "30.1.0.3"
+      )
+    )
+    .dependsOn(`quill-cassandra` % "compile->compile;test->test")
+    .dependsOn(`quill-zio` % "compile->compile;test->test")
 
 
 lazy val `quill-cassandra-lagom` =

--- a/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
@@ -1,0 +1,191 @@
+package io.getquill
+
+import com.datastax.driver.core._
+import com.typesafe.config.Config
+import io.getquill.CassandraZioContext._
+import io.getquill.context.StandardContext
+import io.getquill.context.cassandra.{ CassandraBaseContext, CqlIdiom }
+import io.getquill.context.zio.ZioContext
+import io.getquill.util.Messages.fail
+import io.getquill.util.ZioConversions._
+import io.getquill.util.{ ContextLogger, LoadConfig }
+import zio.blocking.{ Blocking, blocking }
+import zio.stream.ZStream
+import zio.{ Chunk, ChunkBuilder, Has, ZIO, ZLayer, ZManaged }
+
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+object CassandraZioContext {
+  type BlockingSession = Has[ZioCassandraSession] with Blocking
+  type CIO[T] = ZIO[BlockingSession, Throwable, T]
+  type CStream[T] = ZStream[BlockingSession, Throwable, T]
+  object Layers {
+    def sessionFromContextConfig(config: CassandraContextConfig) = {
+      val managed =
+        for {
+          env <- ZManaged.environment[Blocking]
+          block = env.get[Blocking.Service]
+          // Evaluate the configuration inside of 'effect' and then create the session from it
+          session <- ZManaged.fromAutoCloseable(
+            ZIO.effect(ZioCassandraSession(config.cluster, config.keyspace, config.preparedStatementCacheSize))
+          )
+        } yield Has(session) ++ Has(block)
+      ZLayer.fromManagedMany(managed)
+    }
+
+    def sessionFromConfig(config: Config) = sessionFromContextConfig(CassandraContextConfig(config))
+    // Call the by-name constructor for the construction to fail inside of the effect if it fails
+    def sessionFromPrefix(configPrefix: String) = sessionFromContextConfig(CassandraContextConfig(LoadConfig(configPrefix)))
+  }
+  implicit class CioExt[T](cio: CIO[T]) {
+    def provideSession(session: ZioCassandraSession): ZIO[Blocking, Throwable, T] =
+      for {
+        block <- ZIO.environment[Blocking]
+        result <- cio.provide(Has(session) ++ block)
+      } yield result
+  }
+}
+
+class CassandraZioContext[N <: NamingStrategy](val naming: N)
+  extends CassandraBaseContext[N]
+  with ZioContext[CqlIdiom, N]
+  with StandardContext[CqlIdiom, N] {
+
+  private val logger = ContextLogger(classOf[CassandraZioContext[_]])
+
+  override type Error = Throwable
+  override type Environment = Has[ZioCassandraSession] with Blocking
+
+  override type StreamResult[T] = CStream[T]
+  override type RunActionResult = Unit
+  override type Result[T] = CIO[T]
+
+  override type RunQueryResult[T] = List[T]
+  override type RunQuerySingleResult[T] = T
+  override type RunBatchActionResult = Unit
+
+  override type PrepareRow = BoundStatement
+  override type ResultRow = Row
+
+  protected def page(rs: ResultSet): CIO[Chunk[Row]] = ZIO.succeed { // TODO Is this right? Was Task.defer in monix
+    val available = rs.getAvailableWithoutFetching
+    val builder = ChunkBuilder.make[Row]()
+    builder.sizeHint(available)
+    while (rs.getAvailableWithoutFetching() > 0) {
+      builder += rs.one()
+    }
+    builder.result()
+  }
+
+  private[getquill] def execute(cql: String, prepare: Prepare, csession: ZioCassandraSession, fetchSize: Option[Int]) =
+    blocking {
+      prepareRowAndLog(cql, prepare)
+        .mapEffect { p =>
+          // Set the fetch size of the result set if it exists
+          fetchSize match {
+            case Some(value) => p.setFetchSize(value)
+            case None        =>
+          }
+          p
+        }
+        .flatMap(p => {
+          csession.session.executeAsync(p).asCio
+        })
+    }
+
+  val streamBlocker: ZStream[Blocking, Nothing, Any] =
+    ZStream.managed(zio.blocking.blockingExecutor.toManaged_.flatMap { executor =>
+      ZManaged.lock(executor)
+    })
+
+  def streamQuery[T](fetchSize: Option[Int], cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor) = {
+    val stream =
+      for {
+        env <- ZStream.environment[Has[ZioCassandraSession]]
+        csession = env.get[ZioCassandraSession]
+        rs <- ZStream.fromEffect(execute(cql, prepare, csession, fetchSize))
+        row <- ZStream.unfoldChunkM(rs) { rs =>
+          // keep taking pages while chunk sizes are non-zero
+          val nextPage = page(rs)
+          nextPage.flatMap { chunk =>
+            if (chunk.length > 0) {
+              rs.fetchMoreResults().asCio.map(rs => Some((chunk, rs)))
+            } else
+              ZIO.succeed(None)
+          }
+        }
+      } yield extractor(row)
+
+    // Run the entire chunking flow on the blocking executor
+    streamBlocker *> stream
+  }
+
+  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): CIO[List[T]] = blocking {
+    for {
+      env <- ZIO.environment[Has[ZioCassandraSession] with Blocking]
+      csession = env.get[ZioCassandraSession]
+      rs <- execute(cql, prepare, csession, None)
+      rows <- ZIO.effect(rs.all())
+    } yield (rows.asScala.map(extractor).toList)
+  }
+
+  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): CIO[T] = blocking {
+    executeQuery(cql, prepare, extractor).map(handleSingleResult(_))
+    for {
+      env <- ZIO.environment[Has[ZioCassandraSession] with Blocking]
+      csession = env.get[ZioCassandraSession]
+      rs <- execute(cql, prepare, csession, None)
+      rows <- ZIO.effect(rs.all())
+      singleRow <- ZIO.effect(handleSingleResult(rows.asScala.map(extractor).toList))
+    } yield singleRow
+  }
+
+  def executeAction[T](cql: String, prepare: Prepare = identityPrepare): CIO[Unit] = blocking {
+    for {
+      env <- ZIO.environment[BlockingSession]
+      r <- prepareRowAndLog(cql, prepare).provide(env)
+      csession = env.get[ZioCassandraSession]
+      result <- csession.session.executeAsync(r).asCio
+    } yield result
+  }
+
+  def executeBatchAction(groups: List[BatchGroup]): CIO[Unit] = blocking {
+    for {
+      env <- ZIO.environment[Has[ZioCassandraSession] with Blocking]
+      result <- {
+        val batchGroups =
+          groups.flatMap {
+            case BatchGroup(cql, prepare) =>
+              prepare
+                .map(prep => executeAction(cql, prep).provide(env))
+          }
+        ZIO.collectAll(batchGroups)
+      }
+    } yield result
+  }
+
+  private[getquill] def prepareRowAndLog(cql: String, prepare: Prepare = identityPrepare): CIO[PrepareRow] =
+    for {
+      env <- ZIO.environment[Has[ZioCassandraSession] with Blocking]
+      csession = env.get[ZioCassandraSession]
+      boundStatement <- {
+        csession.prepareAsync(cql)
+          .mapEffect(prepare)
+          .map(p => p._2)
+      }
+    } yield boundStatement
+
+  def probingSession: Option[ZioCassandraSession] = None
+
+  def probe(statement: String): scala.util.Try[_] = {
+    probingSession match {
+      case Some(csession) =>
+        Try(csession.prepare(statement))
+      case None =>
+        Try(())
+    }
+  }
+
+  def close(): Unit = fail("Zio Cassandra Session does not need to be closed because it does not keep internal state.")
+}

--- a/quill-cassandra-zio/src/main/scala/io/getquill/ZioCassandraSession.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/ZioCassandraSession.scala
@@ -1,0 +1,22 @@
+package io.getquill
+
+import com.datastax.driver.core.{ BoundStatement, Cluster, PreparedStatement }
+import io.getquill.CassandraZioContext.CIO
+import io.getquill.context.{ CassandraSession, SyncCache }
+import io.getquill.context.cassandra.PrepareStatementCache
+import zio.ZIO
+import io.getquill.util.ZioConversions._
+
+trait ZioAsyncCache { self: CassandraSession =>
+  lazy val asyncCache = new PrepareStatementCache[CIO[PreparedStatement]](preparedStatementCacheSize)
+  def prepareAsync(cql: String): CIO[BoundStatement] =
+    asyncCache(cql)(stmt => session.prepareAsync(stmt).asCio.tapError {
+      _ => ZIO.effect(asyncCache.invalidate(stmt))
+    }).map(_.bind())
+}
+
+case class ZioCassandraSession(
+  override val cluster:                    Cluster,
+  override val keyspace:                   String,
+  override val preparedStatementCacheSize: Long
+) extends CassandraSession with SyncCache with ZioAsyncCache with AutoCloseable

--- a/quill-cassandra-zio/src/main/scala/io/getquill/util/ZioConversions.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/util/ZioConversions.scala
@@ -1,0 +1,13 @@
+package io.getquill.util
+
+import com.google.common.util.concurrent.ListenableFuture
+import io.getquill.CassandraZioContext._
+import zio.UIO
+import zio.interop.guava.fromListenableFuture
+
+object ZioConversions {
+  implicit class ZioTaskConverter[A](lf: => ListenableFuture[A]) {
+    def asCio: CIO[A] =
+      fromListenableFuture(UIO.effectTotal(lf))
+  }
+}

--- a/quill-cassandra-zio/src/test/resources/application.conf
+++ b/quill-cassandra-zio/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+testStreamDB.keyspace=quill_test
+testStreamDB.preparedStatementCacheSize=1000
+testStreamDB.session.contactPoint=${?CASSANDRA_HOST}
+testStreamDB.session.port=${?CASSANDRA_PORT}
+testStreamDB.session.queryOptions.fetchSize=1
+testStreamDB.session.queryOptions.consistencyLevel=LOCAL_QUORUM

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/DecodeNullSpec.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/DecodeNullSpec.scala
@@ -1,0 +1,42 @@
+package io.getquill.context.cassandra.zio
+
+class DecodeNullSpec extends ZioCassandraSpec {
+
+  "no default values when reading null" - {
+    "stream" in {
+      import testZioDB._
+      val writeEntities = quote(querySchema[DecodeNullTestWriteEntity]("DecodeNullTestEntity"))
+
+      val ret =
+        for {
+          _ <- testZioDB.run(writeEntities.delete)
+          _ <- testZioDB.run(writeEntities.insert(lift(insertValue)))
+          result <- testZioDB.run(query[DecodeNullTestEntity])
+        } yield {
+          result
+        }
+
+      result(ret.foldCause(
+        cause => {
+          cause.died must equal(true)
+          cause.dieOption match {
+            case Some(e: Exception) =>
+              e.isInstanceOf[IllegalStateException] must equal(true)
+            case _ =>
+              fail("Expected Fatal Error to be here (and to be a IllegalStateException")
+          }
+        },
+        success =>
+          fail("Expected Exception IllegalStateException but operation succeeded")
+      ))
+      ()
+    }
+  }
+
+  case class DecodeNullTestEntity(id: Int, value: Int)
+
+  case class DecodeNullTestWriteEntity(id: Int, value: Option[Int])
+
+  val insertValue = DecodeNullTestWriteEntity(0, None)
+}
+

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/EncodingSpec.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/EncodingSpec.scala
@@ -1,0 +1,43 @@
+package io.getquill.context.cassandra.zio
+
+import io.getquill.context.cassandra.EncodingSpecHelper
+import io.getquill.Query
+
+class EncodingSpec extends EncodingSpecHelper with ZioCassandraSpec {
+  "encodes and decodes types" - {
+    "stream" in {
+      import testZioDB._
+      val ret =
+        for {
+          _ <- testZioDB.run(query[EncodingTestEntity].delete)
+          _ <- testZioDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          result <- testZioDB.run(query[EncodingTestEntity])
+        } yield {
+          result
+        }
+      val f = result(ret)
+      verify(f)
+    }
+  }
+
+  "encodes collections" - {
+    "stream" in {
+      import testZioDB._
+      val q = quote {
+        (list: Query[Int]) =>
+          query[EncodingTestEntity].filter(t => list.contains(t.id))
+      }
+      val ret =
+        for {
+          _ <- testZioDB.run(query[EncodingTestEntity].delete)
+          _ <- testZioDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          result <- testZioDB.run(q(liftQuery(insertValues.map(_.id))))
+        } yield {
+          result
+        }
+      val f = result(ret)
+      verify(f)
+    }
+  }
+}
+

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/QueryResultTypeCassandraZioSpec.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/QueryResultTypeCassandraZioSpec.scala
@@ -1,0 +1,34 @@
+package io.getquill.context.cassandra.zio
+
+import io.getquill.context.cassandra.QueryResultTypeCassandraSpec
+
+class QueryResultTypeCassandraZioSpec extends ZioCassandraSpec with QueryResultTypeCassandraSpec {
+
+  val context = testZioDB
+
+  import context._
+
+  override def beforeAll = {
+    super.beforeAll()
+    result(context.run(deleteAll))
+    result(context.run(liftQuery(entries).foreach(e => insert(e))))
+    ()
+  }
+
+  "query" in {
+    result(context.run(selectAll)) mustEqual entries
+  }
+
+  "stream" in {
+    result(context.stream(selectAll)) mustEqual entries
+  }
+
+  "querySingle" - {
+    "size" in {
+      result(context.run(entitySize)) mustEqual 3
+    }
+    "parametrized size" in {
+      result(context.run(parametrizedSize(lift(10000)))) mustEqual 0
+    }
+  }
+}

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/ZioCassandraSpec.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/ZioCassandraSpec.scala
@@ -1,0 +1,43 @@
+package io.getquill.context.cassandra.zio
+
+import io.getquill.CassandraZioContext.Layers
+import io.getquill.{ CassandraContextConfig, Spec, ZioCassandraSession }
+import zio.blocking.Blocking
+import zio.stream.{ Sink, ZStream }
+import io.getquill.CassandraZioContext._
+import io.getquill.util.LoadConfig
+import zio.ZIO
+import zio.Runtime
+
+trait ZioCassandraSpec extends Spec {
+
+  var pool: ZioCassandraSession = _
+
+  override def beforeAll = {
+    super.beforeAll()
+    val config = CassandraContextConfig(LoadConfig("testStreamDB"))
+    pool = ZioCassandraSession(config.cluster, config.keyspace, config.preparedStatementCacheSize)
+
+  }
+
+  override def afterAll(): Unit = {
+    pool.close()
+  }
+
+  def accumulate[T](stream: ZStream[BlockingSession, Throwable, T]): ZIO[BlockingSession, Throwable, List[T]] =
+    stream.run(Sink.collectAll).map(_.toList)
+
+  def result[T](stream: ZStream[BlockingSession, Throwable, T]): List[T] =
+    Runtime.default.unsafeRun(stream.run(Sink.collectAll).map(_.toList).provideSession(pool))
+
+  def result[T](qzio: ZIO[BlockingSession, Throwable, T]): T =
+    Runtime.default.unsafeRun(qzio.provideSession(pool))
+
+  implicit class ZStreamTestExt[T](stream: ZStream[BlockingSession, Throwable, T]) {
+    def runSyncUnsafe() = result[T](stream)
+  }
+
+  implicit class ZioTestExt[T](qzio: ZIO[BlockingSession, Throwable, T]) {
+    def runSyncUnsafe() = result[T](qzio)
+  }
+}

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/examples/ExampleApp.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/examples/ExampleApp.scala
@@ -1,0 +1,26 @@
+package io.getquill.context.cassandra.zio.examples
+
+import io.getquill.CassandraZioContext._
+import io.getquill.{ CassandraZioContext, _ }
+import zio.App
+import zio.console.putStrLn
+
+object ExampleApp extends App {
+
+  object MyPostgresContext extends CassandraZioContext(Literal)
+  import MyPostgresContext._
+
+  case class Person(name: String, age: Int)
+
+  val zioSession =
+    Layers.sessionFromPrefix("testStreamDB")
+
+  override def run(args: List[String]) = {
+    val people = quote {
+      query[Person]
+    }
+    MyPostgresContext.run(people)
+      .tap(result => putStrLn(result.toString))
+      .provideCustomLayer(zioSession).exitCode
+  }
+}

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/examples/GuavaListenableFutureInterop.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/examples/GuavaListenableFutureInterop.scala
@@ -1,0 +1,41 @@
+package io.getquill.context.cassandra.zio.examples
+
+import com.google.common.util.concurrent.ListenableFuture
+import io.getquill.CassandraZioContext.CIO
+import io.getquill.ZioCassandraSession
+import zio.{ Has, ZIO }
+import zio.blocking.Blocking
+
+import java.util.concurrent.Executor
+import scala.concurrent.Promise
+import scala.util.Try
+
+/**
+ * Example of how to directly convert from a Guava ListenableFuture to a ZIO Task (a CIO for Quill Cassandra).
+ * Can revert to this if zio/interop-guava needs to be removed.
+ */
+object GuavaListenableFutureInterop {
+  implicit class ZioTaskConverter[A](val lf: ListenableFuture[A]) extends AnyVal {
+    def asCio: CIO[A] = {
+      def makePromise(ec: Executor): CIO[A] = {
+        val promise = Promise[A]()
+        lf.addListener(new Runnable {
+          def run(): Unit = {
+            promise.complete(Try {
+              val result = lf.get()
+              result
+            })
+            ()
+          }
+        }, ec.asInstanceOf[Executor])
+        ZIO.fromPromiseScala(promise)
+      }
+
+      for {
+        env <- ZIO.environment[Has[ZioCassandraSession] with Blocking]
+        block = env.get[Blocking.Service]
+        promise <- makePromise(block.blockingExecutor.asJava)
+      } yield promise
+    }
+  }
+}

--- a/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/package.scala
+++ b/quill-cassandra-zio/src/test/scala/io/getquill/context/cassandra/zio/package.scala
@@ -1,0 +1,7 @@
+package io.getquill.context.cassandra
+import io.getquill.{ CassandraZioContext, Literal }
+
+package object zio {
+  lazy val testZioDB = new CassandraZioContext(Literal) with CassandraTestEntities
+}
+

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraClusterSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraClusterSessionContext.scala
@@ -1,53 +1,15 @@
 package io.getquill
 
-import com.datastax.driver.core.{ Cluster, _ }
-import io.getquill.context.cassandra.util.FutureConversions._
-import io.getquill.context.cassandra.{ CassandraSessionContext, PrepareStatementCache }
-import io.getquill.util.Messages.fail
-
-import scala.jdk.CollectionConverters._
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.Failure
+import com.datastax.driver.core.Cluster
+import io.getquill.context.{ CassandraSession, FutureAsyncCache, SyncCache }
+import io.getquill.context.cassandra.CassandraSessionContext
 
 abstract class CassandraClusterSessionContext[N <: NamingStrategy](
-  val naming:                 N,
-  cluster:                    Cluster,
-  keyspace:                   String,
-  preparedStatementCacheSize: Long
+  val naming:                     N,
+  val cluster:                    Cluster,
+  val keyspace:                   String,
+  val preparedStatementCacheSize: Long
 )
-  extends CassandraSessionContext[N] {
-
-  private lazy val asyncCache = new PrepareStatementCache[Future[PreparedStatement]](preparedStatementCacheSize)
-  private lazy val syncCache = new PrepareStatementCache[PreparedStatement](preparedStatementCacheSize)
-
-  protected lazy val session = cluster.connect(keyspace)
-
-  protected val udtMetadata: Map[String, List[UserType]] = cluster.getMetadata.getKeyspaces.asScala.toList
-    .flatMap(_.getUserTypes.asScala)
-    .groupBy(_.getTypeName)
-
-  def udtValueOf(udtName: String, keyspace: Option[String] = None): UDTValue =
-    udtMetadata.getOrElse(udtName.toLowerCase, Nil) match {
-      case udt :: Nil => udt.newValue()
-      case Nil =>
-        fail(s"Could not find UDT `$udtName` in any keyspace")
-      case udts => udts
-        .find(udt => keyspace.contains(udt.getKeyspace) || udt.getKeyspace == session.getLoggedKeyspace)
-        .map(_.newValue())
-        .getOrElse(fail(s"Could not determine to which keyspace `$udtName` UDT belongs. " +
-          s"Please specify desired keyspace using UdtMeta"))
-    }
-
-  protected def prepare(cql: String): BoundStatement =
-    syncCache(cql)(stmt => session.prepare(stmt)).bind()
-
-  protected def prepareAsync(cql: String)(implicit executionContext: ExecutionContext): Future[BoundStatement] =
-    asyncCache(cql)(stmt => session.prepareAsync(stmt).asScala andThen {
-      case Failure(_) => asyncCache.invalidate(stmt)
-    }).map(_.bind())
-
-  def close(): Unit = {
-    session.close()
-    cluster.close()
-  }
-}
+  extends CassandraSessionContext[N] with CassandraSession
+  with SyncCache
+  with FutureAsyncCache

--- a/quill-cassandra/src/main/scala/io/getquill/context/Caches.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/Caches.scala
@@ -1,0 +1,22 @@
+package io.getquill.context
+
+import com.datastax.driver.core.{ BoundStatement, PreparedStatement }
+import io.getquill.context.cassandra.PrepareStatementCache
+import io.getquill.context.cassandra.util.FutureConversions._
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Failure
+
+trait SyncCache { this: CassandraSession =>
+  lazy val syncCache = new PrepareStatementCache[PreparedStatement](preparedStatementCacheSize)
+  def prepare(cql: String): BoundStatement =
+    syncCache(cql)(stmt => session.prepare(stmt)).bind()
+}
+
+trait FutureAsyncCache { this: CassandraSession =>
+  lazy val asyncCache = new PrepareStatementCache[Future[PreparedStatement]](preparedStatementCacheSize)
+  def prepareAsync(cql: String)(implicit executionContext: ExecutionContext): Future[BoundStatement] =
+    asyncCache(cql)(stmt => session.prepareAsync(stmt).asScala andThen {
+      case Failure(_) => asyncCache.invalidate(stmt)
+    }).map(_.bind())
+}

--- a/quill-cassandra/src/main/scala/io/getquill/context/CassandraSession.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/CassandraSession.scala
@@ -1,0 +1,34 @@
+package io.getquill.context
+
+import com.datastax.driver.core.{ Cluster, UDTValue, UserType }
+import io.getquill.util.Messages.fail
+import scala.jdk.CollectionConverters._
+
+trait CassandraSession {
+  def cluster: Cluster
+  def keyspace: String
+  def preparedStatementCacheSize: Long
+
+  lazy val session = cluster.connect(keyspace)
+
+  val udtMetadata: Map[String, List[UserType]] = cluster.getMetadata.getKeyspaces.asScala.toList
+    .flatMap(_.getUserTypes.asScala)
+    .groupBy(_.getTypeName)
+
+  def udtValueOf(udtName: String, keyspace: Option[String] = None): UDTValue =
+    udtMetadata.getOrElse(udtName.toLowerCase, Nil) match {
+      case udt :: Nil => udt.newValue()
+      case Nil =>
+        fail(s"Could not find UDT `$udtName` in any keyspace")
+      case udts => udts
+        .find(udt => keyspace.contains(udt.getKeyspace) || udt.getKeyspace == session.getLoggedKeyspace)
+        .map(_.newValue())
+        .getOrElse(fail(s"Could not determine to which keyspace `$udtName` UDT belongs. " +
+          s"Please specify desired keyspace using UdtMeta"))
+    }
+
+  def close(): Unit = {
+    session.close()
+    cluster.close()
+  }
+}

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
@@ -12,20 +12,8 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 abstract class CassandraSessionContext[N <: NamingStrategy]
-  extends StandardContext[CqlIdiom, N]
-  with CassandraContext[N]
-  with Encoders
-  with Decoders
-  with CassandraTypes
-  with UdtEncoding {
-
-  val idiom = CqlIdiom
-
-  override type PrepareRow = BoundStatement
-  override type ResultRow = Row
-
-  override type RunActionReturningResult[T] = Unit
-  override type RunBatchActionReturningResult[T] = Unit
+  extends CassandraBaseContext[N]
+  with CassandraContext[N] {
 
   protected def prepareAsync(cql: String)(implicit executionContext: ExecutionContext): Future[BoundStatement]
 
@@ -51,5 +39,22 @@ abstract class CassandraSessionContext[N <: NamingStrategy]
 
   def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Unit =
     fail("Cassandra doesn't support `returning`.")
+}
+
+abstract class CassandraBaseContext[N <: NamingStrategy]
+  extends CassandraContext[N]
+  with StandardContext[CqlIdiom, N]
+  with Encoders
+  with Decoders
+  with CassandraTypes
+  with UdtEncoding {
+
+  val idiom = CqlIdiom
+
+  override type PrepareRow = BoundStatement
+  override type ResultRow = Row
+
+  override type RunActionReturningResult[T] = Unit
+  override type RunBatchActionReturningResult[T] = Unit
 }
 

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/CollectionDecoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/CollectionDecoders.scala
@@ -1,13 +1,13 @@
 package io.getquill.context.cassandra.encoding
 
-import io.getquill.context.cassandra.CassandraSessionContext
+import io.getquill.context.cassandra.CassandraBaseContext
 import io.getquill.context.cassandra.util.ClassTagConversions.asClassOf
 
-import scala.reflect.ClassTag
 import scala.jdk.CollectionConverters._
+import scala.reflect.ClassTag
 
 trait CollectionDecoders {
-  this: CassandraSessionContext[_] =>
+  this: CassandraBaseContext[_] =>
 
   implicit def listDecoder[T, Cas: ClassTag](implicit mapper: CassandraMapper[Cas, T]): Decoder[List[T]] =
     decoder((index, row) => row.getList[Cas](index, asClassOf[Cas]).asScala.map(mapper.f).toList)

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/CollectionEncoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/CollectionEncoders.scala
@@ -1,11 +1,11 @@
 package io.getquill.context.cassandra.encoding
 
-import io.getquill.context.cassandra.CassandraSessionContext
+import io.getquill.context.cassandra.CassandraBaseContext
 
 import scala.jdk.CollectionConverters._
 
 trait CollectionEncoders {
-  this: CassandraSessionContext[_] =>
+  this: CassandraBaseContext[_] =>
 
   implicit def listEncoder[T, Cas](implicit mapper: CassandraMapper[T, Cas]): Encoder[List[T]] =
     encoder((index, list, row) => row.setList[Cas](index, list.map(mapper.f).asJava))

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
@@ -1,13 +1,13 @@
 package io.getquill.context.cassandra.encoding
 
-import java.util.{ Date, UUID }
-
 import com.datastax.driver.core.LocalDate
-import io.getquill.context.cassandra.CassandraSessionContext
+import io.getquill.context.cassandra.CassandraBaseContext
 import io.getquill.util.Messages.fail
 
+import java.util.{ Date, UUID }
+
 trait Decoders extends CollectionDecoders {
-  this: CassandraSessionContext[_] =>
+  this: CassandraBaseContext[_] =>
 
   type Decoder[T] = CassandraDecoder[T]
 

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
@@ -1,13 +1,13 @@
 package io.getquill.context.cassandra.encoding
 
+import com.datastax.driver.core.LocalDate
+import io.getquill.context.cassandra.CassandraBaseContext
+
 import java.nio.ByteBuffer
 import java.util.{ Date, UUID }
 
-import com.datastax.driver.core.LocalDate
-import io.getquill.context.cassandra.CassandraSessionContext
-
 trait Encoders extends CollectionEncoders {
-  this: CassandraSessionContext[_] =>
+  this: CassandraBaseContext[_] =>
 
   type Encoder[T] = CassandraEncoder[T]
 

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/UdtEncoding.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/UdtEncoding.scala
@@ -1,13 +1,13 @@
 package io.getquill.context.cassandra.encoding
 
 import com.datastax.driver.core.UDTValue
-import io.getquill.context.cassandra.{ CassandraSessionContext }
 import io.getquill.Udt
+import io.getquill.context.cassandra.CassandraBaseContext
 
 import scala.language.experimental.macros
 
 trait UdtEncoding {
-  this: CassandraSessionContext[_] =>
+  this: CassandraBaseContext[_] =>
 
   implicit def udtDecoder[T <: Udt]: Decoder[T] = macro UdtEncodingMacro.udtDecoder[T]
   implicit def udtEncoder[T <: Udt]: Encoder[T] = macro UdtEncodingMacro.udtEncoder[T]

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioAppWithLayers.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioAppWithLayers.scala
@@ -2,7 +2,6 @@ package io.getquill.examples
 
 import io.getquill._
 import io.getquill.context.ZioJdbc.Layers
-import zio.blocking.blocking
 import zio.console.putStrLn
 import zio.{ App, ExitCode, URIO }
 
@@ -14,16 +13,15 @@ object ZioAppWithLayers extends App {
   case class Person(name: String, age: Int)
 
   val zioConn =
-    Layers.dataSourceFromPrefix("testPostgresDB") >>> Layers.dataSourceToConnection
+    Layers.dataSourceFromPrefix("testPostgresDB") >>>
+      Layers.dataSourceToConnection
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] = {
     val people = quote {
       query[Person].filter(p => p.name == "Alex")
     }
-    blocking(
-      MyPostgresContext.run(people)
-        .tap(result => putStrLn(result.toString))
-        .provideCustomLayer(zioConn).exitCode
-    )
+    MyPostgresContext.run(people)
+      .tap(result => putStrLn(result.toString))
+      .provideCustomLayer(zioConn).exitCode
   }
 }

--- a/quill-zio/src/main/scala/io/getquill/context/zio/ZioContext.scala
+++ b/quill-zio/src/main/scala/io/getquill/context/zio/ZioContext.scala
@@ -10,14 +10,15 @@ trait ZioContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] ext
   with StreamingContext[Idiom, Naming] {
 
   type Error
+  type Environment
 
   // It's nice that we don't actually have to import any JDBC libraries to have a Connection type here
-  override type StreamResult[T] = ZStream[Has[Session] with Blocking, Error, T]
-  override type Result[T] = ZIO[Has[Session] with Blocking, Error, T]
+  override type StreamResult[T] = ZStream[Environment, Error, T]
+  override type Result[T] = ZIO[Environment, Error, T]
   override type RunQueryResult[T] = List[T]
   override type RunQuerySingleResult[T] = T
 
   // Need explicit return-type annotations due to scala/bug#8356. Otherwise macro system will not understand Result[Long]=Task[Long] etc...
-  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): ZIO[Has[Session] with Blocking, Error, List[T]]
-  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): ZIO[Has[Session] with Blocking, Error, T]
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): ZIO[Environment, Error, List[T]]
+  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): ZIO[Environment, Error, T]
 }

--- a/quill-zio/src/main/scala/io/getquill/context/zio/ZioTranslateContext.scala
+++ b/quill-zio/src/main/scala/io/getquill/context/zio/ZioTranslateContext.scala
@@ -10,11 +10,12 @@ trait ZioTranslateContext extends TranslateContextBase {
   this: Context[_ <: Idiom, _ <: NamingStrategy] =>
 
   type Error
+  type Environment
 
-  override type TranslateResult[T] = ZIO[Has[Session] with Blocking, Error, T]
+  override type TranslateResult[T] = ZIO[Environment, Error, T]
 
   override private[getquill] val translateEffect: ContextEffect[TranslateResult] = new ContextEffect[TranslateResult] {
-    override def wrap[T](t: => T): TranslateResult[T] = ZIO.environment[Has[Session] with Blocking].as(t)
+    override def wrap[T](t: => T): TranslateResult[T] = ZIO.environment[Environment].as(t)
     override def push[A, B](result: TranslateResult[A])(f: A => B): TranslateResult[B] = result.map(f)
     override def seq[A](list: List[TranslateResult[A]]): TranslateResult[List[A]] = ZIO.collectAll(list)
   }


### PR DESCRIPTION
Implementing ZIO Cassandra module.

Quite a few refactorings in the Cassandra subsystem had to be made in order to accommodate a 1st-class experience with ZIO. The CassandraSessionContext on which the CassandraMonixContext and all the others are based on kept a bunch of internal state which needed to be pulled out as a separate classes e.g. `SyncCache`, `FutureAsyncCache` (which uses Futures so with Zio it's `ZioCassandraSession` instead). Then we created a ZioCassandraSession which extends these and is returned as a dependency from the CassandraZioContext commands as part of the type `ZIO[Has[ZioCassandraSession] with Blocking, Throwable, T]`. This allows the primary context CassandraZioContext to be stateless.

Similar to QIO in ZioJdbcContext which has `ZIO[Has[Connection] with Blocking, SQLException, T]`
there is a `CIO[Has[ZioCassandraSession] with Blocking, Throwable, T]` which is the primary signature of the methods in CassandraZioContext.

Also, some static helper methods were introduced in CassandraZioContext.Layers to help with the construction of a ZLayer containing ZioCassandraSession.


### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
