### PR TITLE
add Instant decoder/encoder to jdbc Decoders/Encoders

### DIFF
--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
@@ -1,10 +1,8 @@
 package io.getquill.context.jdbc
 
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{ Instant, LocalDate, LocalDateTime }
 import java.util
 import java.util.Calendar
-
-import scala.math.BigDecimal.javaBigDecimal2bigDecimal
 
 trait Decoders {
   this: JdbcRunContext[_, _] =>
@@ -62,4 +60,7 @@ trait Decoders {
   implicit val localDateTimeDecoder: Decoder[LocalDateTime] =
     decoder((index, row, session) =>
       row.getTimestamp(index, Calendar.getInstance(dateTimeZone)).toLocalDateTime)
+  implicit val instantDecoder: Decoder[Instant] =
+    decoder((index, row, _) =>
+      row.getTimestamp(index).toInstant)
 }

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -1,7 +1,7 @@
 package io.getquill.context.jdbc
 
 import java.sql.{ Date, Timestamp, Types }
-import java.time.{ LocalDate, LocalDateTime }
+import java.time.{ Instant, LocalDate, LocalDateTime }
 import java.util.{ Calendar, TimeZone }
 import java.{ sql, util }
 
@@ -60,4 +60,8 @@ trait Encoders {
   implicit val localDateTimeEncoder: Encoder[LocalDateTime] =
     encoder(Types.TIMESTAMP, (index, value, row) =>
       row.setTimestamp(index, Timestamp.valueOf(value), Calendar.getInstance(dateTimeZone)))
+  implicit val instantEncoder: Encoder[Instant] =
+    encoder(Types.TIMESTAMP, (index, value, row) =>
+      row.setTimestamp(index, Timestamp.from(value)))
+
 }


### PR DESCRIPTION
### Problem

Out of the box, Quill does not provide a JDBC Encoder/Decoder for `java.time.Instant`

### Solution

Provide encoder/decoder for `java.time.Instant` alongside the existing Date/DateTime encoders/decoders

@getquill/maintainers
