### PR TITLE
bump zio-json to 0.9.2 (was 0.7.44) for quill-jdbc-zio

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -424,7 +424,7 @@ lazy val `quill-jdbc-zio` =
       libraryDependencies ++= Seq(
         // Needed for PGObject in JsonExtensions but not necessary if user is not using postgres
         "org.postgresql" % "postgresql" % "42.7.7" % "provided",
-        "dev.zio"       %% "zio-json"   % "0.7.44"
+        "dev.zio"       %% "zio-json"   % "0.9.2"
       ),
       Test / testGrouping := {
         (Test / definedTests).value map { test =>
@@ -599,7 +599,7 @@ def excludePaths(paths: Seq[String]) = {
 }
 
 val scala_v_12 = "2.12.20"
-val scala_v_13 = "2.13.16"
+val scala_v_13 = "2.13.18"
 val scala_v_30 = "3.3.6"
 
 val scalaCollectionCompatVersion = "2.13.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,8 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 addDependencyTreePlugin
 
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"             % "2.5.5")
-addSbtPlugin("org.scoverage"  % "sbt-scoverage"            % "2.3.1")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"             % "2.5.6")
+addSbtPlugin("org.scoverage"  % "sbt-scoverage"            % "2.4.4")
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin"          % "1.1.4")
 addSbtPlugin("com.etsy"       % "sbt-compile-quick-plugin" % "1.4.0")
 addSbtPlugin("dev.zio"        % "zio-sbt-website"          % "0.3.10")


### PR DESCRIPTION
Had to bump scala 2.13.18 too

> [error] java.lang.RuntimeException: Expected `quill-jdbc-zio / scalaVersion` to be 2.13.18 or later, but found 2.13.16.
> [error] To support backwards-only binary compatibility (SIP-51), the Scala 2.13 compiler
> [error] should not be older than scala-library on the dependency classpath.
> 

Fixes #issue_number

### Problem

Explain here the context, and why you're making that change.
What is the problem you're trying to solve?

### Solution

Describe the modifications you've done.

### Notes

Additional notes.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [ ] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
