### PR TITLE
Add a single ZIO-inspired root type QAC for all actions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ import scala.sys.process.Process
 import sbtcrossproject.crossProject
 import java.io.{File => JFile}
 
-enablePlugins(TutPlugin)
-
 val CodegenTag = Tags.Tag("CodegenTag")
 (concurrentRestrictions in Global) += Tags.exclusive(CodegenTag)
 (concurrentRestrictions in Global) += Tags.limit(ScalaJSTags.Link, 1)
@@ -118,7 +116,6 @@ lazy val `quill` = {
   val quill =
     (project in file("."))
     .settings(commonSettings: _*)
-    .settings(`tut-settings`:_*)
 
   // Do not do aggregate project builds when debugging since during that time
   // typically only individual modules are being build/compiled. This is mostly for convenience with IntelliJ.
@@ -656,29 +653,6 @@ lazy val `quill-orientdb` =
         )
       )
       .dependsOn(`quill-sql-jvm` % "compile->compile;test->test")
-
-lazy val `tut-sources` = Seq(
-  "CASSANDRA.md",
-  "README.md"
-)
-
-lazy val `tut-settings` = Seq(
-  scalacOptions in Tut := Seq(),
-  tutSourceDirectory := baseDirectory.value / "target" / "tut",
-  tutNameFilter := `tut-sources`.map(_.replaceAll("""\.""", """\.""")).mkString("(", "|", ")").r,
-  sourceGenerators in Compile +=
-    Def.task {
-      `tut-sources`.foreach { name =>
-        val source = baseDirectory.value / name
-        val file = baseDirectory.value / "target" / "tut" / name
-        val str = IO.read(source).replace("```scala", "```tut")
-        // workaround tut bug due to https://github.com/tpolecat/tut/pull/220
-        val fixed = str.replaceAll("\\n//.*", "\n1").replaceAll("//.*", "")
-        IO.write(file, fixed)
-      }
-      Seq()
-    }.taskValue
-)
 
 lazy val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
   mimaPreviousArtifacts := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,6 @@ resolvers += Classpaths.sbtPluginReleases
 
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.13")
-
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")

--- a/quill-core-portable/src/main/scala/io/getquill/Model.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/Model.scala
@@ -4,7 +4,14 @@ import io.getquill.quotation.NonQuotedException
 
 import scala.annotation.compileTimeOnly
 
