### PR TITLE
Github CI Jobs name with short scala version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,18 @@ jobs:
       matrix:
         scala: [2.11.12, 2.12.10, 2.13.2]
         module: [db, js, async, codegen, bigdata]
+        include:
+          - scala: 2.11.12
+            scala_short: 211
+            scala_short_dot: 2.11
+          - scala: 2.12.10
+            scala_short: 212
+            scala_short_dot: 2.12
+          - scala: 2.13.2
+            scala_short: 213
+            scala_short_dot: 2.13
+
+    name: Build ${{matrix.scala_short_dot}} - ${{matrix.module}}
 
     steps:
     - uses: actions/checkout@v2
@@ -58,12 +70,17 @@ jobs:
         scala: [2.11.12, 2.12.10, 2.13.2]
         module: [base, db, js, async, codegen, bigdata]
         include:
-        - scala: 2.11.12
-          scala_short: 211
-        - scala: 2.12.10
-          scala_short: 212
-        - scala: 2.13.2
-          scala_short: 213
+          - scala: 2.11.12
+            scala_short: 211
+            scala_short_dot: 2.11
+          - scala: 2.12.10
+            scala_short: 212
+            scala_short_dot: 2.12
+          - scala: 2.13.2
+            scala_short: 213
+            scala_short_dot: 2.13
+
+    name: Release ${{matrix.scala_short_dot}} - ${{matrix.module}}
 
     steps:
     - uses: actions/checkout@v2
@@ -108,6 +125,9 @@ jobs:
         include:
           - scala: 2.11.12
             scala_short: 211
+            scala_short_dot: 2.11
+
+    name: Publish ${{matrix.scala_short_dot}} - ${{matrix.module}}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Under github settings, the setting to require a particular dependency (before committing) is based on the name. The problem is by default all the build matrix settings are part of the name which includes the minor scala version can change with any build. 
![image](https://user-images.githubusercontent.com/1369480/124407059-fd129200-dd10-11eb-9a51-caf438bcbe4f.png)

Then when the build happens where the version has changed, Git will thinks that requirement has not been met because the actual name has changed:
![image](https://user-images.githubusercontent.com/1369480/124407256-701c0880-dd11-11eb-8621-c00fa364ddcf.png)
...
![image](https://user-images.githubusercontent.com/1369480/124407283-832ed880-dd11-11eb-8806-915869611a8a.png)

Note that since the Scala 2.12 dependency has been updated for 2.12.10 to 2.12.14 but since the requirement based on 2.12.10 has been added, it thinks that it has not been met.




