### PR TITLE
Fix #3403: wrap top-level infix queries decoding into case classes

### DIFF
--- a/quill-engine/src/main/scala/io/getquill/sql/SqlQuery.scala
+++ b/quill-engine/src/main/scala/io/getquill/sql/SqlQuery.scala
@@ -68,9 +68,11 @@ final case class UnaryOperationSqlQuery(
 }
 
 // A top-level infix query. This needs special rendering because we don't
-// want to tokenize column names, e.g. sql"select foo, bar from baz".as[Person]
+// want to tokenize column names, e.g. sql"select foo, bar from baz".as[Query[(String, Int)]]
 // should become just "select foo, bar from baz", not the fully expanded form
-// "select p.name, p.age from (select foo, bar from baz) as Person p"
+// "select x._1, x._2 from (select foo, bar from baz) as x".
+// Only used for values and tuples; case-class results keep the expanded form
+// to pin column order for positional decoding (see SqlQueryApply below, #3403).
 final case class TopInfixQuery(ast: Infix) extends SqlQuery {
   override def quat: Quat = ast.quat
 }
@@ -119,6 +121,22 @@ class SqlQueryApply(traceConfig: TraceConfig, allowTopLevelInfix: Boolean = true
 
   def apply(query: Ast) = build(query, true)
 
+  // Raw passthrough is only safe when positional decoding can't mismatch the raw
+  // SQL's column order: single values (one column) and tuples (order is explicit
+  // in the same expression). Case classes decode in field-declaration order, so e.g.
+  // sql"SELECT t.* FROM TestEntity t".as[Query[TestEntity]] would decode whatever
+  // order the table's DDL has; they keep the wrapping query whose projection
+  // pins the column order. See #3403.
+  private def infixSafeForRawPassthrough(infix: Infix): Boolean =
+    infix.quat match {
+      case p: Quat.Product => isTupleQuat(p)
+      case _               => true
+    }
+
+  private def isTupleQuat(p: Quat.Product): Boolean =
+    p.name.matches("Tuple[0-9]+") &&
+      p.fields.keysIterator.zipWithIndex.forall { case (f, i) => f == s"_${i + 1}" }
+
   private def build(query: Ast, isTopLevel: Boolean = false): SqlQuery =
     query match {
       case Union(a, b) =>
@@ -155,7 +173,7 @@ class SqlQueryApply(traceConfig: TraceConfig, allowTopLevelInfix: Boolean = true
           flatten(infix, "x")
         }
       case infix: Infix =>
-        if (allowTopLevelInfix && isTopLevel)
+        if (allowTopLevelInfix && isTopLevel && infixSafeForRawPassthrough(infix))
           TopInfixQuery(infix)
         else
           trace"Construct SqlQuery from: Infix" andReturn {

--- a/quill-sql-test/src/test/scala/io/getquill/context/sql/InfixSpec.scala
+++ b/quill-sql-test/src/test/scala/io/getquill/context/sql/InfixSpec.scala
@@ -168,7 +168,7 @@ class InfixSpec extends Spec { // //
         val ids = liftQuery(List(1, 2))
         sql"select id from Data where id in ($ids)".as[Query[Data]]
       }
-      ctx.translate(q) mustEqual "select id from Data where id in (lift(1), lift(2))"
+      ctx.translate(q) mustEqual "SELECT x.id FROM (select id from Data where id in (lift(1), lift(2))) AS x"
     }
 
   }

--- a/quill-sql-test/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
+++ b/quill-sql-test/src/test/scala/io/getquill/context/sql/SqlQuerySpec.scala
@@ -378,6 +378,24 @@ class SqlQuerySpec extends Spec {
         testContext.run(q).string mustEqual
           """SELECT x.* FROM (SELECT foo, bar FROM baz) AS x"""
       }
+      // Case classes decode positionally in field-declaration order, so raw
+      // passthrough would mis-decode whenever the raw SQL's column order differs
+      // (e.g. SELECT * returning table-DDL order). They keep the wrapping query
+      // whose projection pins the column order. See #3403.
+      "using a case class - wrapped to pin column order" in {
+        val q = quote {
+          sql"""SELECT * FROM TestEntity""".as[Query[TestEntity]]
+        }
+        testContext.run(q).string mustEqual
+          """SELECT x.s, x.i, x.l, x.o, x.b FROM (SELECT * FROM TestEntity) AS x"""
+      }
+      "using a case class - pure is also wrapped" in {
+        val q = quote {
+          sql"""SELECT * FROM TestEntity""".pure.as[Query[TestEntity]]
+        }
+        testContext.run(q).string mustEqual
+          """SELECT x.s, x.i, x.l, x.o, x.b FROM (SELECT * FROM TestEntity) AS x"""
+      }
     }
 
     "nested infix query" - {

--- a/quill-sql-test/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
+++ b/quill-sql-test/src/test/scala/io/getquill/context/sql/idiom/OracleDialectSpec.scala
@@ -188,8 +188,9 @@ class OracleDialectSpec extends Spec {
 
   case class Person(name: String, age: Int)
   "No 'AS' aliases" in {
+    // Case-class result: wrapped to pin column order (see #3403); Oracle still omits AS on the alias.
     ctx.run(sql"SELECT name, age FROM Person p".as[Query[Person]]).string mustEqual
-      "SELECT name, age FROM Person p"
+      "SELECT x.name, x.age FROM (SELECT name, age FROM Person p) x"
   }
 
   case class Document(filename: String)

--- a/quill-sql-test/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
+++ b/quill-sql-test/src/test/scala/io/getquill/context/sql/idiom/SqlIdiomSpec.scala
@@ -948,8 +948,9 @@ class SqlIdiomSpec extends Spec {
           "SELECT a.i FROM (SELECT 1 i FROM DUAL) AS a"
       }
       "full infix query" in {
+        // Case-class result: wrapped to pin column order for positional decoding (see #3403).
         testContext.run(sql"SELECT * FROM TestEntity".as[Query[TestEntity]]).string mustEqual
-          "SELECT * FROM TestEntity"
+          "SELECT x.s, x.i, x.l, x.o, x.b FROM (SELECT * FROM TestEntity) AS x"
       }
       "full infix action" in {
         testContext.run(sql"DELETE FROM TestEntity".as[Action[TestEntity]]).string mustEqual

--- a/quill-sql-test/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
+++ b/quill-sql-test/src/test/scala/io/getquill/context/sql/norm/ExpandNestedQueriesSpec.scala
@@ -700,8 +700,9 @@ class ExpandNestedQueriesSpec extends Spec {
       val q = quote {
         sql"fromSomewhere()".as[Query[Person]]
       }
+      // Case-class result: wrapped to pin column order for positional decoding (see #3403).
       testContext.run(q).string mustEqual
-        "fromSomewhere()"
+        "SELECT x.first_name AS firstName, x.last_name AS lastName FROM (fromSomewhere()) AS x"
     }
 
     "should be handled correctly in a regular schema - nested" in {
@@ -719,8 +720,9 @@ class ExpandNestedQueriesSpec extends Spec {
       val q = quote {
         sql"fromSomewhere()".as[Query[Person]]
       }
+      // Case-class result: wrapped to pin column order for positional decoding (see #3403).
       testContext.run(q).string mustEqual
-        "fromSomewhere()"
+        "SELECT x.first_name AS firstName, x.last_name AS lastName, x.the_age AS theAge FROM (fromSomewhere()) AS x"
     }
   }
 


### PR DESCRIPTION
Fixes #3403.

## Problem

#3147 (`c334986f`, released in quill-engine 4.8.6) made top-level infix queries pass through unwrapped (`TopInfixQuery`). For **case-class** results this silently changes the decode contract: extractors decode positionally in field-declaration order, while the raw SQL — e.g. `SELECT b.* FROM blocked_periods b` — returns the table's **physical column order** (including columns appended by later ALTERs). When the orders differ, decoders read neighboring columns' values: exceptions if types/enum members mismatch, **silently wrong data** if they don't.

## Reproduction

Any table whose DDL column order differs from the case class:

```sql
CREATE TABLE blocked_periods (id UUID, home_id UUID, period DATERANGE, reason VARCHAR, active BOOLEAN);
ALTER TABLE blocked_periods ADD COLUMN source VARCHAR;          -- appended later
ALTER TABLE blocked_periods ADD COLUMN occupancy_status VARCHAR; -- appended later
```

```scala
case class BlockedPeriod(id: UUID, homeId: UUID, period: DateRange, reason: String,
                         source: BlockedPeriodSource /* enum */, occupancyStatus: OccupancyStatus /* enum */, ...)

run(quote { sql"""SELECT b.* FROM blocked_periods b WHERE ...""".as[Query[BlockedPeriod]] })
// 4.8.5: SELECT x.id, x.home_id, ... FROM (SELECT b.* ...) AS x  -> correct
// 4.8.6: SELECT b.* ...                                          -> source decoder reads occupancy_status:
// NoSuchElementException: OCCUPIED is not a member of Enum(BOOKING, ...)
```

The new `SqlQuerySpec` cases in this PR encode the contract at the SQL level (`sql"SELECT * FROM TestEntity".as[Query[TestEntity]]` must stay wrapped).

## Fix

Raw passthrough remains for **single values** (one column) and **tuples** (column order is explicit in the same expression — the #3147 use case). **Case-class** results keep the wrapping query, whose explicit projection pins column order — the pre-4.8.6 behavior.

## Validation

- `SqlQuerySpec`: 92/92, including the existing #3147 tuple/value passthrough tests (unchanged) and the two new case-class tests.
- Production reproducer (200+ module Scala 3 codebase, Postgres testcontainers): the failing spec above goes red → green with only this engine change applied; the affected service's full persistence suite passes (71/71).

Single-commit bisection that identified #3147 is documented in #3403.