### PR TITLE
Defunct AsyncZioCache accidentally returned in #2174. Remove it.

### DIFF
--- a/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
@@ -173,7 +173,7 @@ class CassandraZioContext[N <: NamingStrategy](val naming: N)
       env <- ZIO.environment[Has[CassandraZioSession]]
       csession = env.get[CassandraZioSession]
       boundStatement <- {
-        csession.prepareAsync(cql)
+        ZIO.fromFuture { implicit ec => csession.prepareAsync(cql) }
           .mapEffect(row => prepare(row, csession))
           .map(p => p._2)
       }

--- a/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioSession.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioSession.scala
@@ -1,27 +1,16 @@
 package io.getquill
 
-import com.datastax.driver.core.{ BoundStatement, Cluster, PreparedStatement }
+import com.datastax.driver.core.Cluster
 import com.typesafe.config.Config
-import io.getquill.CassandraZioContext.CIO
-import io.getquill.context.{ CassandraSession, SyncCache }
-import io.getquill.context.cassandra.PrepareStatementCache
+import io.getquill.context.{ AsyncFutureCache, CassandraSession, SyncCache }
 import io.getquill.util.LoadConfig
 import zio.{ Has, ZIO, ZLayer, ZManaged }
-import io.getquill.util.ZioConversions._
-
-trait AsyncZioCache { self: CassandraSession =>
-  lazy val asyncCache = new PrepareStatementCache[CIO[PreparedStatement]](preparedStatementCacheSize)
-  def prepareAsync(cql: String): CIO[BoundStatement] =
-    asyncCache(cql)(stmt => session.prepareAsync(stmt).asZio.tapError {
-      _ => ZIO.effect(asyncCache.invalidate(stmt))
-    }).map(_.bind())
-}
 
 case class CassandraZioSession(
   override val cluster:                    Cluster,
   override val keyspace:                   String,
   override val preparedStatementCacheSize: Long
-) extends CassandraSession with SyncCache with AsyncZioCache with AutoCloseable
+) extends CassandraSession with SyncCache with AsyncFutureCache with AutoCloseable
 
 object CassandraZioSession {
   val live: ZLayer[Has[CassandraContextConfig], Throwable, Has[CassandraZioSession]] =


### PR DESCRIPTION
Changes done to fix quill-cassanra-zio in #2162 were accidentally undone in #2174. This fixes that.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
