### PR TITLE
Catch close() exceptions

### DIFF
--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
@@ -32,8 +32,8 @@ import scala.reflect.ClassTag
  * {{
  *   val zioConn =
  *     ZLayer.fromManaged(for {
- *       ds <- ZManaged.fromAutoCloseable(Task(JdbcContextConfig(LoadConfig("testPostgresDB")).dataSource))
- *       conn <- ZManaged.fromAutoCloseable(Task(ds.getConnection))
+ *       ds <- ZioJdbc.managedBestEffort(Task(JdbcContextConfig(LoadConfig("testPostgresDB")).dataSource))
+ *       conn <- ZioJdbc.managedBestEffort(Task(ds.getConnection))
  *     } yield conn)
  *
  *   MyZioContext.run(query[Person]).provideCustomLayer(zioConn)
@@ -228,8 +228,8 @@ abstract class ZioJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy] ext
         ZStream.managed {
           for {
             conn <- ZManaged.make(Task(conn))(c => Task.unit)
-            ps <- ZManaged.fromAutoCloseable(Task(prepareStatement(conn)))
-            rs <- ZManaged.fromAutoCloseable(Task(ps.executeQuery()))
+            ps <- managedBestEffort(Task(prepareStatement(conn)))
+            rs <- managedBestEffort(Task(ps.executeQuery()))
           } yield (conn, ps, rs)
         }
       }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioApp.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioApp.scala
@@ -1,6 +1,7 @@
 package io.getquill.examples
 
 import io.getquill._
+import io.getquill.context.ZioJdbc
 import io.getquill.util.LoadConfig
 import zio.{ App, ExitCode, Task, URIO, ZLayer, ZManaged }
 import zio.console.putStrLn
@@ -14,8 +15,8 @@ object ZioApp extends App {
 
   val zioConn =
     ZLayer.fromManaged(for {
-      ds <- ZManaged.fromAutoCloseable(Task(JdbcContextConfig(LoadConfig("testPostgresDB")).dataSource))
-      conn <- ZManaged.fromAutoCloseable(Task(ds.getConnection))
+      ds <- ZioJdbc.managedBestEffort(Task(JdbcContextConfig(LoadConfig("testPostgresDB")).dataSource))
+      conn <- ZioJdbc.managedBestEffort(Task(ds.getConnection))
     } yield conn)
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] = {


### PR DESCRIPTION
The call `ZManaged.fromAutoCloseable` does not catch exceptions thrown on `connection.close()` but instead directly proceeds to the die-channel. This makes sense for ZIO because resource-releases are typically indicative of filesystem-level resource leaks (e.g. open-file handles). However, for JDBC this does not make sense.

My Personal Thoughts about this issue:

Typically I think of finalizers as something you need to do in order to avoid OS-level resource leaks e.g. open-file handles, database connetions are a little different. They're a resource that can leak but when they do, the application should not have a panic-attack because ultimately the connection pool will "take care of it" and if it doesn't, the Database will. That's not to say that in high-system-stress production scenarios, Database resource leakage isn't dangerous, it most definitely is! However the way you typically deal with that is by putting circut breakers on the incoming user-connections and let 'enough time pass' so that the DB can kill off the connections that it can't serve. What you absolutely don't want to do is to kill the whole application since if you do, when it starts back up it will immediately hammer the DB with requests that have probably been buffered upstream.

It's interesting to note that in practice, nearly all of the cases where I've seen `connection.close()` fail is where a connection becomes stale (because it's held by a user-thread which is blocked by something else) and the database times out the connection. In practice, most good JDBC implementations try not to throw exceptions on a `connecction.close()` if another exception has already been thrown (especially if these connections are pooled!) but the JDBC API was designed to allow the former scenario to happen.

@getquill/maintainers
