### PR TITLE
`transaction` supports ZIO effects with mixed environments

### DIFF
--- a/quill-jdbc-zio/src/test/scala/io/getquill/TransactionEnvironmentSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/TransactionEnvironmentSpec.scala
@@ -1,0 +1,33 @@
+package io.getquill
+
+class TransactionEnvironmentSpec extends Spec {
+  val ctx = new PostgresZioJdbcUnderlyingContext(Literal)
+
+  "transaction with mixed environments" - {
+    "compiles with just Has[Connection]" in {
+      """|import zio.{ Has, ZIO }
+         |import java.sql.Connection
+         |
+         |def service: ZIO[Has[Connection], Throwable, Unit] = ???
+         |
+         |ctx.transaction(service)""".stripMargin must compile
+    }
+
+    "compiles with env requiring more than just Has[Connection]" in {
+      """|import zio.{ Has, ZIO }
+         |import java.sql.Connection
+         |
+         |trait Something
+         |trait SomeOtherThing
+         |def serviceA(): ZIO[Has[Something] with Has[Connection], Throwable, Unit] = ???
+         |def serviceB(): ZIO[Has[Connection] with Has[SomeOtherThing], Throwable, Unit] = ???
+         |
+         |ctx.transaction {
+         |  for {
+         |    _ <- serviceA() //   ZIO[Has[Something]      with Has[Connection], Throwable, A]
+         |    _ <- serviceB() //   ZIO[Has[SomeOtherThing] with Has[Connection], Throwable, A]
+         |  } yield ()
+         |}""".stripMargin must compile
+    }
+  }
+}

--- a/quill-jdbc-zio/src/test/scala/io/getquill/ZioSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/ZioSpec.scala
@@ -13,7 +13,7 @@ import javax.sql.DataSource
 case class Prefix(name: String)
 
 trait ZioSpec extends Spec with BeforeAndAfterAll {
-  def prefix: Prefix;
+  def prefix: Prefix
 
   var pool: DataSource with Closeable = _
 


### PR DESCRIPTION
Fixes #2293

### Problem

The `transaction` method on `ZioJdbcUnderlyingContext` expects an effect that only has a requirement on `Has[Connection]` and nothing else. 

### Solution

This PR changes the signature so it can handle an `R` that has at least `Has[Connection]`.

Added some compilation tests to make sure both versions compile, i.e.:

```scala
val service: ZIO[Has[Connection], Throwable Unit] = ???
ctx.transaction(service)
```

and 

```scala
trait Something
trait SomethingElse
val serviceA: ZIO[Has[Connection] with Has[Something], Throwable Unit] = ???
val serviceB: ZIO[Has[Something] with Has[Connection], Throwable Unit] = ???

ctx.transaction {
  for {
    _ <- serviceA   //   ZIO[Has[Something]  with Has[Connection], Throwable, A]
    _ <- serviceB   //   ZIO[Has[Connection] with Has[SomethingElse], Throwable, A]
  } yield ()
} 
```

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted