### PR TITLE
Line-up core API with ProtoQuill so child contexts can have same code

### DIFF
--- a/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
+++ b/quill-async/src/main/scala/io/getquill/context/async/AsyncContext.scala
@@ -15,7 +15,7 @@ import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.{ NamingStrategy, ReturnAction }
 import io.getquill.util.ContextLogger
 import io.getquill.monad.ScalaFutureIOMonad
-import io.getquill.context.{ Context, TranslateContext }
+import io.getquill.context.{ Context, ExecutionInfo, TranslateContext }
 
 abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection](val idiom: D, val naming: N, pool: PartitionedConnectionPool[C])
   extends Context[D, N]
@@ -38,6 +38,7 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
   override type RunBatchActionResult = List[Long]
   override type RunBatchActionReturningResult[T] = List[T]
   override type Session = Unit
+  override type DatasourceContext = Unit
 
   override def close = {
     Await.result(pool.close, Duration.Inf)
@@ -70,7 +71,7 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
       case true  => transaction(super.performIO(io)(_))
     }
 
-  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[List[T]] = {
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[List[T]] = {
     val (params, values) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withConnection(_.sendPreparedStatement(sql, values)).map {
@@ -81,16 +82,16 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
     }
   }
 
-  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[T] =
-    executeQuery(sql, prepare, extractor).map(handleSingleResult)
+  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[T] =
+    executeQuery(sql, prepare, extractor)(info, dc).map(handleSingleResult)
 
-  def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Long] = {
+  def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[Long] = {
     val (params, values) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withConnection(_.sendPreparedStatement(sql, values)).map(_.rowsAffected)
   }
 
-  def executeActionReturning[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T], returningAction: ReturnAction)(implicit ec: ExecutionContext): Future[T] = {
+  def executeActionReturning[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T], returningAction: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[T] = {
     val expanded = expandAction(sql, returningAction)
     val (params, values) = prepare(Nil, ())
     logger.logQuery(sql, params)
@@ -98,27 +99,27 @@ abstract class AsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: Connection]
       .map(extractActionResult(returningAction, extractor))
   }
 
