### PR TITLE
Changed the type of Cassandra timestamps from Int to Long

### DIFF
--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/Ops.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/Ops.scala
@@ -7,9 +7,9 @@ trait Ops {
   this: CassandraContext[_] =>
 
   abstract class Options[A](q: A) {
-    def usingTimestamp(ts: Int)  = quote(sql"$q USING TIMESTAMP $ts".as[A])
-    def usingTtl(ttl: Int)       = quote(sql"$q USING TTL $ttl".as[A])
-    def using(ts: Int, ttl: Int) = quote(sql"$q USING TIMESTAMP $ts AND TTL $ttl".as[A])
+    def usingTimestamp(ts: Long)  = quote(sql"$q USING TIMESTAMP $ts".as[A])
+    def usingTtl(ttl: Int)        = quote(sql"$q USING TTL $ttl".as[A])
+    def using(ts: Long, ttl: Int) = quote(sql"$q USING TIMESTAMP $ts AND TTL $ttl".as[A])
   }
 
   implicit final class QueryOps[Q <: Query[_]](q: Q) {

--- a/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ops/CassandraOpsSpec.scala
+++ b/quill-cassandra/src/test/scala/io/getquill/context/cassandra/ops/CassandraOpsSpec.scala
@@ -29,10 +29,10 @@ class CassandraOpsSpec extends Spec {
     "options" - {
       "timestamp" in {
         val q = quote {
-          query[TestEntity].insert(_.s -> "s").usingTimestamp(1)
+          query[TestEntity].insert(_.s -> "s").usingTimestamp(Long.MaxValue)
         }
         mirrorContext.run(q).string mustEqual
-          "INSERT INTO TestEntity (s) VALUES ('s') USING TIMESTAMP 1"
+          "INSERT INTO TestEntity (s) VALUES ('s') USING TIMESTAMP 9223372036854775807"
       }
       "ttl" in {
         val q = quote {
@@ -43,10 +43,10 @@ class CassandraOpsSpec extends Spec {
       }
       "both" in {
         val q = quote {
-          query[TestEntity].insert(_.s -> "s").using(1, 2)
+          query[TestEntity].insert(_.s -> "s").using(Long.MaxValue, 2)
         }
         mirrorContext.run(q).string mustEqual
-          "INSERT INTO TestEntity (s) VALUES ('s') USING TIMESTAMP 1 AND TTL 2"
+          "INSERT INTO TestEntity (s) VALUES ('s') USING TIMESTAMP 9223372036854775807 AND TTL 2"
       }
     }
   }
@@ -55,10 +55,10 @@ class CassandraOpsSpec extends Spec {
     "options" - {
       "timestamp" in {
         val q = quote {
-          query[TestEntity].usingTimestamp(99).updateValue(lift(TestEntity("s", 1, 2L, None, true)))
+          query[TestEntity].usingTimestamp(Long.MaxValue).updateValue(lift(TestEntity("s", 1, 2L, None, true)))
         }
         mirrorContext.run(q).string mustEqual
-          "UPDATE TestEntity USING TIMESTAMP 99 SET s = ?, i = ?, l = ?, o = ?, b = ?"
+          "UPDATE TestEntity USING TIMESTAMP 9223372036854775807 SET s = ?, i = ?, l = ?, o = ?, b = ?"
       }
       "ttl" in {
         val q = quote {
@@ -69,10 +69,10 @@ class CassandraOpsSpec extends Spec {
       }
       "both" in {
         val q = quote {
-          query[TestEntity].using(1, 2).updateValue(lift(TestEntity("s", 1, 2L, None, true)))
+          query[TestEntity].using(Long.MaxValue, 2).updateValue(lift(TestEntity("s", 1, 2L, None, true)))
         }
         mirrorContext.run(q).string mustEqual
-          "UPDATE TestEntity USING TIMESTAMP 1 AND TTL 2 SET s = ?, i = ?, l = ?, o = ?, b = ?"
+          "UPDATE TestEntity USING TIMESTAMP 9223372036854775807 AND TTL 2 SET s = ?, i = ?, l = ?, o = ?, b = ?"
       }
     }
     "ifExists" in {


### PR DESCRIPTION
Fixes #3397

According to the CQL documentation the timestamp is interpreted as microseconds since Epoch. The timestamp parameter was modeled as Integer, which was insufficient for current timestamps.

### Solution

Expanded the type to Long, which should cover any reasonable timestamps.

### Checklist

- [X] Unit test all changes
- [X] Update `README.md` if applicable
- [X] Add `[WIP]` to the pull request title if it's work in progress
- [X] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
