### PR TITLE
Bump minor Cassandra version

### DIFF
--- a/build/Dockerfile-setup
+++ b/build/Dockerfile-setup
@@ -25,7 +25,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
 
-ENV CASSANDRA_VERSION 3.11.10
+ENV CASSANDRA_VERSION 3.11.11
 
 RUN echo "Cassandra Version: $CASSANDRA_VERSION"
 RUN echo "Getting http://apache.volia.net/cassandra/$CASSANDRA_VERSION/apache-cassandra-$CASSANDRA_VERSION-bin.tar.gz"


### PR DESCRIPTION
There is no 3.11.10 at http://apache.volia.net/cassandra/ anymore,
DB containers preparation was crushing.

### Problem

Could not prepare databases for project using command `docker-compose run --rm setup` from `CONTRIBUTING.md`.

### Solution

Bump minor Cassandra version.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