-  def executeBatchAction(groups: List[BatchGroup])(implicit ec: ExecutionContext): Future[List[Long]] =
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[List[Long]] =
     Future.sequence {
       groups.map {
         case BatchGroup(sql, prepare) =>
           prepare.foldLeft(Future.successful(List.newBuilder[Long])) {
             case (acc, prepare) =>
               acc.flatMap { list =>
-                executeAction(sql, prepare).map(list += _)
+                executeAction(sql, prepare)(info, dc).map(list += _)
               }
           }.map(_.result())
       }
     }.map(_.flatten.toList)
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(implicit ec: ExecutionContext): Future[List[T]] =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[List[T]] =
     Future.sequence {
       groups.map {
         case BatchGroupReturning(sql, column, prepare) =>
           prepare.foldLeft(Future.successful(List.newBuilder[T])) {
             case (acc, prepare) =>
               acc.flatMap { list =>
-                executeActionReturning(sql, prepare, extractor, column).map(list += _)
+                executeActionReturning(sql, prepare, extractor, column)(info, dc).map(list += _)
               }
           }.map(_.result())
       }

--- a/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomAsyncContext.scala
+++ b/quill-cassandra-lagom/src/main/scala/io/getquill/CassandraLagomAsyncContext.scala
@@ -3,6 +3,7 @@ package io.getquill
 import akka.Done
 import com.datastax.driver.core.BoundStatement
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraSession
+import io.getquill.context.ExecutionInfo
 import io.getquill.util.ContextLogger
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -22,7 +23,7 @@ class CassandraLagomAsyncContext[N <: NamingStrategy](
 
   private val logger = ContextLogger(this.getClass)
 
-  def prepareAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit executionContext: ExecutionContext): CassandraLagomSession => Future[BoundStatement] = (session: Session) => {
+  def prepareAction[T](cql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): CassandraLagomSession => Future[BoundStatement] = (session: Session) => {
     val prepareResult = session.cs.prepare(cql).map(bs => prepare(bs.bind(), session))
     val preparedRow = prepareResult.map {
       case (params, bs) =>
@@ -32,37 +33,37 @@ class CassandraLagomAsyncContext[N <: NamingStrategy](
     preparedRow
   }
 
-  def prepareBatchAction[T](groups: List[BatchGroup])(implicit executionContext: ExecutionContext): CassandraLagomSession => Future[List[BoundStatement]] = (session: Session) => {
+  def prepareBatchAction[T](groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): CassandraLagomSession => Future[List[BoundStatement]] = (session: Session) => {
     val batches = groups.flatMap {
       case BatchGroup(cql, prepares) =>
         prepares.map(cql -> _)
     }
     Future.traverse(batches) {
       case (cql, prepare) =>
-        val prepareCql = prepareAction(cql, prepare)
+        val prepareCql = prepareAction(cql, prepare)(info, dc)
         prepareCql(session)
     }
   }
 
-  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit executionContext: ExecutionContext): Result[RunQueryResult[T]] = {
+  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): Result[RunQueryResult[T]] = {
     val statement = prepareAsyncAndGetStatement(cql, prepare, wrappedSession, logger)
     statement.flatMap(st => session.selectAll(st)).map(_.map(row => extractor(row, wrappedSession)))
   }
 
-  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit executionContext: ExecutionContext): Result[RunQuerySingleResult[T]] = {
-    executeQuery(cql, prepare, extractor).map(_.headOption)
+  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): Result[RunQuerySingleResult[T]] = {
+    executeQuery(cql, prepare, extractor)(info, dc).map(_.headOption)
   }
 
-  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit executionContext: ExecutionContext): Result[RunActionResult] = {
+  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): Result[RunActionResult] = {
     val statement = prepareAsyncAndGetStatement(cql, prepare, wrappedSession, logger)
     statement.flatMap(st => session.executeWrite(st))
   }
 
-  def executeBatchAction(groups: List[BatchGroup])(implicit executionContext: ExecutionContext): Result[RunBatchActionResult] = {
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): Result[RunBatchActionResult] = {
     Future.sequence {
       groups.flatMap {
         case BatchGroup(cql, prepares) =>
-          prepares.map(executeAction(cql, _))
+          prepares.map(executeAction(cql, _)(info, dc))
       }
     }.map(_ => Done)
   }

--- a/quill-cassandra-monix/src/main/scala/io/getquill/CassandraMonixContext.scala
+++ b/quill-cassandra-monix/src/main/scala/io/getquill/CassandraMonixContext.scala
@@ -2,6 +2,7 @@ package io.getquill
 
 import com.datastax.driver.core.{ Cluster, ResultSet, Row }
 import com.typesafe.config.Config
+import io.getquill.context.ExecutionInfo
 import io.getquill.context.cassandra.CqlIdiom
 import io.getquill.context.monix.MonixContext
 import io.getquill.util.{ ContextLogger, LoadConfig }
@@ -46,7 +47,7 @@ class CassandraMonixContext[N <: NamingStrategy](
       Task.fromFuture(rs.fetchMoreResults().asScalaWithDefaultGlobal).map(_ => page)
   }
 
-  def streamQuery[T](fetchSize: Option[Int], cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Observable[T] = {
+  def streamQuery[T](fetchSize: Option[Int], cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Observable[T] = {
 
     Observable
       .fromTask(prepareRowAndLog(cql, prepare))
@@ -57,25 +58,25 @@ class CassandraMonixContext[N <: NamingStrategy](
       .map(row => extractor(row, this))
   }
 
-  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[List[T]] = {
-    streamQuery[T](None, cql, prepare, extractor)
+  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Task[List[T]] = {
+    streamQuery[T](None, cql, prepare, extractor)(info, dc)
       .foldLeftL(List[T]())({ case (l, r) => r +: l }).map(_.reverse)
   }
 
-  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[T] =
-    executeQuery(cql, prepare, extractor).map(handleSingleResult(_))
+  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Task[T] =
+    executeQuery(cql, prepare, extractor)(info, dc).map(handleSingleResult(_))
 
-  def executeAction[T](cql: String, prepare: Prepare = identityPrepare): Task[Unit] = {
+  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Task[Unit] = {
     prepareRowAndLog(cql, prepare)
       .flatMap(r => Task.fromFuture(session.executeAsync(r).asScalaWithDefaultGlobal))
       .map(_ => ())
   }
 
-  def executeBatchAction(groups: List[BatchGroup]): Task[Unit] =
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Task[Unit] =
     Observable.fromIterable(groups).flatMap {
       case BatchGroup(cql, prepare) =>
         Observable.fromIterable(prepare)
-          .flatMap(prep => Observable.fromTask(executeAction(cql, prep)))
+          .flatMap(prep => Observable.fromTask(executeAction(cql, prep)(info, dc)))
           .map(_ => ())
     }.completedL
 

--- a/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
@@ -2,7 +2,7 @@ package io.getquill
 
 import com.datastax.driver.core._
 import io.getquill.CassandraZioContext._
-import io.getquill.context.StandardContext
+import io.getquill.context.{ ExecutionInfo, StandardContext }
 import io.getquill.context.cassandra.{ CassandraRowContext, CqlIdiom }
 import io.getquill.context.qzio.ZioContext
 import io.getquill.util.Messages.fail
@@ -103,7 +103,7 @@ class CassandraZioContext[N <: NamingStrategy](val naming: N)
       ZManaged.lock(Blocking.Service.live.blockingExecutor)
     )
 
-  def streamQuery[T](fetchSize: Option[Int], cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor) = {
+  def streamQuery[T](fetchSize: Option[Int], cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext) = {
     val stream =
       for {
         csession <- ZStream.service[CassandraZioSession]
@@ -127,7 +127,7 @@ class CassandraZioContext[N <: NamingStrategy](val naming: N)
   private[getquill] def simpleBlocking[R, E, A](zio: ZIO[R, E, A]): ZIO[R, E, A] =
     Blocking.Service.live.blocking(zio)
 
-  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): CIO[List[T]] = simpleBlocking {
+  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): CIO[List[T]] = simpleBlocking {
     for {
       csession <- ZIO.service[CassandraZioSession]
       rs <- execute(cql, prepare, csession, None)
@@ -135,8 +135,8 @@ class CassandraZioContext[N <: NamingStrategy](val naming: N)
     } yield (rows.asScala.map(row => extractor(row, csession)).toList)
   }
 
-  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): CIO[T] = simpleBlocking {
-    executeQuery(cql, prepare, extractor).map(handleSingleResult(_))
+  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): CIO[T] = simpleBlocking {
+    executeQuery(cql, prepare, extractor)(info, dc).map(handleSingleResult(_))
     for {
       csession <- ZIO.service[CassandraZioSession]
       rs <- execute(cql, prepare, csession, None)
@@ -145,7 +145,7 @@ class CassandraZioContext[N <: NamingStrategy](val naming: N)
     } yield singleRow
   }
 
-  def executeAction[T](cql: String, prepare: Prepare = identityPrepare): CIO[Unit] = simpleBlocking {
+  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): CIO[Unit] = simpleBlocking {
     for {
       csession <- ZIO.service[CassandraZioSession]
       r <- prepareRowAndLog(cql, prepare).provide(Has(csession))
@@ -153,7 +153,7 @@ class CassandraZioContext[N <: NamingStrategy](val naming: N)
     } yield ()
   }
 
-  def executeBatchAction(groups: List[BatchGroup]): CIO[Unit] = simpleBlocking {
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): CIO[Unit] = simpleBlocking {
     for {
       env <- ZIO.service[CassandraZioSession]
       result <- {
@@ -161,7 +161,7 @@ class CassandraZioContext[N <: NamingStrategy](val naming: N)
           groups.flatMap {
             case BatchGroup(cql, prepare) =>
               prepare
-                .map(prep => executeAction(cql, prep).provide(Has(env)))
+                .map(prep => executeAction(cql, prep)(info, dc).provide(Has(env)))
           }
         ZIO.collectAll(batchGroups)
       }

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -2,6 +2,7 @@ package io.getquill
 
 import com.datastax.driver.core.Cluster
 import com.typesafe.config.Config
+import io.getquill.context.ExecutionInfo
 import io.getquill.context.cassandra.util.FutureConversions._
 import io.getquill.monad.ScalaFutureIOMonad
 import io.getquill.util.{ ContextLogger, LoadConfig }
@@ -31,32 +32,33 @@ class CassandraAsyncContext[N <: NamingStrategy](
   override type RunQuerySingleResult[T] = T
   override type RunActionResult = Unit
   override type RunBatchActionResult = Unit
+  override type DatasourceContext = Unit
 
   override def performIO[T](io: IO[T, _], transactional: Boolean = false)(implicit ec: ExecutionContext): Result[T] = {
     if (transactional) logger.underlying.warn("Cassandra doesn't support transactions, ignoring `io.transactional`")
     super.performIO(io)
   }
 
-  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit executionContext: ExecutionContext): Result[RunQueryResult[T]] = {
+  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): Result[RunQueryResult[T]] = {
     val statement = prepareAsyncAndGetStatement(cql, prepare, this, logger)
     statement.flatMap(st => session.executeAsync(st).asScala)
       .map(_.all.asScala.toList.map(row => extractor(row, this)))
   }
 
-  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit executionContext: ExecutionContext): Result[RunQuerySingleResult[T]] = {
-    executeQuery(cql, prepare, extractor).map(handleSingleResult)
+  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): Result[RunQuerySingleResult[T]] = {
+    executeQuery(cql, prepare, extractor)(info, dc).map(handleSingleResult)
   }
 
-  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(implicit executionContext: ExecutionContext): Result[RunActionResult] = {
+  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): Result[RunActionResult] = {
     val statement = prepareAsyncAndGetStatement(cql, prepare, this, logger)
     statement.flatMap(st => session.executeAsync(st).asScala).map(_ => ())
   }
 
-  def executeBatchAction(groups: List[BatchGroup])(implicit executionContext: ExecutionContext): Result[RunBatchActionResult] = {
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext)(implicit executionContext: ExecutionContext): Result[RunBatchActionResult] = {
     Future.sequence {
       groups.flatMap {
         case BatchGroup(cql, prepare) =>
-          prepare.map(executeAction(cql, _))
+          prepare.map(executeAction(cql, _)(info, dc))
       }
     }.map(_ => ())
   }

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
@@ -2,6 +2,7 @@ package io.getquill
 
 import com.datastax.driver.core.Cluster
 import com.typesafe.config.Config
+import io.getquill.context.ExecutionInfo
 import io.getquill.monad.SyncIOMonad
 import io.getquill.util.{ ContextLogger, LoadConfig }
 
@@ -33,26 +34,26 @@ class CassandraSyncContext[N <: NamingStrategy](
     super.performIO(io)
   }
 
-  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): List[T] = {
+  def executeQuery[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): List[T] = {
     val (params, bs) = prepare(this.prepare(cql), this)
     logger.logQuery(cql, params)
     session.execute(bs)
       .all.asScala.toList.map(row => extractor(row, this))
   }
 
-  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): T =
-    handleSingleResult(executeQuery(cql, prepare, extractor))
+  def executeQuerySingle[T](cql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): T =
+    handleSingleResult(executeQuery(cql, prepare, extractor)(info, dc))
 
-  def executeAction[T](cql: String, prepare: Prepare = identityPrepare): Unit = {
+  def executeAction[T](cql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Unit = {
     val (params, bs) = prepare(this.prepare(cql), this)
     logger.logQuery(cql, params)
     session.execute(bs)
     ()
   }
 
-  def executeBatchAction(groups: List[BatchGroup]): Unit =
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Unit =
     groups.foreach {
       case BatchGroup(cql, prepare) =>
-        prepare.foreach(executeAction(cql, _))
+        prepare.foreach(executeAction(cql, _)(info, dc))
     }
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/CassandraSessionContext.scala
@@ -2,7 +2,7 @@ package io.getquill.context.cassandra
 
 import com.datastax.driver.core._
 import io.getquill.NamingStrategy
-import io.getquill.context.{ CassandraSession, StandardContext, UdtValueLookup }
+import io.getquill.context.{ CassandraSession, ExecutionInfo, StandardContext, UdtValueLookup }
 import io.getquill.context.cassandra.encoding.{ CassandraTypes, Decoders, Encoders, UdtEncoding }
 import io.getquill.util.ContextLogger
 import io.getquill.util.Messages.fail
@@ -42,10 +42,10 @@ trait CassandraPrepareContext[N <: NamingStrategy] extends CassandraRowContext[N
     preparedRow
   }
 
-  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningColumn: String): Unit =
+  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningColumn: String)(info: ExecutionInfo, dc: DatasourceContext): Unit =
     fail("Cassandra doesn't support `returning`.")
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Unit =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext): Unit =
     fail("Cassandra doesn't support `returning`.")
 }
 
@@ -65,6 +65,7 @@ trait CassandraRowContext[N <: NamingStrategy]
 
   override type PrepareRow = BoundStatement
   override type ResultRow = Row
+  type DatasourceContext = Unit
 
   // Usually this is io.getquill.context.CassandraSession so you can use udtValueOf but not always e.g. for Lagom it is different
   type Session <: UdtValueLookup

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/CassandraContextSpec.scala
@@ -1,6 +1,7 @@
 package io.getquill.context.cassandra
 
 import io.getquill._
+import io.getquill.context.ExecutionInfo
 
 import scala.concurrent.ExecutionContext.Implicits.{ global => ec }
 import scala.util.{ Success, Try }
@@ -32,8 +33,8 @@ class CassandraContextSpec extends Spec {
     val p: Prepare = (x, session) => (Nil, x)
     val e: Extractor[Int] = (_, _) => 1
 
-    intercept[IllegalStateException](executeActionReturning("", p, e, "")).getMessage mustBe
-      intercept[IllegalStateException](executeBatchActionReturning(Nil, e)).getMessage
+    intercept[IllegalStateException](executeActionReturning("", p, e, "")(ExecutionInfo.unknown, ())).getMessage mustBe
+      intercept[IllegalStateException](executeBatchActionReturning(Nil, e)(ExecutionInfo.unknown, ())).getMessage
   }
 
   "probe" in {
@@ -42,12 +43,12 @@ class CassandraContextSpec extends Spec {
 
   "return failed future on `prepare` error in async context" - {
     "query" - {
-      val f = testAsyncDB.executeQuery("bad cql")
+      val f = testAsyncDB.executeQuery("bad cql")(ExecutionInfo.unknown, ())
       Try(await(f)).isFailure mustEqual true
       ()
     }
     "action" - {
-      val f = testAsyncDB.executeAction("bad cql")
+      val f = testAsyncDB.executeAction("bad cql")(ExecutionInfo.unknown, ())
       Try(await(f)).isFailure mustEqual true
       ()
     }

--- a/quill-core-portable/src/main/scala/io/getquill/context/ProtoContext.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/context/ProtoContext.scala
@@ -1,0 +1,73 @@
+package io.getquill.context
+
+import io.getquill.{ NamingStrategy, ReturnAction }
+import io.getquill.ast.Ast
+import scala.language.higherKinds
+
+/**
+ * A common context used between Quill and ProtoQuill. This is more like a pre-context because the actual `run`
+ * methods cannot be contained here since they use macros. Right now not all Scala2-Quill context extend
+ * this context but hopefully they will all in the future. This will establish a common general-api that
+ * Quill contexts can use.
+ */
+trait ProtoContext[Dialect <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends RowContext {
+  type PrepareRow
+  type ResultRow
+
+  type Result[T]
+  type RunQuerySingleResult[T]
+  type RunQueryResult[T]
+  type RunActionResult
+  type RunActionReturningResult[T]
+  type RunBatchActionResult
+  type RunBatchActionReturningResult[T]
+  type Session
+  /** Future class to hold things like ExecutionContext for Cassandra etc... */
+  type DatasourceContext
+
+  def idiom: Dialect
+  def naming: Naming
+
+  def executeQuery[T](sql: String, prepare: Prepare, extractor: Extractor[T])(executionInfo: ExecutionInfo, dc: DatasourceContext): Result[RunQueryResult[T]]
+  def executeQuerySingle[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(executionInfo: ExecutionInfo, dc: DatasourceContext): Result[RunQuerySingleResult[T]]
+  def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: DatasourceContext): Result[RunActionResult]
+  def executeActionReturning[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T], returningBehavior: ReturnAction)(executionInfo: ExecutionInfo, dc: DatasourceContext): Result[RunActionReturningResult[T]]
+  def executeBatchAction(groups: List[BatchGroup])(executionInfo: ExecutionInfo, dc: DatasourceContext): Result[RunBatchActionResult]
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(executionInfo: ExecutionInfo, dc: DatasourceContext): Result[RunBatchActionReturningResult[T]]
+}
+
+/**
+ * Metadata related to query execution. Note that AST should be lazy so as not to be evaluated
+ * at runtime (which would happen with a by-value property since `{ ExecutionInfo(stuff, ast) } is spliced
+ * into a query-execution site). Additionally, there are performance overheads even splicing the finalized
+ * version of the AST into call sites of the `run` functions. For this reason, this functionality
+ * is being used only in ProtoQuill and only when a trait extends the trait AstSplicing.
+ * In the future it might potentially be controlled by a compiler argument.
+ */
+class ExecutionInfo(val executionType: ExecutionType, queryAst: => Ast) {
+  def ast: Ast = queryAst
+}
+object ExecutionInfo {
+  def apply(executionType: ExecutionType, ast: => Ast) = new ExecutionInfo(executionType, ast)
+  val unknown = ExecutionInfo(ExecutionType.Unknown, io.getquill.ast.NullValue)
+}
+
+trait AstSplicing
+
+sealed trait ExecutionType
+object ExecutionType {
+  case object Dynamic extends ExecutionType
+  case object Static extends ExecutionType
+  case object Unknown extends ExecutionType
+}
+
+trait ProtoStreamContext[Dialect <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] extends RowContext {
+  type PrepareRow
+  type ResultRow
+
+  type DatasourceContext
+  type StreamResult[T]
+  type Session
+
+  def streamQuery[T](fetchSize: Option[Int], sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): StreamResult[T]
+}

--- a/quill-core-portable/src/main/scala/io/getquill/context/RowContext.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/context/RowContext.scala
@@ -1,0 +1,18 @@
+package io.getquill.context
+
+import io.getquill.ReturnAction
+
+trait RowContext {
+  type PrepareRow
+  type ResultRow
+
+  protected val identityPrepare: Prepare = (p: PrepareRow, s: Session) => (Nil, p)
+  protected val identityExtractor = (rr: ResultRow, s: Session) => rr
+
+  case class BatchGroup(string: String, prepare: List[Prepare])
+  case class BatchGroupReturning(string: String, returningBehavior: ReturnAction, prepare: List[Prepare])
+
+  type Prepare = (PrepareRow, Session) => (List[Any], PrepareRow)
+  type Extractor[T] = (ResultRow, Session) => T
+  type Session
+}

--- a/quill-core/src/main/scala/io/getquill/AsyncMirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/AsyncMirrorContext.scala
@@ -1,6 +1,6 @@
 package io.getquill
 
-import io.getquill.context.{ StandardContext, TranslateContext }
+import io.getquill.context.{ ExecutionInfo, StandardContext, TranslateContext }
 import io.getquill.context.mirror.{ MirrorDecoders, MirrorEncoders, MirrorSession, Row }
 
 import scala.concurrent.Future
@@ -31,6 +31,7 @@ class AsyncMirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom
   override type RunActionReturningResult[T] = ActionReturningMirror[T]
   override type RunBatchActionResult = BatchActionMirror
   override type RunBatchActionReturningResult[T] = BatchActionReturningMirror[T]
+  override type DatasourceContext = Unit
 
   override def close = ()
 
@@ -56,46 +57,46 @@ class AsyncMirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom
       case false => super.performIO(io, transactional)
     }
 
-  case class ActionMirror(string: String, prepareRow: PrepareRow)(implicit val ec: ExecutionContext)
+  case class ActionMirror(string: String, prepareRow: PrepareRow, info: ExecutionInfo)(implicit val ec: ExecutionContext)
 
-  case class ActionReturningMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T], returningBehavior: ReturnAction)(implicit val ec: ExecutionContext)
+  case class ActionReturningMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T], returningBehavior: ReturnAction, info: ExecutionInfo)(implicit val ec: ExecutionContext)
 
-  case class BatchActionMirror(groups: List[(String, List[Row])])(implicit val ec: ExecutionContext)
+  case class BatchActionMirror(groups: List[(String, List[Row])], info: ExecutionInfo)(implicit val ec: ExecutionContext)
 
-  case class BatchActionReturningMirror[T](groups: List[(String, ReturnAction, List[PrepareRow])], extractor: Extractor[T])(implicit val ec: ExecutionContext)
+  case class BatchActionReturningMirror[T](groups: List[(String, ReturnAction, List[PrepareRow])], extractor: Extractor[T], info: ExecutionInfo)(implicit val ec: ExecutionContext)
 
-  case class QueryMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T])(implicit val ec: ExecutionContext)
+  case class QueryMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T], info: ExecutionInfo)(implicit val ec: ExecutionContext)
 
