### PR TITLE
Remove various travism's from codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TRAVIS_SCALA_VERSION: ${{ matrix.scala }}
+      SCALA_VERSION: ${{ matrix.scala }}
       POSTGRES_PASSWORD: postgres
       MYSQL_PASSWORD: root
 
@@ -43,8 +43,8 @@ jobs:
 
     - name: Build modules
       run: |
-        export TRAVIS_SCALA_VERSION=${{ matrix.scala }}
-        echo "TRAVIS_SCALA_VERSION='$TRAVIS_SCALA_VERSION'"
+        export SCALA_VERSION=${{ matrix.scala }}
+        echo "SCALA_VERSION='$SCALA_VERSION'"
         ./build/build.sh ${{ matrix.module }}
 
   release:
@@ -82,15 +82,15 @@ jobs:
 
     - name: Release
       run: |
-        export TRAVIS_SCALA_VERSION=${{ matrix.scala }}
-        echo "TRAVIS_SCALA_VERSION='$TRAVIS_SCALA_VERSION'"
+        export SCALA_VERSION=${{ matrix.scala }}
+        echo "SCALA_VERSION='$SCALA_VERSION'"
         export PGP_PASSPHRASE=${{ secrets.PGP_PASSPHRASE }}
-        export TRAVIS_PULL_REQUEST=${{ !!github.event.pull_request }}
-        echo "TRAVIS_PULL_REQUEST='$TRAVIS_PULL_REQUEST'"
+        export PULL_REQUEST=${{ !!github.event.pull_request }}
+        echo "PULL_REQUEST='$PULL_REQUEST'"
         export GITHUB_REF=${{ github.ref }}
         echo "GITHUB_REF='$GITHUB_REF'"
-        export TRAVIS_BRANCH=$(git for-each-ref ${{ github.ref }} --format='%(refname:short)')
-        echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'"
+        export BRANCH=$(git for-each-ref ${{ github.ref }} --format='%(refname:short)')
+        echo "BRANCH='$BRANCH'"
         ./build/release.sh ${{ matrix.scala_short }} ${{ matrix.module }}
       env:
         ENCRYPTION_PASSWORD: ${{ secrets.ENCRYPTION_PASSWORD }}

--- a/build/build.sh
+++ b/build/build.sh
@@ -20,7 +20,7 @@ export CASSANDRA_PORT=19042
 export ORIENTDB_HOST=127.0.0.1
 export ORIENTDB_PORT=12424
 
-export JVM_OPTS="-Dquill.macro.log=false -Dquill.scala.version=$TRAVIS_SCALA_VERSION -Xms1024m -Xmx3g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+export JVM_OPTS="-Dquill.macro.log=false -Dquill.scala.version=$SCALA_VERSION -Xms1024m -Xmx3g -Xss5m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 
 modules=$1
 echo "Start build modules: $modules"
@@ -59,9 +59,9 @@ function docker_stats() {
 }
 export -f docker_stats
 
-export SBT_ARGS="++$TRAVIS_SCALA_VERSION"
+export SBT_ARGS="++$SCALA_VERSION"
 
-if [[ $TRAVIS_SCALA_VERSION == 2.12* ]]; then
+if [[ $SCALA_VERSION == 2.12* ]]; then
     export SBT_ARGS="$SBT_ARGS coverage"
 fi
 
