### PR TITLE
Use ZIO-Native Iterator chunking for JDBC result sets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -431,8 +431,8 @@ lazy val `quill-zio` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio" % "1.0.5",
-        "dev.zio" %% "zio-streams" % "1.0.5"
+        "dev.zio" %% "zio" % "1.0.9",
+        "dev.zio" %% "zio-streams" % "1.0.9"
       )
     )
     .dependsOn(`quill-core-jvm` % "compile->compile;test->test")
@@ -657,8 +657,8 @@ lazy val `quill-cassandra-zio` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio" % "1.0.5",
-        "dev.zio" %% "zio-streams" % "1.0.5",
+        "dev.zio" %% "zio" % "1.0.9",
+        "dev.zio" %% "zio-streams" % "1.0.9",
         "dev.zio" %% "zio-interop-guava" % "30.1.0.3"
       )
     )

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcContext.scala
@@ -245,7 +245,7 @@ abstract class ZioJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy] ext
             // TODO Assuming chunk size is fetch size. Not sure if this is optimal.
             //      Maybe introduce some switches to control this?
             case Some(size) =>
-              chunkedFetch(iter, size)
+              ZStream.fromIterator(iter, size)
             case None =>
               Stream.fromIterator(new ResultSetIterator(rs, extractor))
           }
@@ -260,53 +260,6 @@ abstract class ZioJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy] ext
     ZStream.managed(zio.blocking.blockingExecutor.toManaged_.flatMap { executor =>
       ZManaged.lock(executor)
     }).provideLayer(Blocking.live)
-
-  def guardedChunkFill[A](n: Int)(hasNext: => Boolean, elem: => A): Chunk[A] =
-    if (n <= 0) Chunk.empty
-    else {
-      val builder = ChunkBuilder.make[A]()
-      builder.sizeHint(n)
-
-      var i = 0
-      while (i < n && hasNext) {
-        builder += elem
-        i += 1
-      }
-      builder.result()
-    }
-
-  def chunkedFetch[T](iter: ResultSetIterator[T], fetchSize: Int) = {
-    object StreamEnd extends Throwable
-    ZStream.fromEffect(Task(iter) <*> ZIO.runtime[Any]).flatMap {
-      case (it, rt) =>
-        ZStream.repeatEffectChunkOption {
-          Task {
-            val hasNext: Boolean =
-              try it.hasNext
-              catch {
-                case e: Throwable if !rt.platform.fatal(e) =>
-                  throw e
-              }
-            if (hasNext) {
-              try {
-                // The most efficent way to load an array is to allocate a slice that has the number of elements
-                // that will be returned by every database fetch i.e. the fetch size. Since the later iteration
-                // may return fewer elements then that, we need a special guard for that particular scenario.
-                // However, since we do not know which slice is that last, the guard (i.e. hasNext())
-                // needs to be used for all of them.
-                guardedChunkFill(fetchSize)(it.hasNext, it.next())
-              } catch {
-                case e: Throwable if !rt.platform.fatal(e) =>
-                  throw e
-              }
-            } else throw StreamEnd
-          }.mapError {
-            case StreamEnd => None
-            case e         => Some(e)
-          }
-        }
-    }
-  }
 
   override private[getquill] def prepareParams(statement: String, prepare: Prepare): QIO[Seq[String]] = {
     withConnectionWrapped { conn =>

--- a/quill-jdbc-zio/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/integration/StreamResultsOrBlowUpSpec.scala
@@ -68,6 +68,7 @@ class StreamResultsOrBlowUpSpec extends ZioSpec {
     deletes.runSyncUnsafe()
   }
 
+  // Note, to actually have no chunking, remove the 100 in stream(query[Person], 100) and run with a small memory size e.g. -Xmx50m
   "stream a large result set without blowing up - no chunking" in {
     deletes.runSyncUnsafe()
 


### PR DESCRIPTION
Since ZIO `1.0.5` did not have a native chunked stream, one needed to be implemented so that fetch-size of the JDBC result set would translate into correspondingly-sized chunks of the ZStream (when the `context.stream` function was called). Now since the is a `ZStream.fromIterator` method takes a size-hint argument, we should just use that instead.