### PR TITLE
Cats Effect context for cassanda

### DIFF
--- a/quill-cassandra-ce/src/main/scala-2.12/io/getquill/CassandraCeContext.scala
+++ b/quill-cassandra-ce/src/main/scala-2.12/io/getquill/CassandraCeContext.scala
@@ -1,0 +1,94 @@
+package io.getquill
+
+import cats._
+import cats.effect._
+import com.datastax.driver.core._
+import cats.syntax.all._
+import fs2.Stream
+import com.typesafe.config.Config
+import io.getquill.context.cassandra.CqlIdiom
+import io.getquill.util.{ ContextLogger, LoadConfig }
+import io.getquill.util.GuavaCeUtils._
+import io.getquill.context.ExecutionInfo
+import io.getquill.context.ce.CeContext
+
+import scala.jdk.CollectionConverters._
+import scala.language.higherKinds
+
+class CassandraCeContext[N <: NamingStrategy, F[_]](
+  naming:                     N,
+  cluster:                    Cluster,
+  keyspace:                   String,
+  preparedStatementCacheSize: Long
+)(implicit val af: Async[F])
+  extends CassandraClusterSessionContext[N](naming, cluster, keyspace, preparedStatementCacheSize)
+  with CeContext[CqlIdiom, N, F] {
+
+  private val logger = ContextLogger(classOf[CassandraCeContext[_, F]])
+
+  private[getquill] def prepareRowAndLog(cql: String, prepare: Prepare = identityPrepare): F[PrepareRow] = for {
+    ec <- Async[F].executionContext
+    futureStatement = Sync[F].delay(prepareAsync(cql)(ec))
+    prepStatement <- Async[F].fromFuture(futureStatement)
+    (params, bs) = prepare(prepStatement, this)
+    _ <- Sync[F].delay(logger.logQuery(cql, params))
+  } yield bs
+
+  protected def page(rs: ResultSet): F[Iterable[Row]] = for {
+    available <- af.delay(rs.getAvailableWithoutFetching)
+    page_isFullyFetched <- af.delay {
+      (rs.asScala.take(available), rs.isFullyFetched)
+    }
+    (page, isFullyFetched) = page_isFullyFetched
+    it <- if (isFullyFetched)
+      af.delay {
+        page
+      }
+    else {
+      af.delay {
+        rs.fetchMoreResults()
+      }.toAsync.map(_ => page)
+    }
+  } yield it
+
+  def streamQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): StreamResult[T] = {
+    Stream
+      .eval(prepareRowAndLog(cql, prepare))
+      .evalMap(p => af.delay(session.executeAsync(p)).toAsync)
+      .flatMap(rs => Stream.repeatEval(page(rs)))
+      .takeWhile(_.nonEmpty)
+      .flatMap(Stream.iterable)
+      .map(it => extractor(it, this))
+  }
+
+  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Result[RunQueryResult[T]] =
+    streamQuery[T](cql, prepare, extractor)(info, dc).compile.toList
+
+  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Result[RunQuerySingleResult[T]] =
+    Functor[F].map(executeQuery(cql, prepare, extractor)(info, dc))(handleSingleResult)
+
+  def executeAction(cql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Result[RunActionResult] = {
+    prepareRowAndLog(cql, prepare)
+      .flatMap(r => af.delay(session.executeAsync(r)).toAsync)
+      .map(_ => ())
+  }
+
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Result[RunBatchActionResult] =
+    groups.traverse_ {
+      case BatchGroup(cql, prepare) =>
+        prepare.traverse_(executeAction(cql, _)(info, dc))
+    }
+}
+
+object CassandraCeContext {
+
+  def apply[N <: NamingStrategy, F[_]: Async: FlatMap](naming: N, config: CassandraContextConfig): CassandraCeContext[N, F] =
+    new CassandraCeContext(naming, config.cluster, config.keyspace, config.preparedStatementCacheSize)
+
+  def apply[N <: NamingStrategy, F[_]: Async: FlatMap](naming: N, config: Config): CassandraCeContext[N, F] =
+    CassandraCeContext(naming, CassandraContextConfig(config))
+
+  def apply[N <: NamingStrategy, F[_]: Async: FlatMap](naming: N, configPrefix: String): CassandraCeContext[N, F] =
+    CassandraCeContext(naming, LoadConfig(configPrefix))
+
+}