-  def executeQuery[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext) =
-    Future(QueryMirror(string, prepare(Row(), session)._2, extractor))
+  def executeQuery[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(executionInfo: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext) =
+    Future(QueryMirror(string, prepare(Row(), session)._2, extractor, executionInfo))
 
-  def executeQuerySingle[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext) =
-    Future(QueryMirror(string, prepare(Row(), session)._2, extractor))
+  def executeQuerySingle[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(executionInfo: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext) =
+    Future(QueryMirror(string, prepare(Row(), session)._2, extractor, executionInfo))
 
-  def executeAction(string: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext) =
-    Future(ActionMirror(string, prepare(Row(), session)._2))
+  def executeAction(string: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext) =
+    Future(ActionMirror(string, prepare(Row(), session)._2, executionInfo))
 
-  def executeActionReturning[O](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[O],
-                                returningBehavior: ReturnAction)(implicit ec: ExecutionContext) =
-    Future(ActionReturningMirror[O](string, prepare(Row(), session)._2, extractor, returningBehavior))
+  def executeActionReturning[O](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(executionInfo: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext) =
+    Future(ActionReturningMirror[O](string, prepare(Row(), session)._2, extractor, returningBehavior, executionInfo))
 
-  def executeBatchAction(groups: List[BatchGroup])(implicit ec: ExecutionContext) =
+  def executeBatchAction(groups: List[BatchGroup])(executionInfo: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext) =
     Future {
-      BatchActionMirror {
+      BatchActionMirror(
         groups.map {
           case BatchGroup(string, prepare) =>
             (string, prepare.map(_(Row(), session)._2))
-        }
-      }
+        },
+        executionInfo
+      )
     }
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(implicit ec: ExecutionContext) =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(executionInfo: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext) =
     Future {
       BatchActionReturningMirror[T](
         groups.map {
           case BatchGroupReturning(string, returningBehavior, prepare) =>
             (string, returningBehavior, prepare.map(_(Row(), session)._2))
-        }, extractor
+        }, extractor, executionInfo
       )
     }
 

--- a/quill-core/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-core/src/main/scala/io/getquill/MirrorContext.scala
@@ -1,7 +1,7 @@
 package io.getquill
 
 import io.getquill.context.mirror.{ MirrorDecoders, MirrorEncoders, MirrorSession, Row }
-import io.getquill.context.{ StandardContext, TranslateContext }
+import io.getquill.context.{ ExecutionInfo, StandardContext, TranslateContext }
 import io.getquill.idiom.{ Idiom => BaseIdiom }
 import io.getquill.monad.SyncIOMonad
 
@@ -19,6 +19,7 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom: Idi
 
   override type PrepareRow = Row
   override type ResultRow = Row
+  override type DatasourceContext = Unit
 
   override type Result[T] = T
   override type RunQueryResult[T] = QueryMirror[T]
@@ -39,15 +40,15 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom: Idi
 
   def transaction[T](f: => T) = f
 
-  case class ActionMirror(string: String, prepareRow: PrepareRow)
+  case class ActionMirror(string: String, prepareRow: PrepareRow, info: ExecutionInfo)
 
-  case class ActionReturningMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T], returningBehavior: ReturnAction)
+  case class ActionReturningMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T], returningBehavior: ReturnAction, info: ExecutionInfo)
 
-  case class BatchActionMirror(groups: List[(String, List[Row])])
+  case class BatchActionMirror(groups: List[(String, List[Row])], info: ExecutionInfo)
 
-  case class BatchActionReturningMirror[T](groups: List[(String, ReturnAction, List[PrepareRow])], extractor: Extractor[T])
+  case class BatchActionReturningMirror[T](groups: List[(String, ReturnAction, List[PrepareRow])], extractor: Extractor[T], info: ExecutionInfo)
 
-  case class QueryMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T]) {
+  case class QueryMirror[T](string: String, prepareRow: PrepareRow, extractor: Extractor[T], info: ExecutionInfo) {
     def string(pretty: Boolean): String =
       if (pretty)
         idiom.format(string)
@@ -55,40 +56,40 @@ class MirrorContext[Idiom <: BaseIdiom, Naming <: NamingStrategy](val idiom: Idi
         string
   }
 
-  def executeQuery[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor) =
-    QueryMirror(string, prepare(Row(), session)._2, extractor)
+  def executeQuery[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext) =
+    QueryMirror(string, prepare(Row(), session)._2, extractor, info)
 
-  def executeQuerySingle[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor) =
-    QueryMirror(string, prepare(Row(), session)._2, extractor)
+  def executeQuerySingle[T](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext) =
+    QueryMirror(string, prepare(Row(), session)._2, extractor, info)
 
-  def executeAction(string: String, prepare: Prepare = identityPrepare) =
-    ActionMirror(string, prepare(Row(), session)._2)
+  def executeAction(string: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext) =
+    ActionMirror(string, prepare(Row(), session)._2, info)
 
-  def executeActionReturning[O](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[O],
-                                returningBehavior: ReturnAction) =
-    ActionReturningMirror[O](string, prepare(Row(), session)._2, extractor, returningBehavior)
+  def executeActionReturning[O](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext) =
+    ActionReturningMirror[O](string, prepare(Row(), session)._2, extractor, returningBehavior, info)
 
-  def executeBatchAction(groups: List[BatchGroup]) =
-    BatchActionMirror {
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext) =
+    BatchActionMirror(
       groups.map {
         case BatchGroup(string, prepare) =>
           (string, prepare.map(_(Row(), session)._2))
-      }
-    }
+      },
+      info
+    )
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]) =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext) =
     BatchActionReturningMirror[T](
       groups.map {
         case BatchGroupReturning(string, returningBehavior, prepare) =>
           (string, returningBehavior, prepare.map(_(Row(), session)._2))
-      }, extractor
+      }, extractor, info
     )
 