@@ -162,7 +162,7 @@ function wait_for_bigdata() {
 function db_build() {
     echo "build.sh =:> DB Build Specified"
     wait_for_databases
-    export JVM_OPTS="-Dquill.macro.log=false -Dquill.scala.version=$TRAVIS_SCALA_VERSION -Xms4g -Xmx4g -Xss10m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+    export JVM_OPTS="-Dquill.macro.log=false -Dquill.scala.version=$SCALA_VERSION -Xms4g -Xmx4g -Xss10m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
     echo "build.sh =:> Starting DB Build Primary"
     ./build/aware_run.sh "sbt -Dmodules=db $SBT_ARGS test"
 }
@@ -170,7 +170,7 @@ function db_build() {
 function js_build() {
     echo "build.sh =:> JS Build Specified"
     show_mem
-    export JVM_OPTS="-Dquill.macro.log=false -Dquill.scala.version=$TRAVIS_SCALA_VERSION -Xms4g -Xmx4g -Xss10m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
+    export JVM_OPTS="-Dquill.macro.log=false -Dquill.scala.version=$SCALA_VERSION -Xms4g -Xmx4g -Xss10m -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
     echo "build.sh =:> Starting JS Build Primary"
     sbt -Dmodules=js $SBT_ARGS test
 }
@@ -205,7 +205,7 @@ function full_build() {
 }
 
 if [[ (! -z "$DOCKER_USERNAME") && (! -z "$DOCKER_USERNAME") ]]; then
-  echo "Logging into Docker via $DOCKER_USERNAME for $TRAVIS_EVENT_TYPE"
+  echo "Logging into Docker via $DOCKER_USERNAME for $EVENT_TYPE"
   echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
   echo "Getting Per-Account Statistics for Docker Pull Limits"
@@ -216,7 +216,7 @@ else
   TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
   curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
 
-  echo "Not Logging into Docker for $TRAVIS_EVENT_TYPE build, restarting Docker using GCR mirror"
+  echo "Not Logging into Docker for $EVENT_TYPE build, restarting Docker using GCR mirror"
 fi
 
 echo "Building cache:"
@@ -249,7 +249,7 @@ show_mem
 echo "Tests completed. Shutting down"
 time docker-compose down
 # for 2.12 publish coverage
-if [[ $TRAVIS_SCALA_VERSION == 2.12* ]]; then
+if [[ $SCALA_VERSION == 2.12* ]]; then
     echo "Coverage"
     time sbt $SBT_ARGS coverageReport coverageAggregate
     pip install --user codecov && codecov

--- a/build/release.sh
+++ b/build/release.sh
@@ -28,7 +28,7 @@ else
 fi
 
 echo $SBT_CMD
-if [[ $TRAVIS_PULL_REQUEST == "false" ]]
+if [[ $PULL_REQUEST == "false" ]]
 then
     echo "Export secring"
     openssl aes-256-cbc -md sha256 -salt -pbkdf2 -pass pass:$ENCRYPTION_PASSWORD -in ./build/secring.gpg.enc -out local.secring.gpg -d
@@ -62,16 +62,16 @@ then
     ls -ltr
     sleep 3 # Need to wait until credential files fully written or build fails sometimes
     project_version="v$(cat version.sbt | awk -F'"' '{print $2}')"
-    echo "Detected project_version '$project_version' from SBT Files (on TRAVIS_BRANCH '$TRAVIS_BRANCH')"
+    echo "Detected project_version '$project_version' from SBT Files (on BRANCH '$BRANCH')"
 
     # When an artifact is actually published, a build will go out on the git commit: "Setting version to <YOUR VERSION>".
     # The job before that is the one that creates the vX.X.X tag e.g. v3.0.0. We build and release on that one
     # as well as any branch name 're-release*' in case a build fails and we need to re-publish.
     # (Also note, we could technically use $project_version instead of $(cat version.sbt) but I don't want to change that this time around.)
 
-    if [[ ($TRAVIS_BRANCH == "master" || $TRAVIS_BRANCH == "re-release"*) && $(cat version.sbt) != *"SNAPSHOT"* ]]
+    if [[ ($BRANCH == "master" || $BRANCH == "re-release"*) && $(cat version.sbt) != *"SNAPSHOT"* ]]
     then
-        echo "Release Build for $TRAVIS_BRANCH - Artifact: '$ARTIFACT'"
+        echo "Release Build for $BRANCH - Artifact: '$ARTIFACT'"
         eval "$(ssh-agent -s)"
         chmod 600 local.deploy_key.pem
         ssh-add local.deploy_key.pem
@@ -87,11 +87,11 @@ then
         if [[ $ARTIFACT == "bigdata" ]]; then $SBT_VER -Dmodules=bigdata -DskipPush=true 'release with-defaults'; fi
 
         # Commit next version and tag if we are on the master branch (i.e. not if we are on a re-release)
-        if [[ $TRAVIS_BRANCH == "master" && $ARTIFACT == "publish" ]]; then $SBT_VER -Dmodules=none 'release with-defaults default-tag-exists-answer o'; fi
+        if [[ $BRANCH == "master" && $ARTIFACT == "publish" ]]; then $SBT_VER -Dmodules=none 'release with-defaults default-tag-exists-answer o'; fi
 
-    elif [[ $TRAVIS_BRANCH == "master" && $(cat version.sbt) == *"SNAPSHOT"* ]]
+    elif [[ $BRANCH == "master" && $(cat version.sbt) == *"SNAPSHOT"* ]]
     then
-        echo "Master Non-Release Build for $TRAVIS_BRANCH - Artifact: '$ARTIFACT'"
+        echo "Master Non-Release Build for $BRANCH - Artifact: '$ARTIFACT'"
         if [[ $ARTIFACT == "base" ]]; then    $SBT_VER -Dmodules=base publish; fi
         if [[ $ARTIFACT == "db" ]]; then      $SBT_VER -Dmodules=db publish; fi
         if [[ $ARTIFACT == "js" ]]; then      $SBT_VER -Dmodules=js publish; fi
@@ -104,10 +104,10 @@ then
 
     # If we are a branch build publish it. We are assuming this script does NOT become activated in pulls requests
     # and that condition is done at a higher level then this script
-    elif [[ $TRAVIS_BRANCH != "master" ]]
+    elif [[ $BRANCH != "master" ]]
     then
-        echo "Branch build for $TRAVIS_BRANCH - Artifact: '$ARTIFACT'"
-        echo "version in ThisBuild := \"$TRAVIS_BRANCH-SNAPSHOT\"" > version.sbt
+        echo "Branch build for $BRANCH - Artifact: '$ARTIFACT'"
+        echo "version in ThisBuild := \"$BRANCH-SNAPSHOT\"" > version.sbt
         if [[ $ARTIFACT == "base" ]]; then    $SBT_VER -Dmodules=base publish; fi
         if [[ $ARTIFACT == "db" ]]; then      $SBT_VER -Dmodules=db publish; fi
         if [[ $ARTIFACT == "js" ]]; then      $SBT_VER -Dmodules=js publish; fi
@@ -119,6 +119,6 @@ then
         if [[ $ARTIFACT == "publish" ]]; then echo "No-Op Publish for Non Release Snapshot Branch"; fi
     else
         VERSION_FILE=$(cat version.sbt)
-        echo "Travis branch was: ${$TRAVIS_BRANCH} and version file is $VERSION_FILE. Not Sure what to do."
+        echo "Github actions branch was: ${$BRANCH} and version file is $VERSION_FILE. Not Sure what to do."
     fi
 fi

--- a/quill-jdbc-monix/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
+++ b/quill-jdbc-monix/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
@@ -63,7 +63,7 @@ class StreamResultsOrBlowUpSpec extends Spec {
       .zipWithIndex
       .foldLeftL(0L)({
         case (totalYears, (person, index)) => {
-          // Need to print something out as we stream or travis will thing the build is stalled and kill it with the following message:
+          // Need to print something out as we stream or github actions will think the build is stalled and kill it with the following message:
           // "No output has been received in the last 10m0s..."
           if (index % 10000 == 0) println(s"Streaming Test Row: ${index}")
           totalYears + person.age

--- a/quill-jdbc-zio/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
@@ -57,7 +57,7 @@ class StreamResultsOrBlowUpSpec extends ZioSpec {
       .zipWithIndex
       .fold(0L)({
         case (totalYears, (person, index)) => {
-          // Need to print something out as we stream or travis will thing the build is stalled and kill it with the following message:
+          // Need to print something out as we stream or github actions will think the build is stalled and kill it with the following message:
           // "No output has been received in the last 10m0s..."
           if (index % 10000 == 0) println(s"Streaming Test Row: ${index}")
           totalYears + person.age
@@ -78,7 +78,7 @@ class StreamResultsOrBlowUpSpec extends ZioSpec {
       .zipWithIndex
       .fold(0L)({
         case (totalYears, (person, index)) => {
-          // Need to print something out as we stream or travis will thing the build is stalled and kill it with the following message:
+          // Need to print something out as we stream or github actions will think the build is stalled and kill it with the following message:
           // "No output has been received in the last 10m0s..."
           if (index % 10000 == 0) println(s"Streaming Test Row: ${index}")
           totalYears + person.age


### PR DESCRIPTION
### Problem

This PR removes all of the travism's from the getquill codebase (since we are not using travis anymore)

### Solution

The main significant change is that environment variables have been renamed. Theoretically this shouldn't break anything as its a literal substitution but there might be some unknown clash. 

### Notes

In places in Quill I noticed

```
// Need to print something out as we stream or github actions will think the build is stalled and kill it with the following message:
```

I am not sure if this is the case with github actions but I suppose its not really a big issue to not fix it if its not true?

I am also not sure how to fully test this, it appears the environment variables are typically used when releasing quill which I am not that familiar with.

### Checklist

- [ ] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
