### PR TITLE
Fix ivy pom info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -941,24 +941,15 @@ lazy val releaseSettings = Seq(
       case _ => Seq[ReleaseStep]()
     }
   },
-  pomExtra := (
-    <url>http://github.com/getquill/quill</url>
-    <licenses>
-      <license>
-        <name>Apache License 2.0</name>
-        <url>https://raw.githubusercontent.com/getquill/quill/master/LICENSE.txt</url>
-        <distribution>repo</distribution>
-      </license>
-    </licenses>
-    <scm>
-      <url>git@github.com:getquill/quill.git</url>
-      <connection>scm:git:git@github.com:getquill/quill.git</connection>
-    </scm>
-    <developers>
-      <developer>
-        <id>fwbrasil</id>
-        <name>Flavio W. Brasil</name>
-        <url>http://github.com/fwbrasil/</url>
-      </developer>
-    </developers>)
+
+  homepage := Some(url("http://github.com/getquill/quill")),
+  licenses := List(("Apache License 2.0", url("https://raw.githubusercontent.com/getquill/quill/master/LICENSE.txt"))),
+  developers := List(
+    Developer("fwbrasil", "Flavio W. Brasil", "", url("http://github.com/fwbrasil")),
+    Developer("deusaquilus", "Alexander Ioffe", "", url("https://github.com/deusaquilus"))
+  ),
+  scmInfo := Some(
+    ScmInfo(url("https://github.com/getquill/quill"), "git:git@github.com:getquill/quill.git")
+  ),
+
 )


### PR DESCRIPTION
### Problem

Currently in the sbt build, we manually add the pom information by xml. Due to this we ended up adding information that was either redundant or incorrect (i.e. not providing a valid email).

### Solution

Instead of manually writing the pom info with xml literals, we use SBT's inbuilt strongly typed settings which makes sure that we pom info is valid.

### Notes
Check the review notes for explanations.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