-  def prepareAction(string: String, prepare: Prepare = identityPrepare) =
+  def prepareAction(string: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext) =
     (session: Session) =>
       prepare(Row(), session)._2
 
-  def prepareBatchAction(groups: List[BatchGroup]) =
+  def prepareBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext) =
     (session: Session) =>
       groups.flatMap {
         case BatchGroup(string, prepare) =>

--- a/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/ActionMacro.scala
@@ -26,7 +26,7 @@ class ActionMacro(val c: MacroContext)
           expanded.string,
           expanded.prepare,
           prettyPrint = ${prettyPrint}
-        )
+        )(io.getquill.context.ExecutionInfo.unknown, ())
       """
     }
 
@@ -47,7 +47,7 @@ class ActionMacro(val c: MacroContext)
                 ${c.prefix}.BatchGroup(string, items.map(_._2).toList)
             }.toList,
             ${prettyPrint}
-          )
+          )(io.getquill.context.ExecutionInfo.unknown, ())
         """
     }
 
@@ -59,7 +59,7 @@ class ActionMacro(val c: MacroContext)
         ${c.prefix}.executeAction(
           expanded.string,
           expanded.prepare
-        )
+        )(io.getquill.context.ExecutionInfo.unknown, ())
       """
     }
 
@@ -73,7 +73,7 @@ class ActionMacro(val c: MacroContext)
           expanded.prepare,
           ${returningExtractor[T]},
           $returningColumn
-        )
+        )(io.getquill.context.ExecutionInfo.unknown, ())
       """
     }
 
@@ -96,7 +96,7 @@ class ActionMacro(val c: MacroContext)
               case (string, items) =>
                 ${c.prefix}.BatchGroup(string, items.map(_._2).toList)
             }.toList
-          )
+          )(io.getquill.context.ExecutionInfo.unknown, ())
         """
     }
 
@@ -114,7 +114,7 @@ class ActionMacro(val c: MacroContext)
                 ${c.prefix}.BatchGroupReturning(string, column, items.map(_._2).toList)
             }.toList,
             ${returningExtractor[T]}
-          )
+          )(io.getquill.context.ExecutionInfo.unknown, ())
         """
     }
 
@@ -161,7 +161,7 @@ class ActionMacro(val c: MacroContext)
         ${c.prefix}.prepareAction(
           expanded.string,
           expanded.prepare
-        )
+        )(io.getquill.context.ExecutionInfo.unknown, ())
       """
     }
 

--- a/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
+++ b/quill-core/src/main/scala/io/getquill/context/QueryMacro.scala
@@ -63,7 +63,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.string,
               expanded.prepare,
               (row, session) => $decoder(0, row, session)
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case StreamQuery(UsesDefaultFetch) =>
           q"""
@@ -72,7 +72,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.string,
               expanded.prepare,
               (row, session) => $decoder(0, row, session)
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case StreamQuery(DoesNotUseFetch) =>
           q"""
@@ -80,7 +80,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.string,
               expanded.prepare,
               (row, session) => $decoder(0, row, session)
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case TranslateQuery(ExplicitPrettyPrint(argValue)) =>
           q"""
@@ -89,7 +89,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.prepare,
               (row, session) => $decoder(0, row, session),
               prettyPrint = ${argValue}
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case TranslateQuery(DefaultPrint) =>
           q"""
@@ -98,7 +98,14 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.prepare,
               (row, session) => $decoder(0, row, session),
               prettyPrint = false
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
+           """
+        case PrepareQuery =>
+          q"""
+            ${c.prefix}.${TermName(method.name)}(
+              expanded.string,
+              expanded.prepare
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case _ =>
           q"""
@@ -106,7 +113,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.string,
               expanded.prepare,
               (row, session) => $decoder(0, row, session)
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
       }
 
@@ -132,7 +139,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.string,
               expanded.prepare,
               $meta.extract
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case StreamQuery(UsesDefaultFetch) =>
           q"""
@@ -141,7 +148,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.string,
               expanded.prepare,
               $meta.extract
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case StreamQuery(DoesNotUseFetch) =>
           q"""
@@ -149,7 +156,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.string,
               expanded.prepare,
               $meta.extract
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case TranslateQuery(ExplicitPrettyPrint(argValue)) =>
           q"""
@@ -158,7 +165,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.prepare,
               $meta.extract,
               prettyPrint = ${argValue}
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case TranslateQuery(DefaultPrint) =>
           q"""
@@ -167,7 +174,14 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.prepare,
               $meta.extract,
               prettyPrint = false
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
+           """
+        case PrepareQuery =>
+          q"""
+            ${c.prefix}.${TermName(method.name)}(
+              expanded.string,
+              expanded.prepare
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
         case _ =>
           q"""
@@ -175,7 +189,7 @@ class QueryMacro(val c: MacroContext) extends ContextMacro {
               expanded.string,
               expanded.prepare,
               $meta.extract
-            )
+            )(io.getquill.context.ExecutionInfo.unknown, ())
            """
       }
 

--- a/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
+++ b/quill-finagle-mysql/src/main/scala/io/getquill/FinagleMysqlContext.scala
@@ -1,7 +1,6 @@
 package io.getquill
 
 import java.util.TimeZone
-
 import scala.util.Try
 import com.twitter.concurrent.AsyncStream
 import com.twitter.finagle.mysql.Client
@@ -24,7 +23,7 @@ import io.getquill.context.sql.SqlContext
 import io.getquill.util.{ ContextLogger, LoadConfig }
 import io.getquill.util.Messages.fail
 import io.getquill.monad.TwitterFutureIOMonad