--- a/quill-cassandra-ce/src/main/scala-2.12/io/getquill/util/GuavaCeUtils.scala
+++ b/quill-cassandra-ce/src/main/scala-2.12/io/getquill/util/GuavaCeUtils.scala
@@ -1,0 +1,45 @@
+package io.getquill.util
+
+import com.google.common.util.concurrent.{ FutureCallback, Futures, ListenableFuture }
+import cats.effect.Async
+
+import cats.implicits._
+import com.datastax.driver.core.{ ResultSet, ResultSetFuture }
+
+import java.util.concurrent.Executor
+import scala.concurrent.ExecutionContext
+import scala.language.higherKinds
+
+object GuavaCeUtils {
+
+  case class ecExecutor(ec: ExecutionContext) extends Executor {
+    def execute(command: Runnable): Unit = ec.execute(command)
+  }
+
+  implicit class RichResultSetFuture[F[_]: Async](rsf: F[ResultSetFuture]) {
+    def toAsync: F[ResultSet] = (Async[F].executionContext product rsf) flatMap {
+      case (ec, lf) =>
+        Async[F].async_ { cb =>
+          Futures.addCallback(lf, new FutureCallback[ResultSet] {
+            override def onFailure(t: Throwable): Unit = cb(Left(t))
+
+            override def onSuccess(result: ResultSet): Unit = cb(Right(result))
+          }, ecExecutor(ec))
+        }
+    }
+  }
+
+  implicit class RichListenableFuture[T, F[_]: Async](flf: F[ListenableFuture[T]]) {
+
+    def toAsync: F[T] = (Async[F].executionContext product flf) flatMap {
+      case (ec, lf) =>
+        Async[F].async_ { cb =>
+          Futures.addCallback(lf, new FutureCallback[T] {
+            override def onFailure(t: Throwable): Unit = cb(Left(t))
+
+            override def onSuccess(result: T): Unit = cb(Right(result))
+          }, ecExecutor(ec))
+        }
+    }
+  }
+}

--- a/quill-cassandra-ce/src/main/scala-2.13/io/getquill/CassandraCeContext.scala
+++ b/quill-cassandra-ce/src/main/scala-2.13/io/getquill/CassandraCeContext.scala
@@ -1,0 +1,94 @@
+package io.getquill
+
+import cats._
+import cats.effect._
+import com.datastax.driver.core._
+import cats.syntax.all._
+import fs2.Stream
+import com.typesafe.config.Config
+import io.getquill.context.cassandra.CqlIdiom
+import io.getquill.util.{ ContextLogger, LoadConfig }
+import io.getquill.util.GuavaCeUtils._
+import io.getquill.context.ExecutionInfo
+import io.getquill.context.ce.CeContext
+
+import scala.jdk.CollectionConverters._
+import scala.language.higherKinds
+
+class CassandraCeContext[N <: NamingStrategy, F[_]](
+  naming:                     N,
+  cluster:                    Cluster,
+  keyspace:                   String,
+  preparedStatementCacheSize: Long
+)(implicit val af: Async[F])
+  extends CassandraClusterSessionContext[N](naming, cluster, keyspace, preparedStatementCacheSize)
+  with CeContext[CqlIdiom, N, F] {
+
+  private val logger = ContextLogger(classOf[CassandraCeContext[_, F]])
+
+  private[getquill] def prepareRowAndLog(cql: String, prepare: Prepare = identityPrepare): F[PrepareRow] = for {
+    ec <- Async[F].executionContext
+    futureStatement = Sync[F].delay(prepareAsync(cql)(ec))
+    prepStatement <- Async[F].fromFuture(futureStatement)
+    (params, bs) = prepare(prepStatement, this)
+    _ <- Sync[F].delay(logger.logQuery(cql, params))
+  } yield bs
+
+  protected def page(rs: ResultSet): F[Iterable[Row]] = for {
+    available <- af.delay(rs.getAvailableWithoutFetching)
+    page_isFullyFetched <- af.delay {
+      (rs.asScala.take(available), rs.isFullyFetched)
+    }
+    (page, isFullyFetched) = page_isFullyFetched
+    it <- if (isFullyFetched)
+      af.delay {
+        page
+      }
+    else {
+      af.delay {
+        rs.fetchMoreResults()
+      }.toAsync.map(_ => page)
+    }
+  } yield it
+
+  def streamQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): StreamResult[T] = {
+    Stream
+      .eval(prepareRowAndLog(cql, prepare))
+      .evalMap(p => af.delay(session.executeAsync(p)).toAsync)
+      .flatMap(rs => Stream.repeatEval(page(rs)))
+      .takeWhile(_.nonEmpty)
+      .flatMap(Stream.iterable)
+      .map(it => extractor(it, this))
+  }
+
+  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Result[RunQueryResult[T]] =
+    streamQuery[T](cql, prepare, extractor)(info, dc).compile.toList
+
+  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Result[RunQuerySingleResult[T]] =
+    Functor[F].map(executeQuery(cql, prepare, extractor)(info, dc))(handleSingleResult)
+
+  def executeAction(cql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Result[RunActionResult] = {
+    prepareRowAndLog(cql, prepare)
+      .flatMap(r => af.delay(session.executeAsync(r)).toAsync)
+      .map(_ => ())
+  }
+
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Result[RunBatchActionResult] =
+    groups.traverse_ {
+      case BatchGroup(cql, prepare) =>
+        prepare.traverse_(executeAction(cql, _)(info, dc))
+    }
+}
+
+object CassandraCeContext {
+
+  def apply[N <: NamingStrategy, F[_]: Async: FlatMap](naming: N, config: CassandraContextConfig): CassandraCeContext[N, F] =
+    new CassandraCeContext(naming, config.cluster, config.keyspace, config.preparedStatementCacheSize)
+
+  def apply[N <: NamingStrategy, F[_]: Async: FlatMap](naming: N, config: Config): CassandraCeContext[N, F] =
+    CassandraCeContext(naming, CassandraContextConfig(config))
+
+  def apply[N <: NamingStrategy, F[_]: Async: FlatMap](naming: N, configPrefix: String): CassandraCeContext[N, F] =
+    CassandraCeContext(naming, LoadConfig(configPrefix))
+
+}

