### PR TITLE
CI: Replace JDK 11 with JDK 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/setup-java@v4.7.1
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
           check-latest: true
       - name: Setup sbt
         uses: sbt/setup-sbt@v1


### PR DESCRIPTION
## Summary
- Replace JDK 11 with JDK 17 in CI