### PR TITLE
Change logging output to append mode

### DIFF
--- a/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
+++ b/quill-core-portable/src/main/scala/io/getquill/util/Messages.scala
@@ -25,7 +25,7 @@ object Messages {
   private[getquill] def traceOpinions = cache("quill.trace.opinion", variable("quill.trace.opinion", "quill_trace_opinion", "false").toBoolean)
   private[getquill] def traceAstSimple = cache("quill.trace.ast.simple", variable("quill.trace.ast.simple", "quill_trace_ast_simple", "false").toBoolean)
   private[getquill] def traceQuats = cache("quill.trace.quat", QuatTrace(variable("quill.trace.quat", "quill_trace_quat", QuatTrace.None.value)))
-  private[getquill] def quillLogFile = cache("quill.log.file", LogToFile(variable("quill.log.file", "quill_log_file", "./queries.sql")))
+  private[getquill] def quillLogFile = cache("quill.log.file", LogToFile(variable("quill.log.file", "quill_log_file", "./target/queries.sql")))
 
   sealed trait LogToFile
   object LogToFile {

--- a/quill-core/src/main/scala/io/getquill/util/QueryLogger.scala
+++ b/quill-core/src/main/scala/io/getquill/util/QueryLogger.scala
@@ -1,19 +1,98 @@
 package io.getquill.util
 
-import io.getquill.idiom.Idiom
 import io.getquill.util.Messages.{ LogToFile, quillLogFile }
 import zio._
+import zio.clock.Clock
+import zio.console.Console
+import zio.logging.LogAppender.Service
+import zio.logging.Logging.{ addTimestamp, modifyLoggerM }
 import zio.logging._
 
-import java.nio.file.Paths
+import java.io.{ BufferedWriter, FileOutputStream, OutputStreamWriter, Writer }
+import java.nio.charset.{ Charset, StandardCharsets }
+import java.nio.file.{ Path, Paths }
 import java.time.ZonedDateTime
 
+class AppendingLogWriter(
+  destination:        Path,
+  charset:            Charset,
+  autoFlushBatchSize: Int,
+  bufferedIOSize:     Option[Int]
+) extends Writer {
+  private val writer: Writer = {
+    val output = new OutputStreamWriter(new FileOutputStream(destination.toFile, true), charset)
+    bufferedIOSize match {
+      case Some(bufferSize) => new BufferedWriter(output, bufferSize)
+      case None             => output
+    }
+  }
+
+  private var entriesWritten: Long = 0
+
+  def write(buffer: Array[Char], offset: Int, length: Int): Unit =
+    writer.write(buffer, offset, length)
+
+  def writeln(line: String): Unit = {
+    writer.write(line)
+    writer.write(System.lineSeparator)
+
+    entriesWritten += 1
+
+    if (entriesWritten % autoFlushBatchSize == 0)
+      writer.flush()
+  }
+
+  def flush(): Unit = writer.flush()
+
+  def close(): Unit = writer.close()
+}
+
 class QueryLogger(logToFile: LogToFile) {
+
+  def appendFile[A](
+    destination:        Path,
+    charset:            Charset,
+    autoFlushBatchSize: Int,
+    bufferedIOSize:     Option[Int],
+    format0:            LogFormat[A]
+  )(implicit tag: Tag[LogAppender.Service[A]]): ZLayer[Any, Throwable, Appender[A]] =
+    ZManaged
+      .fromAutoCloseable(UIO(new AppendingLogWriter(destination, charset, autoFlushBatchSize, bufferedIOSize)))
+      .zip(ZRef.makeManaged(false))
+      .map {
+        case (writer, hasWarned) =>
+          new Service[A] {
+            override def write(ctx: LogContext, msg: => A): UIO[Unit] =
+              Task(writer.writeln(format0.format(ctx, msg))).catchAll { t =>
+                UIO {
+                  System.err.println(
+                    s"Logging to file $destination failed with an exception. Further exceptions will be suppressed in order to prevent log spam."
+                  )
+                  t.printStackTrace(System.err)
+                }.unlessM(hasWarned.getAndSet(true))
+              }
+          }
+      }
+      .toLayer[LogAppender.Service[A]]
+
+  def logFile(
+    destination:        Path,
+    charset:            Charset           = StandardCharsets.UTF_8,
+    autoFlushBatchSize: Int               = 1,
+    bufferedIOSize:     Option[Int]       = None,
+    logLevel:           LogLevel          = LogLevel.Info,
+    format:             LogFormat[String] = LogFormat.SimpleConsoleLogFormat((_, s) => s)
+  ): ZLayer[Console with Clock, Throwable, Logging] =
+    (ZLayer.requires[Clock] ++
+      appendFile[String](destination, charset, autoFlushBatchSize, bufferedIOSize, format)
+      .map(appender => Has(appender.get.filter((ctx, _) => ctx.get(LogAnnotation.Level) >= logLevel)))
+      >+> Logging.make >>> modifyLoggerM(addTimestamp[String]))
+
   private[getquill] val env = {
     logToFile match {
       case LogToFile.Enabled(file) =>
         ZEnv.live >>>
-          Logging.file(
+          logFile(
             logLevel = LogLevel.Info,
             format = LogFormat.fromFunction((ctx, str) => {
               str
@@ -31,9 +110,7 @@ class QueryLogger(logToFile: LogToFile) {
       case LogToFile.Enabled(_) =>
         runtime.unsafeRunAsync_(log.info(
           s"""
-             |-- file: $sourcePath
-             |-- line: $line
-             |-- col: $column
+             |-- file: $sourcePath:$line:$column
              |-- time: ${ZonedDateTime.now().format(LogDatetimeFormatter.isoLocalDateTimeFormatter)}
              |$queryString;
              |""".stripMargin


### PR DESCRIPTION
TODO
* Issue for logging per compilation unit being overridden. Related to zio/zio-logging#372.

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