--- a/quill-cassandra-ce/src/main/scala-2.13/io/getquill/util/GuavaCeUtils.scala
+++ b/quill-cassandra-ce/src/main/scala-2.13/io/getquill/util/GuavaCeUtils.scala
@@ -1,0 +1,45 @@
+package io.getquill.util
+
+import com.google.common.util.concurrent.{ FutureCallback, Futures, ListenableFuture }
+import cats.effect.Async
+
+import cats.implicits._
+import com.datastax.driver.core.{ ResultSet, ResultSetFuture }
+
+import java.util.concurrent.Executor
+import scala.concurrent.ExecutionContext
+import scala.language.higherKinds
+
+object GuavaCeUtils {
+
+  case class ecExecutor(ec: ExecutionContext) extends Executor {
+    def execute(command: Runnable): Unit = ec.execute(command)
+  }
+
+  implicit class RichResultSetFuture[F[_]: Async](rsf: F[ResultSetFuture]) {
+    def toAsync: F[ResultSet] = (Async[F].executionContext product rsf) flatMap {
+      case (ec, lf) =>
+        Async[F].async_ { cb =>
+          Futures.addCallback(lf, new FutureCallback[ResultSet] {
+            override def onFailure(t: Throwable): Unit = cb(Left(t))
+
+            override def onSuccess(result: ResultSet): Unit = cb(Right(result))
+          }, ecExecutor(ec))
+        }
+    }
+  }
+
+  implicit class RichListenableFuture[T, F[_]: Async](flf: F[ListenableFuture[T]]) {
+
+    def toAsync: F[T] = (Async[F].executionContext product flf) flatMap {
+      case (ec, lf) =>
+        Async[F].async_ { cb =>
+          Futures.addCallback(lf, new FutureCallback[T] {
+            override def onFailure(t: Throwable): Unit = cb(Left(t))
+
+            override def onSuccess(result: T): Unit = cb(Right(result))
+          }, ecExecutor(ec))
+        }
+    }
+  }
+}

--- a/quill-cassandra-ce/src/test/resources/application.conf
+++ b/quill-cassandra-ce/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+testStreamDB.keyspace=quill_test
+testStreamDB.preparedStatementCacheSize=1000
+testStreamDB.session.contactPoint=${?CASSANDRA_HOST}
+testStreamDB.session.port=${?CASSANDRA_PORT}
+testStreamDB.session.queryOptions.fetchSize=1
+testStreamDB.session.queryOptions.consistencyLevel=LOCAL_QUORUM

