### PR TITLE
Fix MySQL related tests not working with docker-compose sbt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       - POSTGRES_PORT=5432
       - MYSQL_HOST=mysql
       - MYSQL_PORT=3306
+      - MYSQL_PASSWORD=root
       - SQL_SERVER_HOST=sqlserver
       - SQL_SERVER_PORT=1433
       - ORACLE_HOST=oracle


### PR DESCRIPTION
### Problem

When following the contribution guidelines to run docker tests locally using `docker-compose run --rm sbt sbt test` all MySQL JDBC tests fail with 

```
[info]   Cause: com.zaxxer.hikari.pool.HikariPool$PoolInitializationException: Failed to initialize pool: Access denied for user 'root'@'172.19.0.8' (using password: NO)
[info]   at com.zaxxer.hikari.pool.HikariPool.throwPoolInitializationException(HikariPool.java:595)
[info]   at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:581)
[info]   at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:115)
[info]   at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:81)
[info]   at io.getquill.JdbcContextConfig.dataSource(JdbcContextConfig.scala:22)
[info]   at io.getquill.MysqlJdbcContext.<init>(MysqlJdbcContext.scala:14)
[info]   at io.getquill.MysqlJdbcContext.<init>(MysqlJdbcContext.scala:15)
[info]   at io.getquill.MysqlJdbcContext.<init>(MysqlJdbcContext.scala:16)
[info]   at io.getquill.context.jdbc.mysql.package$testContext$.<init>(package.scala:8)
[info]   at io.getquill.context.jdbc.mysql.package$testContext$.<clinit>(package.scala)
```

### Solution

The core problems is the sbt tests get a rejection when connecting to MySQL that is spun up by docker. Adding `MYSQL_PASSWORD=root` as an environment variable to the docker-compose sbt scripts allows the tests to run without problem.

### Notes

The regression is likely to have sneaked in due to an update in HikariCP, it seems like HikariCP can no longer access the MySQL database (even with MySQL being setup with  `MYSQL_ALLOW_EMPTY_PASSWORD=yes`). Its likely the underlying cause is that HikariCP either renamed or removed the property that allows you to access MySQL without a password (either that or accessing a MySQL database without a password is no longer supported).

In any case, adding the `MYSQL_PASSWORD` to the sbt tests solves the problem.

If you want to quickly verify the PR, you can run `docker-compose run --rm sbt sbt quill-jdbc/test` instead of `docker-compose run --rm sbt sbt test` (in addition to `docker-compose run --rm setup` which sets up all of the databases)

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
