### PR TITLE
Fix Scala.js tests not running plus update SBT/Scala Version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -796,8 +796,8 @@ def excludePathsIfOracle(paths:Seq[String]) = {
 }
 
 val scala_v_11 = "2.11.12"
-val scala_v_12 = "2.12.10"
-val scala_v_13 = "2.13.2"
+val scala_v_12 = "2.12.14"
+val scala_v_13 = "2.13.3"
 
 
 val crossVersions = {

--- a/build/Dockerfile-sbt
+++ b/build/Dockerfile-sbt
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:8u222_1.3.2_2.13.1
+FROM hseeberger/scala-sbt:8u282_1.5.4_2.12.13
 MAINTAINER mdedetrich@gmail.com
 
 RUN apt-get update

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       - ~/.ivy2:/root/.ivy2:cached
       - ~/.m2:/root/.m2:cached
       - ~/.sbt:/root/.sbt:cached
+      - ~/.cache/coursier:/root/.cache/coursier:cached
     environment:
       - SBT_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Dfile.encoding=UTF-8 -Xms512m -Xmx1536m -Xss2m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC
       - POSTGRES_HOST=postgres

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.5.4


### PR DESCRIPTION
### Problem

The Scala.js tests were not running when using `docker-compose run --rm sbt sbt test` likely due to node changing the binary path of the installation which Scala.js couldn't detect

### Solution

Update the SBT docker image to the latest version gets the Scala tests running again. It seems like the upgrade of SBT has also fixed historical memory issues with SBT, i.e.

```
[warn] In the last 9 seconds, 5.127 (60.2%) were spent in GC. [Heap: 0.37GB free of 1.45GB, max 1.45GB] Consider increasing the JVM heap using `-Xmx` or try a different collector, e.g. `-XX:+UseG1GC`, for better performance.
java.lang.OutOfMemoryError: Java heap space
[error] [launcher] error during sbt launcher: java.lang.OutOfMemoryError: Java heap space
```

No longer seems to occur on my local machine

### Notes

Since the SBT docker image was updated to the latest version, I also updated the corresponding Scala versions. I have also added the coursier directory to be cached so that every test invocation doesn't need to re-download dependencies. 

~~Note that the PR will fail to build until https://github.com/getquill/quill/pull/2183 is merged (and I rebase this PR)~~

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