--- a/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/DecodeNullSpec.scala
+++ b/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/DecodeNullSpec.scala
@@ -1,0 +1,36 @@
+package io.getquill.context.cassandra.catEffect
+
+import io.getquill._
+
+class DecodeNullSpec extends Spec {
+
+  "no default values when reading null" - {
+    "stream" in {
+      import io.getquill.context.cassandra.catsEffect.testCeDB._
+      import io.getquill.context.cassandra.catsEffect.testCeDB
+      import cats.effect.unsafe.implicits.global
+
+      val writeEntities = quote(querySchema[DecodeNullTestWriteEntity]("DecodeNullTestEntity"))
+
+      val result =
+        for {
+          _ <- testCeDB.run(writeEntities.delete)
+          _ <- testCeDB.run(writeEntities.insert(lift(insertValue)))
+          result <- testCeDB.run(query[DecodeNullTestEntity])
+        } yield {
+          result
+        }
+      intercept[IllegalStateException] {
+        await {
+          result.unsafeToFuture()
+        }
+      }
+    }
+  }
+
+  case class DecodeNullTestEntity(id: Int, value: Int)
+
+  case class DecodeNullTestWriteEntity(id: Int, value: Option[Int])
+
+  val insertValue = DecodeNullTestWriteEntity(0, None)
+}

--- a/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/EncodingSpec.scala
+++ b/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/EncodingSpec.scala
@@ -1,0 +1,44 @@
+package io.getquill.context.cassandra.catEffect
+
+import io.getquill.Query
+import io.getquill.context.cassandra.EncodingSpecHelper
+import io.getquill.context.cassandra.catsEffect.testCeDB._
+import io.getquill.context.cassandra.catsEffect.testCeDB
+import cats.effect.unsafe.implicits.global
+
+class EncodingSpec extends EncodingSpecHelper {
+  "encodes and decodes types" - {
+    "stream" in {
+      val result =
+        for {
+          _ <- testCeDB.run(query[EncodingTestEntity].delete)
+          _ <- testCeDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          result <- testCeDB.run(query[EncodingTestEntity])
+        } yield {
+          result
+        }
+      val f = result.unsafeToFuture()
+      val r = await(f)
+      verify(r)
+    }
+  }
+
+  "encodes collections" - {
+    "stream" in {
+      val q = quote {
+        (list: Query[Int]) =>
+          query[EncodingTestEntity].filter(t => list.contains(t.id))
+      }
+      val result =
+        for {
+          _ <- testCeDB.run(query[EncodingTestEntity].delete)
+          _ <- testCeDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          result <- testCeDB.run(q(liftQuery(insertValues.map(_.id))))
+        } yield {
+          result
+        }
+      val f = result.unsafeToFuture()
+      verify(await(f))
+    }
+  }
+}

--- a/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/QueryResultTypeCassandraCeSpec.scala
+++ b/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/QueryResultTypeCassandraCeSpec.scala
@@ -1,0 +1,54 @@
+package io.getquill.context.cassandra.catEffect
+
+import io.getquill.context.cassandra.QueryResultTypeCassandraSpec
+import io.getquill.context.cassandra.catsEffect.testCeDB._
+import io.getquill.context.cassandra.catsEffect.testCeDB
+import cats.effect.unsafe.implicits.global
+import cats.effect.IO
+import io.getquill.{ Ord, Spec }
+
+class QueryResultTypeCassandraCeSpec extends Spec {
+
+  def result[A](fa: IO[A]): A = fa.unsafeRunSync()
+  case class OrderTestEntity(id: Int, i: Int)
+
+  val entries = List(
+    OrderTestEntity(1, 1),
+    OrderTestEntity(2, 2),
+    OrderTestEntity(3, 3)
+  )
+
+  val insert = quote((e: OrderTestEntity) => query[OrderTestEntity].insert(e))
+  val deleteAll = quote(query[OrderTestEntity].delete)
+  val selectAll = quote(query[OrderTestEntity])
+  val map = quote(query[OrderTestEntity].map(_.id))
+  val filter = quote(query[OrderTestEntity].filter(_.id == 1))
+  val withFilter = quote(query[OrderTestEntity].withFilter(_.id == 1))
+  val sortBy = quote(query[OrderTestEntity].filter(_.id == 1).sortBy(_.i)(Ord.asc))
+  val take = quote(query[OrderTestEntity].take(10))
+  val entitySize = quote(query[OrderTestEntity].size)
+  val parametrizedSize = quote { (id: Int) =>
+    query[OrderTestEntity].filter(_.id == id).size
+  }
+  val distinct = quote(query[OrderTestEntity].map(_.id).distinct)
+
+  override def beforeAll: Unit = {
+    testCeDB.run(deleteAll).unsafeRunSync()
+    testCeDB.run(liftQuery(entries).foreach(e => insert(e))).unsafeRunSync()
+    ()
+  }
+
+  "query" in {
+    result(testCeDB.run(selectAll)) mustEqual entries
+  }
+
+  "querySingle" - {
+    "size" in {
+      result(testCeDB.run(entitySize)) mustEqual 3
+    }
+
+    "parametrized size" in {
+      result(testCeDB.run(parametrizedSize(lift(10000)))) mustEqual 0
+    }
+  }
+}