-sealed trait Query[+T] {
+/**
+ * A Quill-Action-Concept centrally defines Quill Query, Insert, Update, Delete, etc... actions.
+ * This ZIO-inspired construct makes it easier to reason about Quoted actions
+ * (particularly in Dotty) in a type-full way.
+ */
+sealed trait QAC[ModificationEntity, +OutputEntity]
+
+sealed trait Query[+T] extends QAC[Nothing, T] {
 
   def map[R](f: T => R): Query[R] = NonQuotedException()
 
@@ -55,7 +62,7 @@ sealed trait Query[+T] {
    * @param unquote is used for conversion of `Quoted[A]` to A` with `unquote`
    * @return
    */
-  def foreach[A <: Action[_], B](f: T => B)(implicit unquote: B => A): BatchAction[A] = NonQuotedException()
+  def foreach[A <: QAC[_, _] with Action[_], B](f: T => B)(implicit unquote: B => A): BatchAction[A] = NonQuotedException()
 }
 
 sealed trait JoinQuery[A, B, R] extends Query[R] {
@@ -82,9 +89,9 @@ trait EntityQueryModel[T]
   def delete: Delete[T] = NonQuotedException()
 }
 
-sealed trait Action[E]
+sealed trait Action[E] extends QAC[E, Any]
 
-sealed trait Insert[E] extends Action[E] {
+sealed trait Insert[E] extends QAC[E, Nothing] with Action[E] {
   @compileTimeOnly(NonQuotedException.message)
   def returning[R](f: E => R): ActionReturning[E, R] = NonQuotedException()
 
@@ -121,16 +128,16 @@ sealed trait Insert[E] extends Action[E] {
   def onConflictUpdate(target: E => Any, targets: (E => Any)*)(assign: ((E, E) => (Any, Any)), assigns: ((E, E) => (Any, Any))*): Insert[E] = NonQuotedException()
 }
 
-sealed trait ActionReturning[E, Output] extends Action[E]
+sealed trait ActionReturning[E, +Output] extends QAC[E, Output] with Action[E]
 
-sealed trait Update[E] extends Action[E] {
+sealed trait Update[E] extends QAC[E, Nothing] with Action[E] {
   @compileTimeOnly(NonQuotedException.message)
   def returning[R](f: E => R): ActionReturning[E, R] = NonQuotedException()
 }
 
-sealed trait Delete[E] extends Action[E] {
+sealed trait Delete[E] extends QAC[E, Nothing] with Action[E] {
   @compileTimeOnly(NonQuotedException.message)
   def returning[R](f: E => R): ActionReturning[E, R] = NonQuotedException()
 }
 
-sealed trait BatchAction[+A <: Action[_]]
+sealed trait BatchAction[+A <: QAC[_, _] with Action[_]]

--- a/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
@@ -597,6 +597,7 @@ object OnConflict {
 }
 //************************************************************
 
+/** For Dynamic Infix Splices */
 class Dynamic(val tree: Any)(theQuat: => Quat) extends Ast {
   private lazy val computedQuat = theQuat
   def quat = computedQuat

--- a/quill-core-portable/src/main/scala/io/getquill/dsl/InfixDsl.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/dsl/InfixDsl.scala
@@ -4,9 +4,9 @@ import io.getquill.quotation.NonQuotedException
 
 import scala.annotation.compileTimeOnly
 
-private[dsl] trait InfixDsl {
+private[getquill] trait InfixDsl {
 
-  private[dsl] trait InfixValue {
+  private[getquill] trait InfixValue {
     def as[T]: T
     def asCondition: Boolean
     def pure: InfixValue

--- a/quill-core-portable/src/main/scala/io/getquill/dsl/OrdDsl.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/dsl/OrdDsl.scala
@@ -2,7 +2,7 @@ package io.getquill.dsl
 
 import io.getquill.Ord
 
-private[dsl] trait OrdDsl {
+private[getquill] trait OrdDsl {
 
   implicit def implicitOrd[T]: Ord[T] = Ord.ascNullsFirst
 }

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -960,7 +960,7 @@ trait Parsing extends ValueComputation with QuatMaking {
   private def reprocessReturnClause(ident: Ident, originalBody: Ast, action: Tree) = {
     val actionType = typecheckUnquoted(action)
 
-    (ident == originalBody, actionType.tpe) match {
+    (ident == originalBody, actionType.tpe.dealias) match {
       // Note, tuples are also case classes so this also matches for tuples
       case (true, ClassTypeRefMatch(cls, List(arg))) if (cls == asClass[DslInsert[_]] || cls == asClass[DslUpdate[_]] || cls == asClass[DslDelete[_]]) && isTypeCaseClass(arg) =>
 

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -337,6 +337,7 @@ trait Parsing extends ValueComputation with QuatMaking {
 
   def combinedInfixParser(infixIsPure: Boolean, quat: Quat): Parser[Ast] = Parser[Ast] {
     case q"$pack.InfixInterpolator(scala.StringContext.apply(..${ parts: List[String] })).infix(..$params)" =>
+      // Parts that end with # indicate this is a dynamic infix.
       if (parts.find(_.endsWith("#")).isDefined) {
         val elements =
           parts.zipWithIndex.flatMap {

--- a/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
+++ b/quill-finagle-mysql/src/test/scala/io/getquill/context/finagle/mysql/FinagleMysqlContextSpec.scala
@@ -6,7 +6,10 @@ import com.twitter.finagle.mysql
 import com.twitter.finagle.mysql.{ EmptyValue, Error, IsolationLevel }
 import com.twitter.util._
 import io.getquill.context.sql.{ TestDecoders, TestEncoders }
-import io.getquill.{ testContext => _, _ }
+import io.getquill.Spec
+import io.getquill.FinagleMysqlContext
+import io.getquill.Literal
+import io.getquill.TestEntities
 
 class FinagleMysqlContextSpec extends Spec {
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -58,7 +58,7 @@ class SqlQuerySpec extends Spec {
       }
     }
 
-    "nested join - named variables - query schema" in {
+    "nested join - named variables - query schema " in {
       val qs1 = quote {
         querySchema[TestEntity]("CustomEntity", _.i -> "field_i")
       }


### PR DESCRIPTION
The implementation of an execution context in Dotty either requires type-lambdas to be used or we can implement a single ZIO-inspired root action type (for Query, Action, etc...). In order to avoid complexity, I have chosen the latter approach.