### PR TITLE
Fixing on-conflict case with querySchema/schemaMeta renamed columns

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CqlIdiom.scala
@@ -41,6 +41,7 @@ trait CqlIdiom extends Idiom {
       case a: Infix             => a.token
       case a: External          => a.token
       case a: Assignment        => a.token
+      case a: AssignmentDual    => a.token
       case a: IterableOperation => a.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
@@ -146,6 +147,11 @@ trait CqlIdiom extends Idiom {
 
   implicit def assignmentTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy): Tokenizer[Assignment] = Tokenizer[Assignment] {
     case Assignment(alias, prop, value) =>
+      stmt"${prop.token} = ${value.token}"
+  }
+
+  implicit def assignmentDualTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy): Tokenizer[AssignmentDual] = Tokenizer[AssignmentDual] {
+    case AssignmentDual(alias1, alias2, prop, value) =>
       stmt"${prop.token} = ${value.token}"
   }
 

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CqlIdiomSpec.scala
@@ -385,6 +385,10 @@ class CqlIdiomSpec extends Spec {
       val a: Ast = Assignment(Ident("a"), Ident("b"), Ident("c"))
       translate(a: Ast) mustBe (a -> stmt"b = c")
     }
+    "assignmentDual" in {
+      val a: Ast = AssignmentDual(Ident("a1"), Ident("a2"), Ident("b"), Ident("c"))
+      translate(a: Ast) mustBe (a -> stmt"b = c")
+    }
     "aggregation" in {
       val t = implicitly[Tokenizer[AggregationOperator]]
       t.token(AggregationOperator.`size`) mustBe stmt"COUNT"

--- a/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/ast/Ast.scala
@@ -439,6 +439,7 @@ case class ListContains(ast: Ast, body: Ast) extends IterableOperation { def qua
 case class If(condition: Ast, `then`: Ast, `else`: Ast) extends Ast { def quat = `then`.quat } // then and else clauses should have identical quats
 
 case class Assignment(alias: Ident, property: Ast, value: Ast) extends Ast { def quat = Quat.Value }
+case class AssignmentDual(alias1: Ident, alias2: Ident, property: Ast, value: Ast) extends Ast { def quat = Quat.Value }
 
 //************************************************************
 
@@ -557,23 +558,9 @@ object OnConflict {
 
   case class Excluded(alias: Ident) extends Ast {
     def quat = alias.quat
-    override def equals(obj: Any): Boolean =
-      obj match {
-        case e: Excluded => e.alias == alias
-        case e: Ident    => e == alias
-        case _           => false
-      }
-    override def hashCode(): Int = alias.hashCode
   }
   case class Existing(alias: Ident) extends Ast {
     def quat = alias.quat
-    override def equals(obj: Any): Boolean =
-      obj match {
-        case e: Existing => e.alias == alias
-        case e: Ident    => e == alias
-        case _           => false
-      }
-    override def hashCode(): Int = alias.hashCode
   }
 
   sealed trait Target
@@ -582,7 +569,7 @@ object OnConflict {
 
   sealed trait Action
   case object Ignore extends Action
-  case class Update(assignments: List[Assignment]) extends Action
+  case class Update(assignments: List[AssignmentDual]) extends Action
 }
 //************************************************************
 

--- a/quill-core-portable/src/main/scala/io/getquill/ast/StatefulTransformer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/ast/StatefulTransformer.scala
@@ -11,6 +11,7 @@ trait StatefulTransformer[T] {
       case e: Action              => apply(e)
       case e: Value               => apply(e)
       case e: Assignment          => apply(e)
+      case e: AssignmentDual      => apply(e)
       case e: Ident               => (e, this)
       case e: ExternalIdent       => (e, this)
       case e: OptionOperation     => apply(e)
@@ -206,6 +207,14 @@ trait StatefulTransformer[T] {
         val (bt, btt) = apply(b)
         val (ct, ctt) = btt.apply(c)
         (Assignment(a, bt, ct), ctt)
+    }
+
+  def apply(e: AssignmentDual): (AssignmentDual, StatefulTransformer[T]) =
+    e match {
+      case AssignmentDual(a1, a2, b, c) =>
+        val (bt, btt) = apply(b)
+        val (ct, ctt) = btt.apply(c)
+        (AssignmentDual(a1, a2, bt, ct), ctt)
     }
 
   def apply(e: Property): (Property, StatefulTransformer[T]) =

--- a/quill-core-portable/src/main/scala/io/getquill/ast/StatelessTransformer.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/ast/StatelessTransformer.scala
@@ -11,6 +11,7 @@ trait StatelessTransformer {
       case e: Action              => apply(e)
       case e: Value               => apply(e)
       case e: Assignment          => apply(e)
+      case e: AssignmentDual      => apply(e)
       case Function(params, body) => Function(params, apply(body))
       case e: Ident               => applyIdent(e)
       case e: ExternalIdent       => e
@@ -25,8 +26,18 @@ trait StatelessTransformer {
       case Block(statements)      => Block(statements.map(apply))
       case Val(name, body)        => Val(name, apply(body))
       case o: Ordering            => o
-      case e: OnConflict.Excluded => e
-      case e: OnConflict.Existing => e
+      case e: OnConflict.Excluded => apply(e)
+      case e: OnConflict.Existing => apply(e)
+    }
+
+  def apply(e: OnConflict.Excluded): OnConflict.Excluded =
+    e match {
+      case OnConflict.Excluded(alias) => OnConflict.Excluded(apply(alias).asInstanceOf[Ident])
+    }
+
+  def apply(e: OnConflict.Existing): OnConflict.Existing =
+    e match {
+      case OnConflict.Existing(alias) => OnConflict.Existing(apply(alias).asInstanceOf[Ident])
     }
 
   def apply(o: OptionOperation): OptionOperation =
@@ -84,6 +95,11 @@ trait StatelessTransformer {
   def apply(e: Assignment): Assignment =
     e match {
       case Assignment(a, b, c) => Assignment(applyIdent(a), apply(b), apply(c))
+    }
+
+  def apply(e: AssignmentDual): AssignmentDual =
+    e match {
+      case AssignmentDual(a1, a2, b, c) => AssignmentDual(applyIdent(a1), applyIdent(a2), apply(b), apply(c))
     }
 
   def apply(e: Property): Property =

--- a/quill-core-portable/src/main/scala/io/getquill/norm/BetaReduction.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/norm/BetaReduction.scala
@@ -148,6 +148,13 @@ case class BetaReduction(map: IMap[Ast, Ast], typeBehavior: TypeBehavior)
         Assignment(alias, t(prop), t(value))
     }
 
+  override def apply(e: AssignmentDual): AssignmentDual =
+    e match {
+      case AssignmentDual(alias1, alias2, prop, value) =>
+        val t = BetaReduction(map - alias1 - alias2, typeBehavior)
+        AssignmentDual(alias1, alias2, t(prop), t(value))
+    }
+
   override def apply(query: Query): Query =
     query match {
       case Filter(a, b, c) =>

--- a/quill-core-portable/src/main/scala/io/getquill/norm/RenameProperties.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/norm/RenameProperties.scala
@@ -79,8 +79,8 @@ object ApplyRenamesToProps extends StatelessTransformer {
   def applyProperty(p: Property) =
     p match {
       case p @ Property.Opinionated(ast, name, renameable, visibility) =>
-        trace"Checking Property: ${p} for possible rename".andLog()
         val newAst = apply(ast)
+        trace"Checking Property: ${p} for possible rename. Renames on Quat: ${newAst.quat.renames}".andLog()
         // Check the quat if it is renaming this property if so rename it. Otherwise property is the same
         newAst.quat.renames.get(name) match {
           case Some(newName) =>

--- a/quill-core-portable/src/main/scala/io/getquill/norm/RepropagateQuats.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/norm/RepropagateQuats.scala
@@ -1,6 +1,6 @@
 package io.getquill.norm
 
-import io.getquill.ast.{ Action, Assignment, Ast, ConcatMap, Filter, FlatJoin, FlatMap, GroupBy, Ident, Insert, Join, Map, OnConflict, Property, Query, Returning, ReturningGenerated, SortBy, StatelessTransformer, Update }
+import io.getquill.ast.{ Action, Assignment, AssignmentDual, Ast, ConcatMap, Filter, FlatJoin, FlatMap, GroupBy, Ident, Insert, Join, Map, OnConflict, Property, Query, Returning, ReturningGenerated, SortBy, StatelessTransformer, Update }
 import io.getquill.quat.Quat
 import io.getquill.quat.Quat.Product
 import io.getquill.util.Interpolator
@@ -65,37 +65,29 @@ object RepropagateQuats extends StatelessTransformer {
   }
 
   override def apply(e: Query): Query = {
-    //println("==================== Before ==================")
-    //println(io.getquill.util.Messages.qprint(e))
-
-    val o =
-      e match {
-        case Filter(a, b, c) => applyBody(a, b, c)(Filter)
-        case Map(a, b, c) =>
-          applyBody(a, b, c)(Map)
-        case FlatMap(a, b, c)   => applyBody(a, b, c)(FlatMap)
-        case ConcatMap(a, b, c) => applyBody(a, b, c)(ConcatMap)
-        case GroupBy(a, b, c)   => applyBody(a, b, c)(GroupBy)
-        case SortBy(a, b, c, d) => applyBody(a, b, c)(SortBy(_, _, _, d))
-        case Join(t, a, b, iA, iB, on) =>
-          val ar = apply(a)
-          val br = apply(b)
-          val iAr = iA.retypeQuatFrom(ar.quat)
-          val iBr = iB.retypeQuatFrom(br.quat)
-          val onr = BetaReduction(on, RWR, iA -> iAr, iB -> iBr)
-          trace"Repropagate ${a.quat.suppress(msg)} from $a and ${b.quat.suppress(msg)} from $b into:" andReturn Join(t, ar, br, iAr, iBr, apply(onr))
-        case FlatJoin(t, a, iA, on) =>
-          val ar = apply(a)
-          val iAr = iA.retypeQuatFrom(ar.quat)
-          val onr = BetaReduction(on, RWR, iA -> iAr)
-          trace"Repropagate ${a.quat.suppress(msg)} from $a into:" andReturn FlatJoin(t, a, iAr, apply(onr))
-        case other =>
-          super.apply(other)
-      }
-
-    //println("==================== After ==================")
-    //println(io.getquill.util.Messages.qprint(o))
-    o
+    e match {
+      case Filter(a, b, c) => applyBody(a, b, c)(Filter)
+      case Map(a, b, c) =>
+        applyBody(a, b, c)(Map)
+      case FlatMap(a, b, c)   => applyBody(a, b, c)(FlatMap)
+      case ConcatMap(a, b, c) => applyBody(a, b, c)(ConcatMap)
+      case GroupBy(a, b, c)   => applyBody(a, b, c)(GroupBy)
+      case SortBy(a, b, c, d) => applyBody(a, b, c)(SortBy(_, _, _, d))
+      case Join(t, a, b, iA, iB, on) =>
+        val ar = apply(a)
+        val br = apply(b)
+        val iAr = iA.retypeQuatFrom(ar.quat)
+        val iBr = iB.retypeQuatFrom(br.quat)
+        val onr = BetaReduction(on, RWR, iA -> iAr, iB -> iBr)
+        trace"Repropagate ${a.quat.suppress(msg)} from $a and ${b.quat.suppress(msg)} from $b into:" andReturn Join(t, ar, br, iAr, iBr, apply(onr))
+      case FlatJoin(t, a, iA, on) =>
+        val ar = apply(a)
+        val iAr = iA.retypeQuatFrom(ar.quat)
+        val onr = BetaReduction(on, RWR, iA -> iAr)
+        trace"Repropagate ${a.quat.suppress(msg)} from $a into:" andReturn FlatJoin(t, a, iAr, apply(onr))
+      case other =>
+        super.apply(other)
+    }
   }
 
   def reassign(assignments: List[Assignment], quat: Quat) =
@@ -158,13 +150,17 @@ object RepropagateQuats extends StatelessTransformer {
           }
         val actR = act match {
           case OnConflict.Update(assignments) =>
+            def p(any: Any) = io.getquill.util.Messages.qprint(any)
             val assignmentsR =
               assignments.map { assignment =>
-                val aliasR = assignment.alias.copy(quat = oca.quat)
-                val propertyR = BetaReduction(assignment.property, RWR, assignment.alias -> aliasR)
-                val valueR = BetaReduction(assignment.value, RWR, assignment.alias -> aliasR)
+                val alias1R = assignment.alias1.copy(quat = oca.quat)
+                val alias2R = assignment.alias2.copy(quat = oca.quat)
+                val propertyR = BetaReduction(assignment.property, RWR, assignment.alias1 -> alias1R, assignment.alias2 -> alias2R)
+                trace"OnConflict.Update property ${assignment.property} becomes ${propertyR}".andLog()
+                val valueR = BetaReduction(assignment.value, RWR, assignment.alias1 -> alias1R, assignment.alias2 -> alias2R)
+                trace"OnConflict.Update value ${assignment.value} becomes ${valueR}".andLog()
                 trace"Repropagate OnConflict.Update Quat ${oca.quat.suppress(msg)} from $oca into:" andReturn
-                  Assignment(aliasR, propertyR, valueR)
+                  AssignmentDual(alias1R, alias2R, propertyR, valueR)
               }
             OnConflict.Update(assignmentsR)
           case _ => act

--- a/quill-core-portable/src/main/scala/io/getquill/quotation/FreeVariables.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/quotation/FreeVariables.scala
@@ -53,6 +53,15 @@ case class FreeVariables(state: State)
         (Assignment(a, bt, ct), FreeVariables(State(state.seen, state.free ++ btt.state.free ++ ctt.state.free)))
     }
 
+  override def apply(e: AssignmentDual): (AssignmentDual, StatefulTransformer[State]) =
+    e match {
+      case AssignmentDual(a1, a2, b, c) =>
+        val t = FreeVariables(State(state.seen + a1.idName + a2.idName, state.free))
+        val (bt, btt) = t(b)
+        val (ct, ctt) = t(c)
+        (AssignmentDual(a1, a2, bt, ct), FreeVariables(State(state.seen, state.free ++ btt.state.free ++ ctt.state.free)))
+    }
+
   override def apply(action: Action): (Action, StatefulTransformer[State]) =
     action match {
       case q @ Returning(a, b, c) =>

--- a/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Liftables.scala
@@ -20,6 +20,7 @@ trait Liftables extends QuatLiftable {
     case ast: Ordering => orderingLiftable(ast)
     case ast: Lift => liftLiftable(ast)
     case ast: Assignment => assignmentLiftable(ast)
+    case ast: AssignmentDual => assignmentDualLiftable(ast)
     case ast: OptionOperation => optionOperationLiftable(ast)
     case ast: IterableOperation => traversableOperationLiftable(ast)
     case ast: Property => propertyLiftable(ast)
@@ -181,6 +182,10 @@ trait Liftables extends QuatLiftable {
 
   implicit val assignmentLiftable: Liftable[Assignment] = Liftable[Assignment] {
     case Assignment(a, b, c) => q"$pack.Assignment($a, $b, $c)"
+  }
+
+  implicit val assignmentDualLiftable: Liftable[AssignmentDual] = Liftable[AssignmentDual] {
+    case AssignmentDual(a1, a2, b, c) => q"$pack.AssignmentDual($a1, $a2, $b, $c)"
   }
 
   implicit val valueLiftable: Liftable[Value] = Liftable[Value] {

--- a/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Parsing.scala
@@ -988,18 +988,21 @@ trait Parsing extends ValueComputation with QuatMaking {
     }
   }
 
-  private val assignmentParser: Parser[Assignment] = Parser[Assignment] {
-    case q"((${ identParser(i1) }) => $pack.Predef.ArrowAssoc[$t]($prop).$arrow[$v]($value))" =>
-      checkTypes(prop, value)
-      Assignment(i1, astParser(prop), astParser(value))
-
+  private val assignmentDualParser: Parser[AssignmentDual] = Parser[AssignmentDual] {
     case q"((${ identParser(i1) }, ${ identParser(i2) }) => $pack.Predef.ArrowAssoc[$t]($prop).$arrow[$v]($value))" =>
       checkTypes(prop, value)
       val valueAst = Transform(astParser(value)) {
         case `i1` => OnConflict.Existing(i1)
         case `i2` => OnConflict.Excluded(i2)
       }
-      Assignment(i1, astParser(prop), valueAst)
+      AssignmentDual(i1, i2, astParser(prop), valueAst)
+  }
+
+  private val assignmentParser: Parser[Assignment] = Parser[Assignment] {
+    case q"((${ identParser(i1) }) => $pack.Predef.ArrowAssoc[$t]($prop).$arrow[$v]($value))" =>
+      checkTypes(prop, value)
+      Assignment(i1, astParser(prop), astParser(value))
+
     // Unused, it's here only to make eclipse's presentation compiler happy
     case astParser(ast) => Assignment(Ident("unused", Quat.Value), Ident("unused", Quat.Value), Constant("unused", Quat.Value))
   }
@@ -1013,7 +1016,9 @@ trait Parsing extends ValueComputation with QuatMaking {
     case q"$query.onConflictUpdate(..$assigns)" =>
       OnConflict(astParser(query), OnConflict.NoTarget, parseConflictAssigns(assigns))
     case q"$query.onConflictUpdate(..$targets)(..$assigns)" =>
-      OnConflict(astParser(query), parseConflictProps(targets), parseConflictAssigns(assigns))
+      val output = OnConflict(astParser(query), parseConflictProps(targets), parseConflictAssigns(assigns))
+      println(io.getquill.util.Messages.qprint(output))
+      output
   }
 
   private def parseConflictProps(targets: List[Tree]) = OnConflict.Properties {
@@ -1024,7 +1029,7 @@ trait Parsing extends ValueComputation with QuatMaking {
   }
 
   private def parseConflictAssigns(targets: List[Tree]) =
-    OnConflict.Update(targets.map(assignmentParser(_)))
+    OnConflict.Update(targets.map(assignmentDualParser(_)))
 
   trait OptionCheckBehavior
   /** Allow T == Option[T] comparison **/

--- a/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
+++ b/quill-core/src/main/scala/io/getquill/quotation/Unliftables.scala
@@ -175,12 +175,16 @@ trait Unliftables extends QuatUnliftable {
   }
 
   implicit val conflictActionUnliftable: Unliftable[OnConflict.Action] = Unliftable[OnConflict.Action] {
-    case q"$pack.OnConflict.Ignore"                                 => OnConflict.Ignore
-    case q"$pack.OnConflict.Update.apply(${ a: List[Assignment] })" => OnConflict.Update(a)
+    case q"$pack.OnConflict.Ignore"                                     => OnConflict.Ignore
+    case q"$pack.OnConflict.Update.apply(${ a: List[AssignmentDual] })" => OnConflict.Update(a)
   }
 
   implicit val assignmentUnliftable: Unliftable[Assignment] = Unliftable[Assignment] {
     case q"$pack.Assignment.apply(${ a: Ident }, ${ b: Ast }, ${ c: Ast })" => Assignment(a, b, c)
+  }
+
+  implicit val assignmentDualUnliftable: Unliftable[AssignmentDual] = Unliftable[AssignmentDual] {
+    case q"$pack.AssignmentDual.apply(${ a1: Ident }, ${ a2: Ident }, ${ b: Ast }, ${ c: Ast })" => AssignmentDual(a1, a2, b, c)
   }
 
   implicit val valueUnliftable: Unliftable[Value] = Unliftable[Value] {

--- a/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatefulTransformerSpec.scala
@@ -257,10 +257,12 @@ class StatefulTransformerSpec extends Spec {
         }
       }
       "update" in {
-        val action: OnConflict.Action = OnConflict.Update(List(Assignment(Ident("a"), Ident("b"), Ident("c"))))
-        Subject(Nil, Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(action) match {
+        val action: OnConflict.Action = OnConflict.Update(List(AssignmentDual(Ident("a1"), Ident("a2"), Ident("b"), Ident("c"))))
+        Subject(Nil, Ident("a1") -> Ident("a1'"), Ident("a2") -> Ident("a2'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(action) match {
           case (at, att) =>
-            at mustEqual OnConflict.Update(List(Assignment(Ident("a"), Ident("b'"), Ident("c'"))))
+            // I.e. values should be changed in this case but not identifiers. Identifiers are not modified in the stateful transformer.
+            // The stateless transformer has a specific clause for them that will activate in some instances.
+            at mustEqual OnConflict.Update(List(AssignmentDual(Ident("a1"), Ident("a2"), Ident("b'"), Ident("c'"))))
             att.state mustEqual List(Ident("b"), Ident("c"))
         }
       }

--- a/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/ast/StatelessTransformerSpec.scala
@@ -180,9 +180,9 @@ class StatelessTransformerSpec extends Spec {
         Subject()(action) mustEqual action
       }
       "update" in {
-        val action: OnConflict.Action = OnConflict.Update(List(Assignment(Ident("a"), Ident("b"), Ident("c"))))
-        Subject(Ident("a") -> Ident("a'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(action) mustEqual
-          OnConflict.Update(List(Assignment(Ident("a"), Ident("b'"), Ident("c'"))))
+        val action: OnConflict.Action = OnConflict.Update(List(AssignmentDual(Ident("a1"), Ident("a2"), Ident("b"), Ident("c"))))
+        Subject(Ident("a1") -> Ident("a1'"), Ident("a2") -> Ident("a2'"), Ident("b") -> Ident("b'"), Ident("c") -> Ident("c'"))(action) mustEqual
+          OnConflict.Update(List(AssignmentDual(Ident("a1"), Ident("a2"), Ident("b'"), Ident("c'"))))
       }
     }
 

--- a/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
+++ b/quill-core/src/test/scala/io/getquill/norm/BetaReductionSpec.scala
@@ -7,7 +7,7 @@ import io.getquill.ast._
 import io.getquill.quat.Quat
 
 class BetaReductionSpec extends Spec {
-
+  //hello
   "simplifies the ast by applying functons" - {
     "tuple field" in {
       val ast: Ast = Property(Tuple(List(Ident("a"))), "_1")
@@ -41,12 +41,12 @@ class BetaReductionSpec extends Spec {
     "with OnConflict.Excluded" in {
       val ast: Ast = OnConflict.Excluded(Ident("a"))
       BetaReduction(ast, Ident("a") -> Ident("a'")) mustEqual
-        Ident("a'")
+        OnConflict.Excluded(Ident("a'"))
     }
     "with OnConflict.Existing" in {
       val ast: Ast = OnConflict.Existing(Ident("a"))
       BetaReduction(ast, Ident("a") -> Ident("a'")) mustEqual
-        Ident("a'")
+        OnConflict.Existing(Ident("a'"))
     }
     "with inline" - {
       val entity = Entity("a", Nil, QEP)

--- a/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
+++ b/quill-orientdb/src/main/scala/io/getquill/context/orientdb/OrientDBIdiom.scala
@@ -70,6 +70,8 @@ trait OrientDBIdiom extends Idiom {
         a.token
       case a: Assignment =>
         a.token
+      case a: AssignmentDual =>
+        a.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
         _: Val | _: Ordering | _: QuotedReference | _: IterableOperation | _: OnConflict.Excluded | _: OnConflict.Existing
@@ -272,6 +274,11 @@ trait OrientDBIdiom extends Idiom {
 
   implicit def assignmentTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy): Tokenizer[Assignment] = Tokenizer[Assignment] {
     case Assignment(alias, prop, value) =>
+      stmt"${prop.token} = ${scopedTokenizer(value)}"
+  }
+
+  implicit def assignmentDualTokenizer(implicit propertyTokenizer: Tokenizer[Property], strategy: NamingStrategy): Tokenizer[AssignmentDual] = Tokenizer[AssignmentDual] {
+    case AssignmentDual(alias1, alias2, prop, value) =>
       stmt"${prop.token} = ${scopedTokenizer(value)}"
   }
 

--- a/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
+++ b/quill-sql-portable/src/main/scala/io/getquill/sql/idiom/SqlIdiom.scala
@@ -81,6 +81,7 @@ trait SqlIdiom extends Idiom {
       case a: If              => a.token
       case a: External        => a.token
       case a: Assignment      => a.token
+      case a: AssignmentDual  => a.token
       case a: OptionOperation => a.token
       case a @ (
         _: Function | _: FunctionApply | _: Dynamic | _: OptionOperation | _: Block |
@@ -422,6 +423,11 @@ trait SqlIdiom extends Idiom {
 
   implicit def assignmentTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[Assignment] = Tokenizer[Assignment] {
     case Assignment(alias, prop, value) =>
+      stmt"${prop.token} = ${scopedTokenizer(value)}"
+  }
+
+  implicit def assignmentDualTokenizer(implicit astTokenizer: Tokenizer[Ast], strategy: NamingStrategy): Tokenizer[AssignmentDual] = Tokenizer[AssignmentDual] {
+    case AssignmentDual(alias1, alias2, prop, value) =>
       stmt"${prop.token} = ${scopedTokenizer(value)}"
   }
 

--- a/quill-sql/src/test/scala/io/getquill/context/sql/QuerySchemaSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/QuerySchemaSpec.scala
@@ -1,0 +1,33 @@
+package io.getquill.context.sql
+
+import io.getquill.{ Literal, PostgresDialect, Spec, SqlMirrorContext, TestEntities }
+
+class QuerySchemaSpec extends Spec {
+
+  val ctx = new SqlMirrorContext(PostgresDialect, Literal) with TestEntities
+  import ctx._
+
+  "OnConflict Should work correct with" - {
+    case class Person(id: Long, name: String)
+    val p = Person(1, "Joe")
+
+    "querySchema" in {
+      val q = quote {
+        querySchema[Person]("thePerson", _.id -> "theId", _.name -> "theName")
+          .insert(lift(p))
+          .onConflictUpdate(_.id)(_.name -> _.name)
+      }
+      ctx.run(q).string mustEqual "INSERT INTO thePerson AS t (theId,theName) VALUES (?, ?) ON CONFLICT (theId) DO UPDATE SET theName = EXCLUDED.theName"
+    }
+
+    "schemaMeta" in {
+      implicit val personSchemaMeta = schemaMeta[Person]("thePerson", _.id -> "theId", _.name -> "theName")
+      val q = quote {
+        query[Person]
+          .insert(lift(p))
+          .onConflictUpdate(_.id)(_.name -> _.name)
+      }
+      ctx.run(q).string mustEqual "INSERT INTO thePerson AS t (theId,theName) VALUES (?, ?) ON CONFLICT (theId) DO UPDATE SET theName = EXCLUDED.theName"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1797

As it turns out, the issues that cause the column `x` of a `querySchema[Tbl]("Tbl", _.x -> "y")` to show up in a on-conflict clause as `EXCLUDED.x` instead of `EXCLUDED.y` were just an external symptom of some deeper problems. When a on-conflict assignment clause like `(a, b) => a.x -> b.x + 1` is parsed, it becomes a regular ast.Assignment in which the `b` part is ostensibly ignored.
```scala
Assignment(Ident("a"), Property(Ident("a"), "x"), BinaryOperation(Property(Ident("b"), "x"), + Constant(1)))
```
... and since `b` is ignored, it is very difficult to understand that `b.x` needs to be renamed to `b.y`.

This broken logic of renaming properties has never actually worked, even before the Quats change. If you have a look at the old `RenameProperties` [here](https://github.com/getquill/quill/blob/1fa9d4eb4f0d28428c7f524e23e149b02d73b216/quill-core/src/main/scala/io/getquill/norm/RenameProperties.scala#L44) you will see the following implementation:
```scala
  private def applySchema(q: Query, a: List[Assignment], f: (Query, List[Assignment]) => Action): (Action, Ast) =
    applySchema(q) match {
      case (q, schema) =>
        val ar = a.map {
          case Assignment(alias, prop, value) =>
            val replace = replacements(alias, schema)
            val propr = BetaReduction(prop, replace: _*)
            val valuer = BetaReduction(value, replace: _*)
            Assignment(alias, propr, valuer)
        }
        (f(q, ar), schema)
    }
```
This `schema` variable is either an `ast.Entity` or `ast.Tuple` that is just used as a datastructure to whole values that need to be replaced (in the `replacements` function) which is how the replacements for `valuer` are propagated. Note however that `replacements` only looks up `alias` (i.e. `a` in our querySchema example above) in `replacements(alias, schema)`. The other alias i.e. `b` is nowhere to be found (in the Assignments construct). Therefore a `b.x` would never be renamed to `b.y`.


When the Quats change came along, the convoluted logic of replacement via stateful propagation of Entities/Schemas was removed because product-quats were supposed to propagate field-renames instead.

If you have a look at how `OnConflict` is processed in the Quats-Based property-renaming logic (i.e. in [RepropagateQuats](https://github.com/getquill/quill/blob/175106ffd03641b1ff96a914522acf162186f726/quill-core-portable/src/main/scala/io/getquill/norm/RepropagateQuats.scala#L142)) you will see that it 
has the same flaw. Namely, that it takes only the 1st parameter `a` in `(a, b) => a.x -> b.x + 1` and renames it's properties (via propagating the Quats from the left hand side of Assignment) but not the 2nd parameter `b`. That is because `a.x -> b.x + 1` was parsed (in Parsing.scala) long before to:
```scala
Assignment(Ident("a"), Property(Ident("a"), "x"), BinaryOperation(Property(Ident("b"), "x"), + Constant(1)))
```

and there is no information about where `b` comes from on the right-hand side of the the assignment, it lives as tenuous `Ident("b")` but we have no idea where it is actually coming from unlike `Ident("a")` that is explicitly defined in the beginning of `Assignment`. For that reason, when computing `valueR` in the (reassign method)[https://github.com/getquill/quill/blob/175106ffd03641b1ff96a914522acf162186f726/quill-core-portable/src/main/scala/io/getquill/norm/RepropagateQuats.scala#L106] it is very difficult to locate the right-hand side element of the assignment tuple (i.e. `Ident("b")`) and use it for quat replacements.

The solution to all this is to simply create another version of `ast.Assignment` that caries both of the aliases in the `(a, b) => a.x -> b.x + 1` clauses (i.e. `a` and the `b` variables). I call this `ast.AssignmentDual`. Naturally, it needs to be incorporated into all necessary clauses in the classes StatefulTransfomer, StatelessTransformer, FreeVariables etc... Additionally, RenameProperties needs to be modified to detect it and be reduce the `ast.OnConflict` body with the new value (i.e. `b.x -> b.y`). In the Post-Quats world, this is done in the `RepropagateQuats` class.
This is done [here](https://github.com/getquill/quill/blob/cfc9d409f19ec9922986df670d871c8ec2db4f2d/quill-core-portable/src/main/scala/io/getquill/norm/RepropagateQuats.scala#L156) in two parts.
First of all we get both aliases in AssignmentDual:
```scala
  val alias1R = assignment.alias1.copy(quat = oca.quat)
  val alias2R = assignment.alias2.copy(quat = oca.quat)
```
Then we do this in the beta reduction of the `ast.AssignmentDual.value` clause:
```scala
  val valueR = BetaReduction(assignment.value, RWR, assignment.alias1 -> alias1R, assignment.alias2 -> alias2R)
```
Finally, we use this valueR to construct the new AssignmentDual:
```scala
  AssignmentDual(alias1R, alias2R, propertyR, valueR)
```

This change conclusively gives the secondary onConflict alias (i.e. `b`) the correct attention it needs in order to properly be able to rename it's properties based on querySchemas and schemaMetas.


- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