--- a/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/UdtEncodingSessionContextSpec.scala
+++ b/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/UdtEncodingSessionContextSpec.scala
@@ -1,0 +1,78 @@
+package io.getquill.context.cassandra.catEffect
+
+import io.getquill.Udt
+import io.getquill.context.cassandra.udt.UdtSpec
+import io.getquill.context.cassandra.catsEffect.testCeDB._
+import io.getquill.context.cassandra.catsEffect.testCeDB
+import cats.effect.unsafe.implicits.global
+
+class UdtEncodingSessionContextSpec extends UdtSpec {
+
+  val ctx = testCeDB
+  import ctx._
+
+  "Provide encoding for UDT" - {
+    "raw" in {
+      implicitly[Decoder[Name]]
+      implicitly[Encoder[Name]]
+    }
+    "collections" in {
+      4
+      implicitly[Decoder[List[Name]]]
+      implicitly[Decoder[Set[Name]]]
+      implicitly[Decoder[Map[String, Name]]]
+      implicitly[Encoder[List[Name]]]
+      implicitly[Encoder[Set[Name]]]
+      implicitly[Encoder[Map[String, Name]]]
+    }
+    "nested" in {
+      implicitly[Decoder[Personal]]
+      implicitly[Encoder[Personal]]
+      implicitly[Decoder[List[Personal]]]
+      implicitly[Encoder[List[Personal]]]
+    }
+    "MappedEncoding" in {
+      case class FirstName(name: String)
+      case class MyName(firstName: FirstName) extends Udt
+
+      implicit val encodeFirstName = MappedEncoding[FirstName, String](_.name)
+      implicit val decodeFirstName = MappedEncoding[String, FirstName](FirstName)
+
+      implicitly[Encoder[MyName]]
+      implicitly[Decoder[MyName]]
+      implicitly[Encoder[List[MyName]]]
+      implicitly[Decoder[List[MyName]]]
+    }
+  }
+
+  "Complete examples" - {
+    "without meta" in {
+      case class WithEverything(id: Int, personal: Personal, nameList: List[Name])
+
+      val e = WithEverything(1, Personal(1, "strt",
+        Name("first", Some("last")),
+        Some(Name("f", None)),
+        List("e"),
+        Set(1, 2),
+        Map(1 -> "1", 2 -> "2")),
+        List(Name("first", None)))
+      ctx.run(query[WithEverything].insert(lift(e))).unsafeRunSync()
+      ctx.run(query[WithEverything].filter(_.id == 1)).unsafeRunSync().headOption must contain(e)
+    }
+    "with meta" in {
+      case class MyName(first: String) extends Udt
+      case class WithEverything(id: Int, name: MyName, nameList: List[MyName])
+      implicit val myNameMeta = udtMeta[MyName]("Name", _.first -> "firstName")
+
+      val e = WithEverything(2, MyName("first"), List(MyName("first")))
+      ctx.run(query[WithEverything].insert(lift(e))).unsafeRunSync()
+      ctx.run(query[WithEverything].filter(_.id == 2)).unsafeRunSync().headOption must contain(e)
+    }
+  }
+
+  override def beforeAll: Unit = {
+    ctx.run(querySchema[Name]("WithEverything").delete).unsafeRunSync()
+    super.beforeAll()
+    ()
+  }
+}