-import io.getquill.context.{ Context, StreamingContext, TranslateContext }
+import io.getquill.context.{ Context, ExecutionInfo, StreamingContext, TranslateContext }
 
 sealed trait OperationType
 object OperationType {
@@ -87,6 +86,7 @@ class FinagleMysqlContext[N <: NamingStrategy](
   override type RunBatchActionReturningResult[T] = List[T]
   override type StreamResult[T] = Future[AsyncStream[T]]
   override type Session = Unit
+  type DatasourceContext = Unit
 
   protected val timestampValue =
     new TimestampValue(
@@ -127,56 +127,56 @@ class FinagleMysqlContext[N <: NamingStrategy](
       case true  => transaction(super.performIO(io))
     }
 
-  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[List[T]] = {
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Future[List[T]] = {
     val (params, prepared) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withClient(Read)(_.prepare(sql).select(prepared: _*)(row => extractor(row, ()))).map(_.toList)
   }
 
-  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[T] =
-    executeQuery(sql, prepare, extractor).map(handleSingleResult)
+  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Future[T] =
+    executeQuery(sql, prepare, extractor)(info, dc).map(handleSingleResult)
 
-  def executeAction[T](sql: String, prepare: Prepare = identityPrepare): Future[Long] = {
+  def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Future[Long] = {
     val (params, prepared) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withClient(Write)(_.prepare(sql)(prepared: _*))
       .map(r => toOk(r).affectedRows)
   }
 
-  def executeActionReturning[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T], returningAction: ReturnAction): Future[T] = {
+  def executeActionReturning[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T], returningAction: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext): Future[T] = {
     val (params, prepared) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withClient(Write)(_.prepare(sql)(prepared: _*))
       .map(extractReturningValue(_, extractor))
   }
 
-  def executeBatchAction[B](groups: List[BatchGroup]): Future[List[Long]] =
+  def executeBatchAction[B](groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Future[List[Long]] =
     Future.collect {
       groups.map {
         case BatchGroup(sql, prepare) =>
           prepare.foldLeft(Future.value(List.newBuilder[Long])) {
             case (acc, prepare) =>
               acc.flatMap { list =>
-                executeAction(sql, prepare).map(list += _)
+                executeAction(sql, prepare)(info, dc).map(list += _)
               }
           }.map(_.result())
       }
     }.map(_.flatten.toList)
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Future[List[T]] =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext): Future[List[T]] =
     Future.collect {
       groups.map {
         case BatchGroupReturning(sql, column, prepare) =>
           prepare.foldLeft(Future.value(List.newBuilder[T])) {
             case (acc, prepare) =>
               acc.flatMap { list =>
-                executeActionReturning(sql, prepare, extractor, column).map(list += _)
+                executeActionReturning(sql, prepare, extractor, column)(info, dc).map(list += _)
               }
           }.map(_.result())
       }
     }.map(_.flatten.toList)
 
-  def streamQuery[T](fetchSize: Option[Int], sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[AsyncStream[T]] = {
+  def streamQuery[T](fetchSize: Option[Int], sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Future[AsyncStream[T]] = {
     val rowsPerFetch = fetchSize.getOrElse(20)
     val (params: List[Any], prepared: List[Parameter]) = prepare(Nil, ())
     logger.logQuery(sql, params)

--- a/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
+++ b/quill-finagle-postgres/src/main/scala/io/getquill/FinaglePostgresContext.scala
@@ -9,7 +9,7 @@ import io.getquill.context.sql.SqlContext
 import io.getquill.util.{ ContextLogger, LoadConfig }
 
 import scala.util.Try
-import io.getquill.context.{ Context, TranslateContext }
+import io.getquill.context.{ Context, ExecutionInfo, TranslateContext }
 import io.getquill.monad.TwitterFutureIOMonad
 
 class FinaglePostgresContext[N <: NamingStrategy](val naming: N, client: PostgresClient)
@@ -41,6 +41,7 @@ class FinaglePostgresContext[N <: NamingStrategy](val naming: N, client: Postgre
   override type RunActionReturningResult[T] = T
   override type RunBatchActionResult = List[Long]
   override type RunBatchActionReturningResult[T] = List[T]
+  type DatasourceContext = Unit
 
   private val currentClient = new Local[PostgresClient]
 
@@ -74,47 +75,47 @@ class FinaglePostgresContext[N <: NamingStrategy](val naming: N, client: Postgre
       case true  => transaction(super.performIO(io))
     }
 
-  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[List[T]] = {
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Future[List[T]] = {
     val (params, prepared) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withClient(_.prepareAndQuery(sql, prepared: _*)(row => extractor(row, ())).map(_.toList))
   }
 
-  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[T] =
-    executeQuery(sql, prepare, extractor).map(handleSingleResult)
+  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Future[T] =
+    executeQuery(sql, prepare, extractor)(info, dc).map(handleSingleResult)
 
-  def executeAction[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[Long] = {
+  def executeAction[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Future[Long] = {
     val (params, prepared) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withClient(_.prepareAndExecute(sql, prepared: _*)).map(_.toLong)
   }
 
-  def executeBatchAction[B](groups: List[BatchGroup]): Future[List[Long]] = Future.collect {
+  def executeBatchAction[B](groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Future[List[Long]] = Future.collect {
     groups.map {
       case BatchGroup(sql, prepare) =>
         prepare.foldLeft(Future.value(List.newBuilder[Long])) {
           case (acc, prepare) =>
             acc.flatMap { list =>
-              executeAction(sql, prepare).map(list += _)
+              executeAction(sql, prepare)(info, dc).map(list += _)
             }
         }.map(_.result())
     }
   }.map(_.flatten.toList)
 
-  def executeActionReturning[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T], returningAction: ReturnAction): Future[T] = {
+  def executeActionReturning[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T], returningAction: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext): Future[T] = {
     val (params, prepared) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withClient(_.prepareAndQuery(expandAction(sql, returningAction), prepared: _*)(row => extractor(row, ()))).map(v => handleSingleResult(v.toList))
   }
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Future[List[T]] =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext): Future[List[T]] =
     Future.collect {
       groups.map {
         case BatchGroupReturning(sql, column, prepare) =>
           prepare.foldLeft(Future.value(List.newBuilder[T])) {
             case (acc, prepare) =>
               acc.flatMap { list =>
-                executeActionReturning(sql, prepare, extractor, column).map(list += _)
+                executeActionReturning(sql, prepare, extractor, column)(info, dc).map(list += _)
               }
           }.map(_.result())
       }

--- a/quill-jasync/src/main/scala/io/getquill/context/jasync/JAsyncContext.scala
+++ b/quill-jasync/src/main/scala/io/getquill/context/jasync/JAsyncContext.scala
@@ -1,23 +1,23 @@
 package io.getquill.context.jasync
 
 import java.util.concurrent.CompletableFuture
-
 import com.github.jasync.sql.db.{ ConcreteConnection, Connection, QueryResult, RowData }
 import com.github.jasync.sql.db.pool.ConnectionPool
+
 import scala.language.implicitConversions
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.Try
-
 import io.getquill.context.sql.SqlContext
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.{ NamingStrategy, ReturnAction }
 import io.getquill.util.ContextLogger
 import io.getquill.monad.ScalaFutureIOMonad
-import io.getquill.context.{ Context, TranslateContext }
+import io.getquill.context.{ Context, ExecutionInfo, TranslateContext }
 import kotlin.jvm.functions.Function1
+
 import scala.compat.java8.FutureConverters
 import scala.jdk.CollectionConverters._
 
@@ -42,6 +42,7 @@ abstract class JAsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: ConcreteCo
   override type RunActionReturningResult[T] = T
   override type RunBatchActionResult = Seq[Long]
   override type RunBatchActionReturningResult[T] = Seq[T]
+  type DatasourceContext = Unit
 
   implicit def toFuture[T](cf: CompletableFuture[T]): Future[T] = FutureConverters.toScala(cf)
   implicit def toCompletableFuture[T](f: Future[T]): CompletableFuture[T] = FutureConverters.toJava(f).asInstanceOf[CompletableFuture[T]]
@@ -80,23 +81,23 @@ abstract class JAsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: ConcreteCo
       case true  => transaction(super.performIO(io)(_))
     }
 
-  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[List[T]] = {
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[List[T]] = {
     val (params, values) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withConnection(_.sendPreparedStatement(sql, values.asJava))
       .map(_.getRows.asScala.iterator.map(row => extractor(row, ())).toList)
   }
 
-  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit ec: ExecutionContext): Future[T] =
-    executeQuery(sql, prepare, extractor).map(handleSingleResult)
+  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[T] =
+    executeQuery(sql, prepare, extractor)(info, dc).map(handleSingleResult)
 
-  def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(implicit ec: ExecutionContext): Future[Long] = {
+  def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[Long] = {
     val (params, values) = prepare(Nil, ())
     logger.logQuery(sql, params)
     withConnection(_.sendPreparedStatement(sql, values.asJava)).map(_.getRowsAffected)
   }
 
-  def executeActionReturning[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T], returningAction: ReturnAction)(implicit ec: ExecutionContext): Future[T] = {
+  def executeActionReturning[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T], returningAction: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[T] = {
     val expanded = expandAction(sql, returningAction)
     val (params, values) = prepare(Nil, ())
     logger.logQuery(sql, params)
@@ -104,27 +105,27 @@ abstract class JAsyncContext[D <: SqlIdiom, N <: NamingStrategy, C <: ConcreteCo
       .map(extractActionResult(returningAction, extractor))
   }
 
-  def executeBatchAction(groups: List[BatchGroup])(implicit ec: ExecutionContext): Future[List[Long]] =
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[List[Long]] =
     Future.sequence {
       groups.map {
         case BatchGroup(sql, prepare) =>
           prepare.foldLeft(Future.successful(List.newBuilder[Long])) {
             case (acc, prepare) =>
               acc.flatMap { list =>
-                executeAction(sql, prepare).map(list += _)
+                executeAction(sql, prepare)(info, dc).map(list += _)
               }
           }.map(_.result())
       }
     }.map(_.flatten.toList)
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(implicit ec: ExecutionContext): Future[List[T]] =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext)(implicit ec: ExecutionContext): Future[List[T]] =
     Future.sequence {
       groups.map {
         case BatchGroupReturning(sql, column, prepare) =>
           prepare.foldLeft(Future.successful(List.newBuilder[T])) {
             case (acc, prepare) =>
               acc.flatMap { list =>
-                executeActionReturning(sql, prepare, extractor, column).map(list += _)
+                executeActionReturning(sql, prepare, extractor, column)(info, dc).map(list += _)
               }
           }.map(_.result())
       }

--- a/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
+++ b/quill-jdbc-monix/src/main/scala/io/getquill/context/monix/MonixJdbcContext.scala
@@ -2,15 +2,14 @@ package io.getquill.context.monix
 
 import java.io.Closeable
 import java.sql.{ Array => _, _ }
-
 import cats.effect.ExitCase
 import io.getquill.{ NamingStrategy, ReturnAction }
-import io.getquill.context.ContextEffect
-import io.getquill.context.StreamingContext
+import io.getquill.context.{ ContextEffect, ExecutionInfo, StreamingContext }
 import io.getquill.context.jdbc.JdbcContextBase
 import io.getquill.context.monix.MonixJdbcContext.Runner
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.util.ContextLogger
+
 import javax.sql.DataSource
 import monix.eval.{ Task, TaskLocal }
 import monix.execution.Scheduler
@@ -41,24 +40,24 @@ abstract class MonixJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](
   override type RunBatchActionReturningResult[T] = List[T]
 
   // Need explicit return-type annotations due to scala/bug#8356. Otherwise macro system will not understand Result[Long]=Task[Long] etc...
-  override def executeAction[T](sql: String, prepare: Prepare = identityPrepare): Task[Long] =
-    super.executeAction(sql, prepare)
-  override def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[List[T]] =
-    super.executeQuery(sql, prepare, extractor)
-  override def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[T] =
-    super.executeQuerySingle(sql, prepare, extractor)
-  override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction): Task[O] =
-    super.executeActionReturning(sql, prepare, extractor, returningBehavior)
-  override def executeBatchAction(groups: List[BatchGroup]): Task[List[Long]] =
-    super.executeBatchAction(groups)
-  override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Task[List[T]] =
-    super.executeBatchActionReturning(groups, extractor)
-  override def prepareQuery[T](sql: String, prepare: Prepare, extractor: Extractor[T] = identityExtractor): Connection => Task[PreparedStatement] =
-    super.prepareQuery(sql, prepare, extractor)
-  override def prepareAction(sql: String, prepare: Prepare): Connection => Task[PreparedStatement] =
-    super.prepareAction(sql, prepare)
-  override def prepareBatchAction(groups: List[BatchGroup]): Connection => Task[List[PreparedStatement]] =
-    super.prepareBatchAction(groups)
+  override def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Task[Long] =
+    super.executeAction(sql, prepare)(info, dc)
+  override def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Task[List[T]] =
+    super.executeQuery(sql, prepare, extractor)(info, dc)
+  override def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Task[T] =
+    super.executeQuerySingle(sql, prepare, extractor)(info, dc)
+  override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext): Task[O] =
+    super.executeActionReturning(sql, prepare, extractor, returningBehavior)(info, dc)
+  override def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Task[List[Long]] =
+    super.executeBatchAction(groups)(info, dc)
+  override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext): Task[List[T]] =
+    super.executeBatchActionReturning(groups, extractor)(info, dc)
+  override def prepareQuery(sql: String, prepare: Prepare)(info: ExecutionInfo, dc: DatasourceContext): Connection => Task[PreparedStatement] =
+    super.prepareQuery(sql, prepare)(info, dc)
+  override def prepareAction(sql: String, prepare: Prepare)(info: ExecutionInfo, dc: DatasourceContext): Connection => Task[PreparedStatement] =
+    super.prepareAction(sql, prepare)(info, dc)
+  override def prepareBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Connection => Task[List[PreparedStatement]] =
+    super.prepareBatchAction(groups)(info, dc)
 
   override protected val effect: Runner = runner
   import runner._
@@ -228,7 +227,7 @@ abstract class MonixJdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy](
     stmt
   }
 
-  def streamQuery[T](fetchSize: Option[Int], sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Observable[T] =
+  def streamQuery[T](fetchSize: Option[Int], sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Observable[T] =
     withConnectionObservable { conn =>
       Observable.eval {
         val stmt = prepareStatementForStreaming(sql, conn, fetchSize)

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextBase.scala
@@ -1,16 +1,19 @@
 package io.getquill.context.jdbc
 
-import java.sql._
-
 import io.getquill._
-import io.getquill.ReturnAction._
-import io.getquill.context.sql.SqlContext
 import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.{ Context, ContextEffect, StagedPrepare, PrepareContext }
-import io.getquill.util.ContextLogger
+import io.getquill.context.{ ExecutionInfo, PrepareContext, StagedPrepare }
+
+import java.sql._
 
 trait JdbcContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends JdbcContextSimplified[Dialect, Naming]
   with StagedPrepare {
+
+  // Need to re-define these here or they conflict with staged-prepare imported types
+  override type PrepareQueryResult = Connection => Result[PreparedStatement]
+  override type PrepareActionResult = Connection => Result[PreparedStatement]
+  override type PrepareBatchActionResult = Connection => Result[List[PreparedStatement]]
+
   def constructPrepareQuery(f: Connection => Result[PreparedStatement]): Connection => Result[PreparedStatement] = f
   def constructPrepareAction(f: Connection => Result[PreparedStatement]): Connection => Result[PreparedStatement] = f
   def constructPrepareBatchAction(f: Connection => Result[List[PreparedStatement]]): Connection => Result[List[PreparedStatement]] = f
@@ -19,25 +22,29 @@ trait JdbcContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy] extends Jdb
 trait JdbcContextSimplified[Dialect <: SqlIdiom, Naming <: NamingStrategy]
   extends JdbcRunContext[Dialect, Naming] with PrepareContext {
 
+  override type PrepareQueryResult = Connection => Result[PreparedStatement]
+  override type PrepareActionResult = Connection => Result[PreparedStatement]
+  override type PrepareBatchActionResult = Connection => Result[List[PreparedStatement]]
+
   import effect._
   def constructPrepareQuery(f: Connection => Result[PreparedStatement]): PrepareQueryResult
   def constructPrepareAction(f: Connection => Result[PreparedStatement]): PrepareActionResult
   def constructPrepareBatchAction(f: Connection => Result[List[PreparedStatement]]): PrepareBatchActionResult
 
-  def prepareQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): PrepareQueryResult =
-    constructPrepareQuery(prepareSingle(sql, prepare))
+  def prepareQuery(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: DatasourceContext): PrepareQueryResult =
+    constructPrepareQuery(prepareSingle(sql, prepare)(executionInfo, dc))
 
-  def prepareAction(sql: String, prepare: Prepare = identityPrepare): PrepareActionResult =
-    constructPrepareAction(prepareSingle(sql, prepare))
+  def prepareAction(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: DatasourceContext): PrepareActionResult =
+    constructPrepareAction(prepareSingle(sql, prepare)(executionInfo, dc))
 
-  def prepareSingle(sql: String, prepare: Prepare = identityPrepare): Connection => Result[PreparedStatement] =
+  def prepareSingle(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: DatasourceContext): Connection => Result[PreparedStatement] =
     (conn: Connection) => wrap {
       val (params, ps) = prepare(conn.prepareStatement(sql), conn)
       logger.logQuery(sql, params)
       ps
     }
 
-  def prepareBatchAction(groups: List[BatchGroup]): PrepareBatchActionResult =
+  def prepareBatchAction(groups: List[BatchGroup])(executionInfo: ExecutionInfo, dc: DatasourceContext): PrepareBatchActionResult =
     constructPrepareBatchAction {
       (session: Connection) =>
         seq {
@@ -47,109 +54,10 @@ trait JdbcContextSimplified[Dialect <: SqlIdiom, Naming <: NamingStrategy]
           }
           batches.map {
             case (sql, prepare) =>
-              val prepareSql = prepareSingle(sql, prepare)
+              val prepareSql = prepareSingle(sql, prepare)(executionInfo, dc)
               prepareSql(session)
           }
         }
     }
 
-}
-
-trait JdbcRunContext[Dialect <: SqlIdiom, Naming <: NamingStrategy]
-  extends Context[Dialect, Naming]
-  with SqlContext[Dialect, Naming]
-  with Encoders
-  with Decoders {
-  private[getquill] val logger = ContextLogger(classOf[JdbcContext[_, _]])
-
-  override type PrepareRow = PreparedStatement
-  override type ResultRow = ResultSet
-  override type Session = Connection
-
-  protected val effect: ContextEffect[Result]
-  import effect._
-
-  protected def withConnection[T](f: Connection => Result[T]): Result[T]
-  protected def withConnectionWrapped[T](f: Connection => T): Result[T] =
-    withConnection(conn => wrap(f(conn)))
-
-  def executeAction[T](sql: String, prepare: Prepare = identityPrepare): Result[Long] =
-    withConnectionWrapped { conn =>
-      val (params, ps) = prepare(conn.prepareStatement(sql), conn)
-      logger.logQuery(sql, params)
-      ps.executeUpdate().toLong
-    }
-
-  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Result[List[T]] =
-    withConnectionWrapped { conn =>
-      val (params, ps) = prepare(conn.prepareStatement(sql), conn)
-      logger.logQuery(sql, params)
-      val rs = ps.executeQuery()
-      extractResult(rs, conn, extractor)
-    }
-
-  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Result[T] =
-    handleSingleWrappedResult(executeQuery(sql, prepare, extractor))
-
-  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction): Result[O] =
-    withConnectionWrapped { conn =>
-      val (params, ps) = prepare(prepareWithReturning(sql, conn, returningBehavior), conn)
-      logger.logQuery(sql, params)
-      ps.executeUpdate()
-      handleSingleResult(extractResult(ps.getGeneratedKeys, conn, extractor))
-    }
-
-  protected def prepareWithReturning(sql: String, conn: Connection, returningBehavior: ReturnAction) =
-    returningBehavior match {
-      case ReturnRecord           => conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)
-      case ReturnColumns(columns) => conn.prepareStatement(sql, columns.toArray)
-      case ReturnNothing          => conn.prepareStatement(sql)
-    }
-
-  def executeBatchAction(groups: List[BatchGroup]): Result[List[Long]] =
-    withConnectionWrapped { conn =>
-      groups.flatMap {
-        case BatchGroup(sql, prepare) =>
-          val ps = conn.prepareStatement(sql)
-          logger.underlying.debug("Batch: {}", sql)
-          prepare.foreach { f =>
-            val (params, _) = f(ps, conn)
-            logger.logBatchItem(sql, params)
-            ps.addBatch()
-          }
-          ps.executeBatch().map(_.toLong)
-      }
-    }
-
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Result[List[T]] =
-    withConnectionWrapped { conn =>
-      groups.flatMap {
-        case BatchGroupReturning(sql, returningBehavior, prepare) =>
-          val ps = prepareWithReturning(sql, conn, returningBehavior)
-          logger.underlying.debug("Batch: {}", sql)
-          prepare.foreach { f =>
-            val (params, _) = f(ps, conn)
-            logger.logBatchItem(sql, params)
-            ps.addBatch()
-          }
-          ps.executeBatch()
-          extractResult(ps.getGeneratedKeys, conn, extractor)
-      }
-    }
-
-  protected def handleSingleWrappedResult[T](list: Result[List[T]]): Result[T] =
-    push(list)(handleSingleResult(_))
-
-  /**
-   * Parses instances of java.sql.Types to string form so it can be used in creation of sql arrays.
-   * Some databases does not support each of generic types, hence it's welcome to override this method
-   * and provide alternatives to non-existent types.
-   *
-   * @param intType one of java.sql.Types
-   * @return JDBC type in string form
-   */
-  def parseJdbcType(intType: Int): String = JDBCType.valueOf(intType).getName
-
-  private[getquill] final def extractResult[T](rs: ResultSet, conn: Connection, extractor: Extractor[T]): List[T] =
-    ResultSetExtractor(rs, conn, extractor)
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcPrepareBase.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcPrepareBase.scala
@@ -1,10 +1,9 @@
 package io.getquill.context.jdbc
 
 import java.sql.{ Connection, PreparedStatement }
-
 import io.getquill.NamingStrategy
 import io.getquill.context.sql.idiom.SqlIdiom
-import io.getquill.context.{ Context, ContextEffect }
+import io.getquill.context.{ Context, ContextEffect, ExecutionInfo }
 import io.getquill.util.ContextLogger
 
 trait JdbcPrepareBase[Dialect <: SqlIdiom, Naming <: NamingStrategy]
@@ -14,13 +13,14 @@ trait JdbcPrepareBase[Dialect <: SqlIdiom, Naming <: NamingStrategy]
 
   type PrepareResult
   type PrepareBatchResult
+  type DatasourceContext = Unit
   override type PrepareRow = PreparedStatement
   override type Session = Connection
 
-  def prepareQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): PrepareResult
-  def prepareAction(sql: String, prepare: Prepare = identityPrepare): PrepareResult
-  def prepareSingle(sql: String, prepare: Prepare = identityPrepare): PrepareResult
-  def prepareBatchAction(groups: List[BatchGroup]): PrepareBatchResult
+  def prepareQuery(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: DatasourceContext): PrepareResult
+  def prepareAction(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: DatasourceContext): PrepareResult
+  def prepareSingle(sql: String, prepare: Prepare = identityPrepare)(executionInfo: ExecutionInfo, dc: DatasourceContext): PrepareResult
+  def prepareBatchAction(groups: List[BatchGroup])(executionInfo: ExecutionInfo, dc: DatasourceContext): PrepareBatchResult
 
   protected val effect: ContextEffect[Result]
   import effect._

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcRunContext.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcRunContext.scala
@@ -1,0 +1,110 @@
+package io.getquill.context.jdbc
+
+import io.getquill.{ NamingStrategy, ReturnAction }
+import io.getquill.ReturnAction.{ ReturnColumns, ReturnNothing, ReturnRecord }
+import io.getquill.context.{ Context, ContextEffect, ExecutionInfo }
+import io.getquill.context.sql.SqlContext
+import io.getquill.context.sql.idiom.SqlIdiom
+import io.getquill.util.ContextLogger
+
+import java.sql.{ Connection, JDBCType, PreparedStatement, ResultSet, Statement }
+
+trait JdbcRunContext[Dialect <: SqlIdiom, Naming <: NamingStrategy]
+  extends Context[Dialect, Naming]
+  with SqlContext[Dialect, Naming]
+  with Encoders
+  with Decoders {
+  private[getquill] val logger = ContextLogger(classOf[JdbcContext[_, _]])
+
+  override type PrepareRow = PreparedStatement
+  override type ResultRow = ResultSet
+  override type Session = Connection
+  override type DatasourceContext = Unit
+
+  protected val effect: ContextEffect[Result]
+  import effect._
+
+  protected def withConnection[T](f: Connection => Result[T]): Result[T]
+  protected def withConnectionWrapped[T](f: Connection => T): Result[T] =
+    withConnection(conn => wrap(f(conn)))
+
+  def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Result[Long] =
+    withConnectionWrapped { conn =>
+      val (params, ps) = prepare(conn.prepareStatement(sql), conn)
+      logger.logQuery(sql, params)
+      ps.executeUpdate().toLong
+    }
+
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Result[List[T]] =
+    withConnectionWrapped { conn =>
+      val (params, ps) = prepare(conn.prepareStatement(sql), conn)
+      logger.logQuery(sql, params)
+      val rs = ps.executeQuery()
+      extractResult(rs, conn, extractor)
+    }
+
+  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Result[T] =
+    handleSingleWrappedResult(executeQuery(sql, prepare, extractor)(info, dc))
+
+  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext): Result[O] =
+    withConnectionWrapped { conn =>
+      val (params, ps) = prepare(prepareWithReturning(sql, conn, returningBehavior), conn)
+      logger.logQuery(sql, params)
+      ps.executeUpdate()
+      handleSingleResult(extractResult(ps.getGeneratedKeys, conn, extractor))
+    }
+
+  protected def prepareWithReturning(sql: String, conn: Connection, returningBehavior: ReturnAction) =
+    returningBehavior match {
+      case ReturnRecord           => conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)
+      case ReturnColumns(columns) => conn.prepareStatement(sql, columns.toArray)
+      case ReturnNothing          => conn.prepareStatement(sql)
+    }
+
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Result[List[Long]] =
+    withConnectionWrapped { conn =>
+      groups.flatMap {
+        case BatchGroup(sql, prepare) =>
+          val ps = conn.prepareStatement(sql)
+          logger.underlying.debug("Batch: {}", sql)
+          prepare.foreach { f =>
+            val (params, _) = f(ps, conn)
+            logger.logBatchItem(sql, params)
+            ps.addBatch()
+          }
+          ps.executeBatch().map(_.toLong)
+      }
+    }
+
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext): Result[List[T]] =
+    withConnectionWrapped { conn =>
+      groups.flatMap {
+        case BatchGroupReturning(sql, returningBehavior, prepare) =>
+          val ps = prepareWithReturning(sql, conn, returningBehavior)
+          logger.underlying.debug("Batch: {}", sql)
+          prepare.foreach { f =>
+            val (params, _) = f(ps, conn)
+            logger.logBatchItem(sql, params)
+            ps.addBatch()
+          }
+          ps.executeBatch()
+          extractResult(ps.getGeneratedKeys, conn, extractor)
+      }
+    }
+
+  protected def handleSingleWrappedResult[T](list: Result[List[T]]): Result[T] =
+    push(list)(handleSingleResult(_))
+
+  /**
+   * Parses instances of java.sql.Types to string form so it can be used in creation of sql arrays.
+   * Some databases does not support each of generic types, hence it's welcome to override this method
+   * and provide alternatives to non-existent types.
+   *
+   * @param intType one of java.sql.Types
+   * @return JDBC type in string form
+   */
+  def parseJdbcType(intType: Int): String = JDBCType.valueOf(intType).getName
+
+  private[getquill] final def extractResult[T](rs: ResultSet, conn: Connection, extractor: Extractor[T]): List[T] =
+    ResultSetExtractor(rs, conn, extractor)
+}

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
@@ -1,8 +1,8 @@
 package io.getquill.context.jdbc
 
 import java.sql.Types
-
 import io.getquill._
+import io.getquill.context.ExecutionInfo
 
 trait PostgresJdbcContextSimplified[N <: NamingStrategy] extends JdbcContextSimplified[PostgresDialect, N]
   with PostgresJdbcRunContext[N]
@@ -62,7 +62,7 @@ trait SqlServerJdbcRunContext[N <: NamingStrategy] extends JdbcRunContext[SQLSer
 
   val idiom = SQLServerDialect
 
-  override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction): Result[O] =
+  override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(executionInfo: ExecutionInfo, dc: DatasourceContext): Result[O] =
     withConnectionWrapped { conn =>
       val (params, ps) = prepare(prepareWithReturning(sql, conn, returningBehavior), conn)
       logger.logQuery(sql, params)

--- a/quill-monix/src/main/scala/io/getquill/context/monix/MonixContext.scala
+++ b/quill-monix/src/main/scala/io/getquill/context/monix/MonixContext.scala
@@ -1,7 +1,8 @@
 package io.getquill.context.monix
 
 import io.getquill.NamingStrategy
-import io.getquill.context.{ Context, StreamingContext }
+import io.getquill.context.{ Context, ExecutionInfo, StreamingContext }
+import io.getquill.mirrorContextWithQueryProbing.DatasourceContext
 import monix.eval.Task
 import monix.reactive.Observable
 
@@ -14,6 +15,6 @@ trait MonixContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] e
   override type RunQuerySingleResult[T] = T
 
   // Need explicit return-type annotations due to scala/bug#8356. Otherwise macro system will not understand Result[Long]=Task[Long] etc...
-  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[List[T]]
-  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[T]
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Task[List[T]]
+  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Task[T]
 }

--- a/quill-ndbc-monix/src/main/scala/io/getquill/context/monix/MonixNdbcContext.scala
+++ b/quill-ndbc-monix/src/main/scala/io/getquill/context/monix/MonixNdbcContext.scala
@@ -1,8 +1,7 @@
 package io.getquill.context.monix
 
 import java.sql.{ Array => _ }
-
-import io.getquill.context.StreamingContext
+import io.getquill.context.{ ExecutionInfo, StreamingContext }
 import io.getquill.context.monix.MonixNdbcContext.Runner
 import io.getquill.context.ndbc.NdbcContextBase
 import io.getquill.context.sql.idiom.SqlIdiom
@@ -100,23 +99,23 @@ abstract class MonixNdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy, P
   }
 
   // Need explicit return-type annotations due to scala/bug#8356. Otherwise macro system will not understand Result[Long]=Task[Long] etc...
-  override def executeAction[T](sql: String, prepare: Prepare = identityPrepare): Task[Long] =
-    super.executeAction(sql, prepare)
+  override def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Task[Long] =
+    super.executeAction(sql, prepare)(info, dc)
 
-  override def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[List[T]] =
-    super.executeQuery(sql, prepare, extractor)
+  override def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Task[List[T]] =
+    super.executeQuery(sql, prepare, extractor)(info, dc)
 
-  override def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Task[T] =
-    super.executeQuerySingle(sql, prepare, extractor)
+  override def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Task[T] =
+    super.executeQuerySingle(sql, prepare, extractor)(info, dc)
 
-  override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction): Task[O] =
-    super.executeActionReturning(sql, prepare, extractor, returningBehavior)
+  override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext): Task[O] =
+    super.executeActionReturning(sql, prepare, extractor, returningBehavior)(info, dc)
 
-  override def executeBatchAction(groups: List[BatchGroup]): Task[List[Long]] =
-    super.executeBatchAction(groups)
+  override def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Task[List[Long]] =
+    super.executeBatchAction(groups)(info, dc)
 
-  override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Task[List[T]] =
-    super.executeBatchActionReturning(groups, extractor)
+  override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext): Task[List[T]] =
+    super.executeBatchActionReturning(groups, extractor)(info, dc)
 
   override def transaction[T](f: => Task[T]): Task[T] = super.transaction(f)
 
@@ -127,7 +126,7 @@ abstract class MonixNdbcContext[Dialect <: SqlIdiom, Naming <: NamingStrategy, P
     schedule(f(dataSource))
 
   // TODO: What about fetchSize? Not really applicable here
-  def streamQuery[T](fetchSize: Option[Index], sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Observable[T] =
+  def streamQuery[T](fetchSize: Option[Index], sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Observable[T] =
     Observable
       .eval {
         // TODO: Do we need to set ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY?

--- a/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContext.scala
+++ b/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContext.scala
@@ -1,6 +1,6 @@
 package io.getquill.context.ndbc
 
-import io.getquill.context.TranslateContextBase
+import io.getquill.context.{ ExecutionInfo, TranslateContextBase }
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.{ NamingStrategy, ReturnAction }
 import io.trane.future.scala.{ Await, Future, Promise }
@@ -29,23 +29,23 @@ abstract class NdbcContext[I <: SqlIdiom, N <: NamingStrategy, P <: PreparedStat
   override private[getquill] val translateEffect = resultEffect
 
   // Need explicit return-type annotations due to scala/bug#8356. Otherwise macro system will not understand Result[Long]=Long etc...
-  override def executeAction[T](sql: String, prepare: Prepare = identityPrepare): Future[Long] =
-    super.executeAction(sql, prepare)
+  override def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Future[Long] =
+    super.executeAction(sql, prepare)(info, dc)
 
-  override def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[List[T]] =
-    super.executeQuery(sql, prepare, extractor)
+  override def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Future[List[T]] =
+    super.executeQuery(sql, prepare, extractor)(info, dc)
 
-  override def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): Future[T] =
-    super.executeQuerySingle(sql, prepare, extractor)
+  override def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): Future[T] =
+    super.executeQuerySingle(sql, prepare, extractor)(info, dc)
 
-  override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction): Future[O] =
-    super.executeActionReturning(sql, prepare, extractor, returningBehavior)
+  override def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[O], returningBehavior: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext): Future[O] =
+    super.executeActionReturning(sql, prepare, extractor, returningBehavior)(info, dc)
 
-  override def executeBatchAction(groups: List[BatchGroup]): Future[List[Long]] =
-    super.executeBatchAction(groups)
+  override def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Future[List[Long]] =
+    super.executeBatchAction(groups)(info, dc)
 
-  override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T]): Future[List[T]] =
-    super.executeBatchActionReturning(groups, extractor)
+  override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: DatasourceContext): Future[List[T]] =
+    super.executeBatchActionReturning(groups, extractor)(info, dc)
 
   override def transaction[T](f: => Future[T]): Future[T] = super.transaction(f)
 

--- a/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContextBase.scala
+++ b/quill-ndbc/src/main/scala/io/getquill/context/ndbc/NdbcContextBase.scala
@@ -3,8 +3,8 @@ package io.getquill.context.ndbc
 import java.util
 import java.util.concurrent.Executors
 import java.util.function.Supplier
-
 import io.getquill._
+import io.getquill.context.ExecutionInfo
 import io.getquill.context.sql.SqlContext
 import io.getquill.context.sql.idiom.SqlIdiom
 import io.getquill.ndbc.TraneFutureConverters._
@@ -24,6 +24,7 @@ object NdbcContextBase {
     final type Complete[T] = (Try[T] => Unit)
 
     final type FutureExecutionContext = FutureExecutionContext_
+    type DatasourceContext = Unit
 
     def wrapAsync[T](f: Complete[T] => Unit): F[T]
 
@@ -48,6 +49,7 @@ trait NdbcContextBase[Idiom <: SqlIdiom, Naming <: NamingStrategy, P <: Prepared
   final override type PrepareRow = P
   final override type ResultRow = R
   override type Session = Unit
+  type DatasourceContext = Unit
 
   protected implicit val resultEffect: NdbcContextBase.ContextEffect[Result, _]
   import resultEffect._
@@ -61,7 +63,7 @@ trait NdbcContextBase[Idiom <: SqlIdiom, Naming <: NamingStrategy, P <: Prepared
 
   protected def expandAction(sql: String, returningAction: ReturnAction) = sql
 
-  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: (R, Session) => T = (r: R, s: Session) => r): Result[List[T]] = {
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: (R, Session) => T = (r: R, s: Session) => r)(info: ExecutionInfo, dc: DatasourceContext): Result[List[T]] = {
     withDataSourceFromFuture { ds =>
       val (params, ps) = prepare(createPreparedStatement(sql), ())
       logger.logQuery(sql, params)
@@ -72,10 +74,10 @@ trait NdbcContextBase[Idiom <: SqlIdiom, Naming <: NamingStrategy, P <: Prepared
     }
   }
 
-  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: (R, Session) => T = (r: R, s: Session) => r): Result[T] =
-    push(executeQuery(sql, prepare, extractor))(handleSingleResult)
+  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: (R, Session) => T = (r: R, s: Session) => r)(info: ExecutionInfo, dc: DatasourceContext): Result[T] =
+    push(executeQuery(sql, prepare, extractor)(info, dc))(handleSingleResult)
 
-  def executeAction[T](sql: String, prepare: Prepare = identityPrepare): Result[Long] = {
+  def executeAction[T](sql: String, prepare: Prepare = identityPrepare)(info: ExecutionInfo, dc: DatasourceContext): Result[Long] = {
     withDataSourceFromFuture { ds =>
       val (params, ps) = prepare(createPreparedStatement(sql), ())
       logger.logQuery(sql, params)
@@ -83,18 +85,18 @@ trait NdbcContextBase[Idiom <: SqlIdiom, Naming <: NamingStrategy, P <: Prepared
     }
   }
 
-  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: (R, Session) => O, returningAction: ReturnAction): Result[O] = {
+  def executeActionReturning[O](sql: String, prepare: Prepare = identityPrepare, extractor: (R, Session) => O, returningAction: ReturnAction)(info: ExecutionInfo, dc: DatasourceContext): Result[O] = {
     val expanded = expandAction(sql, returningAction)
-    executeQuerySingle(expanded, prepare, extractor)
+    executeQuerySingle(expanded, prepare, extractor)(info, dc)
   }
 
-  def executeBatchAction(groups: List[BatchGroup]): Result[List[Long]] =
+  def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: DatasourceContext): Result[List[Long]] =
     push(
       traverse(groups) {
         case BatchGroup(sql, prepares) =>
           prepares.foldLeft(wrap(ArrayBuffer.empty[Long])) { (acc, prepare) =>
             flatMap(acc) { array =>
-              push(executeAction(sql, prepare))(array :+ _)
+              push(executeAction(sql, prepare)(info, dc))(array :+ _)
             }
           }
       }
@@ -104,13 +106,13 @@ trait NdbcContextBase[Idiom <: SqlIdiom, Naming <: NamingStrategy, P <: Prepared
   def probe(sql: String): Try[_] =
     Try(runBlocking(withDataSourceFromFuture(_.query(sql).toScala), Duration.Inf))
 
-  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: (R, Session) => T): Result[List[T]] =
+  def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: (R, Session) => T)(info: ExecutionInfo, dc: DatasourceContext): Result[List[T]] =
     push(
       traverse(groups) {
         case BatchGroupReturning(sql, column, prepare) =>
           prepare.foldLeft(wrap(ArrayBuffer.empty[T])) { (acc, prepare) =>
             flatMap(acc) { array =>
-              push(executeActionReturning(sql, prepare, extractor, column))(array :+ _)
+              push(executeActionReturning(sql, prepare, extractor, column)(info, dc))(array :+ _)
             }
           }
       }

--- a/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
+++ b/quill-spark/src/main/scala/io/getquill/QuillSparkContext.scala
@@ -1,12 +1,11 @@
 package io.getquill
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.util.Success
 import scala.util.Try
 import org.apache.spark.sql.{ Column, Dataset, SQLContext, Encoder => SparkEncoder }
 import org.apache.spark.sql.functions.{ col, struct }
-import io.getquill.context.Context
+import io.getquill.context.{ Context, ExecutionInfo }
 import io.getquill.context.spark.Encoders
 import io.getquill.context.spark.Decoders
 import io.getquill.context.spark.SparkDialect
@@ -14,9 +13,9 @@ import io.getquill.context.spark.Binding
 import io.getquill.context.spark.DatasetBinding
 import io.getquill.context.spark.ValueBinding
 import org.apache.spark.sql.types.{ StructField, StructType }
-
 import io.getquill.context.spark.norm.QuestionMarkEscaper._
 import org.apache.spark.sql.functions._
+
 import scala.reflect.runtime.universe.TypeTag
 
 object QuillSparkContext extends QuillSparkContext
@@ -30,6 +29,7 @@ trait QuillSparkContext
   type RunQuerySingleResult[T] = T
   type RunQueryResult[T] = T
   type Session = Unit
+  type DatasourceContext = Unit
 
   private[getquill] val queryCounter = new AtomicInteger(0)
 
@@ -132,12 +132,12 @@ trait QuillSparkContext
     }
   }
 
-  def executeQuery[T: TypeTag](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit enc: SparkEncoder[T], spark: SQLContext) = {
+  def executeQuery[T: TypeTag](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit enc: SparkEncoder[T], spark: SQLContext) = {
     val ds = spark.sql(prepareString(string, prepare))
     percolateNullArrays(ds.toDF(CaseAccessors[T](ds.schema): _*).as[T])
   }
 
-  def executeQuerySingle[T: TypeTag](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(implicit enc: SparkEncoder[T], spark: SQLContext) = {
+  def executeQuerySingle[T: TypeTag](string: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext)(implicit enc: SparkEncoder[T], spark: SQLContext) = {
     val ds = spark.sql(prepareString(string, prepare))
     percolateNullArrays(ds.toDF(CaseAccessors[T](ds.schema): _*).as[T])
   }

--- a/quill-zio/src/main/scala/io/getquill/context/qzio/ZioContext.scala
+++ b/quill-zio/src/main/scala/io/getquill/context/qzio/ZioContext.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.qzio
 
 import io.getquill.NamingStrategy
-import io.getquill.context.{ Context, StreamingContext }
+import io.getquill.context.{ Context, ExecutionInfo, StreamingContext }
 import zio.ZIO
 import zio.stream.ZStream
 
@@ -18,6 +18,6 @@ trait ZioContext[Idiom <: io.getquill.idiom.Idiom, Naming <: NamingStrategy] ext
   override type RunQuerySingleResult[T] = T
 
   // Need explicit return-type annotations due to scala/bug#8356. Otherwise macro system will not understand Result[Long]=Task[Long] etc...
-  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): ZIO[Environment, Error, List[T]]
-  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor): ZIO[Environment, Error, T]
+  def executeQuery[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): ZIO[Environment, Error, List[T]]
+  def executeQuerySingle[T](sql: String, prepare: Prepare = identityPrepare, extractor: Extractor[T] = identityExtractor)(info: ExecutionInfo, dc: DatasourceContext): ZIO[Environment, Error, T]
 }


### PR DESCRIPTION
Child contexts currently implemented have begun to drift. The `execute___` methods need to be lined up with the ProtoQuill signatures so that child contexts (i.e. ZIO contexts, Monix contexts, Doobie contexts, etc...) can have identical code in Quill and ProtoQuill.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
