### PR TITLE
Update Microsoft SQL Server Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     init: true
 
   sqlserver:
-    image: microsoft/mssql-server-linux
+    image: mcr.microsoft.com/mssql/server:2017-CU24-ubuntu-16.04
     ports:
       - "11433:1433"
     environment:


### PR DESCRIPTION
Fixes #issue_number

### Problem

The Microsoft SQL Server docker image that is being used no longer exists against that tag

### Solution

I have updated to the new tag, specifically the 2017 ubuntu version of Microsoft SQL Server (see https://hub.docker.com/_/microsoft-mssql-server) for reference

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