--- a/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/package.scala
+++ b/quill-cassandra-ce/src/test/scala-2.12/io/getquill/context/cassandra/catEffect/package.scala
@@ -1,0 +1,15 @@
+package io.getquill.context.cassandra
+
+import io.getquill.util.LoadConfig
+import io.getquill.{ CassandraCeContext, CassandraContextConfig, Literal }
+import cats.effect.{ Async, IO }
+import io.getquill.context.cassandra.encoding.{ Decoders, Encoders }
+
+package object catsEffect {
+
+  lazy val testCeDB: CassandraCeContext[Literal.type, IO] = {
+    val c = CassandraContextConfig(LoadConfig("testStreamDB"))
+    new CassandraCeContext(Literal, c.cluster, c.keyspace, c.preparedStatementCacheSize)(Async[IO]) with CassandraTestEntities with Encoders with Decoders
+  }
+
+}

--- a/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/DecodeNullSpec.scala
+++ b/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/DecodeNullSpec.scala
@@ -1,0 +1,35 @@
+package io.getquill.context.cassandra.catEffect
+
+import io.getquill._
+import io.getquill.context.cassandra.catsEffect.testCeDB._
+import io.getquill.context.cassandra.catsEffect.testCeDB
+import cats.effect.unsafe.implicits.global
+
+class DecodeNullSpec extends Spec {
+
+  "no default values when reading null" - {
+    "stream" in {
+      val writeEntities = quote(querySchema[DecodeNullTestWriteEntity]("DecodeNullTestEntity"))
+
+      val result =
+        for {
+          _ <- testCeDB.run(writeEntities.delete)
+          _ <- testCeDB.run(writeEntities.insert(lift(insertValue)))
+          result <- testCeDB.run(query[DecodeNullTestEntity])
+        } yield {
+          result
+        }
+      intercept[IllegalStateException] {
+        await {
+          result.unsafeToFuture()
+        }
+      }
+    }
+  }
+
+  case class DecodeNullTestEntity(id: Int, value: Int)
+
+  case class DecodeNullTestWriteEntity(id: Int, value: Option[Int])
+
+  val insertValue = DecodeNullTestWriteEntity(0, None)
+}

--- a/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/EncodingSpec.scala
+++ b/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/EncodingSpec.scala
@@ -1,0 +1,44 @@
+package io.getquill.context.cassandra.catEffect
+
+import io.getquill.Query
+import io.getquill.context.cassandra.EncodingSpecHelper
+import io.getquill.context.cassandra.catsEffect.testCeDB._
+import io.getquill.context.cassandra.catsEffect.testCeDB
+import cats.effect.unsafe.implicits.global
+
+class EncodingSpec extends EncodingSpecHelper {
+  "encodes and decodes types" - {
+    "stream" in {
+      val result =
+        for {
+          _ <- testCeDB.run(query[EncodingTestEntity].delete)
+          _ <- testCeDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          result <- testCeDB.run(query[EncodingTestEntity])
+        } yield {
+          result
+        }
+      val f = result.unsafeToFuture()
+      val r = await(f)
+      verify(r)
+    }
+  }
+
+  "encodes collections" - {
+    "stream" in {
+      val q = quote {
+        (list: Query[Int]) =>
+          query[EncodingTestEntity].filter(t => list.contains(t.id))
+      }
+      val result =
+        for {
+          _ <- testCeDB.run(query[EncodingTestEntity].delete)
+          _ <- testCeDB.run(liftQuery(insertValues).foreach(e => query[EncodingTestEntity].insert(e)))
+          result <- testCeDB.run(q(liftQuery(insertValues.map(_.id))))
+        } yield {
+          result
+        }
+      val f = result.unsafeToFuture()
+      verify(await(f))
+    }
+  }
+}

--- a/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/QueryResultTypeCassandraCeSpec.scala
+++ b/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/QueryResultTypeCassandraCeSpec.scala
@@ -1,0 +1,54 @@
+package io.getquill.context.cassandra.catEffect
+
+import io.getquill.context.cassandra.QueryResultTypeCassandraSpec
+import io.getquill.context.cassandra.catsEffect.testCeDB._
+import io.getquill.context.cassandra.catsEffect.testCeDB
+import cats.effect.unsafe.implicits.global
+import cats.effect.IO
+import io.getquill.{ Ord, Spec }
+
+class QueryResultTypeCassandraCeSpec extends Spec {
+
+  def result[A](fa: IO[A]): A = fa.unsafeRunSync()
+  case class OrderTestEntity(id: Int, i: Int)
+
+  val entries = List(
+    OrderTestEntity(1, 1),
+    OrderTestEntity(2, 2),
+    OrderTestEntity(3, 3)
+  )
+
+  val insert = quote((e: OrderTestEntity) => query[OrderTestEntity].insert(e))
+  val deleteAll = quote(query[OrderTestEntity].delete)
+  val selectAll = quote(query[OrderTestEntity])
+  val map = quote(query[OrderTestEntity].map(_.id))
+  val filter = quote(query[OrderTestEntity].filter(_.id == 1))
+  val withFilter = quote(query[OrderTestEntity].withFilter(_.id == 1))
+  val sortBy = quote(query[OrderTestEntity].filter(_.id == 1).sortBy(_.i)(Ord.asc))
+  val take = quote(query[OrderTestEntity].take(10))
+  val entitySize = quote(query[OrderTestEntity].size)
+  val parametrizedSize = quote { (id: Int) =>
+    query[OrderTestEntity].filter(_.id == id).size
+  }
+  val distinct = quote(query[OrderTestEntity].map(_.id).distinct)
+
+  override def beforeAll: Unit = {
+    testCeDB.run(deleteAll).unsafeRunSync()
+    testCeDB.run(liftQuery(entries).foreach(e => insert(e))).unsafeRunSync()
+    ()
+  }
+
+  "query" in {
+    result(testCeDB.run(selectAll)) mustEqual entries
+  }
+
+  "querySingle" - {
+    "size" in {
+      result(testCeDB.run(entitySize)) mustEqual 3
+    }
+
+    "parametrized size" in {
+      result(testCeDB.run(parametrizedSize(lift(10000)))) mustEqual 0
+    }
+  }
+}

--- a/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/UdtEncodingSessionContextSpec.scala
+++ b/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/UdtEncodingSessionContextSpec.scala
@@ -1,0 +1,78 @@
+package io.getquill.context.cassandra.catEffect
+
+import io.getquill.Udt
+import io.getquill.context.cassandra.udt.UdtSpec
+import io.getquill.context.cassandra.catsEffect.testCeDB._
+import io.getquill.context.cassandra.catsEffect.testCeDB
+import cats.effect.unsafe.implicits.global
+
+class UdtEncodingSessionContextSpec extends UdtSpec {
+
+  val ctx = testCeDB
+  import ctx._
+
+  "Provide encoding for UDT" - {
+    "raw" in {
+      implicitly[Decoder[Name]]
+      implicitly[Encoder[Name]]
+    }
+    "collections" in {
+      4
+      implicitly[Decoder[List[Name]]]
+      implicitly[Decoder[Set[Name]]]
+      implicitly[Decoder[Map[String, Name]]]
+      implicitly[Encoder[List[Name]]]
+      implicitly[Encoder[Set[Name]]]
+      implicitly[Encoder[Map[String, Name]]]
+    }
+    "nested" in {
+      implicitly[Decoder[Personal]]
+      implicitly[Encoder[Personal]]
+      implicitly[Decoder[List[Personal]]]
+      implicitly[Encoder[List[Personal]]]
+    }
+    "MappedEncoding" in {
+      case class FirstName(name: String)
+      case class MyName(firstName: FirstName) extends Udt
+
+      implicit val encodeFirstName = MappedEncoding[FirstName, String](_.name)
+      implicit val decodeFirstName = MappedEncoding[String, FirstName](FirstName)
+
+      implicitly[Encoder[MyName]]
+      implicitly[Decoder[MyName]]
+      implicitly[Encoder[List[MyName]]]
+      implicitly[Decoder[List[MyName]]]
+    }
+  }
+
+  "Complete examples" - {
+    "without meta" in {
+      case class WithEverything(id: Int, personal: Personal, nameList: List[Name])
+
+      val e = WithEverything(1, Personal(1, "strt",
+        Name("first", Some("last")),
+        Some(Name("f", None)),
+        List("e"),
+        Set(1, 2),
+        Map(1 -> "1", 2 -> "2")),
+        List(Name("first", None)))
+      ctx.run(query[WithEverything].insert(lift(e))).unsafeRunSync()
+      ctx.run(query[WithEverything].filter(_.id == 1)).unsafeRunSync().headOption must contain(e)
+    }
+    "with meta" in {
+      case class MyName(first: String) extends Udt
+      case class WithEverything(id: Int, name: MyName, nameList: List[MyName])
+      implicit val myNameMeta = udtMeta[MyName]("Name", _.first -> "firstName")
+
+      val e = WithEverything(2, MyName("first"), List(MyName("first")))
+      ctx.run(query[WithEverything].insert(lift(e))).unsafeRunSync()
+      ctx.run(query[WithEverything].filter(_.id == 2)).unsafeRunSync().headOption must contain(e)
+    }
+  }
+
+  override def beforeAll: Unit = {
+    ctx.run(querySchema[Name]("WithEverything").delete).unsafeRunSync()
+    super.beforeAll()
+    ()
+  }
+}

--- a/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/package.scala
+++ b/quill-cassandra-ce/src/test/scala-2.13/io/getquill/context/cassandra/catEffect/package.scala
@@ -1,0 +1,15 @@
+package io.getquill.context.cassandra
+
+import io.getquill.util.LoadConfig
+import io.getquill.{ CassandraCeContext, CassandraContextConfig, Literal }
+import cats.effect.{ Async, IO }
+import io.getquill.context.cassandra.encoding.{ Decoders, Encoders }
+
+package object catsEffect {
+
+  lazy val testCeDB: CassandraCeContext[Literal.type, IO] = {
+    val c = CassandraContextConfig(LoadConfig("testStreamDB"))
+    new CassandraCeContext(Literal, c.cluster, c.keyspace, c.preparedStatementCacheSize)(Async[IO]) with CassandraTestEntities with Encoders with Decoders
+  }
+
+}

--- a/quill-ce/src/main/scala-2.12/io/getquill/context/ce/CeContext.scala
+++ b/quill-ce/src/main/scala-2.12/io/getquill/context/ce/CeContext.scala
@@ -1,0 +1,18 @@
+package io.getquill.context.ce
+
+import io.getquill.NamingStrategy
+import io.getquill.context.{ Context, ExecutionInfo, StreamingContext }
+import fs2.{ Stream => FStream }
+import scala.language.higherKinds
+
+trait CeContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy, F[_]]
+  extends Context[Idiom, Naming]
+  with StreamingContext[Idiom, Naming] {
+
+  override type StreamResult[T] = FStream[F, T]
+  override type Result[T] = F[T]
+  override type RunActionResult = Unit
+  override type RunBatchActionResult = Unit
+  override type RunQueryResult[T] = List[T]
+  override type RunQuerySingleResult[T] = T
+}

--- a/quill-ce/src/main/scala-2.13/io/getquill/context/ce/CeContext.scala
+++ b/quill-ce/src/main/scala-2.13/io/getquill/context/ce/CeContext.scala
@@ -1,0 +1,18 @@
+package io.getquill.context.ce
+
+import io.getquill.NamingStrategy
+import io.getquill.context.{ Context, ExecutionInfo, StreamingContext }
+import fs2.{ Stream => FStream }
+import scala.language.higherKinds
+
+trait CeContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy, F[_]]
+  extends Context[Idiom, Naming]
+  with StreamingContext[Idiom, Naming] {
+
+  override type StreamResult[T] = FStream[F, T]
+  override type Result[T] = F[T]
+  override type RunActionResult = Unit
+  override type RunBatchActionResult = Unit
+  override type RunQueryResult[T] = List[T]
+  override type RunQuerySingleResult[T] = T
+}


### PR DESCRIPTION
Fixes #issue_number

### Problem

Cats Effect context for cassanda. Cats ecosystem currently missing cassandra orms.

### Solution

Cats Effect context for cassanda

### Notes

2.11 is not support. Makes empty artifact.

Increased the  `ReservedCodeCacheSize` to avoid warning on 2.12 compilation.

```
OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
CodeCache: size=262144Kb used=229683Kb max_used=257547Kb free=32460Kb
 bounds [0x00007f75e0000000, 0x00007f75f0000000, 0x00007f75f0000000]
 total_blobs=51233 nmethods=50316 adapters=826
 compilation: enabled
```
Also changed the courier directory to the` /home/sbtuser/` from `/root`.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [X] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
